### PR TITLE
fix: set displayname correctly in EnsureDisplayName

### DIFF
--- a/internal/domain/human.go
+++ b/internal/domain/human.go
@@ -91,7 +91,13 @@ func (u *Human) CheckDomainPolicy(policy *DomainPolicy) error {
 }
 
 func (u *Human) EnsureDisplayName() {
-	if u.Profile != nil && u.DisplayName == "" && u.FirstName != "" && u.LastName != "" {
+	if u.Profile == nil {
+		u.Profile = new(Profile)
+	}
+	if u.DisplayName != "" {
+		return
+	}
+	if u.FirstName != "" && u.LastName != "" {
 		u.DisplayName = u.FirstName + " " + u.LastName
 		return
 	}

--- a/internal/domain/human_test.go
+++ b/internal/domain/human_test.go
@@ -1,0 +1,78 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHuman_EnsureDisplayName(t *testing.T) {
+	type fields struct {
+		Username string
+		Profile  *Profile
+		Email    *Email
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			"display name set",
+			fields{
+				Username: "username",
+				Profile: &Profile{
+					FirstName:   "firstName",
+					LastName:    "lastName",
+					DisplayName: "displayName",
+				},
+				Email: &Email{
+					EmailAddress: "email",
+				},
+			},
+			"displayName",
+		},
+		{
+			"first and lastname set",
+			fields{
+				Username: "username",
+				Profile: &Profile{
+					FirstName: "firstName",
+					LastName:  "lastName",
+				},
+				Email: &Email{
+					EmailAddress: "email",
+				},
+			},
+			"firstName lastName",
+		},
+		{
+			"profile nil, email set",
+			fields{
+				Username: "username",
+				Email: &Email{
+					EmailAddress: "email",
+				},
+			},
+			"email",
+		},
+		{
+			"email nil, username set",
+			fields{
+				Username: "username",
+			},
+			"username",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &Human{
+				Username: tt.fields.Username,
+				Profile:  tt.fields.Profile,
+				Email:    tt.fields.Email,
+			}
+			u.EnsureDisplayName()
+			assert.Equal(t, tt.want, u.DisplayName)
+		})
+	}
+}


### PR DESCRIPTION
```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
