### PR TITLE
docs: Typo in SPA examples

### DIFF
--- a/docs/docs/examples/introduction.mdx
+++ b/docs/docs/examples/introduction.mdx
@@ -38,7 +38,7 @@ Our examples cover a range of programming languages and frameworks, so no matter
     <td width="100px">
       <img src="/docs/img/tech/vue.svg" alt="vue"/>
     </td>
-    <td>React</td>
+    <td>Vue</td>
     <td><a href="https://github.com/zitadel/zitadel/issues/5223" target="_blank">🚧</a></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
Just a small typo. 
