### PR TITLE
fix: only reuse port for integration tests

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"math"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,7 +21,6 @@ import (
 	"github.com/zitadel/saml/pkg/provider"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"golang.org/x/sys/unix"
 
 	"github.com/zitadel/zitadel/cmd/key"
 	cmd_tls "github.com/zitadel/zitadel/cmd/tls"
@@ -392,20 +390,11 @@ func startAPIs(
 	return nil
 }
 
-func reusePort(network, address string, conn syscall.RawConn) error {
-	return conn.Control(func(descriptor uintptr) {
-		err := syscall.SetsockoptInt(int(descriptor), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-		if err != nil {
-			panic(err)
-		}
-	})
-}
-
 func listen(ctx context.Context, router *mux.Router, port uint16, tlsConfig *tls.Config, shutdown <-chan os.Signal) error {
 	http2Server := &http2.Server{}
 	http1Server := &http.Server{Handler: h2c.NewHandler(router, http2Server), TLSConfig: tlsConfig}
 
-	lc := &net.ListenConfig{Control: reusePort}
+	lc := listenConfig()
 	lis, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return fmt.Errorf("tcp listener on %d failed: %w", port, err)

--- a/cmd/start/start_port.go
+++ b/cmd/start/start_port.go
@@ -1,0 +1,9 @@
+package start
+
+import (
+	"net"
+)
+
+func listenConfig() *net.ListenConfig {
+	return &net.ListenConfig{}
+}

--- a/cmd/start/start_port_integration.go
+++ b/cmd/start/start_port_integration.go
@@ -1,0 +1,25 @@
+//go:build integration
+
+package start
+
+import (
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func listenConfig() *net.ListenConfig {
+	return &net.ListenConfig{
+		Control: reusePort,
+	}
+}
+
+func reusePort(network, address string, conn syscall.RawConn) error {
+	return conn.Control(func(descriptor uintptr) {
+		err := syscall.SetsockoptInt(int(descriptor), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		if err != nil {
+			panic(err)
+		}
+	})
+}


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
