### PR TITLE
ci: improve release times

### DIFF
--- a/.goreleaser-dev.yaml
+++ b/.goreleaser-dev.yaml
@@ -1,0 +1,23 @@
+before:
+  hooks:
+    # this file would invalidate go source caches
+    - sh -c "rm openapi/statik/statik.go || true"
+    - docker build -f build/grpc/Dockerfile -t zitadel-base:local .
+    - docker build -f build/zitadel/Dockerfile . -t zitadel-go-test --target go-codecov -o .artifacts/codecov
+    - docker build -f build/zitadel/Dockerfile . -t zitadel-go-base --target go-copy -o .artifacts/grpc/go-client
+    - sh -c "cp -r .artifacts/grpc/go-client/* ."
+    - docker build -f build/console/Dockerfile . -t zitadel-npm-base --target npm-copy -o .artifacts/grpc/js-client
+    - docker build -f build/console/Dockerfile . -t zitadel-npm-console --target angular-export -o .artifacts/console
+    - sh -c "cp -r .artifacts/console/* internal/api/ui/console/static/"
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: zitadel-debug
+    gcflags: all=-N -l
+    ldflags: ""
+
+dist: .artifacts/goreleaser
+
+gomod:
+  proxy: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,8 +24,7 @@ before:
     - sh -c "cp -r .artifacts/console/* internal/api/ui/console/static/"
 
 builds:
-  - id: prod
-    env:
+  - env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -36,12 +35,6 @@ builds:
       - arm64
     ldflags:
       -s -w -X github.com/zitadel/zitadel/cmd/build.version={{.Version}} -X github.com/zitadel/zitadel/cmd/build.commit={{.Commit}} -X github.com/zitadel/zitadel/cmd/build.date={{.Date}}
-  - id: dev
-    env:
-      - CGO_ENABLED=0
-    binary: zitadel-debug
-    gcflags: all=-N -l
-    ldflags: ""
 
 dist: .artifacts/goreleaser
 
@@ -54,8 +47,6 @@ dockers:
   dockerfile: build/Dockerfile
   build_flag_templates:
   - "--platform=linux/amd64"
-  ids:
-  - prod
 - image_templates:
     - ghcr.io/zitadel/zitadel:{{ .Tag }}-arm64
     - ghcr.io/zitadel/zitadel:{{ .ShortCommit }}-arm64
@@ -64,8 +55,6 @@ dockers:
   dockerfile: build/Dockerfile
   build_flag_templates:
   - "--platform=linux/arm64"
-  ids:
-  - prod
 
 docker_manifests:
 - id: zitadel-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Build the binary. This takes some minutes, but you can speed up rebuilds.
 
 ```bash
 # You just need goreleasers build part (--snapshot) and you just need to target your current platform (--single-target)
-goreleaser build --id dev --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel
+goreleaser build --config ./.goreleaser-dev.yaml --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel
 ```
 
 > Note: With this command, several steps are executed.
@@ -143,7 +143,7 @@ goreleaser build --id dev --snapshot --single-target --rm-dist --output .artifac
 > Generating gRPC stubs: `DOCKER_BUILDKIT=1 docker build -f build/zitadel/Dockerfile . --target go-copy -o .`  
 > Running unit tests: `DOCKER_BUILDKIT=1 docker build -f build/zitadel/Dockerfile . --target go-codecov`  
 > Generating the console: `DOCKER_BUILDKIT=1 docker build -f build/console/Dockerfile . -t zitadel-npm-console --target angular-export -o internal/api/ui/console/static/`  
-> Build the binary: `goreleaser build --id dev --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel --skip-before`  
+> Build the binary: `goreleaser build --config ./.goreleaser-dev.yaml --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel --skip-before`
 
 You can now run and debug the binary in .artifacts/zitadel/zitadel using your favourite IDE, for example GoLand.
 You can test if ZITADEL does what you expect by using the UI at http://localhost:8080/ui/console.
@@ -153,7 +153,7 @@ As soon as you are ready to battle test your changes, run the end-to-end tests.
 
 ```bash
 # Build the production binary (unit tests are executed, too)
-goreleaser build --id prod --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel
+goreleaser build --snapshot --single-target --rm-dist --output .artifacts/zitadel/zitadel
 
 # Pack the binary into a docker image
 DOCKER_BUILDKIT=1 docker build --file build/Dockerfile .artifacts/zitadel -t zitadel:local


### PR DESCRIPTION
Uses separate config file for dev builds, so `goreleaser release` doesn't build them anymore.