### PR TITLE
fix(auth): always get token by id and user id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ migrations/cockroach/migrate_cloud.go
 !/.artifacts/zitadel
 /zitadel
 
+go.work
+go.work.sum

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -174,7 +174,7 @@ func (o *OPStorage) RevokeToken(ctx context.Context, token, userID, clientID str
 		}
 		return oidc.ErrServerError().WithParent(err)
 	}
-	accessToken, err := o.repo.TokenByID(ctx, userID, token)
+	accessToken, err := o.repo.TokenByIDs(ctx, userID, token)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/internal/api/oidc/client.go
+++ b/internal/api/oidc/client.go
@@ -119,7 +119,7 @@ func (o *OPStorage) AuthorizeClientIDSecret(ctx context.Context, id string, secr
 func (o *OPStorage) SetUserinfoFromToken(ctx context.Context, userInfo oidc.UserInfoSetter, tokenID, subject, origin string) (err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
-	token, err := o.repo.TokenByID(ctx, subject, tokenID)
+	token, err := o.repo.TokenByIDs(ctx, subject, tokenID)
 	if err != nil {
 		return errors.ThrowPermissionDenied(nil, "OIDC-Dsfb2", "token is not valid or has expired")
 	}
@@ -154,7 +154,7 @@ func (o *OPStorage) SetUserinfoFromScopes(ctx context.Context, userInfo oidc.Use
 }
 
 func (o *OPStorage) SetIntrospectionFromToken(ctx context.Context, introspection oidc.IntrospectionResponse, tokenID, subject, clientID string) error {
-	token, err := o.repo.TokenByID(ctx, subject, tokenID)
+	token, err := o.repo.TokenByIDs(ctx, subject, tokenID)
 	if err != nil {
 		return errors.ThrowPermissionDenied(nil, "OIDC-Dsfb2", "token is not valid or has expired")
 	}

--- a/internal/auth/repository/eventsourcing/eventstore/token.go
+++ b/internal/auth/repository/eventsourcing/eventstore/token.go
@@ -23,7 +23,7 @@ type TokenRepo struct {
 }
 
 func (repo *TokenRepo) IsTokenValid(ctx context.Context, userID, tokenID string) (bool, error) {
-	token, err := repo.TokenByID(ctx, userID, tokenID)
+	token, err := repo.TokenByIDs(ctx, userID, tokenID)
 	if err == nil {
 		return token.Expiration.After(time.Now().UTC()), nil
 	}
@@ -33,8 +33,8 @@ func (repo *TokenRepo) IsTokenValid(ctx context.Context, userID, tokenID string)
 	return false, err
 }
 
-func (repo *TokenRepo) TokenByID(ctx context.Context, userID, tokenID string) (*usr_model.TokenView, error) {
-	token, viewErr := repo.View.TokenByID(tokenID, authz.GetInstance(ctx).InstanceID())
+func (repo *TokenRepo) TokenByIDs(ctx context.Context, userID, tokenID string) (*usr_model.TokenView, error) {
+	token, viewErr := repo.View.TokenByIDs(tokenID, userID, authz.GetInstance(ctx).InstanceID())
 	if viewErr != nil && !errors.IsNotFound(viewErr) {
 		return nil, viewErr
 	}

--- a/internal/auth/repository/eventsourcing/view/token.go
+++ b/internal/auth/repository/eventsourcing/view/token.go
@@ -12,8 +12,8 @@ const (
 	tokenTable = "auth.tokens"
 )
 
-func (v *View) TokenByID(tokenID, instanceID string) (*model.TokenView, error) {
-	return usr_view.TokenByID(v.Db, tokenTable, tokenID, instanceID)
+func (v *View) TokenByIDs(tokenID, userID, instanceID string) (*model.TokenView, error) {
+	return usr_view.TokenByIDs(v.Db, tokenTable, tokenID, userID, instanceID)
 }
 
 func (v *View) TokensByUserID(userID, instanceID string) ([]*model.TokenView, error) {

--- a/internal/auth/repository/token.go
+++ b/internal/auth/repository/token.go
@@ -8,5 +8,5 @@ import (
 
 type TokenRepository interface {
 	IsTokenValid(ctx context.Context, userID, tokenID string) (bool, error)
-	TokenByID(ctx context.Context, userID, tokenID string) (*usr_model.TokenView, error)
+	TokenByIDs(ctx context.Context, userID, tokenID string) (*usr_model.TokenView, error)
 }

--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -49,7 +49,7 @@ func (repo *TokenVerifierRepo) tokenByID(ctx context.Context, tokenID, userID st
 		OnError(err).
 		Errorf("could not get current sequence for token check")
 
-	token, viewErr := repo.View.TokenByID(tokenID, instanceID)
+	token, viewErr := repo.View.TokenByIDs(tokenID, userID, instanceID)
 	if viewErr != nil && !caos_errs.IsNotFound(viewErr) {
 		return nil, viewErr
 	}
@@ -146,7 +146,7 @@ func (repo *TokenVerifierRepo) getUserEvents(ctx context.Context, userID, instan
 	return repo.Eventstore.FilterEvents(ctx, query)
 }
 
-//getTokenIDAndSubject returns the TokenID and Subject of both opaque tokens and JWTs
+// getTokenIDAndSubject returns the TokenID and Subject of both opaque tokens and JWTs
 func (repo *TokenVerifierRepo) getTokenIDAndSubject(ctx context.Context, accessToken string) (tokenID string, subject string, valid bool) {
 	// accessToken can be either opaque or JWT
 	// let's try opaque first:
@@ -188,8 +188,8 @@ type openIDKeySet struct {
 	*query.Queries
 }
 
-//VerifySignature implements the oidc.KeySet interface
-//providing an implementation for the keys retrieved directly from Queries
+// VerifySignature implements the oidc.KeySet interface
+// providing an implementation for the keys retrieved directly from Queries
 func (o *openIDKeySet) VerifySignature(ctx context.Context, jws *jose.JSONWebSignature) ([]byte, error) {
 	keySet, err := o.Queries.ActivePublicKeys(ctx, time.Now())
 	if err != nil {

--- a/internal/authz/repository/eventsourcing/view/token.go
+++ b/internal/authz/repository/eventsourcing/view/token.go
@@ -12,8 +12,8 @@ const (
 	tokenTable = "auth.tokens"
 )
 
-func (v *View) TokenByID(tokenID, instanceID string) (*usr_view_model.TokenView, error) {
-	return usr_view.TokenByID(v.Db, tokenTable, tokenID, instanceID)
+func (v *View) TokenByIDs(tokenID, userID, instanceID string) (*usr_view_model.TokenView, error) {
+	return usr_view.TokenByIDs(v.Db, tokenTable, tokenID, userID, instanceID)
 }
 
 func (v *View) PutToken(token *usr_view_model.TokenView, event *models.Event) error {

--- a/internal/user/repository/view/token_view.go
+++ b/internal/user/repository/view/token_view.go
@@ -10,10 +10,11 @@ import (
 	"github.com/zitadel/zitadel/internal/view/repository"
 )
 
-func TokenByID(db *gorm.DB, table, tokenID, instanceID string) (*usr_model.TokenView, error) {
+func TokenByIDs(db *gorm.DB, table, tokenID, userID, instanceID string) (*usr_model.TokenView, error) {
 	token := new(usr_model.TokenView)
 	query := repository.PrepareGetByQuery(table,
 		&usr_model.TokenSearchQuery{Key: model.TokenSearchKeyTokenID, Method: domain.SearchMethodEquals, Value: tokenID},
+		&usr_model.TokenSearchQuery{Key: model.TokenSearchKeyUserID, Method: domain.SearchMethodEquals, Value: userID},
 		&usr_model.TokenSearchQuery{Key: model.TokenSearchKeyInstanceID, Method: domain.SearchMethodEquals, Value: instanceID},
 	)
 	err := query(db, token)


### PR DESCRIPTION
If userinfo is called using an opaque access token, the token is encoded into `tokenID:subject` if the last view letters were removed from the access token, the userinfo are still returned because the code currently does not check the subject while reading from the database. This fix changes this behaviour by always checking `tokenID` and `subject`.

Example:
`NsQonadRdZZ9HXaJ1dMF4cfaq99x9BuOVcH7cVYNuYRBnmXRaGnB-S0iYeS8DF1vtJlO7qA`: `178930652421292452: 178050570823800541`

remove the last 12 letters
`NsQonadRdZZ9HXaJ1dMF4cfaq99x9BuOVcH7cVYNuYRBnmXRaGnB-S0iYeS8`: `178930652421292452 : 1780505708`

The lower request should fail but doesn't at the moment because the subject is not checked