### PR TITLE
fix(saml): correct handling of remove

### DIFF
--- a/internal/command/project_application_saml_model.go
+++ b/internal/command/project_application_saml_model.go
@@ -241,12 +241,11 @@ func (wm *SAMLEntityIDsWriteModel) Reduce() error {
 	for _, event := range wm.Events {
 		switch e := event.(type) {
 		case *project.ApplicationRemovedEvent:
-			removeAppIDFromEntityIDs(wm.EntityIDs, e.AppID)
+			wm.EntityIDs = removeAppIDFromEntityIDs(wm.EntityIDs, e.AppID)
 		case *project.SAMLConfigAddedEvent:
 			wm.EntityIDs = append(wm.EntityIDs, &AppIDToEntityID{AppID: e.AppID, EntityID: e.EntityID})
 		case *project.SAMLConfigChangedEvent:
-			for i := range wm.EntityIDs {
-				item := wm.EntityIDs[i]
+			for _, item := range wm.EntityIDs {
 				if e.AppID == item.AppID && e.EntityID != "" {
 					item.EntityID = e.EntityID
 				}


### PR DESCRIPTION
fixes the following panic:

```
runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xf79054]
at github.com/zitadel/zitadel/internal/command.removeAppIDFromEntityIDs ( [/home/runner/work/zitadel/zitadel/internal/command/project_application_saml_model.go:261](https://console.cloud.google.com/debug?referrer=fromlog&file=%2Fhome%2Frunner%2Fwork%2Fzitadel%2Fzitadel%2Finternal%2Fcommand%2Fproject_application_saml_model.go&line=261&project=zitadel-domains) )
```


```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
