### PR TITLE
fix: switch log level of failed locks to debug

### DIFF
--- a/internal/api/oidc/key.go
+++ b/internal/api/oidc/key.go
@@ -176,7 +176,7 @@ func (o *OPStorage) lockAndGenerateSigningKeyPair(ctx context.Context, algorithm
 		if errors.IsErrorAlreadyExists(err) {
 			return nil
 		}
-		logging.OnError(err).Warn("initial lock failed")
+		logging.OnError(err).Debug("initial lock failed")
 		return err
 	}
 

--- a/internal/api/saml/certificate.go
+++ b/internal/api/saml/certificate.go
@@ -123,7 +123,7 @@ func (p *Storage) lockAndGenerateCertificateAndKey(ctx context.Context, usage do
 		if errors.IsErrorAlreadyExists(err) {
 			return nil
 		}
-		logging.OnError(err).Warn("initial lock failed")
+		logging.OnError(err).Debug("initial lock failed")
 		return err
 	}
 

--- a/internal/eventstore/handler/handler_projection.go
+++ b/internal/eventstore/handler/handler_projection.go
@@ -223,7 +223,7 @@ func (h *ProjectionHandler) schedule(ctx context.Context) {
 			errs := h.lock(lockCtx, h.requeueAfter, "system")
 			if err, ok := <-errs; err != nil || !ok {
 				cancelLock()
-				logging.WithFields("projection", h.ProjectionName).OnError(err).Warn("initial lock failed for first schedule")
+				logging.WithFields("projection", h.ProjectionName).OnError(err).Debug("initial lock failed for first schedule")
 				h.triggerProjection.Reset(h.requeueAfter)
 				continue
 			}
@@ -253,7 +253,7 @@ func (h *ProjectionHandler) schedule(ctx context.Context) {
 			//wait until projection is locked
 			if err, ok := <-errs; err != nil || !ok {
 				cancelInstanceLock()
-				logging.WithFields("projection", h.ProjectionName).OnError(err).Warn("initial lock failed")
+				logging.WithFields("projection", h.ProjectionName).OnError(err).Debug("initial lock failed")
 				failed = true
 				continue
 			}

--- a/internal/eventstore/v1/spooler/spooler.go
+++ b/internal/eventstore/v1/spooler/spooler.go
@@ -126,7 +126,7 @@ func (s *spooledHandler) load(workerID string) {
 			var err error
 			s.succeededOnce, err = s.hasSucceededOnce(ctx)
 			if err != nil {
-				logging.WithFields("view", s.ViewModel()).OnError(err).Warn("initial lock failed for first schedule")
+				logging.WithFields("view", s.ViewModel()).OnError(err).Debug("initial lock failed for first schedule")
 				errs <- err
 				return
 			}


### PR DESCRIPTION
```[tasklist]

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
```
