### PR TITLE
fix: back button in detail view should not navigate to create dialog again

### DIFF
--- a/console/src/app/directives/back/back.directive.ts
+++ b/console/src/app/directives/back/back.directive.ts
@@ -1,16 +1,30 @@
 import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { NavigationService } from 'src/app/services/navigation.service';
 
 @Directive({
   selector: '[cnslBack]',
 })
 export class BackDirective {
+  new: Boolean = false;
   @HostListener('click')
   onClick(): void {
     this.navigation.back();
+    if (this.new) {
+      this.navigation.back();
+    }
   }
 
-  constructor(private navigation: NavigationService, private elRef: ElementRef, private renderer2: Renderer2) {
+  constructor(
+    private navigation: NavigationService,
+    private elRef: ElementRef,
+    private renderer2: Renderer2,
+    private route: ActivatedRoute,
+  ) {
+    this.route.queryParams.subscribe((params) => {
+      this.new = params['new'];
+    });
+
     if (navigation.isBackPossible) {
       // this.renderer2.removeStyle(this.elRef.nativeElement, 'visibility');
     } else {

--- a/console/src/app/directives/back/back.directive.ts
+++ b/console/src/app/directives/back/back.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { take } from 'rxjs';
 import { NavigationService } from 'src/app/services/navigation.service';
 
 @Directive({
@@ -23,7 +24,7 @@ export class BackDirective {
     private route: ActivatedRoute,
   ) {
     // Check if a new element was created using a create dialog
-    this.route.queryParams.subscribe((params) => {
+    this.route.queryParams.pipe(take(1)).subscribe((params) => {
       this.new = params['new'];
     });
 

--- a/console/src/app/directives/back/back.directive.ts
+++ b/console/src/app/directives/back/back.directive.ts
@@ -10,6 +10,7 @@ export class BackDirective {
   @HostListener('click')
   onClick(): void {
     this.navigation.back();
+    // Go back again to avoid create dialog starts again
     if (this.new) {
       this.navigation.back();
     }
@@ -21,6 +22,7 @@ export class BackDirective {
     private renderer2: Renderer2,
     private route: ActivatedRoute,
   ) {
+    // Check if a new element was created using a create dialog
     this.route.queryParams.subscribe((params) => {
       this.new = params['new'];
     });

--- a/console/src/app/pages/projects/apps/app-create/app-create.component.ts
+++ b/console/src/app/pages/projects/apps/app-create/app-create.component.ts
@@ -378,7 +378,7 @@ export class AppCreateComponent implements OnInit, OnDestroy {
           if (resp.clientId || resp.clientSecret) {
             this.showSavedDialog(resp);
           } else {
-            this.router.navigate(['projects', this.projectId, 'apps', resp.appId]);
+            this.router.navigate(['projects', this.projectId, 'apps', resp.appId], { queryParams: { new: true } });
           }
         })
         .catch((error) => {
@@ -410,7 +410,7 @@ export class AppCreateComponent implements OnInit, OnDestroy {
         .addSAMLApp(this.samlAppRequest)
         .then((resp) => {
           this.loading = false;
-          this.router.navigate(['projects', this.projectId, 'apps', resp.appId]);
+          this.router.navigate(['projects', this.projectId, 'apps', resp.appId], { queryParams: { new: true } });
         })
         .catch((error) => {
           this.loading = false;

--- a/console/src/app/pages/projects/apps/app-create/app-create.component.ts
+++ b/console/src/app/pages/projects/apps/app-create/app-create.component.ts
@@ -396,7 +396,7 @@ export class AppCreateComponent implements OnInit, OnDestroy {
           if (resp.clientId || resp.clientSecret) {
             this.showSavedDialog(resp);
           } else {
-            this.router.navigate(['projects', this.projectId, 'apps', resp.appId]);
+            this.router.navigate(['projects', this.projectId, 'apps', resp.appId], { queryParams: { new: true } });
           }
         })
         .catch((error) => {
@@ -436,7 +436,7 @@ export class AppCreateComponent implements OnInit, OnDestroy {
     });
 
     dialogRef.afterClosed().subscribe(() => {
-      this.router.navigate(['projects', this.projectId, 'apps', added.appId]);
+      this.router.navigate(['projects', this.projectId, 'apps', added.appId], { queryParams: { new: true } });
     });
   }
 

--- a/console/src/app/pages/projects/owned-projects/project-role-create/project-role-create.component.ts
+++ b/console/src/app/pages/projects/owned-projects/project-role-create/project-role-create.component.ts
@@ -88,7 +88,7 @@ export class ProjectRoleCreateComponent implements OnInit, OnDestroy {
       .bulkAddProjectRoles(this.projectId, rolesToAdd)
       .then(() => {
         this.toast.showInfo('PROJECT.TOAST.ROLESCREATED', true);
-        this.router.navigate(['projects', this.projectId], { queryParams: { id: 'roles' } });
+        this.router.navigate(['projects', this.projectId], { queryParams: { id: 'roles', new: true } });
       })
       .catch((error) => {
         this.toast.showError(error);

--- a/console/src/app/pages/projects/project-create/project-create.component.ts
+++ b/console/src/app/pages/projects/project-create/project-create.component.ts
@@ -33,7 +33,7 @@ export class ProjectCreateComponent {
       .addProject(this.project)
       .then((resp: AddProjectResponse.AsObject) => {
         this.toast.showInfo('PROJECT.TOAST.CREATED', true);
-        this.router.navigate(['projects', resp.id]);
+        this.router.navigate(['projects', resp.id], { queryParams: { new: true } });
       })
       .catch((error) => {
         this.toast.showError(error);

--- a/console/src/app/pages/users/user-create-machine/user-create-machine.component.ts
+++ b/console/src/app/pages/users/user-create-machine/user-create-machine.component.ts
@@ -71,7 +71,7 @@ export class UserCreateMachineComponent implements OnDestroy {
         this.toast.showInfo('USER.TOAST.CREATED', true);
         const id = data.userId;
         if (id) {
-          this.router.navigate(['users', id]);
+          this.router.navigate(['users', id], { queryParams: { new: true } });
         }
       })
       .catch((error: any) => {

--- a/console/src/app/pages/users/user-create/user-create.component.ts
+++ b/console/src/app/pages/users/user-create/user-create.component.ts
@@ -183,7 +183,7 @@ export class UserCreateComponent implements OnInit, OnDestroy {
       .then((data) => {
         this.loading = false;
         this.toast.showInfo('USER.TOAST.CREATED', true);
-        this.router.navigate(['users', data.userId]);
+        this.router.navigate(['users', data.userId], { queryParams: { new: true } });
       })
       .catch((error) => {
         this.loading = false;


### PR DESCRIPTION
@mffap detected in #5069 that after creating a new client and go on the back button the create app dialog starts again.

This is a video showing the current situation:

https://github.com/zitadel/zitadel/assets/30386061/4a0f8b97-38b0-4f18-8452-1328a8922924

The same behavior should apper after creating a project, a user, a machine user and a project role. As a workaround once of those elements are created I suggest adding a query param: new=true. When the back directive is applied after clicking the back button if the new param exists, a new back navigation is performed so the create dialog is not shown. Maybe is not the most elegant solution with going back twice.

This is a video showing the proposed change:

https://github.com/zitadel/zitadel/assets/30386061/57bc2855-0725-4feb-b315-49d56dd1f22d

This PR should close #5069.

Acceptance Criteria
- [X] I land on the project detail when clicking back (<--) on the application detail
- [X] I land on the project detail when clicking back (<--) on the application detail when i just created the application

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
