### PR TITLE
fix: clear call timestamp for authz checks

### DIFF
--- a/internal/api/authz/authorization.go
+++ b/internal/api/authz/authorization.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/zitadel/zitadel/internal/api/call"
 	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 )
@@ -17,6 +18,9 @@ const (
 func CheckUserAuthorization(ctx context.Context, req interface{}, token, orgID string, verifier *TokenVerifier, authConfig Config, requiredAuthOption Option, method string) (ctxSetter func(context.Context) context.Context, err error) {
 	ctx, span := tracing.NewServerInterceptorSpan(ctx)
 	defer func() { span.EndWithError(err) }()
+
+	// clear the call timestamp for all auth check calls
+	ctx = call.ClearTimestamp(ctx)
 
 	ctxData, err := VerifyTokenAndCreateCtxData(ctx, token, orgID, verifier, method)
 	if err != nil {

--- a/internal/api/call/duration.go
+++ b/internal/api/call/duration.go
@@ -28,6 +28,11 @@ func FromContext(ctx context.Context) (t time.Time) {
 	return t
 }
 
+// ClearTimestamp clears the call timestamp on the context
+func ClearTimestamp(parent context.Context) context.Context {
+	return context.WithValue(parent, key, nil)
+}
+
 // Took returns the time the call took so far
 func Took(ctx context.Context) time.Duration {
 	start := FromContext(ctx)


### PR DESCRIPTION
closes #2760

```[tasklist]
### Definition of Ready
- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
