### PR TITLE
fix: twitter account link

### DIFF
--- a/console/src/app/modules/footer/footer.component.html
+++ b/console/src/app/modules/footer/footer.component.html
@@ -15,7 +15,7 @@
       <a target="_blank" rel="noreferrer" href="https://github.com/zitadel">
         <i class="text-3xl lab la-github"></i>
       </a>
-      <a target="_blank" rel="noreferrer" href="https://twitter.com/zitadel_ch">
+      <a target="_blank" rel="noreferrer" href="https://twitter.com/zitadel">
         <i class="text-3xl lab la-twitter"></i>
       </a>
       <a target="_blank" rel="noreferrer" href="https://www.linkedin.com/company/zitadel/">


### PR DESCRIPTION
The twitter account `zitadel_ch` doesn't exist. `zitadel` does.