### PR TITLE
proposal: use Struct type for passkey JSON objects

### DIFF
--- a/internal/api/grpc/fields.go
+++ b/internal/api/grpc/fields.go
@@ -30,7 +30,9 @@ func AllFieldsSet(t testing.TB, msg protoreflect.Message, ignoreTypes ...protore
 		}
 
 		if fd.Kind() == protoreflect.MessageKind {
-			AllFieldsSet(t, msg.Get(fd).Message(), ignoreTypes...)
+			if m, ok := msg.Get(fd).Interface().(protoreflect.Message); ok {
+				AllFieldsSet(t, m, ignoreTypes...)
+			}
 		}
 	}
 }

--- a/internal/api/grpc/user/v2/passkey_integration_test.go
+++ b/internal/api/grpc/user/v2/passkey_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zitadel/zitadel/internal/webauthn"
 	object "github.com/zitadel/zitadel/pkg/grpc/object/v2alpha"
 	user "github.com/zitadel/zitadel/pkg/grpc/user/v2alpha"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestServer_RegisterPasskey(t *testing.T) {
@@ -125,7 +126,7 @@ func TestServer_RegisterPasskey(t *testing.T) {
 			if tt.want != nil {
 				assert.NotEmpty(t, got.GetPasskeyId())
 				assert.NotEmpty(t, got.GetPublicKeyCredentialCreationOptions())
-				_, err := client.CreateAttestationResponse(got.GetPublicKeyCredentialCreationOptions())
+				_, err = client.CreateAttestationResponse(got.GetPublicKeyCredentialCreationOptions())
 				require.NoError(t, err)
 			}
 		})
@@ -167,7 +168,7 @@ func TestServer_VerifyPasskeyRegistration(t *testing.T) {
 				ctx: CTX,
 				req: &user.VerifyPasskeyRegistrationRequest{
 					PasskeyId:           pkr.GetPasskeyId(),
-					PublicKeyCredential: []byte(attestationResponse),
+					PublicKeyCredential: attestationResponse,
 					PasskeyName:         "nice name",
 				},
 			},
@@ -195,10 +196,12 @@ func TestServer_VerifyPasskeyRegistration(t *testing.T) {
 			args: args{
 				ctx: CTX,
 				req: &user.VerifyPasskeyRegistrationRequest{
-					UserId:              userID,
-					PasskeyId:           pkr.GetPasskeyId(),
-					PublicKeyCredential: []byte("attestationResponseattestationResponseattestationResponse"),
-					PasskeyName:         "nice name",
+					UserId:    userID,
+					PasskeyId: pkr.GetPasskeyId(),
+					PublicKeyCredential: &structpb.Struct{
+						Fields: map[string]*structpb.Value{"foo": {Kind: &structpb.Value_StringValue{StringValue: "bar"}}},
+					},
+					PasskeyName: "nice name",
 				},
 			},
 			wantErr: true,

--- a/internal/api/grpc/user/v2/passkey_test.go
+++ b/internal/api/grpc/user/v2/passkey_test.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/zitadel/zitadel/internal/api/grpc"
 	"github.com/zitadel/zitadel/internal/domain"
+	caos_errs "github.com/zitadel/zitadel/internal/errors"
 	object "github.com/zitadel/zitadel/pkg/grpc/object/v2alpha"
 	user "github.com/zitadel/zitadel/pkg/grpc/user/v2alpha"
 )
@@ -51,9 +54,10 @@ func Test_passkeyRegistrationDetailsToPb(t *testing.T) {
 		err     error
 	}
 	tests := []struct {
-		name string
-		args args
-		want *user.RegisterPasskeyResponse
+		name    string
+		args    args
+		want    *user.RegisterPasskeyResponse
+		wantErr error
 	}{
 		{
 			name: "an error",
@@ -61,6 +65,23 @@ func Test_passkeyRegistrationDetailsToPb(t *testing.T) {
 				details: nil,
 				err:     io.ErrClosedPipe,
 			},
+			wantErr: io.ErrClosedPipe,
+		},
+		{
+			name: "unmarshall error",
+			args: args{
+				details: &domain.PasskeyRegistrationDetails{
+					ObjectDetails: &domain.ObjectDetails{
+						Sequence:      22,
+						EventDate:     time.Unix(3000, 22),
+						ResourceOwner: "me",
+					},
+					PasskeyID:                          "123",
+					PublicKeyCredentialCreationOptions: []byte(`\\`),
+				},
+				err: nil,
+			},
+			wantErr: caos_errs.ThrowInternal(nil, "USERv2-Dohr6", "todo"),
 		},
 		{
 			name: "ok",
@@ -72,7 +93,7 @@ func Test_passkeyRegistrationDetailsToPb(t *testing.T) {
 						ResourceOwner: "me",
 					},
 					PasskeyID:                          "123",
-					PublicKeyCredentialCreationOptions: []byte{1, 2, 3},
+					PublicKeyCredentialCreationOptions: []byte(`{"foo": "bar"}`),
 				},
 				err: nil,
 			},
@@ -85,16 +106,20 @@ func Test_passkeyRegistrationDetailsToPb(t *testing.T) {
 					},
 					ResourceOwner: "me",
 				},
-				PasskeyId:                          "123",
-				PublicKeyCredentialCreationOptions: []byte{1, 2, 3},
+				PasskeyId: "123",
+				PublicKeyCredentialCreationOptions: &structpb.Struct{
+					Fields: map[string]*structpb.Value{"foo": {Kind: &structpb.Value_StringValue{StringValue: "bar"}}},
+				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := passkeyRegistrationDetailsToPb(tt.args.details, tt.args.err)
-			require.ErrorIs(t, err, tt.args.err)
-			assert.Equal(t, tt.want, got)
+			require.ErrorIs(t, err, tt.wantErr)
+			if !proto.Equal(tt.want, got) {
+				t.Errorf("Not equal:\nExpected\n%s\nActual:%s", tt.want, got)
+			}
 			if tt.want != nil {
 				grpc.AllFieldsSet(t, got.ProtoReflect())
 			}

--- a/internal/webauthn/client.go
+++ b/internal/webauthn/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/descope/virtualwebauthn"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type Client struct {
@@ -25,12 +27,21 @@ func NewClient(name, domain, origin string) *Client {
 	}
 }
 
-func (c *Client) CreateAttestationResponse(options []byte) ([]byte, error) {
+func (c *Client) CreateAttestationResponse(optionsPb *structpb.Struct) (*structpb.Struct, error) {
+	options, err := protojson.Marshal(optionsPb)
+	if err != nil {
+		return nil, fmt.Errorf("webauthn.Client.CreateAttestationResponse: %w", err)
+	}
 	parsedAttestationOptions, err := virtualwebauthn.ParseAttestationOptions(string(options))
 	if err != nil {
 		return nil, fmt.Errorf("webauthn.Client.CreateAttestationResponse: %w", err)
 	}
-	return []byte(virtualwebauthn.CreateAttestationResponse(
+	resp := new(structpb.Struct)
+	err = protojson.Unmarshal([]byte(virtualwebauthn.CreateAttestationResponse(
 		c.rp, c.auth, c.credential, *parsedAttestationOptions,
-	)), nil
+	)), resp)
+	if err != nil {
+		return nil, fmt.Errorf("webauthn.Client.CreateAttestationResponse: %w", err)
+	}
+	return resp, nil
 }

--- a/proto/zitadel/user/v2alpha/user_service.proto
+++ b/proto/zitadel/user/v2alpha/user_service.proto
@@ -12,6 +12,7 @@ import "zitadel/user/v2alpha/user.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
@@ -429,7 +430,7 @@ message RegisterPasskeyResponse{
       example: "\"fabde5c8-c13f-481d-a90b-5e59a001a076\""
     }
   ];
-  bytes public_key_credential_creation_options = 3 [
+  google.protobuf.Struct public_key_credential_creation_options = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "json representation of public key credential creation options used by the passkey client"
       example: "\"eyJwdWJsaWNLZXkiOnsiY2hhbGxlbmdlIoplfZm4vM21qSzBPdjltN2x6VWhnclYyejFJSlVzZnpLd0Z1TytWTWtzRW1Icz0iLCJycCI6eyJuYW1lIjoiWklUQURFTCIsImlkIjoiYWNtZS1nem9lNHgueml0YWRlbC5jbG91ZCJ9LCJ1c2VyIjp7Im5hbWUiOiJ0ZXN0dXNlcjU1QGFjbWUueml0YWRlbC5jbG91ZCIsImRpc3BsYXlOYW1lIjoiVGVzdCBUZXN0IiwiaWQiOiJNVGd5TVRVMk1qWTBNakk1TXpBMk5qSTEifSwicHViS2V5Q3JlZFBhcmFtcyI6W3sidHlwZSI6InB1YmxpYy1rZXkiLCJhbGciOi03fSx7InR5cGUiOiJwdWJsaWMta2V5IiwiYWxnIjotMzV9LHsidHlwZSI6InB1YmxpYy1rZXkiLCJhbGciOi0zNn0seyJ0eXBlIjoicHVibGljLWtleSIsImFsZyI6LTI1N30seyJ0eXBlIjoicHVibGljLWtleSIsImFsZyI6LTI1OH0seyJ0eXBlIjoicHVibGljLWtleSIsImFsZyI6LTI1OX0seyJ0eXBlIjoicHVibGljLWtleSIsImFsZyI6LTM3fSx7InR5cGUiOiJwdWJsaWMta2V5IiwiYWxnIjotMzh9LHsidHlwZSI6InB1YmxpYy1rZXkiLCJhbGciOi0zOX0seyJ0eXBlIjoicHVibGljLWtleSIsImFsZyI6LTh9XSwiYXV0aGVudGljYXRvclNlbGVjdGlvbiI6eyJ1c2VyVmVyaWZpY2F0aW9uIjoiZGlzY291cmFnZWQifn2ilGltZW91dCI6NjAwMDAsImF0dGVzdGF0aW9uIjoibm9uZSJ9fQ==\""
@@ -456,8 +457,8 @@ message VerifyPasskeyRegistrationRequest{
       example: "\"fabde5c8-c13f-481d-a90b-5e59a001a076\"";
     }
   ];
-  bytes public_key_credential = 3 [
-    (validate.rules).bytes = {min_len: 55, max_len: 1048576},
+  google.protobuf.Struct public_key_credential = 3 [
+    (validate.rules).message.required = true,
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "JSON representation of public key credential issued by the passkey client";


### PR DESCRIPTION
byte type proto fields get encoded to base64, making it impractical to use in frondends. We can use the Struct wellknown type instead, which encode properly to JSON objects.

As an example this is only implemented for v2 user passkey endpoints.

## Benefits

JSON can be directly used for input and output in front-ends, including grpcui, and does no longer need to be encoded in base64:

![Screenshot_20230525_171525](https://github.com/zitadel/zitadel/assets/5411563/04b336ca-3c06-4bd5-a20a-072f53bcef01)

![Screenshot_20230525_172356](https://github.com/zitadel/zitadel/assets/5411563/8b42d26f-0dbe-4431-98f7-b359e1fc3769)

## Drawbacks

1. Where libraries, such as `webauthn`, return raw JSON as []byte, we need to unmarshal it in to the `Struct` type. This gives a little bit of extra code in the backend:

https://github.com/zitadel/zitadel/blob/f29a2f7b97939786b2d52d760eb0ca31b44accb8/internal/api/grpc/user/v2/passkey.go#L47-L50

https://github.com/zitadel/zitadel/blob/f29a2f7b97939786b2d52d760eb0ca31b44accb8/internal/api/grpc/user/v2/passkey.go#L60-L64

2. The `Struct` type is quite verbose if you want to set some key/value pairs directly instead of from JSON. So it is only feasible to unmarshal from JSON. This should not be an issue, as we should define type-safe proto messages for data we control.

```
&structpb.Struct{
	Fields: map[string]*structpb.Value{"foo": {Kind: &structpb.Value_StringValue{StringValue: "bar"}}},
}
```