### PR TITLE
feat: shortcut arrangement start page

### DIFF
--- a/console/src/app/modules/shortcuts/shortcuts.component.ts
+++ b/console/src/app/modules/shortcuts/shortcuts.component.ts
@@ -178,10 +178,10 @@ export class ShortcutsComponent implements OnDestroy {
       } else {
         switch (listName) {
           case 'main':
-            this.main = [PROFILE_SHORTCUT /* CREATE_ORG, CREATE_PROJECT, CREATE_USER */];
+            this.main = [CREATE_ORG, CREATE_PROJECT, CREATE_USER];
             break;
           case 'secondary':
-            this.secondary = [CREATE_ORG, CREATE_PROJECT, CREATE_USER];
+            this.secondary = this.ALL_SHORTCUTS.filter((item) => item.i18nTitle === 'SETTINGS.GROUPS.APPEARANCE');
             // [LOGIN_POLICY, PRIVATELABEL_POLICY].map((p) => {
             //   const policy: string = {
             //     i18nTitle: p.i18nTitle,
@@ -196,7 +196,7 @@ export class ShortcutsComponent implements OnDestroy {
             // });
             break;
           case 'third':
-            this.third = this.ALL_SHORTCUTS.filter((item) => item.i18nTitle === 'SETTINGS.GROUPS.APPEARANCE');
+            this.third = [PROFILE_SHORTCUT];
             // [LOGIN_TEXTS_POLICY, MESSAGE_TEXTS_POLICY].map((p) => {
             //   const policy: ShortcutItem = {
             //     i18nTitle: p.i18nTitle,


### PR DESCRIPTION
As described by @juergrinaldi a user of ZITADEL should be able to access the part she use the most as fast as possible so she can configure them faster.

Acceptance Criteria

- [X] The start screen is arranged according to the screenshot

![image](https://user-images.githubusercontent.com/30386061/216768798-4322f097-bd21-45e1-b163-3d683117bb05.png)

Closes #3914 

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.

