### PR TITLE
docs: Add warning for ldap in zitadel cloud

### DIFF
--- a/docs/docs/guides/integrate/identity-providers/_ldap_warn.mdx
+++ b/docs/docs/guides/integrate/identity-providers/_ldap_warn.mdx
@@ -1,0 +1,4 @@
+:::caution
+LDAP does send your user passwords in clear text. Due to this we do not recommend using it with the ZITADEL cloud.
+If you want to use it anyway, please reach out to us.
+:::

--- a/docs/docs/guides/integrate/identity-providers/ldap.mdx
+++ b/docs/docs/guides/integrate/identity-providers/ldap.mdx
@@ -5,14 +5,12 @@ sidebar_label: LDAP
 
 import GeneralConfigDescription from './_general_config_description.mdx';
 import Intro from './_intro.mdx';
+import LDAPWarn from './_ldap_warn.mdx';
 import CustomLoginPolicy from './_custom_login_policy.mdx';
 import Activate from './_activate.mdx';
 import TestSetup from './_test_setup.mdx';
 
-:::caution
-LDAP does send your user passwords in clear text. Due to this we do not recommend using it with the ZITADEL cloud.
-If you want to use it anyway, please reach out to us.
-:::
+<LDAPWarn/>
 
 <Intro provider="an LDAP server"/>
 

--- a/docs/docs/guides/integrate/identity-providers/ldap.mdx
+++ b/docs/docs/guides/integrate/identity-providers/ldap.mdx
@@ -9,6 +9,11 @@ import CustomLoginPolicy from './_custom_login_policy.mdx';
 import Activate from './_activate.mdx';
 import TestSetup from './_test_setup.mdx';
 
+:::caution
+LDAP does send your user passwords in clear text. Due to this we do not recommend using it with the ZITADEL cloud.
+If you want to use it anyway, please reach out to us.
+:::
+
 <Intro provider="an LDAP server"/>
 
 ## ZITADEL Configuration

--- a/docs/docs/guides/integrate/identity-providers/openldap.mdx
+++ b/docs/docs/guides/integrate/identity-providers/openldap.mdx
@@ -5,15 +5,12 @@ sidebar_label: Local OpenLDAP
 
 import GeneralConfigDescription from './_general_config_description.mdx';
 import Intro from './_intro.mdx';
+import LDAPWarn from './_ldap_warn.mdx';
 import CustomLoginPolicy from './_custom_login_policy.mdx';
 import Activate from './_activate.mdx';
 import TestSetup from './_test_setup.mdx';
 
-
-:::caution
-LDAP does send your user passwords in clear text. Due to this we do not recommend using it with the ZITADEL cloud.
-If you want to use it anyway, please reach out to us.
-:::
+<LDAPWarn/>
 
 <Intro provider="a local OpenLDAP server"/>
 

--- a/docs/docs/guides/integrate/identity-providers/openldap.mdx
+++ b/docs/docs/guides/integrate/identity-providers/openldap.mdx
@@ -9,6 +9,12 @@ import CustomLoginPolicy from './_custom_login_policy.mdx';
 import Activate from './_activate.mdx';
 import TestSetup from './_test_setup.mdx';
 
+
+:::caution
+LDAP does send your user passwords in clear text. Due to this we do not recommend using it with the ZITADEL cloud.
+If you want to use it anyway, please reach out to us.
+:::
+
 <Intro provider="a local OpenLDAP server"/>
 
 ## OpenLDAP Configuration


### PR DESCRIPTION
```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
