### PR TITLE
fix: ignore 0 retention on event search

### DIFF
--- a/console/src/app/modules/filter-events/filter-events.component.html
+++ b/console/src/app/modules/filter-events/filter-events.component.html
@@ -5,6 +5,7 @@
     (click)="showFilter = !showFilter"
     class="cnsl-action-button"
     #triggereventfilter="cdkOverlayOrigin"
+    data-e2e="open-filter-button"
   >
     <i class="las la-filter no-margin"></i>
     <span>{{ 'ACTIONS.FILTER' | translate }}</span>
@@ -29,7 +30,7 @@
       <div class="filter-events-top">
         <button mat-stroked-button type="button" (click)="reset()">{{ 'ACTIONS.RESET' | translate }}</button>
         <span class="filter-middle">{{ 'FILTER.TITLE' | translate }}</span>
-        <button mat-raised-button color="primary" type="button" (click)="finish()">
+        <button mat-raised-button color="primary" type="button" (click)="finish()" data-e2e="filter-finish-button">
           {{ 'ACTIONS.FINISH' | translate }}
         </button>
       </div>
@@ -96,6 +97,7 @@
               name="eventTypesFilterSet"
               class="cb"
               formControlName="eventTypesFilterSet"
+              data-e2e="event-type-filter-checkbox"
               >{{ 'IAM.EVENTS.FILTERS.TYPE.CHECKBOX' | translate }}
             </mat-checkbox>
           </div>

--- a/console/src/app/pages/events/events.component.html
+++ b/console/src/app/pages/events/events.component.html
@@ -91,7 +91,7 @@
 
       <ng-container matColumnDef="type">
         <th mat-header-cell *matHeaderCellDef>{{ 'IAM.EVENTS.TYPE' | translate }}</th>
-        <td mat-cell *matCellDef="let event">
+        <td mat-cell *matCellDef="let event" data-e2e="event-type-cell">
           <ng-container *ngIf="event | toobject as event">
             <span *ngIf="event.type?.localized?.localizedMessage">{{ event.type.localized.localizedMessage }}</span>
           </ng-container>

--- a/e2e/cypress/e2e/events/events.cy.ts
+++ b/e2e/cypress/e2e/events/events.cy.ts
@@ -1,0 +1,18 @@
+describe('events', () => {
+  beforeEach(() => {
+    cy.context().as('ctx');
+  });
+
+  it('events can be filtered', () => {
+    const eventTypeEnglish = 'Instance added';
+    cy.visit('/events');
+    cy.get('[data-e2e="event-type-cell"]').should('have.length', 20);
+    cy.get('[data-e2e="open-filter-button"]').click();
+    cy.get('[data-e2e="event-type-filter-checkbox"]').click();
+    cy.get('#mat-select-value-1').click();
+    cy.contains('mat-option', eventTypeEnglish).click();
+    cy.get('body').click();
+    cy.get('[data-e2e="filter-finish-button"]').click();
+    cy.contains('[data-e2e="event-type-cell"]', eventTypeEnglish).should('have.length.at.least', 1);
+  });
+});


### PR DESCRIPTION
Bug found while reviewing #5580

With this PR...
- 0 retention duration is ignored
- all events from the search result are checked
- filtering events in the console is e2e tested

```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
