### PR TITLE
docs(api): link rate limit policy to rules

### DIFF
--- a/docs/docs/apis/ratelimits/ratelimits.md
+++ b/docs/docs/apis/ratelimits/ratelimits.md
@@ -2,6 +2,8 @@
 title: ZITADEL Cloud Rate Limits
 ---
 
+Rate limits are implemented according to our [rate limit policy](/docs/legal/rate-limit-policy.md) with the following rules:
+
 | Path                     | Description                            | Throttling                           | One Minute Banning        |
 |--------------------------|----------------------------------------|--------------------------------------|----------------------------------------|
 | /ui/login*               | Global Login, Register and Reset Limit | 10 requests per second over a minute | 15 requests per sencond over 3 minutes |


### PR DESCRIPTION
When you only look at the api/ratelimits page then a reader would miss the context of the rate limit policy. specifically how the rate limit is implemnted (by IP address). The two docs are in different sections, so navigation is also not very clear.