### PR TITLE
fix(command): return empty object detail if not found

### DIFF
--- a/internal/command/instance_member.go
+++ b/internal/command/instance_member.go
@@ -126,7 +126,8 @@ func (c *Commands) RemoveInstanceMember(ctx context.Context, userID string) (*do
 		return nil, err
 	}
 	if errors.IsNotFound(err) {
-		return nil, nil
+		// empty response because we have no data that match the request
+		return &domain.ObjectDetails{}, nil
 	}
 
 	instanceAgg := InstanceAggregateFromWriteModel(&memberWriteModel.MemberWriteModel.WriteModel)

--- a/internal/command/instance_member_test.go
+++ b/internal/command/instance_member_test.go
@@ -480,7 +480,7 @@ func TestCommandSide_RemoveIAMMember(t *testing.T) {
 			},
 		},
 		{
-			name: "member not existing, nil result",
+			name: "member not existing, empty object details result",
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
@@ -492,7 +492,7 @@ func TestCommandSide_RemoveIAMMember(t *testing.T) {
 				userID: "user1",
 			},
 			res: res{
-				want: nil,
+				want: &domain.ObjectDetails{},
 			},
 		},
 		{

--- a/internal/command/org_member.go
+++ b/internal/command/org_member.go
@@ -145,7 +145,8 @@ func (c *Commands) RemoveOrgMember(ctx context.Context, orgID, userID string) (*
 		return nil, err
 	}
 	if errors.IsNotFound(err) {
-		return nil, nil
+		// empty response because we have no data that match the request
+		return &domain.ObjectDetails{}, nil
 	}
 
 	orgAgg := OrgAggregateFromWriteModel(&m.MemberWriteModel.WriteModel)

--- a/internal/command/org_member_test.go
+++ b/internal/command/org_member_test.go
@@ -784,7 +784,7 @@ func TestCommandSide_RemoveOrgMember(t *testing.T) {
 			},
 		},
 		{
-			name: "member not existing, nil result",
+			name: "member not existing, empty object details result",
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
@@ -798,7 +798,7 @@ func TestCommandSide_RemoveOrgMember(t *testing.T) {
 				resourceOwner: "org1",
 			},
 			res: res{
-				want: nil,
+				want: &domain.ObjectDetails{},
 			},
 		},
 		{

--- a/internal/command/project_member.go
+++ b/internal/command/project_member.go
@@ -94,7 +94,8 @@ func (c *Commands) RemoveProjectMember(ctx context.Context, projectID, userID, r
 		return nil, err
 	}
 	if errors.IsNotFound(err) {
-		return nil, nil
+		// empty response because we have no data that match the request
+		return &domain.ObjectDetails{}, nil
 	}
 
 	projectAgg := ProjectAggregateFromWriteModel(&m.MemberWriteModel.WriteModel)

--- a/internal/command/project_member_test.go
+++ b/internal/command/project_member_test.go
@@ -551,7 +551,7 @@ func TestCommandSide_RemoveProjectMember(t *testing.T) {
 			},
 		},
 		{
-			name: "member not existing, nil result",
+			name: "member not existing, empty object details result",
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
@@ -565,7 +565,7 @@ func TestCommandSide_RemoveProjectMember(t *testing.T) {
 				resourceOwner: "org1",
 			},
 			res: res{
-				want: nil,
+				want: &domain.ObjectDetails{},
 			},
 		},
 		{


### PR DESCRIPTION
- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
