### PR TITLE
fix(cli): typo in clis

### DIFF
--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -15,8 +15,8 @@ import (
 func New() *cobra.Command {
 	adminCMD := &cobra.Command{
 		Use:   "admin",
-		Short: "The ZITADEL admin CLI let's you interact with your instance",
-		Long:  `The ZITADEL admin CLI let's you interact with your instance`,
+		Short: "The ZITADEL admin CLI lets you interact with your instance",
+		Long:  `The ZITADEL admin CLI lets you interact with your instance`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("no additional command provided")
 		},

--- a/cmd/zitadel.go
+++ b/cmd/zitadel.go
@@ -24,8 +24,8 @@ var (
 func New(out io.Writer, in io.Reader, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zitadel",
-		Short: "The ZITADEL CLI let's you interact with ZITADEL",
-		Long:  `The ZITADEL CLI let's you interact with ZITADEL`,
+		Short: "The ZITADEL CLI lets you interact with ZITADEL",
+		Long:  `The ZITADEL CLI lets you interact with ZITADEL`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("no additional command provided")
 		},


### PR DESCRIPTION
Fix spelling in both cli commands. 
https://www.dictionary.com/e/lets/