### PR TITLE
fix(import): check exists

### DIFF
--- a/internal/command/instance_idp_config.go
+++ b/internal/command/instance_idp_config.go
@@ -81,7 +81,7 @@ func (c *Commands) ChangeDefaultIDPConfig(ctx context.Context, config *domain.ID
 	if config.IDPConfigID == "" {
 		return nil, errors.ThrowInvalidArgument(nil, "INSTANCE-4m9gs", "Errors.IDMissing")
 	}
-	existingIDP, err := c.isntanceIDPConfigWriteModelByID(ctx, config.IDPConfigID)
+	existingIDP, err := c.instanceIDPConfigWriteModelByID(ctx, config.IDPConfigID)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (c *Commands) ChangeDefaultIDPConfig(ctx context.Context, config *domain.ID
 }
 
 func (c *Commands) DeactivateDefaultIDPConfig(ctx context.Context, idpID string) (*domain.ObjectDetails, error) {
-	existingIDP, err := c.isntanceIDPConfigWriteModelByID(ctx, idpID)
+	existingIDP, err := c.instanceIDPConfigWriteModelByID(ctx, idpID)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *Commands) DeactivateDefaultIDPConfig(ctx context.Context, idpID string)
 }
 
 func (c *Commands) ReactivateDefaultIDPConfig(ctx context.Context, idpID string) (*domain.ObjectDetails, error) {
-	existingIDP, err := c.isntanceIDPConfigWriteModelByID(ctx, idpID)
+	existingIDP, err := c.instanceIDPConfigWriteModelByID(ctx, idpID)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (c *Commands) ReactivateDefaultIDPConfig(ctx context.Context, idpID string)
 }
 
 func (c *Commands) RemoveDefaultIDPConfig(ctx context.Context, idpID string, idpProviders []*domain.IDPProvider, externalIDPs ...*domain.UserIDPLink) (*domain.ObjectDetails, error) {
-	existingIDP, err := c.isntanceIDPConfigWriteModelByID(ctx, idpID)
+	existingIDP, err := c.instanceIDPConfigWriteModelByID(ctx, idpID)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (c *Commands) RemoveDefaultIDPConfig(ctx context.Context, idpID string, idp
 }
 
 func (c *Commands) getInstanceIDPConfigByID(ctx context.Context, idpID string) (*domain.IDPConfig, error) {
-	config, err := c.isntanceIDPConfigWriteModelByID(ctx, idpID)
+	config, err := c.instanceIDPConfigWriteModelByID(ctx, idpID)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (c *Commands) getInstanceIDPConfigByID(ctx context.Context, idpID string) (
 	return writeModelToIDPConfig(&config.IDPConfigWriteModel), nil
 }
 
-func (c *Commands) isntanceIDPConfigWriteModelByID(ctx context.Context, idpID string) (policy *InstanceIDPConfigWriteModel, err error) {
+func (c *Commands) instanceIDPConfigWriteModelByID(ctx context.Context, idpID string) (policy *InstanceIDPConfigWriteModel, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 

--- a/internal/command/project_grant_member.go
+++ b/internal/command/project_grant_member.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/errors"
-	caos_errs "github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/project"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
@@ -14,10 +13,10 @@ import (
 
 func (c *Commands) AddProjectGrantMember(ctx context.Context, member *domain.ProjectGrantMember) (*domain.ProjectGrantMember, error) {
 	if !member.IsValid() {
-		return nil, caos_errs.ThrowInvalidArgument(nil, "PROJECT-8fi7G", "Errors.Project.Grant.Member.Invalid")
+		return nil, errors.ThrowInvalidArgument(nil, "PROJECT-8fi7G", "Errors.Project.Grant.Member.Invalid")
 	}
 	if len(domain.CheckForInvalidRoles(member.Roles, domain.ProjectGrantRolePrefix, c.zitadelRoles)) > 0 {
-		return nil, caos_errs.ThrowInvalidArgument(nil, "PROJECT-m9gKK", "Errors.Project.Grant.Member.Invalid")
+		return nil, errors.ThrowInvalidArgument(nil, "PROJECT-m9gKK", "Errors.Project.Grant.Member.Invalid")
 	}
 	err := c.checkUserExists(ctx, member.UserID, "")
 	if err != nil {
@@ -29,7 +28,7 @@ func (c *Commands) AddProjectGrantMember(ctx context.Context, member *domain.Pro
 		return nil, err
 	}
 	if addedMember.State == domain.MemberStateActive {
-		return nil, caos_errs.ThrowAlreadyExists(nil, "PROJECT-16dVN", "Errors.Project.Member.AlreadyExists")
+		return nil, errors.ThrowAlreadyExists(nil, "PROJECT-16dVN", "Errors.Project.Member.AlreadyExists")
 	}
 	projectAgg := ProjectAggregateFromWriteModel(&addedMember.WriteModel)
 	pushedEvents, err := c.eventstore.Push(
@@ -46,13 +45,13 @@ func (c *Commands) AddProjectGrantMember(ctx context.Context, member *domain.Pro
 	return memberWriteModelToProjectGrantMember(addedMember), nil
 }
 
-//ChangeProjectGrantMember updates an existing member
+// ChangeProjectGrantMember updates an existing member
 func (c *Commands) ChangeProjectGrantMember(ctx context.Context, member *domain.ProjectGrantMember) (*domain.ProjectGrantMember, error) {
 	if !member.IsValid() {
-		return nil, caos_errs.ThrowInvalidArgument(nil, "PROJECT-109fs", "Errors.Project.Member.Invalid")
+		return nil, errors.ThrowInvalidArgument(nil, "PROJECT-109fs", "Errors.Project.Member.Invalid")
 	}
 	if len(domain.CheckForInvalidRoles(member.Roles, domain.ProjectGrantRolePrefix, c.zitadelRoles)) > 0 {
-		return nil, caos_errs.ThrowInvalidArgument(nil, "PROJECT-m0sDf", "Errors.Project.Member.Invalid")
+		return nil, errors.ThrowInvalidArgument(nil, "PROJECT-m0sDf", "Errors.Project.Member.Invalid")
 	}
 
 	existingMember, err := c.projectGrantMemberWriteModelByID(ctx, member.AggregateID, member.UserID, member.GrantID)
@@ -61,7 +60,7 @@ func (c *Commands) ChangeProjectGrantMember(ctx context.Context, member *domain.
 	}
 
 	if reflect.DeepEqual(existingMember.Roles, member.Roles) {
-		return nil, caos_errs.ThrowPreconditionFailed(nil, "PROJECT-2n8vx", "Errors.Project.Member.RolesNotChanged")
+		return nil, errors.ThrowPreconditionFailed(nil, "PROJECT-2n8vx", "Errors.Project.Member.RolesNotChanged")
 	}
 	projectAgg := ProjectAggregateFromWriteModel(&existingMember.WriteModel)
 	pushedEvents, err := c.eventstore.Push(
@@ -80,7 +79,7 @@ func (c *Commands) ChangeProjectGrantMember(ctx context.Context, member *domain.
 
 func (c *Commands) RemoveProjectGrantMember(ctx context.Context, projectID, userID, grantID string) (*domain.ObjectDetails, error) {
 	if projectID == "" || userID == "" || grantID == "" {
-		return nil, caos_errs.ThrowInvalidArgument(nil, "PROJECT-66mHd", "Errors.Project.Member.Invalid")
+		return nil, errors.ThrowInvalidArgument(nil, "PROJECT-66mHd", "Errors.Project.Member.Invalid")
 	}
 	m, err := c.projectGrantMemberWriteModelByID(ctx, projectID, userID, grantID)
 	if err != nil {

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+
 	"github.com/zitadel/zitadel/internal/crypto"
 
 	"github.com/zitadel/logging"
@@ -15,6 +16,9 @@ import (
 func (c *Commands) ImportHumanOTP(ctx context.Context, userID, userAgentID, resourceowner string, key string) error {
 	encryptedSecret, err := crypto.Encrypt([]byte(key), c.multifactors.OTP.CryptoMFA)
 	if err != nil {
+		return err
+	}
+	if err = c.checkUserExists(ctx, userID, resourceowner); err != nil {
 		return err
 	}
 

--- a/internal/command/user_idp_link.go
+++ b/internal/command/user_idp_link.go
@@ -58,6 +58,10 @@ func (c *Commands) addUserIDPLink(ctx context.Context, human *eventstore.Aggrega
 	if !link.IsValid() {
 		return nil, caos_errs.ThrowInvalidArgument(nil, "COMMAND-6m9Kd", "Errors.User.ExternalIDP.Invalid")
 	}
+	if err := c.checkUserExists(ctx, human.ID, human.ResourceOwner); err != nil {
+		return nil, err
+	}
+
 	_, err := c.getOrgIDPConfigByID(ctx, link.IDPConfigID, human.ResourceOwner)
 	if caos_errs.IsNotFound(err) {
 		_, err = c.getInstanceIDPConfigByID(ctx, link.IDPConfigID)

--- a/internal/command/user_idp_link_test.go
+++ b/internal/command/user_idp_link_test.go
@@ -129,6 +129,23 @@ func TestCommandSide_BulkAddUserIDPLinks(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanAddedEvent(
+								context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								"userName",
+								"firstName",
+								"lastName",
+								"nickName",
+								"displayName",
+								language.German,
+								domain.GenderFemale,
+								"email@Address.ch",
+								false,
+							),
+						),
+					),
 					expectFilter(),
 					expectFilter(),
 				),
@@ -156,6 +173,23 @@ func TestCommandSide_BulkAddUserIDPLinks(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanAddedEvent(
+								context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								"userName",
+								"firstName",
+								"lastName",
+								"nickName",
+								"displayName",
+								language.German,
+								domain.GenderFemale,
+								"email@Address.ch",
+								false,
+							),
+						),
+					),
 					expectFilter(
 						eventFromEventPusher(
 							org.NewIDPConfigAddedEvent(context.Background(),
@@ -205,6 +239,23 @@ func TestCommandSide_BulkAddUserIDPLinks(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanAddedEvent(
+								context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								"userName",
+								"firstName",
+								"lastName",
+								"nickName",
+								"displayName",
+								language.German,
+								domain.GenderFemale,
+								"email@Address.ch",
+								false,
+							),
+						),
+					),
 					expectFilter(),
 					expectFilter(
 						eventFromEventPusher(

--- a/internal/eventstore/handler/crdb/handler_stmt_test.go
+++ b/internal/eventstore/handler/crdb/handler_stmt_test.go
@@ -1602,7 +1602,7 @@ func TestStatementHandler_updateCurrentSequence(t *testing.T) {
 			},
 			want: want{
 				isErr: func(err error) bool {
-					return errors.As(err, &errSeqNotUpdated)
+					return errors.Is(err, errSeqNotUpdated)
 				},
 				expectations: []mockExpectation{
 					expectUpdateCurrentSequenceNoRows("my_table", "my_projection", 5, "agg", "instanceID"),

--- a/internal/eventstore/handler/crdb/lock_test.go
+++ b/internal/eventstore/handler/crdb/lock_test.go
@@ -167,7 +167,7 @@ func TestStatementHandler_renewLock(t *testing.T) {
 					expectLockNoRows(lockTable, workerName, 2, "instanceID"),
 				},
 				isErr: func(err error) bool {
-					return errors.As(err, &renewNoRowsAffectedErr)
+					return errors.Is(err, renewNoRowsAffectedErr)
 				},
 			},
 			args: args{

--- a/internal/user/repository/view/model/user.go
+++ b/internal/user/repository/view/model/user.go
@@ -310,9 +310,17 @@ func (u *UserView) AppendEvent(event *models.Event) (err error) {
 		u.State = int32(model.UserStateLocked)
 	case user.UserV1MFAOTPAddedType,
 		user.HumanMFAOTPAddedType:
+		if u.HumanView == nil {
+			logging.WithFields("sequence", event.Sequence, "instance", event.InstanceID).Warn("event is ignored because human not exists")
+			break
+		}
 		u.OTPState = int32(model.MFAStateNotReady)
 	case user.UserV1MFAOTPVerifiedType,
 		user.HumanMFAOTPVerifiedType:
+		if u.HumanView == nil {
+			logging.WithFields("sequence", event.Sequence, "instance", event.InstanceID).Warn("event is ignored because human not exists")
+			break
+		}
 		u.OTPState = int32(model.MFAStateReady)
 		u.MFAInitSkipped = time.Time{}
 	case user.UserV1MFAOTPRemovedType,


### PR DESCRIPTION
If import wasn't able to create the org and the org doesn't exist, additional data won't be created. `OTP` and `user idp link`  checks if the user exists.