### PR TITLE
docs: describe linting in the dev process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,7 +270,7 @@ You can also open the test suite interactively for fast success feedback on spec
 npm run open:dev
 ```
 
-When you are happy with your changes, you can format your cleanup your environment
+When you are happy with your changes, you can format your code and cleanup your environment
 
 ```bash
 # Stop and remove the docker containers for zitadel and the database

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,9 @@ goreleaser build --id prod --snapshot --single-target --rm-dist --output .artifa
 # Pack the binary into a docker image
 DOCKER_BUILDKIT=1 docker build --file build/Dockerfile .artifacts/zitadel -t zitadel:local
 
+# If you made changes in the e2e directory, make sure you reformat the files
+(cd ./e2e && npm run lint:fix)
+
 # Run the tests
 ZITADEL_IMAGE=zitadel:local docker compose --file ./e2e/docker-compose.yaml run e2e
 ```
@@ -244,6 +247,9 @@ After making changes to the code, you should run the end-to-end-tests.
 Open another shell.
 
 ```bash
+# Reformat your console code
+npm run lint:fix
+
 # Change to the e2e directory
 cd .. && cd e2e/
 
@@ -261,7 +267,7 @@ You can also open the test suite interactively for fast success feedback on spec
 npm run open:dev
 ```
 
-When you are happy with your changes, you can cleanup your environment
+When you are happy with your changes, you can format your cleanup your environment
 
 ```bash
 # Stop and remove the docker containers for zitadel and the database

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,9 @@ npm run lint:fix
 # Change to the e2e directory
 cd .. && cd e2e/
 
+# If you made changes in the e2e directory, make sure you reformat the files here too
+npm run lint:fix
+
 # Install npm dependencies
 npm install
 


### PR DESCRIPTION
This avoids forgetting to lint the code.

This is triggered by https://discord.com/channels/927474939156643850/1060109150488629248/1060118559545626624

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

