### PR TITLE
docs: fix port number in nextjs tutorial

### DIFF
--- a/docs/docs/examples/login/nextjs.md
+++ b/docs/docs/examples/login/nextjs.md
@@ -39,7 +39,7 @@ As the requests from your application to ZITADEL are made on NextJS serverside, 
 
 With the Redirect URIs field, you tell ZITADEL where it is allowed to redirect users to after authentication. For development, you can set dev mode to `true` to enable insecure HTTP and redirect to a `localhost` URI.
 
-> If you are following along with the [example](https://github.com/zitadel/zitadel-angular), set dev mode to `true` and the Redirect URIs to <http://localhost:300/api/auth/callback/zitadel>.
+> If you are following along with the [example](https://github.com/zitadel/zitadel-angular), set dev mode to `true` and the Redirect URIs to <http://localhost:3000/api/auth/callback/zitadel>.
 
 If you want to redirect the users back to a route on your application after they have logged out, add an optional redirect in the Post Logout URIs field.
 


### PR DESCRIPTION
Adjusting the port number in the Next.JS docs text to match the rest of the tutorial.
