### PR TITLE
fix: hide / show username suffix correctly on registration pages

### DIFF
--- a/internal/api/ui/login/policy_handler.go
+++ b/internal/api/ui/login/policy_handler.go
@@ -28,3 +28,10 @@ func (l *Login) getLoginPolicy(r *http.Request, orgID string) (*query.LoginPolic
 	}
 	return l.query.LoginPolicyByID(r.Context(), false, orgID)
 }
+
+func (l *Login) getLabelPolicy(r *http.Request, orgID string) (*query.LabelPolicy, error) {
+	if orgID == "" {
+		return l.query.DefaultActiveLabelPolicy(r.Context())
+	}
+	return l.query.ActiveLabelPolicyByOrg(r.Context(), orgID)
+}

--- a/internal/api/ui/login/register_handler.go
+++ b/internal/api/ui/login/register_handler.go
@@ -37,6 +37,7 @@ type registerData struct {
 	HasNumber                 string
 	HasSymbol                 string
 	ShowUsername              bool
+	ShowUsernameSuffix        bool
 	OrgRegister               bool
 }
 
@@ -148,6 +149,13 @@ func (l *Login) renderRegister(w http.ResponseWriter, r *http.Request, authReque
 	}
 	data.ShowUsername = orgIAMPolicy.UserLoginMustBeDomain
 	data.OrgRegister = orgIAMPolicy.UserLoginMustBeDomain
+
+	labelPolicy, err := l.getLabelPolicy(r, resourceOwner)
+	if err != nil {
+		l.renderRegister(w, r, authRequest, formData, err)
+		return
+	}
+	data.ShowUsernameSuffix = !labelPolicy.HideLoginNameSuffix
 
 	funcs := map[string]interface{}{
 		"selectedLanguage": func(l string) bool {

--- a/internal/api/ui/login/static/templates/external_not_found_option.html
+++ b/internal/api/ui/login/static/templates/external_not_found_option.html
@@ -39,7 +39,7 @@
             <div class="lgn-suffix-wrapper">
                 <input class="lgn-input lgn-suffix-input" type="text" id="username" name="username"
                        value="{{ .Username }}" required>
-                {{if .ShowUsername}}
+                {{if .ShowUsernameSuffix}}
                 <span id="default-login-suffix" lgnsuffix class="loginname-suffix">@{{.PrimaryDomain}}</span>
                 {{end}}
             </div>

--- a/internal/api/ui/login/static/templates/external_register_overview.html
+++ b/internal/api/ui/login/static/templates/external_register_overview.html
@@ -39,7 +39,7 @@
             <div class="lgn-suffix-wrapper">
                 <input class="lgn-input lgn-suffix-input" type="text" id="username" name="username"
                        value="{{ .Username }}" required>
-                {{if .ShowUsername}}
+                {{if .ShowUsernameSuffix}}
                 <span id="default-login-suffix" lgnsuffix class="loginname-suffix">@{{.PrimaryDomain}}</span>
                 {{end}}
             </div>

--- a/internal/api/ui/login/static/templates/register.html
+++ b/internal/api/ui/login/static/templates/register.html
@@ -42,7 +42,7 @@
             <label class="lgn-label" for="username">{{t "RegistrationUser.UsernameLabel"}}</label>
             <div class="lgn-suffix-wrapper">
                 <input class="lgn-input lgn-suffix-input" type="text" id="username" name="username" autocomplete="email" value="{{ .Email }}" required>
-                {{if .ShowUsername}}
+                {{if .ShowUsernameSuffix}}
                     <span id="default-login-suffix" lgnsuffix class="loginname-suffix">@{{.PrimaryDomain}}</span>
                 {{end}}
             </div>


### PR DESCRIPTION
closes #3968 