### PR TITLE
fix: fixed broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,7 +290,7 @@ You may edit the texts in these files or create a new file for additional langua
 ## Want to start ZITADEL?
 
 You can find an installation guide for all the different environments here:
-[https://docs.zitadel.com/docs/guides/installation](https://docs.zitadel.com/docs/guides/installation)
+[https://docs.zitadel.com/docs/guides/deploy/overview](https://docs.zitadel.com/docs/guides/deploy/overview)
 
 ## **Did you find a security flaw?**
 

--- a/console/src/app/modules/project-members/project-members.component.html
+++ b/console/src/app/modules/project-members/project-members.component.html
@@ -5,7 +5,7 @@
 >
   <p class="subinfo" sub>
     <span class="cnsl-secondary-text">{{ 'PROJECT.MEMBER.DESCRIPTION' | translate }}</span>
-    <a mat-icon-button href="https://docs.zitadel.com/docs/manuals/admin-managers" target="_blank">
+    <a mat-icon-button href="https://docs.zitadel.com/docs/concepts/structure/managers" target="_blank">
       <i class="las la-info-circle"></i>
     </a>
   </p>

--- a/console/src/app/pages/domains/domains.component.html
+++ b/console/src/app/pages/domains/domains.component.html
@@ -6,7 +6,7 @@
           <h1>{{ 'ORG.DOMAINS.TITLE' | translate }}</h1>
           <a
             mat-icon-button
-            href="https://docs.zitadel.com/docs/guides/basics/organizations#how-zitadel-handles-usernames"
+            href="https://docs.zitadel.com/docs/guides/manage/console/organizations#how-zitadel-handles-usernames"
             rel="noreferrer"
             target="_blank"
           >

--- a/console/src/app/pages/home/home.component.html
+++ b/console/src/app/pages/home/home.component.html
@@ -18,7 +18,7 @@
       </a>
 
       <a
-        href="https://docs.zitadel.com/docs/guides/basics/get-started/"
+        href="https://docs.zitadel.com/docs/guides/start/quickstart"
         target="_blank"
         rel="noreferrer"
         class="grid-item green"
@@ -29,12 +29,7 @@
         <span>{{ 'HOME.GETSTARTED.TITLE' | translate }}</span>
       </a>
 
-      <a
-        href="https://docs.zitadel.com/docs/quickstarts/introduction"
-        target="_blank"
-        rel="noreferrer"
-        class="grid-item green"
-      >
+      <a href="https://docs.zitadel.com/docs/examples/introduction" target="_blank" rel="noreferrer" class="grid-item green">
         <div class="grid-item-avatar green">
           <i class="icon las la-play"></i>
         </div>

--- a/console/src/app/pages/instance/instance-members/instance-members.component.html
+++ b/console/src/app/pages/instance/instance-members/instance-members.component.html
@@ -1,7 +1,7 @@
 <cnsl-detail-layout [hasBackButton]="true" title="{{ 'IAM.MEMBER.TITLE' | translate }}">
   <p class="subinfo" sub>
     <span class="cnsl-secondary-text">{{ 'IAM.MEMBER.DESCRIPTION' | translate }}</span>
-    <a mat-icon-button href="https://docs.zitadel.com/docs/manuals/admin-managers" target="_blank">
+    <a mat-icon-button href="https://docs.zitadel.com/docs/concepts/structure/managers" target="_blank">
       <i class="las la-info-circle"></i>
     </a>
   </p>

--- a/console/src/app/pages/orgs/org-members/org-members.component.html
+++ b/console/src/app/pages/orgs/org-members/org-members.component.html
@@ -1,7 +1,7 @@
 <cnsl-detail-layout title="{{ org?.name }} {{ 'ORG.MEMBER.TITLE' | translate }}">
   <p class="subinfo" sub>
     <span class="cnsl-secondary-text">{{ 'ORG.MEMBER.DESCRIPTION' | translate }}</span>
-    <a mat-icon-button href="https://docs.zitadel.com/docs/manuals/admin-managers" target="_blank">
+    <a mat-icon-button href="https://docs.zitadel.com/docs/concepts/structure/managers" target="_blank">
       <i class="las la-info-circle"></i>
     </a>
   </p>

--- a/console/src/app/pages/projects/apps/app-detail/app-detail.component.html
+++ b/console/src/app/pages/projects/apps/app-detail/app-detail.component.html
@@ -1,7 +1,7 @@
 <cnsl-top-view
   title="{{ app?.name }}"
   [hasActions]="isZitadel === false && (['project.app.write:' + projectId, 'project.app.write'] | hasRole | async)"
-  docLink="https://docs.zitadel.com/docs/guides/basics/projects"
+  docLink="https://docs.zitadel.com/docs/guides/manage/console/projects"
   [sub]="app?.oidcConfig ? ('APP.OIDC.APPTYPE.' + app?.oidcConfig?.appType | translate) : app?.apiConfig ? 'API' : 'SAML'"
   [isActive]="app?.state === AppState.APP_STATE_ACTIVE"
   [isInactive]="app?.state === AppState.APP_STATE_INACTIVE"

--- a/console/src/app/pages/projects/granted-projects/granted-project-detail/granted-project-detail.component.html
+++ b/console/src/app/pages/projects/granted-projects/granted-project-detail/granted-project-detail.component.html
@@ -1,7 +1,7 @@
 <cnsl-top-view
   title="{{ project?.projectName }}"
   [hasActions]="false"
-  docLink="https://docs.zitadel.com/docs/guides/basics/projects#what-is-a-granted-project"
+  docLink="https://docs.zitadel.com/docs/guides/manage/console/projects#what-is-a-granted-project"
   sub="{{ 'PROJECT.PAGES.TYPE.GRANTED_SINGULAR' | translate }} {{ 'ACTIONS.OF' | translate }} <strong>{{
     project?.projectOwnerName
   }}</strong>"

--- a/console/src/app/pages/projects/owned-projects/owned-project-detail/owned-project-detail.component.html
+++ b/console/src/app/pages/projects/owned-projects/owned-project-detail/owned-project-detail.component.html
@@ -1,6 +1,6 @@
 <cnsl-top-view
   title="{{ project?.name }}"
-  docLink="https://docs.zitadel.com/docs/guides/basics/projects"
+  docLink="https://docs.zitadel.com/docs/guides/manage/console/projects"
   sub="{{ 'PROJECT.PAGES.TYPE.OWNED_SINGULAR' | translate }}"
   [isActive]="project?.state === ProjectState.PROJECT_STATE_ACTIVE"
   [isInactive]="project?.state === ProjectState.PROJECT_STATE_INACTIVE"

--- a/console/src/app/pages/projects/projects.component.html
+++ b/console/src/app/pages/projects/projects.component.html
@@ -2,7 +2,12 @@
   <div class="enlarged-container">
     <div class="project-title-row">
       <h1>{{ 'PROJECT.PAGES.LIST' | translate }}</h1>
-      <a mat-icon-button href="https://docs.zitadel.com/docs/guides/basics/projects" rel="noreferrer" target="_blank">
+      <a
+        mat-icon-button
+        href="https://docs.zitadel.com/docs/guides/manage/console/projects"
+        rel="noreferrer"
+        target="_blank"
+      >
         <i class="las la-info-circle"></i>
       </a>
     </div>

--- a/console/src/app/pages/users/user-detail/user-detail/user-detail.component.html
+++ b/console/src/app/pages/users/user-detail/user-detail/user-detail.component.html
@@ -1,7 +1,7 @@
 <cnsl-top-view
   *ngIf="user"
   title="{{ user.human ? user.human.profile?.displayName : user.machine?.name }}"
-  docLink="https://docs.zitadel.com/docs/guides/basics/projects"
+  docLink="https://docs.zitadel.com/docs/guides/manage/console/projects"
   sub="{{ user.preferredLoginName }}"
   [isActive]="user.state === UserState.USER_STATE_ACTIVE"
   [isInactive]="user.state === UserState.USER_STATE_INACTIVE"

--- a/docs/docs/apis/proto/management.md
+++ b/docs/docs/apis/proto/management.md
@@ -3091,7 +3091,7 @@ This is an empty request
 | Field | Type | Description | Validation |
 | ----- | ---- | ----------- | ----------- |
 | primary_color |  string | - | string.max_len: 50<br />  |
-| hide_login_name_suffix |  bool | hides the org suffix on the login form if the scope \"urn:zitadel:iam:org:domain:primary:{domainname}\" is set. Details about this scope in https://docs.zitadel.com/concepts#Reserved_Scopes |  |
+| hide_login_name_suffix |  bool | hides the org suffix on the login form if the scope \"urn:zitadel:iam:org:domain:primary:{domainname}\" is set. Details about this scope in https://docs.zitadel.com/docs/apis/openidoauth/scopes#reserved-scopes |  |
 | warn_color |  string | - | string.max_len: 50<br />  |
 | background_color |  string | - | string.max_len: 50<br />  |
 | font_color |  string | - | string.max_len: 50<br />  |

--- a/docs/docs/apis/proto/policy.md
+++ b/docs/docs/apis/proto/policy.md
@@ -33,7 +33,7 @@ title: zitadel/policy.proto
 | details |  zitadel.v1.ObjectDetails | - |  |
 | primary_color |  string | hex value for primary color |  |
 | is_default |  bool | defines if the organisation's admin changed the policy |  |
-| hide_login_name_suffix |  bool | hides the org suffix on the login form if the scope \"urn:zitadel:iam:org:domain:primary:{domainname}\" is set. Details about this scope in https://docs.zitadel.com/concepts#Reserved_Scopes |  |
+| hide_login_name_suffix |  bool | hides the org suffix on the login form if the scope \"urn:zitadel:iam:org:domain:primary:{domainname}\" is set. Details about this scope in https://docs.zitadel.com/docs/apis/openidoauth/scopes#reserved-scopes |  |
 | warn_color |  string | hex value for secondary color |  |
 | background_color |  string | hex value for background color |  |
 | font_color |  string | hex value for font color |  |

--- a/docs/docs/examples/call-zitadel-api/dot-net.md
+++ b/docs/docs/examples/call-zitadel-api/dot-net.md
@@ -7,7 +7,7 @@ It demonstrates how to fetch some data from the ZITADEL management API.
 
 At the end of the guide you should have an application able to read the details of your organization.
 
-If you need any other information about the .NET SDK go to the [documentation](https://caos.github.io/zitadel-net/) of the SDK itself.
+If you need any other information about the .NET SDK go to the [documentation](https://zitadel.github.io/zitadel-net/) of the SDK itself.
 ## Prerequisites
 
 The client [SDK](https://github.com/zitadel/zitadel-net) will handle all necessary OAuth 2.0 requests and send the required headers to the ZITADEL API.


### PR DESCRIPTION
I found some broken links in the UI to the moved documentation.

I used https://github.com/lycheeverse/lychee to scan for broken links.

```
$ cat <<'EOF' > .lycheeignore
^file://
^https://accounts\.exmaple\.com/saml/metadata$
^https://demo\.com/tos-%7B%7B.Lang%7D%7D$
^https://example\.auth0\.com/samlp/metadata\?connection=SAML-ZITADEL$
^https://gitlab\.com/dashboard/groups$%
EOF
$ lychee --verbose --no-progress --exclude-link-local --exclude-mail --exclude-loopback .
```