### PR TITLE
fix: correct type typo in user access token type

### DIFF
--- a/docs/docs/apis/proto/user.md
+++ b/docs/docs/apis/proto/user.md
@@ -134,7 +134,7 @@ title: zitadel/user.proto
 | name |  string | - |  |
 | description |  string | - |  |
 | has_secret |  bool | - |  |
-| access_token_typ |  AccessTokenType | - |  |
+| access_token_type |  AccessTokenType | - |  |
 
 
 

--- a/internal/api/grpc/user/converter.go
+++ b/internal/api/grpc/user/converter.go
@@ -70,10 +70,10 @@ func HumanToPb(view *query.Human, assetPrefix, owner string) *user_pb.Human {
 
 func MachineToPb(view *query.Machine) *user_pb.Machine {
 	return &user_pb.Machine{
-		Name:           view.Name,
-		Description:    view.Description,
-		HasSecret:      view.HasSecret,
-		AccessTokenTyp: AccessTokenTypeToPb(view.AccessTokenType),
+		Name:            view.Name,
+		Description:     view.Description,
+		HasSecret:       view.HasSecret,
+		AccessTokenType: AccessTokenTypeToPb(view.AccessTokenType),
 	}
 }
 

--- a/proto/zitadel/user.proto
+++ b/proto/zitadel/user.proto
@@ -83,7 +83,7 @@ message Machine {
             example: "\"true\"";
         }
     ];
-    AccessTokenType access_token_typ = 4 [
+    AccessTokenType access_token_type = 4 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             description: "Type of access token to receive";
         }


### PR DESCRIPTION
```[tasklist]
### Definition of Ready
- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
