### PR TITLE
fix: allow "org.read" and "policy.read" on ORG_USER_MANAGER

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -874,6 +874,7 @@ InternalAuthZ:
         - "project.grant.member.delete"
     - Role: "ORG_USER_MANAGER"
       Permissions:
+        - "org.read"
         - "user.read"
         - "user.global.read"
         - "user.write"
@@ -882,6 +883,7 @@ InternalAuthZ:
         - "user.grant.write"
         - "user.grant.delete"
         - "user.membership.read"
+        - "policy.read"
         - "project.read"
         - "project.role.read"
     - Role: "ORG_OWNER_VIEWER"


### PR DESCRIPTION
```[tasklist]
### Definition of Ready
- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
