### PR TITLE
fix(postgres): set dbname=postgres in admin mode

### DIFF
--- a/internal/database/postgres/config.go
+++ b/internal/database/postgres/config.go
@@ -145,6 +145,8 @@ func (c Config) String(useAdmin bool) string {
 	}
 	if !useAdmin {
 		fields = append(fields, "dbname="+c.Database)
+	} else {
+		fields = append(fields, "dbname=postgres")
 	}
 	if user.SSL.Mode != sslDisabledMode {
 		fields = append(fields, "sslrootcert="+user.SSL.RootCert)


### PR DESCRIPTION
uses the postgres database when connecting as admin

```[tasklist]
### Definition of Ready
- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
```
