### PR TITLE
fix(goreleaser): fix tap and disable discord for the moment

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,7 +67,7 @@ changelog:
 brews:
   - tap:
       owner: zitadel
-      name: zitadel-tap
+      name: homebrew-tap
       token: "{{ .Env.GORELEASER_TOKEN_TAP }}"
     folder: Formula
     goarm: "7"
@@ -89,5 +89,5 @@ brews:
 
 announce:
   discord:
-    enabled: true
+    enabled: false #enable when we release v2
     message_template: 'ZITADEL {{ .Tag }} is ready! Check the notes: https://github.com/zitadel/zitadel/releases/tag/{{ .Tag }}'


### PR DESCRIPTION
This will add support to auto create the necessary tap.

But be aware the draft we currently publish will not be available to download.