### PR TITLE
feat: configurable OIDC lifetimes via env vars

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    branches: ["main"],
+    branches: ["v1"],
     plugins: [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",

--- a/cmd/zitadel/startup.yaml
+++ b/cmd/zitadel/startup.yaml
@@ -259,10 +259,10 @@ API:
       DefaultLogoutRedirectURI: $ZITADEL_ACCOUNTS/logout/done
     StorageConfig:
       DefaultLoginURL: $ZITADEL_ACCOUNTS/login?authRequestID=
-      DefaultAccessTokenLifetime: $ZITADEL_DEFAUTL_ACCESS_TOKEN_LIFETIME
-      DefaultIdTokenLifetime: $ZITADEL_DEFAUTL_ID_TOKEN_LIFETIME
-      DefaultRefreshTokenIdleExpiration: $ZITADEL_DEFAUTL_REFRESH_TOKEN_IDLE_EXPIRATION
-      DefaultRefreshTokenExpiration: $ZITADEL_DEFAUTL_REFRESH_TOKEN_EXPIRATION
+      DefaultAccessTokenLifetime: $ZITADEL_DEFAULT_ACCESS_TOKEN_LIFETIME
+      DefaultIdTokenLifetime: $ZITADEL_DEFAULT_ID_TOKEN_LIFETIME
+      DefaultRefreshTokenIdleExpiration: $ZITADEL_DEFAULT_REFRESH_TOKEN_IDLE_EXPIRATION
+      DefaultRefreshTokenExpiration: $ZITADEL_DEFAULT_REFRESH_TOKEN_EXPIRATION
       SigningKeyAlgorithm: RS256
     UserAgentCookieConfig:
       Name: caos.zitadel.useragent

--- a/cmd/zitadel/startup.yaml
+++ b/cmd/zitadel/startup.yaml
@@ -259,10 +259,10 @@ API:
       DefaultLogoutRedirectURI: $ZITADEL_ACCOUNTS/logout/done
     StorageConfig:
       DefaultLoginURL: $ZITADEL_ACCOUNTS/login?authRequestID=
-      DefaultAccessTokenLifetime: 12h
-      DefaultIdTokenLifetime: 12h
-      DefaultRefreshTokenIdleExpiration: 720h #30d
-      DefaultRefreshTokenExpiration: 2160h #90d
+      DefaultAccessTokenLifetime: $ZITADEL_DEFAUTL_ACCESS_TOKEN_LIFETIME
+      DefaultIdTokenLifetime: $ZITADEL_DEFAUTL_ID_TOKEN_LIFETIME
+      DefaultRefreshTokenIdleExpiration: $ZITADEL_DEFAUTL_REFRESH_TOKEN_IDLE_EXPIRATION
+      DefaultRefreshTokenExpiration: $ZITADEL_DEFAUTL_REFRESH_TOKEN_EXPIRATION
       SigningKeyAlgorithm: RS256
     UserAgentCookieConfig:
       Name: caos.zitadel.useragent

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -163,17 +163,17 @@ func getSupportedLanguages() ([]language.Tag, error) {
 }
 
 func fillDefaultOIDCLifetimes(config StorageConfig) StorageConfig {
-	if config.DefaultAccessTokenLifetime == (time.Hour * 0) {
-		config.DefaultAccessTokenLifetime = 12 * time.Hour
+	if config.DefaultAccessTokenLifetime.Duration == 0 {
+		config.DefaultAccessTokenLifetime.Duration = 12 * time.Hour
 	}
-	if config.DefaultIdTokenLifetime == (time.Hour * 0) {
-		config.DefaultIdTokenLifetime = 12 * time.Hour
+	if config.DefaultIdTokenLifetime.Duration == 0 {
+		config.DefaultIdTokenLifetime.Duration = 12 * time.Hour
 	}
-	if config.DefaultRefreshTokenIdleExpiration == (time.Hour * 0) {
-		config.DefaultRefreshTokenIdleExpiration = 720 * time.Hour //30d
+	if config.DefaultRefreshTokenIdleExpiration.Duration == 0 {
+		config.DefaultRefreshTokenIdleExpiration.Duration = 720 * time.Hour //30d
 	}
-	if config.DefaultRefreshTokenExpiration == (time.Hour * 0) {
-		config.DefaultRefreshTokenExpiration = 2160 * time.Hour //90d
+	if config.DefaultRefreshTokenExpiration.Duration == 0 {
+		config.DefaultRefreshTokenExpiration.Duration = 2160 * time.Hour //90d
 	}
 	return config
 }

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -129,6 +129,7 @@ func newStorage(config StorageConfig, command *command.Commands, query *query.Qu
 	if err != nil {
 		return nil, err
 	}
+	config = fillDefaultOIDCLifetimes(config)
 	return &OPStorage{
 		repo:                              repo,
 		command:                           command,
@@ -159,4 +160,20 @@ func getSupportedLanguages() ([]language.Tag, error) {
 		return nil, err
 	}
 	return i18n.SupportedLanguages(statikLoginFS)
+}
+
+func fillDefaultOIDCLifetimes(config StorageConfig) StorageConfig {
+	if config.DefaultAccessTokenLifetime == (time.Hour * 0) {
+		config.DefaultAccessTokenLifetime = 12 * time.Hour
+	}
+	if config.DefaultIdTokenLifetime == (time.Hour * 0) {
+		config.DefaultIdTokenLifetime = 12 * time.Hour
+	}
+	if config.DefaultRefreshTokenIdleExpiration == (time.Hour * 0) {
+		config.DefaultRefreshTokenIdleExpiration = 720 * time.Hour //30d
+	}
+	if config.DefaultRefreshTokenExpiration == (time.Hour * 0) {
+		config.DefaultRefreshTokenExpiration = 2160 * time.Hour //90d
+	}
+	return config
 }

--- a/operator/zitadel/kinds/iam/zitadel/configuration/desired.go
+++ b/operator/zitadel/kinds/iam/zitadel/configuration/desired.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	ClusterDNS          string         `yaml:"clusterdns"`
 	AssetStorage        *AssetStorage  `yaml:"assetStorage,omitempty"`
 	Proxy               *Proxy         `yaml:"proxy,omitempty"`
+	OIDCLifetimes       *OIDCLifetimes `yaml:"oidcLifetimes,omitempty"`
 }
 
 func (c *Configuration) Validate() (err error) {
@@ -151,4 +152,11 @@ type Proxy struct {
 	HTTPS         *secret.Secret   `yaml:"https,omitempty"`
 	ExistingHTTP  *secret.Existing `yaml:"existingHTTP,omitempty"`
 	ExistingHTTPS *secret.Existing `yaml:"existingHTTPS,omitempty"`
+}
+
+type OIDCLifetimes struct {
+	AccessTokenLifetime        string `yaml:"accessTokenLifetime,omitempty"`
+	IdTokenLifeTime            string `yaml:"idTokenLifeTime,omitempty"`
+	RefreshTokenIdleExpiration string `yaml:"refreshTokenIdleExpiration,omitempty"`
+	RefreshTokenExpiration     string `yaml:"refreshTokenExpiration,omitempty"`
 }

--- a/operator/zitadel/kinds/iam/zitadel/configuration/literals.go
+++ b/operator/zitadel/kinds/iam/zitadel/configuration/literals.go
@@ -125,6 +125,12 @@ func literalsConfigMap(
 		if desired.Proxy != nil {
 			literalsConfigMap["NO_PROXY"] = strings.Join(desired.Proxy.NoProxy, ",")
 		}
+		if desired.OIDCLifetimes != nil {
+			literalsConfigMap["ZITADEL_DEFAULT_ACCESS_TOKEN_LIFETIME"] = desired.OIDCLifetimes.AccessTokenLifetime
+			literalsConfigMap["ZITADEL_DEFAULT_ID_TOKEN_LIFETIME"] = desired.OIDCLifetimes.IdTokenLifeTime
+			literalsConfigMap["ZITADEL_DEFAULT_REFRESH_TOKEN_IDLE_EXPIRATION"] = desired.OIDCLifetimes.RefreshTokenIdleExpiration
+			literalsConfigMap["ZITADEL_DEFAULT_REFRESH_TOKEN_EXPIRATION"] = desired.OIDCLifetimes.RefreshTokenExpiration
+		}
 	}
 
 	sentryEnv, _, doIngest := mntr.Environment()


### PR DESCRIPTION
env vars:
```
DefaultAccessTokenLifetime: $ZITADEL_DEFAULT_ACCESS_TOKEN_LIFETIME
DefaultIdTokenLifetime: $ZITADEL_DEFAULT_ID_TOKEN_LIFETIME
DefaultRefreshTokenIdleExpiration: $ZITADEL_DEFAULT_REFRESH_TOKEN_IDLE_EXPIRATION
DefaultRefreshTokenExpiration: $ZITADEL_DEFAULT_REFRESH_TOKEN_EXPIRATION
```

operator yaml:
```
oidcLifetimes:
  accessTokenLifetime: 12h
  idTokenLifeTime: 12h
  refreshTokenIdleExpiration: 720h
  refreshTokenExpiration: 21260h
```