### PR TITLE
fix: set exhausted cookie with env json

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -306,9 +306,8 @@ func startAPIs(
 		http_util.WithNonHttpOnly(),
 		http_util.WithMaxAge(int(math.Floor(config.Quotas.Access.ExhaustedCookieMaxAge.Seconds()))),
 	)
-	limitingAccessInterceptor := middleware.NewAccessInterceptor(accessSvc, exhaustedCookieHandler, config.Quotas.Access, false)
-	nonLimitingAccessInterceptor := middleware.NewAccessInterceptor(accessSvc, nil, config.Quotas.Access, true)
-	apis, err := api.New(ctx, config.Port, router, queries, verifier, config.InternalAuthZ, tlsConfig, config.HTTP2HostHeader, config.HTTP1HostHeader, accessSvc, exhaustedCookieHandler, config.Quotas.Access)
+	limitingAccessInterceptor := middleware.NewAccessInterceptor(accessSvc, exhaustedCookieHandler, config.Quotas.Access)
+	apis, err := api.New(ctx, config.Port, router, queries, verifier, config.InternalAuthZ, tlsConfig, config.HTTP2HostHeader, config.HTTP1HostHeader, limitingAccessInterceptor)
 	if err != nil {
 		return fmt.Errorf("error creating api %w", err)
 	}
@@ -376,7 +375,7 @@ func startAPIs(
 	}
 	apis.RegisterHandlerOnPrefix(saml.HandlerPrefix, samlProvider.HttpHandler())
 
-	c, err := console.Start(config.Console, config.ExternalSecure, oidcProvider.IssuerFromRequest, middleware.CallDurationHandler, instanceInterceptor.Handler, nonLimitingAccessInterceptor.Handle, config.CustomerPortal)
+	c, err := console.Start(config.Console, config.ExternalSecure, oidcProvider.IssuerFromRequest, middleware.CallDurationHandler, instanceInterceptor.Handler, limitingAccessInterceptor, config.CustomerPortal)
 	if err != nil {
 		return fmt.Errorf("unable to start console: %w", err)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,24 +19,22 @@ import (
 	http_mw "github.com/zitadel/zitadel/internal/api/http/middleware"
 	"github.com/zitadel/zitadel/internal/api/ui/login"
 	"github.com/zitadel/zitadel/internal/errors"
-	"github.com/zitadel/zitadel/internal/logstore"
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/telemetry/metrics"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 )
 
 type API struct {
-	port          uint16
-	grpcServer    *grpc.Server
-	verifier      *internal_authz.TokenVerifier
-	health        healthCheck
-	router        *mux.Router
-	http1HostName string
-	grpcGateway   *server.Gateway
-	healthServer  *health.Server
-	cookieHandler *http_util.CookieHandler
-	cookieConfig  *http_mw.AccessConfig
-	queries       *query.Queries
+	port              uint16
+	grpcServer        *grpc.Server
+	verifier          *internal_authz.TokenVerifier
+	health            healthCheck
+	router            *mux.Router
+	http1HostName     string
+	grpcGateway       *server.Gateway
+	healthServer      *health.Server
+	accessInterceptor *http_mw.AccessInterceptor
+	queries           *query.Queries
 }
 
 type healthCheck interface {
@@ -51,23 +49,20 @@ func New(
 	verifier *internal_authz.TokenVerifier,
 	authZ internal_authz.Config,
 	tlsConfig *tls.Config, http2HostName, http1HostName string,
-	accessSvc *logstore.Service,
-	cookieHandler *http_util.CookieHandler,
-	cookieConfig *http_mw.AccessConfig,
+	accessInterceptor *http_mw.AccessInterceptor,
 ) (_ *API, err error) {
 	api := &API{
-		port:          port,
-		verifier:      verifier,
-		health:        queries,
-		router:        router,
-		http1HostName: http1HostName,
-		cookieConfig:  cookieConfig,
-		cookieHandler: cookieHandler,
-		queries:       queries,
+		port:              port,
+		verifier:          verifier,
+		health:            queries,
+		router:            router,
+		http1HostName:     http1HostName,
+		queries:           queries,
+		accessInterceptor: accessInterceptor,
 	}
 
-	api.grpcServer = server.CreateServer(api.verifier, authZ, queries, http2HostName, tlsConfig, accessSvc)
-	api.grpcGateway, err = server.CreateGateway(ctx, port, http1HostName, cookieHandler, cookieConfig)
+	api.grpcServer = server.CreateServer(api.verifier, authZ, queries, http2HostName, tlsConfig, accessInterceptor.AccessService())
+	api.grpcGateway, err = server.CreateGateway(ctx, port, http1HostName, accessInterceptor)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +85,7 @@ func (a *API) RegisterServer(ctx context.Context, grpcServer server.WithGatewayP
 		grpcServer,
 		a.port,
 		a.http1HostName,
-		a.cookieHandler,
-		a.cookieConfig,
+		a.accessInterceptor,
 		a.queries,
 	)
 	if err != nil {

--- a/internal/api/http/middleware/access_interceptor.go
+++ b/internal/api/http/middleware/access_interceptor.go
@@ -1,16 +1,18 @@
 package middleware
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/zitadel/zitadel/internal/api/grpc/server/middleware"
+
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
-	"github.com/zitadel/zitadel/internal/api/grpc/server/middleware"
 	http_utils "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/logstore"
 	"github.com/zitadel/zitadel/internal/logstore/emitters/access"
@@ -32,13 +34,52 @@ type AccessConfig struct {
 // NewAccessInterceptor intercepts all requests and stores them to the logstore.
 // If storeOnly is false, it also checks if requests are exhausted.
 // If requests are exhausted, it also returns http.StatusTooManyRequests and sets a cookie
-func NewAccessInterceptor(svc *logstore.Service, cookieHandler *http_utils.CookieHandler, cookieConfig *AccessConfig, storeOnly bool) *AccessInterceptor {
+func NewAccessInterceptor(svc *logstore.Service, cookieHandler *http_utils.CookieHandler, cookieConfig *AccessConfig) *AccessInterceptor {
 	return &AccessInterceptor{
 		svc:           svc,
 		cookieHandler: cookieHandler,
 		limitConfig:   cookieConfig,
-		storeOnly:     storeOnly,
 	}
+}
+
+func (a *AccessInterceptor) WithoutLimiting() *AccessInterceptor {
+	return &AccessInterceptor{
+		svc:           a.svc,
+		cookieHandler: a.cookieHandler,
+		limitConfig:   a.limitConfig,
+		storeOnly:     true,
+	}
+}
+
+func (a *AccessInterceptor) AccessService() *logstore.Service {
+	return a.svc
+}
+
+func (a *AccessInterceptor) Limit(ctx context.Context) bool {
+	if !a.svc.Enabled() || a.storeOnly {
+		return false
+	}
+	instance := authz.GetInstance(ctx)
+	remaining := a.svc.Limit(ctx, instance.InstanceID())
+	return remaining != nil && *remaining <= 0
+}
+
+func (a *AccessInterceptor) SetExhaustedCookie(writer http.ResponseWriter, request *http.Request) {
+	cookieValue := "true"
+	host := request.Header.Get(middleware.HTTP1Host)
+	domain := host
+	if strings.ContainsAny(host, ":") {
+		var err error
+		domain, _, err = net.SplitHostPort(host)
+		if err != nil {
+			logging.WithError(err).WithField("host", host).Warning("failed to extract cookie domain from request host")
+		}
+	}
+	a.cookieHandler.SetCookie(writer, a.limitConfig.ExhaustedCookieKey, domain, cookieValue)
+}
+
+func (a *AccessInterceptor) DeleteExhaustedCookie(writer http.ResponseWriter, request *http.Request) {
+	a.cookieHandler.DeleteCookie(writer, request, a.limitConfig.ExhaustedCookieKey)
 }
 
 func (a *AccessInterceptor) Handle(next http.Handler) http.Handler {
@@ -49,23 +90,16 @@ func (a *AccessInterceptor) Handle(next http.Handler) http.Handler {
 		ctx := request.Context()
 		tracingCtx, checkSpan := tracing.NewNamedSpan(ctx, "checkAccess")
 		wrappedWriter := &statusRecorder{ResponseWriter: writer, status: 0}
-		instance := authz.GetInstance(ctx)
-		limit := false
-		if !a.storeOnly {
-			remaining := a.svc.Limit(tracingCtx, instance.InstanceID())
-			limit = remaining != nil && *remaining == 0
-		}
+		limited := a.Limit(tracingCtx)
 		checkSpan.End()
-		if limit {
-			// Limit can only be true when storeOnly is false, so set the cookie and the response code
-			SetExhaustedCookie(a.cookieHandler, wrappedWriter, a.limitConfig, request)
+		if limited {
+			a.SetExhaustedCookie(wrappedWriter, request)
 			http.Error(wrappedWriter, "quota for authenticated requests is exhausted", http.StatusTooManyRequests)
-		} else {
-			if !a.storeOnly {
-				// If not limited and not storeOnly, ensure the cookie is deleted
-				DeleteExhaustedCookie(a.cookieHandler, wrappedWriter, request, a.limitConfig)
-			}
-			// Always serve if not limited
+		}
+		if !limited && !a.storeOnly {
+			a.DeleteExhaustedCookie(wrappedWriter, request)
+		}
+		if !limited {
 			next.ServeHTTP(wrappedWriter, request)
 		}
 		tracingCtx, writeSpan := tracing.NewNamedSpan(tracingCtx, "writeAccess")
@@ -75,6 +109,7 @@ func (a *AccessInterceptor) Handle(next http.Handler) http.Handler {
 		if err != nil {
 			logging.WithError(err).WithField("url", requestURL).Warning("failed to unescape request url")
 		}
+		instance := authz.GetInstance(tracingCtx)
 		a.svc.Handle(tracingCtx, &access.Record{
 			LogDate:         time.Now(),
 			Protocol:        access.HTTP,
@@ -88,24 +123,6 @@ func (a *AccessInterceptor) Handle(next http.Handler) http.Handler {
 			RequestedHost:   instance.RequestedHost(),
 		})
 	})
-}
-
-func SetExhaustedCookie(cookieHandler *http_utils.CookieHandler, writer http.ResponseWriter, cookieConfig *AccessConfig, request *http.Request) {
-	cookieValue := "true"
-	host := request.Header.Get(middleware.HTTP1Host)
-	domain := host
-	if strings.ContainsAny(host, ":") {
-		var err error
-		domain, _, err = net.SplitHostPort(host)
-		if err != nil {
-			logging.WithError(err).WithField("host", host).Warning("failed to extract cookie domain from request host")
-		}
-	}
-	cookieHandler.SetCookie(writer, cookieConfig.ExhaustedCookieKey, domain, cookieValue)
-}
-
-func DeleteExhaustedCookie(cookieHandler *http_utils.CookieHandler, writer http.ResponseWriter, request *http.Request, cookieConfig *AccessConfig) {
-	cookieHandler.DeleteCookie(writer, request, cookieConfig.ExhaustedCookieKey)
 }
 
 type statusRecorder struct {

--- a/internal/api/http/middleware/access_interceptor.go
+++ b/internal/api/http/middleware/access_interceptor.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/zitadel/zitadel/internal/api/grpc/server/middleware"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/api/grpc/server/middleware"
 	http_utils "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/logstore"
 	"github.com/zitadel/zitadel/internal/logstore/emitters/access"


### PR DESCRIPTION
Reuses methods from http.AccessInterceptor to set the expired or not expired exhausted cookie with the environment.json.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
