### PR TITLE
fix: check linked users before postAuthentication action

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -286,17 +286,20 @@ func (l *Login) handleExternalUserAuthenticated(
 	callback func(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest),
 ) {
 	externalUser := mapIDPUserToExternalUser(user, provider.ID)
-	externalUser, externalUserChange, err := l.runPostExternalAuthenticationActions(externalUser, tokens(session), authReq, r, user, nil)
+	// check and fill in local linked user
+	externalErr := l.authRepo.CheckExternalUserLogin(setContext(r.Context(), ""), authReq.ID, authReq.AgentID, externalUser, domain.BrowserInfoFromRequest(r))
+	// if err then render if not found provide error to action
+	if !errors.IsNotFound(externalErr) {
+		l.renderError(w, r, authReq, externalErr)
+		return
+	}
+	externalUser, externalUserChange, err := l.runPostExternalAuthenticationActions(externalUser, tokens(session), authReq, r, user, externalErr)
 	if err != nil {
 		l.renderError(w, r, authReq, err)
 		return
 	}
-	err = l.authRepo.CheckExternalUserLogin(setContext(r.Context(), ""), authReq.ID, authReq.AgentID, externalUser, domain.BrowserInfoFromRequest(r))
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			l.renderError(w, r, authReq, err)
-			return
-		}
+	// if action is done and no user linked then link or register
+	if externalErr != nil && errors.IsNotFound(externalErr) {
 		l.externalUserNotExisting(w, r, authReq, provider, externalUser)
 		return
 	}

--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -288,7 +288,6 @@ func (l *Login) handleExternalUserAuthenticated(
 	externalUser := mapIDPUserToExternalUser(user, provider.ID)
 	// check and fill in local linked user
 	externalErr := l.authRepo.CheckExternalUserLogin(setContext(r.Context(), ""), authReq.ID, authReq.AgentID, externalUser, domain.BrowserInfoFromRequest(r))
-	// if err then render if not found provide error to action
 	if !errors.IsNotFound(externalErr) {
 		l.renderError(w, r, authReq, externalErr)
 		return
@@ -299,7 +298,7 @@ func (l *Login) handleExternalUserAuthenticated(
 		return
 	}
 	// if action is done and no user linked then link or register
-	if externalErr != nil && errors.IsNotFound(externalErr) {
+	if errors.IsNotFound(externalErr) {
 		l.externalUserNotExisting(w, r, authReq, provider, externalUser)
 		return
 	}


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
