### PR TITLE
fix: remove instance IDPs correctly from org policies

### DIFF
--- a/internal/query/idp_login_policy_link_test.go
+++ b/internal/query/idp_login_policy_link_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 var (
-	loginPolicyIDPLinksQuery = regexp.QuoteMeta(`SELECT projections.idp_login_policy_links4.idp_id,` +
+	loginPolicyIDPLinksQuery = regexp.QuoteMeta(`SELECT projections.idp_login_policy_links5.idp_id,` +
 		` projections.idp_templates4.name,` +
 		` projections.idp_templates4.type,` +
 		` projections.idp_templates4.owner_type,` +
 		` COUNT(*) OVER ()` +
-		` FROM projections.idp_login_policy_links4` +
-		` LEFT JOIN projections.idp_templates4 ON projections.idp_login_policy_links4.idp_id = projections.idp_templates4.id AND projections.idp_login_policy_links4.instance_id = projections.idp_templates4.instance_id` +
+		` FROM projections.idp_login_policy_links5` +
+		` LEFT JOIN projections.idp_templates4 ON projections.idp_login_policy_links5.idp_id = projections.idp_templates4.id AND projections.idp_login_policy_links5.instance_id = projections.idp_templates4.instance_id` +
 		` AS OF SYSTEM TIME '-1 ms'`)
 	loginPolicyIDPLinksCols = []string{
 		"idp_id",

--- a/internal/query/projection/idp_login_policy_link.go
+++ b/internal/query/projection/idp_login_policy_link.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	IDPLoginPolicyLinkTable = "projections.idp_login_policy_links4"
+	IDPLoginPolicyLinkTable = "projections.idp_login_policy_links5"
 
 	IDPLoginPolicyLinkIDPIDCol         = "idp_id"
 	IDPLoginPolicyLinkAggregateIDCol   = "aggregate_id"
@@ -197,45 +197,47 @@ func (p *idpLoginPolicyLinkProjection) reduceCascadeRemoved(event eventstore.Eve
 }
 
 func (p *idpLoginPolicyLinkProjection) reduceIDPConfigRemoved(event eventstore.Event) (*handler.Statement, error) {
-	var idpID string
+	var conditions []handler.Condition
 
 	switch e := event.(type) {
 	case *org.IDPConfigRemovedEvent:
-		idpID = e.ConfigID
+		conditions = []handler.Condition{
+			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, e.ConfigID),
+			handler.NewCond(IDPLoginPolicyLinkResourceOwnerCol, event.Aggregate().ResourceOwner),
+			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
+		}
 	case *instance.IDPConfigRemovedEvent:
-		idpID = e.ConfigID
+		conditions = []handler.Condition{
+			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, e.ConfigID),
+			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
+		}
 	default:
 		return nil, errors.ThrowInvalidArgumentf(nil, "HANDL-u6tze", "reduce.wrong.event.type %v", []eventstore.EventType{org.IDPConfigRemovedEventType, instance.IDPConfigRemovedEventType})
 	}
 
-	return crdb.NewDeleteStatement(event,
-		[]handler.Condition{
-			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, idpID),
-			handler.NewCond(IDPLoginPolicyLinkResourceOwnerCol, event.Aggregate().ResourceOwner),
-			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
-		},
-	), nil
+	return crdb.NewDeleteStatement(event, conditions), nil
 }
 
 func (p *idpLoginPolicyLinkProjection) reduceIDPRemoved(event eventstore.Event) (*handler.Statement, error) {
-	var idpID string
+	var conditions []handler.Condition
 
 	switch e := event.(type) {
 	case *org.IDPRemovedEvent:
-		idpID = e.ID
+		conditions = []handler.Condition{
+			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, e.ID),
+			handler.NewCond(IDPLoginPolicyLinkResourceOwnerCol, event.Aggregate().ResourceOwner),
+			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
+		}
 	case *instance.IDPRemovedEvent:
-		idpID = e.ID
+		conditions = []handler.Condition{
+			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, e.ID),
+			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
+		}
 	default:
 		return nil, errors.ThrowInvalidArgumentf(nil, "HANDL-SFED3", "reduce.wrong.event.type %v", []eventstore.EventType{org.IDPRemovedEventType, instance.IDPRemovedEventType})
 	}
 
-	return crdb.NewDeleteStatement(event,
-		[]handler.Condition{
-			handler.NewCond(IDPLoginPolicyLinkIDPIDCol, idpID),
-			handler.NewCond(IDPLoginPolicyLinkResourceOwnerCol, event.Aggregate().ResourceOwner),
-			handler.NewCond(IDPLoginPolicyLinkInstanceIDCol, event.Aggregate().InstanceID),
-		},
-	), nil
+	return crdb.NewDeleteStatement(event, conditions), nil
 }
 
 func (p *idpLoginPolicyLinkProjection) reducePolicyRemoved(event eventstore.Event) (*handler.Statement, error) {

--- a/internal/query/projection/idp_login_policy_link_test.go
+++ b/internal/query/projection/idp_login_policy_link_test.go
@@ -42,7 +42,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.idp_login_policy_links4 (idp_id, aggregate_id, creation_date, change_date, sequence, resource_owner, instance_id, provider_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+							expectedStmt: "INSERT INTO projections.idp_login_policy_links5 (idp_id, aggregate_id, creation_date, change_date, sequence, resource_owner, instance_id, provider_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -78,7 +78,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -109,7 +109,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -140,7 +140,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.idp_login_policy_links4 (idp_id, aggregate_id, creation_date, change_date, sequence, resource_owner, instance_id, provider_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+							expectedStmt: "INSERT INTO projections.idp_login_policy_links5 (idp_id, aggregate_id, creation_date, change_date, sequence, resource_owner, instance_id, provider_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -176,7 +176,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -204,7 +204,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},
@@ -233,7 +233,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (aggregate_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"agg-id",
@@ -261,7 +261,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (aggregate_id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (aggregate_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"instance-id",
@@ -290,7 +290,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
 								"ro-id",
@@ -320,10 +320,9 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"idp-config-id",
-								"ro-id",
 								"instance-id",
 							},
 						},
@@ -350,7 +349,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"id",
 								"ro-id",
@@ -380,10 +379,9 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.idp_login_policy_links4 WHERE (idp_id = $1) AND (resource_owner = $2) AND (instance_id = $3)",
+							expectedStmt: "DELETE FROM projections.idp_login_policy_links5 WHERE (idp_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"id",
-								"ro-id",
 								"instance-id",
 							},
 						},
@@ -408,7 +406,7 @@ func TestIDPLoginPolicyLinkProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.idp_login_policy_links4 SET (change_date, sequence, owner_removed) = ($1, $2, $3) WHERE (instance_id = $4) AND (resource_owner = $5)",
+							expectedStmt: "UPDATE projections.idp_login_policy_links5 SET (change_date, sequence, owner_removed) = ($1, $2, $3) WHERE (instance_id = $4) AND (resource_owner = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),


### PR DESCRIPTION
```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
