### PR TITLE
fix: display loginname in machine client credentials

### DIFF
--- a/internal/command/user_machine_secret.go
+++ b/internal/command/user_machine_secret.go
@@ -14,7 +14,6 @@ import (
 )
 
 type GenerateMachineSecret struct {
-	ClientID     string
 	ClientSecret string
 }
 
@@ -53,7 +52,6 @@ func prepareGenerateMachineSecret(a *user.Aggregate, generator crypto.Generator,
 			if !isUserStateExists(writeModel.UserState) {
 				return nil, caos_errs.ThrowPreconditionFailed(nil, "COMMAND-x8910n", "Errors.User.NotExisting")
 			}
-			set.ClientID = writeModel.UserName
 
 			clientSecret, secretString, err := domain.NewMachineClientSecret(generator)
 			if err != nil {

--- a/internal/command/user_machine_secret_test.go
+++ b/internal/command/user_machine_secret_test.go
@@ -137,7 +137,6 @@ func TestCommandSide_GenerateMachineSecret(t *testing.T) {
 					ResourceOwner: "org1",
 				},
 				secret: &GenerateMachineSecret{
-					ClientID:     "user1",
 					ClientSecret: "a",
 				},
 			},
@@ -157,7 +156,6 @@ func TestCommandSide_GenerateMachineSecret(t *testing.T) {
 			}
 			if tt.res.err == nil {
 				assert.Equal(t, tt.res.want, got)
-				assert.Equal(t, tt.args.set.ClientID, tt.res.secret.ClientID)
 				assert.Equal(t, tt.args.set.ClientSecret, tt.res.secret.ClientSecret)
 			}
 		})


### PR DESCRIPTION
Take the preferred login name from the query side, so that it is printed correctly in the client credential creation prompt for a machine user.

Fixes #5919 
