### PR TITLE
feat: add status subcommand

### DIFF
--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -3,6 +3,7 @@ package admin
 import (
 	_ "embed"
 	"errors"
+	"github.com/zitadel/zitadel/cmd/admin/status"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +29,7 @@ func New() *cobra.Command {
 		start.New(),
 		start.NewStartFromInit(),
 		key.New(),
+		status.New(),
 	)
 
 	return adminCMD

--- a/cmd/admin/status/status.go
+++ b/cmd/admin/status/status.go
@@ -1,0 +1,58 @@
+package status
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"net/http"
+	"time"
+)
+
+const (
+	flagKeyFile = "file"
+)
+
+type Config struct {
+	Port uint16
+}
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "check zitadel status",
+	}
+	cmd.AddCommand(checkHealth())
+	return cmd
+}
+
+func checkHealth() *cobra.Command {
+	return &cobra.Command{
+		Use:   "health",
+		Short: "check if zitadel is accepting requests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := new(Config)
+			if err := viper.Unmarshal(config); err != nil {
+				return err
+			}
+			return isHealthy(config)
+		},
+	}
+}
+
+func isHealthy(cfg *Config) error {
+
+	client := &http.Client{
+		Timeout: 50 * time.Millisecond,
+	}
+
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/healthz", cfg.Port))
+	if err != nil {
+		return fmt.Errorf("zitadel is not healthy: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("expected status code 200, but got %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This allows health checks, with nothing more than having the zitadel binary and config. It's especially useful when ZITADEL is run with Docker Compose.