### PR TITLE
fix: use id_token without userinfo if set and display error

### DIFF
--- a/internal/api/oidc/key.go
+++ b/internal/api/oidc/key.go
@@ -141,10 +141,13 @@ func (o *OPStorage) refreshSigningKey(ctx context.Context, algorithm string, seq
 }
 
 func (o *OPStorage) ensureIsLatestKey(ctx context.Context, sequence uint64) (bool, error) {
+	logging.WithFields("sequence", sequence).Debug("ensure that the latest key event was handled")
 	maxSequence, err := o.getMaxKeySequence(ctx)
 	if err != nil {
+		logging.WithError(err).Debug("error retrieving new events")
 		return false, fmt.Errorf("error retrieving new events: %w", err)
 	}
+	logging.WithFields("sequence", sequence, "maxSequence", maxSequence).Debug("comparing sequences to ensure that the latest key event was handled")
 	return sequence == maxSequence, nil
 }
 

--- a/internal/api/ui/login/login_handler.go
+++ b/internal/api/ui/login/login_handler.go
@@ -95,7 +95,7 @@ func (l *Login) renderLogin(w http.ResponseWriter, r *http.Request, authReq *dom
 	if err != nil {
 		errID, errMessage = l.getErrorMessage(r, err)
 	}
-	if singleIDPAllowed(authReq) {
+	if err == nil && singleIDPAllowed(authReq) {
 		l.handleIDP(w, r, authReq, authReq.AllowedExternalIDPs[0].IDPConfigID)
 		return
 	}

--- a/internal/idp/providers/oidc/session.go
+++ b/internal/idp/providers/oidc/session.go
@@ -38,6 +38,9 @@ func (s *Session) FetchUser(ctx context.Context) (user idp.User, err error) {
 			return nil, err
 		}
 	}
+	if s.Provider.useIDToken {
+		return s.Provider.userInfoMapper(s.Tokens.IDTokenClaims), nil
+	}
 	info, err := rp.Userinfo(
 		s.Tokens.AccessToken,
 		s.Tokens.TokenType,
@@ -47,11 +50,7 @@ func (s *Session) FetchUser(ctx context.Context) (user idp.User, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if s.Provider.useIDToken {
-		info = s.Tokens.IDTokenClaims
-	}
-	u := s.Provider.userInfoMapper(info)
-	return u, nil
+	return s.Provider.userInfoMapper(info), nil
 }
 
 func (s *Session) authorize(ctx context.Context) (err error) {

--- a/internal/query/key.go
+++ b/internal/query/key.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/call"
@@ -238,6 +239,7 @@ func (q *Queries) ActivePrivateSigningKey(ctx context.Context, t time.Time) (_ *
 		return nil, err
 	}
 	keys.LatestSequence, err = q.latestSequence(ctx, keyTable)
+	logging.WithFields("latestSequence", keys.LatestSequence).WithError(err).Debug("latest sequence for private signing keys")
 	if !errors.IsNotFound(err) {
 		return keys, err
 	}


### PR DESCRIPTION
```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
