### PR TITLE
fix: render only base language in html

### DIFF
--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -332,12 +332,13 @@ func (l *Login) getUserData(r *http.Request, authReq *domain.AuthRequest, title 
 }
 
 func (l *Login) getBaseData(r *http.Request, authReq *domain.AuthRequest, title string, errType, errMessage string) baseData {
+	lang, _ := l.renderer.ReqLang(l.getTranslator(r.Context(), authReq), r).Base()
 	baseData := baseData{
 		errorData: errorData{
 			ErrID:      errType,
 			ErrMessage: errMessage,
 		},
-		Lang:                   l.renderer.ReqLang(l.getTranslator(r.Context(), authReq), r).String(),
+		Lang:                   lang.String(),
 		Title:                  title,
 		Theme:                  l.getTheme(r),
 		ThemeMode:              l.getThemeMode(r),


### PR DESCRIPTION
currently the language is rendered with region as incorrect string, e.g. `en-u-rg-uszzzz`
`{{.Lang}}` can be used in templates, e.g. privacy policy link
with this PR {{.Lang}} will only render the base tag, e.g. `en`