### PR TITLE
docs(integrate): create automatic overviews, move brokering

### DIFF
--- a/docs/docs/apis/actions/external-authentication.md
+++ b/docs/docs/apis/actions/external-authentication.md
@@ -2,7 +2,7 @@
 title: External Authentication Flow
 ---
 
-This flow is executed if the user logs in using an [identity provider](/guides/integrate/identity-providers/introduction.md) or using a [jwt token](/concepts/structure/jwt_idp).
+This flow is executed if the user logs in using an [identity provider](/guides/integrate/identity-providers) or using a [jwt token](/concepts/structure/jwt_idp).
 
 ## Post Authentication
 

--- a/docs/docs/concepts/features/identity-brokering.md
+++ b/docs/docs/concepts/features/identity-brokering.md
@@ -18,5 +18,5 @@ For example, if Google is configured as an identity provider in your organizatio
 
 Configure external identity providers on the instance level or just for one organization via the [Console](/guides/manage/console/instance-settings#identity-providers) or ZITADEL APIs.
 
-The guides listed in this section will help you set up specific identity providers.
+You will find [detailed integration guides for many Identity Providers](/guides/integrate/identity-providers) in our docs.
 ZITADEL also provides templates to configure generic identity providers, which don't have templates.

--- a/docs/docs/guides/manage/console/instance-settings.mdx
+++ b/docs/docs/guides/manage/console/instance-settings.mdx
@@ -141,8 +141,7 @@ Configure the different lifetimes checks for the login process:
 You can configure all kinds of external identity providers for identity brokering, which support OIDC (OpenID Connect).
 Create a new identity provider configuration and enable it in the list afterwards.
 
-For a detailed guide about how to configure a new identity provider for identity brokering have a look at our guide:
-[Identity Brokering](/guides/integrate/identity-providers/introduction.md)
+For a detailed guide about how to configure a new identity provider for identity brokering have a look at our [identity provider guides](/guides/integrate/identity-providers).
 
 ## Password Complexity
 

--- a/docs/docs/guides/manage/customize/behavior.md
+++ b/docs/docs/guides/manage/customize/behavior.md
@@ -11,7 +11,7 @@ Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL _ORG_OWNER_
 - Your ZITADEL organization needs to have the actions feature enabled. <!-- TODO: How to enable it for SaaS ZITADEL? -->
-- [Your ZITADEL organization needs to have at least one external identity provider enabled](../../integrate/identity-providers/introduction.md)
+- [Your ZITADEL organization needs to have at least one external identity provider enabled](../../integrate/identity-providers)
 - [You need to have at least one role configured for a project](../console/projects)
 
 ## Copy some information for the action

--- a/docs/docs/guides/solution-scenarios/configurations.mdx
+++ b/docs/docs/guides/solution-scenarios/configurations.mdx
@@ -15,7 +15,7 @@ If a user of this organization wants to login, you don't want them to enter thei
 ### Settings
 
 1. Go to the "Identity Providers" Settings of the organization
-2. Configure the needed identity provider: Read this [guide](../integrate/identity-providers/introduction.md) if you don't know how
+2. Configure the needed identity provider: Read this [guide](../integrate/identity-providers) if you don't know how
 3. Go to the "Login Behavior and Security" settings of the organization
 4. Disable "Username Password Allowed" and enable "External IDP allowed" in the Advanced Section
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -144,14 +144,13 @@ module.exports = {
           link: {
             type: "generated-index",
             title: "Let users login with their preferred identity provider",
-            slug: "/guides/integrate/identity-provider",
+            slug: "/guides/integrate/identity-providers",
             description:
               "In the following guides you will learn how to configure and setup your preferred external identity provider in ZITADEL.",
 
           },
           collapsed: true,
           items: [
-            "guides/integrate/identity-providers/introduction",
             "guides/integrate/identity-providers/google",
             "guides/integrate/identity-providers/azure-ad",
             "guides/integrate/identity-providers/github",
@@ -258,6 +257,7 @@ module.exports = {
         "concepts/structure/users",
         "concepts/structure/managers",
         "concepts/structure/policies",
+        "concepts/features/identity-brokering",
         "concepts/structure/jwt_idp",
         "concepts/features/actions",
         "concepts/features/selfservice",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -141,6 +141,14 @@ module.exports = {
         {
           type: "category",
           label: "Configure Identity Providers",
+          link: {
+            type: "generated-index",
+            title: "Let users login with their preferred identity provider",
+            slug: "/guides/integrate/identity-provider",
+            description:
+              "In the following guides you will learn how to configure and setup your preferred external identity provider in ZITADEL.",
+
+          },
           collapsed: true,
           items: [
             "guides/integrate/identity-providers/introduction",
@@ -186,6 +194,14 @@ module.exports = {
         {
           type: "category",
           label: "Services",
+          link: {
+            type: "generated-index",
+            title: "Integrate ZITADEL with your favorite services",
+            slug: "/guides/integrate/services",
+            description:
+              "With the guides in this section you will learn how to integrate ZITADEL with your services.",
+
+          },
           collapsed: true,
           items: [
             "guides/integrate/services/gitlab-self-hosted",
@@ -200,6 +216,14 @@ module.exports = {
         {
           type: "category",
           label: "Tools",
+          link: {
+            type: "generated-index",
+            title: "Integrate ZITADEL with your tools",
+            slug: "/guides/integrate/tools",
+            description:
+              "With the guides in this section you will learn how to integrate ZITADEL with your favorite tools.",
+
+          },
           collapsed: true,
           items: [
             "guides/integrate/authenticated-mongodb-charts",


### PR DESCRIPTION
I've created automatic overviews for some integration sections. Makes it easier to share a link to the group of idps, tools, services etc.

Also for consistency I've moved identity brokering to concepts/features to explain the general features with links on how to manage and the guides. 

```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
