### PR TITLE
docs(integrate): move authenticate service users up

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -152,6 +152,23 @@ module.exports = {
         },
         {
           type: "category",
+          label: "Authenticate service users",
+          link: {
+            type: "generated-index",
+            title: "Authenticate Service Users",
+            slug: "/guides/integrate/serviceusers",
+            description:
+              "How to authenticate service users for machine-to-machine (M2M) communication between services. You also need to authenticate service users to access ZITADEL's APIs.",
+          },
+          collapsed: true,
+          items: [
+            "guides/integrate/private-key-jwt",
+            "guides/integrate/client-credentials",
+            "guides/integrate/pat",
+          ],
+        },
+        {
+          type: "category",
           label: "Configure identity providers",
           link: {
             type: "generated-index",
@@ -179,21 +196,9 @@ module.exports = {
           collapsed: true,
           items: [
             {
-              type: "category",
-              label: "Authenticate service users",
-              link: {
-                type: "generated-index",
-                title: "Authenticate Service Users",
-                slug: "/guides/integrate/serviceusers",
-                description:
-                  "How to authenticate service users",
-              },
-              collapsed: true,
-              items: [
-                "guides/integrate/private-key-jwt",
-                "guides/integrate/client-credentials",
-                "guides/integrate/pat",
-              ],
+              type: 'link',
+              label: 'Authenticate service users',
+              href: '/guides/integrate/serviceusers',
             },
             "guides/integrate/access-zitadel-apis",
             "guides/integrate/access-zitadel-system-api",


### PR DESCRIPTION
Before "Authenticate service users" was nested under "Access ZITADEL API's" giving the impression that SU can only be used with our APIs. In fact SU can be used for m2m and for accessing the APIs.

Moved the section up and added a link in the subsection to the main section. Also updated the description.

<img width="313" alt="Screenshot 2023-05-25 at 11 51 59" src="https://github.com/zitadel/zitadel/assets/1366906/1a09ba84-83a8-4b0e-922e-6120f377daab">