### PR TITLE
fix(console): only show verified emails and phonenumbers as loginoptions

### DIFF
--- a/console/src/app/modules/info-row/info-row.component.ts
+++ b/console/src/app/modules/info-row/info-row.component.ts
@@ -39,10 +39,18 @@ export class InfoRowComponent {
     let email: string = '';
     let phone: string = '';
     if (this.loginPolicy) {
-      if (!this.loginPolicy?.disableLoginWithEmail && this.user.human?.email?.email) {
+      if (
+        !this.loginPolicy?.disableLoginWithEmail &&
+        this.user.human?.email?.email &&
+        this.user.human.email.isEmailVerified
+      ) {
         email = this.user.human?.email?.email;
       }
-      if (!this.loginPolicy?.disableLoginWithPhone && this.user.human?.phone?.phone) {
+      if (
+        !this.loginPolicy?.disableLoginWithPhone &&
+        this.user.human?.phone?.phone &&
+        this.user.human.phone.isPhoneVerified
+      ) {
         phone = this.user.human?.phone?.phone;
       }
     }


### PR DESCRIPTION
Followup fix for #5055

Closes #4929

Only shows verified email and phone numbers as login options on the user pages

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

