### PR TITLE
fix(database): create column only if not exists

### DIFF
--- a/cmd/setup/05.sql
+++ b/cmd/setup/05.sql
@@ -6,6 +6,6 @@ CREATE INDEX IF NOT EXISTS failed_events_instance_id_idx ON adminapi.failed_even
 CREATE INDEX IF NOT EXISTS failed_events_instance_id_idx ON auth.failed_events (instance_id);
 CREATE INDEX IF NOT EXISTS failed_events_instance_id_idx ON projections.failed_events (instance_id);
 
-ALTER TABLE adminapi.failed_events ADD COLUMN last_failed TIMESTAMPTZ;
-ALTER TABLE auth.failed_events ADD COLUMN last_failed TIMESTAMPTZ;
-ALTER TABLE projections.failed_events ADD COLUMN last_failed TIMESTAMPTZ;
+ALTER TABLE adminapi.failed_events ADD COLUMN IF NOT EXISTS last_failed TIMESTAMPTZ;
+ALTER TABLE auth.failed_events ADD COLUMN IF NOT EXISTS last_failed TIMESTAMPTZ;
+ALTER TABLE projections.failed_events ADD COLUMN IF NOT EXISTS last_failed TIMESTAMPTZ;


### PR DESCRIPTION
The statements caused an error for me because the columns were already existing.