### PR TITLE
docs: remove TODO comment b2b/Federation section

### DIFF
--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -57,7 +57,6 @@ Particularly because you should focus building your applications.
 ### Federation
 
 ZITADEL supports signup with OIDC Identity providers as well as JWT Identity Providers. On signup, ZITADEL imports user information to the own profile.
-//TODO extend this passage
 
 ### Hosted Login
 


### PR DESCRIPTION
This PR removes the text `//TODO extend this passage` from [B2C#Federation](https://zitadel.com/docs/guides/solution-scenarios/b2c#federation)

```[tasklist]
### Definition of Ready
- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```

<img width="1029" alt="Screenshot 2023-02-14 at 14 57 34" src="https://user-images.githubusercontent.com/1679333/218774743-7acf5cf8-d707-4065-b9de-fc9649d125e3.png">