### PR TITLE
feat(config): configure by env yaml

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,7 +1,8 @@
 module.exports = {
     branches: [
         {name: 'main'},
-        {name: '1.87.x', range: '1.87.x', channel: '1.87.x'}
+        {name: '1.87.x', range: '1.87.x', channel: '1.87.x'},
+        {name: 'yaml-by-env', prerelease: true},
     ],
     plugins: [
         "@semantic-release/commit-analyzer"

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -92,16 +92,22 @@ Database:
       SSL:
         Mode:
         RootCert:
+        RootCertValue:
         Cert:
+        CertValue:
         Key:
+        KeyValue:
     Admin:
       Username:
       Password:
       SSL:
         Mode:
         RootCert:
+        RootCertValue:
         Cert:
+        CertValue:
         Key:
+        KeyValue:
 
 Machine:
   # Cloud hosted VMs need to specify their metadata endpoint so that the machine can be uniquely identified.

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -60,16 +60,22 @@ Database:
       SSL:
         Mode: disable
         RootCert: ""
+        RootCertValue: ""
         Cert: ""
+        CertValue: ""
         Key: ""
+        KeyValue: ""
     Admin:
       Username: root
       Password: ""
       SSL:
         Mode: disable
         RootCert: ""
+        RootCertValue: ""
         Cert: ""
+        CertValue: ""
         Key: ""
+        KeyValue: ""
   # Postgres is used as soon as a value is set
   # The values describe the possible fields to set values
   postgres:

--- a/cmd/zitadel.go
+++ b/cmd/zitadel.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,6 +42,10 @@ func New(out io.Writer, in io.Reader, args []string) *cobra.Command {
 	viper.SetConfigType("yaml")
 	err := viper.ReadConfig(bytes.NewBuffer(defaultConfig))
 	logging.OnError(err).Fatal("unable to read default config")
+	err = viper.MergeConfig(bytes.NewBuffer([]byte(os.Getenv("ZITADEL_CONFIG"))))
+	logging.OnError(err).Fatal("unable to read config from variable ZITADEL_CONFIG")
+	err = viper.MergeConfig(bytes.NewBuffer([]byte(os.Getenv("ZITADEL_SECRETS"))))
+	logging.OnError(err).Fatal("unable to read config from variable ZITADEL_SECRETS")
 
 	cobra.OnInitialize(initConfig)
 	cmd.PersistentFlags().StringArrayVar(&configFiles, "config", nil, "path to config file to overwrite system defaults")

--- a/internal/database/cockroach/config.go
+++ b/internal/database/cockroach/config.go
@@ -125,7 +125,7 @@ func ensureFile(pathConfig, valueConfig, createFileForValue string) string {
 	if pathConfig != "" {
 		return ""
 	}
-	file, err := os.Create(createFileForValue)
+	file, err := os.OpenFile(createFileForValue, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400)
 	logging.OnError(err).Fatalf("creating file %s for certificate failed", createFileForValue)
 
 	_, err = io.Copy(file, strings.NewReader(valueConfig))

--- a/internal/database/cockroach/config.go
+++ b/internal/database/cockroach/config.go
@@ -138,7 +138,7 @@ func (c *Config) checkSSL(user User) {
 		user.SSL = SSL{Mode: sslDisabledMode}
 		return
 	}
-	if user.SSL.RootCert == "" {
+	if user.SSL.RootCert == "" && user.SSL.RootCertValue == "" {
 		logging.WithFields(
 			"cert path set", user.SSL.Cert != "",
 			"cert value set", user.SSL.CertValue != "",

--- a/internal/database/postgres/config.go
+++ b/internal/database/postgres/config.go
@@ -126,7 +126,7 @@ func ensureFile(pathConfig, valueConfig, createFileForValue string) string {
 		return ""
 	}
 
-	file, err := os.Create(createFileForValue)
+	file, err := os.OpenFile(createFileForValue, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400)
 	logging.OnError(err).Fatalf("creating file %s for certificate failed", createFileForValue)
 
 	_, err = io.Copy(file, strings.NewReader(valueConfig))

--- a/internal/database/postgres/config.go
+++ b/internal/database/postgres/config.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"database/sql"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -102,18 +104,49 @@ type SSL struct {
 	Cert string
 	// Key Path to the client private key
 	Key string
+	// RootCertValue is the CA certificate in plain text
+	RootCertValue     string
+	rootCertValueFile string
+	// CertValue is the client certificate in plain text
+	CertValue     string
+	certValueFile string
+	// KeyValue is the client private key in plain text
+	KeyValue     string
+	keyValueFile string
 }
 
-func (s *Config) checkSSL(user User) {
+func (s *SSL) ensureFiles() {
+	s.rootCertValueFile = ensureFile(s.RootCert, s.RootCertValue, "./zitadel-generated-from-config-root.crt")
+	s.certValueFile = ensureFile(s.Cert, s.CertValue, "./zitadel-generated-from-config.crt")
+	s.keyValueFile = ensureFile(s.Key, s.KeyValue, "./zitadel-generated-from-config.key")
+}
+
+func ensureFile(pathConfig, valueConfig, createFileForValue string) string {
+	if pathConfig != "" {
+		return ""
+	}
+
+	file, err := os.Create(createFileForValue)
+	logging.OnError(err).Fatalf("creating file %s for certificate failed", createFileForValue)
+
+	_, err = io.Copy(file, strings.NewReader(valueConfig))
+	logging.OnError(err).Fatalf("copying certificate to file %s failed", file.Name())
+	return file.Name()
+}
+
+func (c *Config) checkSSL(user User) {
 	if user.SSL.Mode == sslDisabledMode || user.SSL.Mode == "" {
 		user.SSL = SSL{Mode: sslDisabledMode}
 		return
 	}
-	if user.SSL.RootCert == "" {
+	if user.SSL.RootCert == "" && user.SSL.RootCertValue == "" {
 		logging.WithFields(
-			"cert set", user.SSL.Cert != "",
-			"key set", user.SSL.Key != "",
-			"rootCert set", user.SSL.RootCert != "",
+			"cert path set", user.SSL.Cert != "",
+			"cert value set", user.SSL.CertValue != "",
+			"key path set", user.SSL.Key != "",
+			"key value set", user.SSL.KeyValue != "",
+			"rootCert path set", user.SSL.RootCert != "",
+			"rootCert value set", user.SSL.RootCertValue != "",
 		).Fatal("at least ssl root cert has to be set")
 	}
 }
@@ -141,12 +174,24 @@ func (c Config) String(useAdmin bool) string {
 		fields = append(fields, "dbname="+c.Database)
 	}
 	if user.SSL.Mode != sslDisabledMode {
-		fields = append(fields, "sslrootcert="+user.SSL.RootCert)
+		rootCertPath := user.SSL.rootCertValueFile
+		if rootCertPath == "" {
+			rootCertPath = user.SSL.RootCert
+		}
+		fields = append(fields, "sslrootcert="+rootCertPath)
+		certPath := user.SSL.certValueFile
+		if certPath == "" {
+			certPath = user.SSL.Cert
+		}
 		if user.SSL.Cert != "" {
-			fields = append(fields, "sslcert="+user.SSL.Cert)
+			fields = append(fields, "sslcert="+certPath)
+		}
+		keyPath := user.SSL.keyValueFile
+		if keyPath == "" {
+			keyPath = user.SSL.Key
 		}
 		if user.SSL.Key != "" {
-			fields = append(fields, "sslkey="+user.SSL.Key)
+			fields = append(fields, "sslkey="+keyPath)
 		}
 	}
 


### PR DESCRIPTION
Contributes to #3588 

There are cases, where ZITADEL is just configurable through environment variables, e.g. Cloud Run Jobs.
In these cases, being able to maintain yaml instead of environment variables can be easier.