### PR TITLE
fix: initial failures

### DIFF
--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zitadel/zitadel/internal/config/systemdefaults"
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/id"
 )
 
 type Config struct {
@@ -26,6 +27,7 @@ type Config struct {
 	Log             *logging.Config
 	EncryptionKeys  *encryptionKeyConfig
 	DefaultInstance command.InstanceSetup
+	Machine         *id.Config
 }
 
 func MustNewConfig(v *viper.Viper) *Config {
@@ -43,6 +45,8 @@ func MustNewConfig(v *viper.Viper) *Config {
 
 	err = config.Log.SetLogger()
 	logging.OnError(err).Fatal("unable to set logger")
+
+	id.Configure(config.Machine)
 
 	return config
 }

--- a/internal/database/cockroach/config.go
+++ b/internal/database/cockroach/config.go
@@ -42,8 +42,9 @@ func (c *Config) MatchName(name string) bool {
 
 func (c *Config) Decode(configs []interface{}) (dialect.Connector, error) {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
-		Result:     c,
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		Result:           c,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/database/postgres/config.go
+++ b/internal/database/postgres/config.go
@@ -41,8 +41,9 @@ func (c *Config) MatchName(name string) bool {
 
 func (c *Config) Decode(configs []interface{}) (dialect.Connector, error) {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
-		Result:     c,
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		Result:           c,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/eventstore/handler/crdb/handler_stmt.go
+++ b/internal/eventstore/handler/crdb/handler_stmt.go
@@ -112,7 +112,7 @@ func (h *StatementHandler) SearchQuery(ctx context.Context, instanceIDs []string
 	return queryBuilder, h.bulkLimit, nil
 }
 
-//Update implements handler.Update
+// Update implements handler.Update
 func (h *StatementHandler) Update(ctx context.Context, stmts []*handler.Statement, reduce handler.Reduce) (index int, err error) {
 	if len(stmts) == 0 {
 		return -1, nil
@@ -248,8 +248,8 @@ stmts:
 	return lastSuccessfulIdx
 }
 
-//executeStmt handles sql statements
-//an error is returned if the statement could not be inserted properly
+// executeStmt handles sql statements
+// an error is returned if the statement could not be inserted properly
 func (h *StatementHandler) executeStmt(tx *sql.Tx, stmt *handler.Statement) error {
 	if stmt.IsNoop() {
 		return nil

--- a/internal/query/projection/app_test.go
+++ b/internal/query/projection/app_test.go
@@ -351,7 +351,7 @@ func TestAppProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.apps2_api_configs SET (client_secret) = ($1) WHERE (app_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.apps2_api_configs SET client_secret = $1 WHERE (app_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"app-id",
@@ -552,7 +552,7 @@ func TestAppProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.apps2_oidc_configs SET (client_secret) = ($1) WHERE (app_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.apps2_oidc_configs SET client_secret = $1 WHERE (app_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"app-id",

--- a/internal/query/projection/authn_key_test.go
+++ b/internal/query/projection/authn_key_test.go
@@ -161,7 +161,7 @@ func TestAuthNKeyProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.authn_keys SET (enabled) = ($1) WHERE (object_id = $2)",
+							expectedStmt: "UPDATE projections.authn_keys SET enabled = $1 WHERE (object_id = $2)",
 							expectedArgs: []interface{}{
 								false,
 								"appId",
@@ -189,7 +189,7 @@ func TestAuthNKeyProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.authn_keys SET (enabled) = ($1) WHERE (object_id = $2)",
+							expectedStmt: "UPDATE projections.authn_keys SET enabled = $1 WHERE (object_id = $2)",
 							expectedArgs: []interface{}{
 								true,
 								"appId",
@@ -264,7 +264,7 @@ func TestAuthNKeyProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.authn_keys SET (enabled) = ($1) WHERE (object_id = $2)",
+							expectedStmt: "UPDATE projections.authn_keys SET enabled = $1 WHERE (object_id = $2)",
 							expectedArgs: []interface{}{
 								false,
 								"appId",
@@ -292,7 +292,7 @@ func TestAuthNKeyProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.authn_keys SET (enabled) = ($1) WHERE (object_id = $2)",
+							expectedStmt: "UPDATE projections.authn_keys SET enabled = $1 WHERE (object_id = $2)",
 							expectedArgs: []interface{}{
 								true,
 								"appId",

--- a/internal/query/projection/login_name_test.go
+++ b/internal/query/projection/login_name_test.go
@@ -165,7 +165,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.login_names_users SET (user_name) = ($1) WHERE (id = $2)",
+							expectedStmt: "UPDATE projections.login_names_users SET user_name = $1 WHERE (id = $2)",
 							expectedArgs: []interface{}{
 								"changed",
 								"agg-id",
@@ -195,7 +195,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.login_names_users SET (user_name) = ($1) WHERE (id = $2)",
+							expectedStmt: "UPDATE projections.login_names_users SET user_name = $1 WHERE (id = $2)",
 							expectedArgs: []interface{}{
 								"claimed",
 								"agg-id",
@@ -257,7 +257,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.login_names_policies SET (must_be_domain) = ($1) WHERE (resource_owner = $2)",
+							expectedStmt: "UPDATE projections.login_names_policies SET must_be_domain = $1 WHERE (resource_owner = $2)",
 							expectedArgs: []interface{}{
 								false,
 								"ro-id",
@@ -395,7 +395,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.login_names_domains SET (is_primary) = ($1) WHERE (resource_owner = $2) AND (is_primary = $3)",
+							expectedStmt: "UPDATE projections.login_names_domains SET is_primary = $1 WHERE (resource_owner = $2) AND (is_primary = $3)",
 							expectedArgs: []interface{}{
 								false,
 								"ro-id",
@@ -403,7 +403,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.login_names_domains SET (is_primary) = ($1) WHERE (name = $2) AND (resource_owner = $3)",
+							expectedStmt: "UPDATE projections.login_names_domains SET is_primary = $1 WHERE (name = $2) AND (resource_owner = $3)",
 							expectedArgs: []interface{}{
 								true,
 								"primary",
@@ -466,7 +466,7 @@ func TestLoginNameProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.login_names_policies SET (must_be_domain) = ($1) WHERE (resource_owner = $2)",
+							expectedStmt: "UPDATE projections.login_names_policies SET must_be_domain = $1 WHERE (resource_owner = $2)",
 							expectedArgs: []interface{}{
 								false,
 								"ro-id",

--- a/internal/query/projection/sms_test.go
+++ b/internal/query/projection/sms_test.go
@@ -150,7 +150,7 @@ func TestSMSProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sms_configs_twilio SET (token) = ($1) WHERE (sms_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.sms_configs_twilio SET token = $1 WHERE (sms_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								&crypto.CryptoValue{
 									CryptoType: crypto.TypeEncryption,

--- a/internal/query/projection/user_grant_test.go
+++ b/internal/query/projection/user_grant_test.go
@@ -342,7 +342,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants2 SET (roles) = (array_remove(roles, $1)) WHERE (project_id = $2)",
+							expectedStmt: "UPDATE projections.user_grants2 SET roles = array_remove(roles, $1) WHERE (project_id = $2)",
 							expectedArgs: []interface{}{
 								"key",
 								"agg-id",

--- a/internal/query/projection/user_test.go
+++ b/internal/query/projection/user_test.go
@@ -450,7 +450,7 @@ func TestUserProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.users3 SET (state) = ($1) WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3 SET state = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								domain.UserStateInitial,
 								"agg-id",
@@ -479,7 +479,7 @@ func TestUserProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.users3 SET (state) = ($1) WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3 SET state = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								domain.UserStateInitial,
 								"agg-id",
@@ -508,7 +508,7 @@ func TestUserProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.users3 SET (state) = ($1) WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3 SET state = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								domain.UserStateActive,
 								"agg-id",
@@ -537,7 +537,7 @@ func TestUserProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.users3 SET (state) = ($1) WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3 SET state = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								domain.UserStateActive,
 								"agg-id",
@@ -904,7 +904,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_notifications SET (last_phone) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_notifications SET last_phone = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								&sql.NullString{String: "+41 00 000 00 00", Valid: true},
 								"agg-id",
@@ -953,7 +953,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_notifications SET (last_phone) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_notifications SET last_phone = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								&sql.NullString{String: "+41 00 000 00 00", Valid: true},
 								"agg-id",
@@ -1087,7 +1087,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (is_phone_verified) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET is_phone_verified = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								true,
 								"agg-id",
@@ -1132,7 +1132,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (is_phone_verified) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET is_phone_verified = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								true,
 								"agg-id",
@@ -1188,7 +1188,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_notifications SET (last_email) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_notifications SET last_email = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								&sql.NullString{String: "email@zitadel.com", Valid: true},
 								"agg-id",
@@ -1237,7 +1237,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_notifications SET (last_email) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_notifications SET last_email = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								&sql.NullString{String: "email@zitadel.com", Valid: true},
 								"agg-id",
@@ -1275,7 +1275,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (is_email_verified) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET is_email_verified = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								true,
 								"agg-id",
@@ -1320,7 +1320,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (is_email_verified) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET is_email_verified = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								true,
 								"agg-id",
@@ -1367,7 +1367,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (avatar_key) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET avatar_key = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"users/agg-id/avatar",
 								"agg-id",
@@ -1405,7 +1405,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_humans SET (avatar_key) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_humans SET avatar_key = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								nil,
 								"agg-id",
@@ -1582,7 +1582,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_machines SET (name) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_machines SET name = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"machine-name",
 								"agg-id",
@@ -1622,7 +1622,7 @@ func TestUserProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.users3_machines SET (description) = ($1) WHERE (user_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.users3_machines SET description = $1 WHERE (user_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"description",
 								"agg-id",


### PR DESCRIPTION
- fix(cli): commands which were broken. The commands read their configuration correctly. 
- fix(database): configurations work now properly using env variables
- fix(database): `UPDATE` and `INSERT ON CONFLICT DO UPDATE` statements are now fully postgresql compatible