### PR TITLE
fix: separate auth request v2 implementation from v1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
           go run main.go init --config internal/integration/config/zitadel.yaml --config internal/integration/config/${INTEGRATION_DB_FLAVOR}.yaml
           go run main.go setup --masterkeyFromEnv --config internal/integration/config/zitadel.yaml --config internal/integration/config/${INTEGRATION_DB_FLAVOR}.yaml
       - name: Run integration tests
-        run: go test -tags=integration -race -p 1 -v -coverprofile=profile.cov -coverpkg=./internal/...,./cmd/... ./internal/integration ./internal/api/grpc/...
+        run: go test -tags=integration -race -p 1 -v -coverprofile=profile.cov -coverpkg=./internal/...,./cmd/... ./internal/integration ./internal/api/grpc/... ./internal/api/oidc
       - name: Publish go coverage
         uses: codecov/codecov-action@v3.1.0
         with:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -235,6 +235,7 @@ OIDC:
       Path: /oauth/v2/keys
     DeviceAuth:
       Path: /oauth/v2/device_authorization
+  DefaultLoginURLV2: "/login?authRequest="
 
 SAML:
   ProviderConfig:

--- a/internal/api/grpc/oidc/v2/oidc.go
+++ b/internal/api/grpc/oidc/v2/oidc.go
@@ -3,12 +3,13 @@ package oidc
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/domain"
-	oidc_pb "github.com/zitadel/zitadel/pkg/grpc/oidc/v2alpha"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zitadel/zitadel/internal/domain"
+	oidc_pb "github.com/zitadel/zitadel/pkg/grpc/oidc/v2alpha"
 )
 
 func (s *Server) GetAuthRequest(ctx context.Context, req *oidc_pb.GetAuthRequestRequest) (*oidc_pb.GetAuthRequestResponse, error) {

--- a/internal/api/grpc/user/v2/user_integration_test.go
+++ b/internal/api/grpc/user/v2/user_integration_test.go
@@ -540,7 +540,7 @@ func TestServer_StartIdentityProviderFlow(t *testing.T) {
 					ResourceOwner: Tester.Organisation.ID,
 				},
 				NextStep: &user.StartIdentityProviderFlowResponse_AuthUrl{
-					AuthUrl: "https://example.com/oauth/v2/authorize?client_id=clientID&prompt=select_account&redirect_uri=https%3A%2F%2Flocalhost%3A8080%2Fidps%2Fcallback&response_type=code&scope=openid+profile+email&state=",
+					AuthUrl: "https://example.com/oauth/v2/authorize?client_id=clientID&prompt=select_account&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fidps%2Fcallback&response_type=code&scope=openid+profile+email&state=",
 				},
 			},
 			wantErr: false,

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	loginClientHeader = "x-zitadel-login-client"
+	LoginClientHeader = "x-zitadel-login-client"
 )
 
 func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (_ op.AuthRequest, err error) {
@@ -28,7 +28,7 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 	defer func() { span.EndWithError(err) }()
 
 	headers, _ := http_utils.HeadersFromCtx(ctx)
-	if loginClient := headers.Get(loginClientHeader); loginClient != "" {
+	if loginClient := headers.Get(LoginClientHeader); loginClient != "" {
 		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
 	}
 

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/zitadel/zitadel/internal/api/authz"
 	http_utils "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/api/http/middleware"
-	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
@@ -26,6 +26,53 @@ const (
 func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (_ op.AuthRequest, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
+
+	headers, _ := http_utils.HeadersFromCtx(ctx)
+	if loginClient := headers.Get(loginClientHeader); loginClient != "" {
+		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
+	}
+
+	return o.createAuthRequest(ctx, req, userID)
+}
+
+func (o *OPStorage) createAuthRequestLoginClient(ctx context.Context, req *oidc.AuthRequest, hintUserID, loginClient string) (op.AuthRequest, error) {
+	project, err := o.query.ProjectByClientID(ctx, req.ClientID, false)
+	if err != nil {
+		return nil, err
+	}
+	scope, err := o.assertProjectRoleScopesByProject(ctx, project, req.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	audience, err := o.audienceFromProjectID(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	authRequest := &command.AuthRequest{
+		LoginClient:   loginClient,
+		ClientID:      req.ClientID,
+		RedirectURI:   req.RedirectURI,
+		State:         req.State,
+		Nonce:         req.Nonce,
+		Scope:         scope,
+		Audience:      audience,
+		ResponseType:  ResponseTypeToBusiness(req.ResponseType),
+		CodeChallenge: CodeChallengeToBusiness(req.CodeChallenge, req.CodeChallengeMethod),
+		Prompt:        PromptToBusiness(req.Prompt),
+		UILocales:     UILocalesToBusiness(req.UILocales),
+		MaxAge:        MaxAgeToBusiness(req.MaxAge),
+		LoginHint:     req.LoginHint,
+		HintUserID:    hintUserID,
+	}
+
+	err = o.command.AddAuthRequest(ctx, authRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthRequestV2{authRequest}, nil
+}
+
+func (o *OPStorage) createAuthRequest(ctx context.Context, req *oidc.AuthRequest, userID string) (_ op.AuthRequest, err error) {
 	userAgentID, ok := middleware.UserAgentIDFromCtx(ctx)
 	if !ok {
 		return nil, errors.ThrowPreconditionFailed(nil, "OIDC-sd436", "no user agent id")
@@ -34,18 +81,7 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 	if err != nil {
 		return nil, errors.ThrowPreconditionFailed(err, "OIDC-Gqrfg", "Errors.Internal")
 	}
-	headers, _ := http_utils.HeadersFromCtx(ctx)
-	authRequest := CreateAuthRequestToBusiness(ctx, req, userAgentID, userID, headers.Get(loginClientHeader))
-	if err = o.setAudience(ctx, authRequest); err != nil {
-		return nil, err
-	}
-	if authRequest.LoginClient != "" {
-		err = o.command.AddAuthRequest(ctx, authRequest)
-		if err != nil {
-			return nil, err
-		}
-		return AuthRequestFromBusiness(authRequest)
-	}
+	authRequest := CreateAuthRequestToBusiness(ctx, req, userAgentID, userID)
 	resp, err := o.repo.CreateAuthRequest(ctx, authRequest)
 	if err != nil {
 		return nil, err
@@ -53,26 +89,17 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 	return AuthRequestFromBusiness(resp)
 }
 
-func (o *OPStorage) setAudience(ctx context.Context, req *domain.AuthRequest) error {
-	project, err := o.query.ProjectByClientID(ctx, req.ApplicationID, false)
+func (o *OPStorage) audienceFromProjectID(ctx context.Context, projectID string) ([]string, error) {
+	projectIDQuery, err := query.NewAppProjectIDSearchQuery(projectID)
 	if err != nil {
-		return err
-	}
-	projectIDQuery, err := query.NewAppProjectIDSearchQuery(project.ID)
-	if err != nil {
-		return err
+		return nil, err
 	}
 	appIDs, err := o.query.SearchClientIDs(ctx, &query.AppSearchQueries{Queries: []query.SearchQuery{projectIDQuery}}, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	req.Audience = appIDs
-	req.AppendAudIfNotExisting(project.ID)
 
-	// the following fields are only set for the internal login UI
-	req.ApplicationResourceOwner = project.ResourceOwner
-	req.PrivateLabelingSetting = project.PrivateLabelingSetting
-	return nil
+	return append(appIDs, projectID), nil
 }
 
 func (o *OPStorage) AuthRequestByID(ctx context.Context, id string) (_ op.AuthRequest, err error) {
@@ -266,6 +293,29 @@ func (o *OPStorage) assertProjectRoleScopes(ctx context.Context, clientID string
 	project, err := o.query.ProjectByID(ctx, false, projectID, false)
 	if err != nil {
 		return nil, errors.ThrowPreconditionFailed(nil, "OIDC-w4wIn", "Errors.Internal")
+	}
+	if !project.ProjectRoleAssertion {
+		return scopes, nil
+	}
+	projectIDQuery, err := query.NewProjectRoleProjectIDSearchQuery(project.ID)
+	if err != nil {
+		return nil, errors.ThrowInternal(err, "OIDC-Cyc78", "Errors.Internal")
+	}
+	roles, err := o.query.SearchProjectRoles(ctx, true, &query.ProjectRoleSearchQueries{Queries: []query.SearchQuery{projectIDQuery}}, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, role := range roles.ProjectRoles {
+		scopes = append(scopes, ScopeProjectRolePrefix+role.Key)
+	}
+	return scopes, nil
+}
+
+func (o *OPStorage) assertProjectRoleScopesByProject(ctx context.Context, project *query.Project, scopes []string) ([]string, error) {
+	for _, scope := range scopes {
+		if strings.HasPrefix(scope, ScopeProjectRolePrefix) {
+			return scopes, nil
+		}
 	}
 	if !project.ProjectRoleAssertion {
 		return scopes, nil

--- a/internal/api/oidc/auth_request_converter.go
+++ b/internal/api/oidc/auth_request_converter.go
@@ -110,7 +110,7 @@ func AuthRequestFromBusiness(authReq *domain.AuthRequest) (_ op.AuthRequest, err
 	return &AuthRequest{authReq}, nil
 }
 
-func CreateAuthRequestToBusiness(ctx context.Context, authReq *oidc.AuthRequest, userAgentID, userID, loginClient string) *domain.AuthRequest {
+func CreateAuthRequestToBusiness(ctx context.Context, authReq *oidc.AuthRequest, userAgentID, userID string) *domain.AuthRequest {
 	return &domain.AuthRequest{
 		CreationDate:        time.Now(),
 		AgentID:             userAgentID,
@@ -132,7 +132,6 @@ func CreateAuthRequestToBusiness(ctx context.Context, authReq *oidc.AuthRequest,
 			Nonce:         authReq.Nonce,
 			CodeChallenge: CodeChallengeToBusiness(authReq.CodeChallenge, authReq.CodeChallengeMethod),
 		},
-		LoginClient: loginClient,
 	}
 }
 

--- a/internal/api/oidc/auth_request_converter_v2.go
+++ b/internal/api/oidc/auth_request_converter_v2.go
@@ -1,0 +1,76 @@
+package oidc
+
+import (
+	"time"
+
+	"github.com/zitadel/oidc/v2/pkg/oidc"
+
+	"github.com/zitadel/zitadel/internal/command"
+)
+
+const IDPrefix = "V2_"
+
+type AuthRequestV2 struct {
+	*command.AuthRequest
+}
+
+func (a *AuthRequestV2) GetID() string {
+	return IDPrefix + a.ID
+}
+
+func (a *AuthRequestV2) GetACR() string {
+	return "" //PLANNED: impl
+}
+
+func (a *AuthRequestV2) GetAMR() []string {
+	//TODO: get from linked session?
+	return nil
+}
+
+func (a *AuthRequestV2) GetAudience() []string {
+	return a.Audience
+}
+
+func (a *AuthRequestV2) GetAuthTime() time.Time {
+	return time.Time{} //TODO: get from linked session?
+}
+
+func (a *AuthRequestV2) GetClientID() string {
+	return a.ClientID
+}
+
+func (a *AuthRequestV2) GetCodeChallenge() *oidc.CodeChallenge {
+	return CodeChallengeToOIDC(a.CodeChallenge)
+}
+
+func (a *AuthRequestV2) GetNonce() string {
+	return a.Nonce
+}
+
+func (a *AuthRequestV2) GetRedirectURI() string {
+	return a.RedirectURI
+}
+
+func (a *AuthRequestV2) GetResponseType() oidc.ResponseType {
+	return ResponseTypeToOIDC(a.ResponseType)
+}
+
+func (a *AuthRequestV2) GetResponseMode() oidc.ResponseMode {
+	return ""
+}
+
+func (a *AuthRequestV2) GetScopes() []string {
+	return a.Scope
+}
+
+func (a *AuthRequestV2) GetState() string {
+	return a.State
+}
+
+func (a *AuthRequestV2) GetSubject() string {
+	return "" //TODO: get from linked session?
+}
+
+func (a *AuthRequestV2) Done() bool {
+	return false //TODO: get from linked session?
+}

--- a/internal/api/oidc/auth_request_integration_test.go
+++ b/internal/api/oidc/auth_request_integration_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package oidc_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v2/pkg/client/rp"
+	"github.com/zitadel/oidc/v2/pkg/oidc"
+
+	http_util "github.com/zitadel/zitadel/internal/api/http"
+	oidc_internal "github.com/zitadel/zitadel/internal/api/oidc"
+	"github.com/zitadel/zitadel/internal/integration"
+	app_pb "github.com/zitadel/zitadel/pkg/grpc/app"
+	mgmt "github.com/zitadel/zitadel/pkg/grpc/management"
+	session "github.com/zitadel/zitadel/pkg/grpc/session/v2alpha"
+	user "github.com/zitadel/zitadel/pkg/grpc/user/v2alpha"
+)
+
+var (
+	CTX               context.Context
+	Tester            *integration.Tester
+	Client            session.SessionServiceClient
+	User              *user.AddHumanUserResponse
+	GenericOAuthIDPID string
+)
+
+const (
+	redirectURI = "oidc_integration_test://callback"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(func() int {
+		ctx, errCtx, cancel := integration.Contexts(5 * time.Minute)
+		defer cancel()
+
+		Tester = integration.NewTester(ctx)
+		defer Tester.Done()
+		Client = Tester.Client.SessionV2
+
+		CTX, _ = Tester.WithSystemAuthorization(ctx, integration.OrgOwner), errCtx
+		return m.Run()
+	}())
+}
+
+func createClient(t testing.TB) string {
+	project, err := Tester.Client.Mgmt.AddProject(CTX, &mgmt.AddProjectRequest{
+		Name: fmt.Sprintf("project-%d", time.Now().UnixNano()),
+	})
+	require.NoError(t, err)
+
+	app, err := Tester.Client.Mgmt.AddOIDCApp(CTX, &mgmt.AddOIDCAppRequest{
+		ProjectId:                project.Id,
+		Name:                     fmt.Sprintf("app-%d", time.Now().UnixNano()),
+		RedirectUris:             []string{redirectURI},
+		ResponseTypes:            []app_pb.OIDCResponseType{app_pb.OIDCResponseType_OIDC_RESPONSE_TYPE_CODE},
+		GrantTypes:               []app_pb.OIDCGrantType{app_pb.OIDCGrantType_OIDC_GRANT_TYPE_AUTHORIZATION_CODE},
+		AppType:                  app_pb.OIDCAppType_OIDC_APP_TYPE_NATIVE,
+		AuthMethodType:           app_pb.OIDCAuthMethodType_OIDC_AUTH_METHOD_TYPE_NONE,
+		PostLogoutRedirectUris:   nil,
+		Version:                  app_pb.OIDCVersion_OIDC_VERSION_1_0,
+		DevMode:                  false,
+		AccessTokenType:          app_pb.OIDCTokenType_OIDC_TOKEN_TYPE_JWT,
+		AccessTokenRoleAssertion: false,
+		IdTokenRoleAssertion:     false,
+		IdTokenUserinfoAssertion: false,
+		ClockSkew:                nil,
+		AdditionalOrigins:        nil,
+		SkipNativeAppSuccessPage: false,
+	})
+	require.NoError(t, err)
+
+	return app.GetClientId()
+}
+
+func createAuthRequest(t testing.TB, clientID string) string {
+	issuer := http_util.BuildHTTP(Tester.Config.ExternalDomain, Tester.Config.Port, Tester.Config.ExternalSecure)
+	provider, err := rp.NewRelyingPartyOIDC(issuer, clientID, "", redirectURI, []string{oidc.ScopeOpenID})
+	require.NoError(t, err)
+	codeVerifier := "codeVerifier"
+	codeChallenge := oidc.NewSHACodeChallenge(codeVerifier)
+	authURL := rp.AuthURL("state", provider, rp.WithCodeChallenge(codeChallenge))
+
+	req, err := http.NewRequest(http.MethodGet, authURL, nil)
+	require.NoError(t, err)
+	req.Header.Set(oidc_internal.LoginClientHeader, "something")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	loc, err := resp.Location()
+	require.NoError(t, err)
+
+	prefixWithHost := issuer + Tester.Config.OIDC.DefaultLoginURLV2
+	require.Truef(t, strings.HasPrefix(loc.String(), prefixWithHost),
+		"login location has not prefix %s, but is %s", prefixWithHost, loc.String())
+
+	return strings.TrimPrefix(loc.String(), prefixWithHost)
+}
+
+func TestOPStorage_CreateAuthRequest(t *testing.T) {
+	clientID := createClient(t)
+
+	id := createAuthRequest(t, clientID)
+	require.NotEmpty(t, id)
+}

--- a/internal/api/oidc/auth_request_integration_test.go
+++ b/internal/api/oidc/auth_request_integration_test.go
@@ -90,7 +90,7 @@ func createAuthRequest(t testing.TB, clientID string) string {
 
 	req, err := http.NewRequest(http.MethodGet, authURL, nil)
 	require.NoError(t, err)
-	req.Header.Set(oidc_internal.LoginClientHeader, "something")
+	req.Header.Set(oidc_internal.LoginClientHeader, "loginClient")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -115,5 +115,5 @@ func TestOPStorage_CreateAuthRequest(t *testing.T) {
 	clientID := createClient(t)
 
 	id := createAuthRequest(t, clientID)
-	require.NotEmpty(t, id)
+	require.Contains(t, id, oidc_internal.IDPrefix)
 }

--- a/internal/api/oidc/client.go
+++ b/internal/api/oidc/client.go
@@ -66,7 +66,7 @@ func (o *OPStorage) GetClientByClientID(ctx context.Context, id string) (_ op.Cl
 		return nil, err
 	}
 
-	return ClientFromBusiness(client, o.defaultLoginURL, accessTokenLifetime, idTokenLifetime, allowedScopes)
+	return ClientFromBusiness(client, o.defaultLoginURL, o.defaultLoginURLV2, accessTokenLifetime, idTokenLifetime, allowedScopes)
 }
 
 func (o *OPStorage) GetKeyByIDAndClientID(ctx context.Context, keyID, userID string) (_ *jose.JSONWebKey, err error) {

--- a/internal/api/oidc/client_converter.go
+++ b/internal/api/oidc/client_converter.go
@@ -15,18 +15,20 @@ import (
 type Client struct {
 	app                        *query.App
 	defaultLoginURL            string
+	defaultLoginURLV2          string
 	defaultAccessTokenLifetime time.Duration
 	defaultIdTokenLifetime     time.Duration
 	allowedScopes              []string
 }
 
-func ClientFromBusiness(app *query.App, defaultLoginURL string, defaultAccessTokenLifetime, defaultIdTokenLifetime time.Duration, allowedScopes []string) (op.Client, error) {
+func ClientFromBusiness(app *query.App, defaultLoginURL, defaultLoginURLV2 string, defaultAccessTokenLifetime, defaultIdTokenLifetime time.Duration, allowedScopes []string) (op.Client, error) {
 	if app.OIDCConfig == nil {
 		return nil, errors.ThrowInvalidArgument(nil, "OIDC-d5bhD", "client is not a proper oidc application")
 	}
 	return &Client{
 			app:                        app,
 			defaultLoginURL:            defaultLoginURL,
+			defaultLoginURLV2:          defaultLoginURLV2,
 			defaultAccessTokenLifetime: defaultAccessTokenLifetime,
 			defaultIdTokenLifetime:     defaultIdTokenLifetime,
 			allowedScopes:              allowedScopes},
@@ -46,6 +48,9 @@ func (c *Client) GetID() string {
 }
 
 func (c *Client) LoginURL(id string) string {
+	if strings.HasPrefix(id, IDPrefix) {
+		return c.defaultLoginURLV2 + id
+	}
 	return c.defaultLoginURL + id
 }
 

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -41,6 +41,7 @@ type Config struct {
 	Cache                             *middleware.CacheConfig
 	CustomEndpoints                   *EndpointConfig
 	DeviceAuth                        *DeviceAuthorizationConfig
+	DefaultLoginURLV2                 string
 }
 
 type EndpointConfig struct {
@@ -65,6 +66,7 @@ type OPStorage struct {
 	query                             *query.Queries
 	eventstore                        *eventstore.Eventstore
 	defaultLoginURL                   string
+	defaultLoginURLV2                 string
 	defaultAccessTokenLifetime        time.Duration
 	defaultIdTokenLifetime            time.Duration
 	signingKeyAlgorithm               string
@@ -181,6 +183,7 @@ func newStorage(config Config, command *command.Commands, query *query.Queries, 
 		query:                             query,
 		eventstore:                        es,
 		defaultLoginURL:                   fmt.Sprintf("%s%s?%s=", login.HandlerPrefix, login.EndpointLogin, login.QueryAuthRequestID),
+		defaultLoginURLV2:                 config.DefaultLoginURLV2,
 		signingKeyAlgorithm:               config.SigningKeyAlgorithm,
 		defaultAccessTokenLifetime:        config.DefaultAccessTokenLifetime,
 		defaultIdTokenLifetime:            config.DefaultIdTokenLifetime,

--- a/internal/auth/repository/eventsourcing/eventstore/auth_request.go
+++ b/internal/auth/repository/eventsourcing/eventstore/auth_request.go
@@ -127,6 +127,22 @@ func (repo *AuthRequestRepo) CreateAuthRequest(ctx context.Context, request *dom
 		return nil, err
 	}
 	request.ID = reqID
+	project, err := repo.ProjectProvider.ProjectByClientID(ctx, request.ApplicationID, false)
+	if err != nil {
+		return nil, err
+	}
+	projectIDQuery, err := query.NewAppProjectIDSearchQuery(project.ID)
+	if err != nil {
+		return nil, err
+	}
+	appIDs, err := repo.Query.SearchClientIDs(ctx, &query.AppSearchQueries{Queries: []query.SearchQuery{projectIDQuery}}, false)
+	if err != nil {
+		return nil, err
+	}
+	request.Audience = appIDs
+	request.AppendAudIfNotExisting(project.ID)
+	request.ApplicationResourceOwner = project.ResourceOwner
+	request.PrivateLabelingSetting = project.PrivateLabelingSetting
 	if err := setOrgID(ctx, repo.OrgViewProvider, request); err != nil {
 		return nil, err
 	}

--- a/internal/command/auth_request_model.go
+++ b/internal/command/auth_request_model.go
@@ -16,9 +16,10 @@ type AuthRequestWriteModel struct {
 	State            string
 	Nonce            string
 	Scope            []string
+	Audience         []string
 	ResponseType     domain.OIDCResponseType
 	CodeChallenge    *domain.OIDCCodeChallenge
-	Prompts          []domain.Prompt
+	Prompt           []domain.Prompt
 	UILocales        []string
 	MaxAge           *time.Duration
 	LoginHint        string
@@ -43,9 +44,10 @@ func (m *AuthRequestWriteModel) Reduce() error {
 			m.State = e.State
 			m.Nonce = e.Nonce
 			m.Scope = e.Scope
+			m.Audience = e.Audience
 			m.ResponseType = e.ResponseType
 			m.CodeChallenge = e.CodeChallenge
-			m.Prompts = e.Prompts
+			m.Prompt = e.Prompt
 			m.UILocales = e.UILocales
 			m.MaxAge = e.MaxAge
 			m.LoginHint = e.LoginHint

--- a/internal/command/auth_request_test.go
+++ b/internal/command/auth_request_test.go
@@ -25,7 +25,7 @@ func TestCommands_AddAuthRequest(t *testing.T) {
 	}
 	type args struct {
 		ctx     context.Context
-		request *domain.AuthRequest
+		request *AuthRequest
 	}
 	tests := []struct {
 		name    string
@@ -46,6 +46,7 @@ func TestCommands_AddAuthRequest(t *testing.T) {
 								"state",
 								"nonce",
 								[]string{"openid"},
+								[]string{"audience"},
 								domain.OIDCResponseTypeCode,
 								nil,
 								nil,
@@ -61,7 +62,7 @@ func TestCommands_AddAuthRequest(t *testing.T) {
 			},
 			args{
 				ctx:     authz.WithInstanceID(context.Background(), "instanceID"),
-				request: &domain.AuthRequest{},
+				request: &AuthRequest{},
 			},
 			caos_errs.ThrowPreconditionFailed(nil, "COMMAND-Sf3gt", "Errors.AuthRequest.AlreadyExisting"),
 		},
@@ -80,6 +81,7 @@ func TestCommands_AddAuthRequest(t *testing.T) {
 								"state",
 								"nonce",
 								[]string{"openid"},
+								[]string{"audience"},
 								domain.OIDCResponseTypeCode,
 								&domain.OIDCCodeChallenge{
 									Challenge: "challenge",
@@ -97,25 +99,24 @@ func TestCommands_AddAuthRequest(t *testing.T) {
 			},
 			args{
 				ctx: authz.WithInstanceID(context.Background(), "instanceID"),
-				request: &domain.AuthRequest{
-					ApplicationID: "clientID",
-					CallbackURI:   "redirectURI",
-					TransferState: "state",
-					Prompt:        []domain.Prompt{domain.PromptNone},
-					UiLocales:     []string{"en", "de"},
-					LoginHint:     "loginHint",
-					MaxAuthAge:    gu.Ptr(time.Duration(0)),
-					Request: &domain.AuthRequestOIDC{
-						Scopes:       []string{"openid"},
-						ResponseType: domain.OIDCResponseTypeCode,
-						Nonce:        "nonce",
-						CodeChallenge: &domain.OIDCCodeChallenge{
-							Challenge: "challenge",
-							Method:    domain.CodeChallengeMethodS256,
-						},
+				request: &AuthRequest{
+					LoginClient:  "loginClient",
+					ClientID:     "clientID",
+					RedirectURI:  "redirectURI",
+					State:        "state",
+					Nonce:        "nonce",
+					Scope:        []string{"openid"},
+					Audience:     []string{"audience"},
+					ResponseType: domain.OIDCResponseTypeCode,
+					CodeChallenge: &domain.OIDCCodeChallenge{
+						Challenge: "challenge",
+						Method:    domain.CodeChallengeMethodS256,
 					},
-					UserID:      "hintUserID",
-					LoginClient: "loginClient",
+					Prompt:     []domain.Prompt{domain.PromptNone},
+					UILocales:  []string{"en", "de"},
+					MaxAge:     gu.Ptr(time.Duration(0)),
+					LoginHint:  "loginHint",
+					HintUserID: "hintUserID",
 				},
 			},
 			nil,

--- a/internal/domain/auth_request.go
+++ b/internal/domain/auth_request.go
@@ -55,7 +55,6 @@ type AuthRequest struct {
 	LockoutPolicy            *LockoutPolicy
 	DefaultTranslations      []*CustomText
 	OrgTranslations          []*CustomText
-	LoginClient              string
 }
 
 type ExternalUser struct {

--- a/internal/integration/config/zitadel.yaml
+++ b/internal/integration/config/zitadel.yaml
@@ -1,6 +1,8 @@
 Log:
   Level: debug
 
+ExternalSecure: false
+
 TLS:
   Enabled: false
 

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zitadel/zitadel/cmd"
 	"github.com/zitadel/zitadel/cmd/start"
 	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/api/http"
 	z_oidc "github.com/zitadel/zitadel/internal/api/oidc"
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/domain"
@@ -238,7 +239,7 @@ func NewTester(ctx context.Context) *Tester {
 	}
 	tester.createClientConn(ctx)
 	tester.createSystemUser(ctx)
-	tester.WebAuthN = webauthn.NewClient(tester.Config.WebAuthNName, tester.Config.ExternalDomain, "https://"+tester.Host())
+	tester.WebAuthN = webauthn.NewClient(tester.Config.WebAuthNName, tester.Config.ExternalDomain, http.BuildOrigin(tester.Host(), tester.Config.ExternalSecure))
 
 	return tester
 }

--- a/internal/query/projection/auth_request.go
+++ b/internal/query/projection/auth_request.go
@@ -24,7 +24,7 @@ const (
 	AuthRequestColumnClientID      = "client_id"
 	AuthRequestColumnRedirectURI   = "redirect_uri"
 	AuthRequestColumnScope         = "scope"
-	AuthRequestColumnPrompts       = "prompts"
+	AuthRequestColumnPrompt        = "prompt"
 	AuthRequestColumnUILocales     = "ui_locales"
 	AuthRequestColumnMaxAge        = "max_age"
 	AuthRequestColumnLoginHint     = "login_hint"
@@ -51,7 +51,7 @@ func newAuthRequestProjection(ctx context.Context, config crdb.StatementHandlerC
 			crdb.NewColumn(AuthRequestColumnClientID, crdb.ColumnTypeText),
 			crdb.NewColumn(AuthRequestColumnRedirectURI, crdb.ColumnTypeText),
 			crdb.NewColumn(AuthRequestColumnScope, crdb.ColumnTypeTextArray),
-			crdb.NewColumn(AuthRequestColumnPrompts, crdb.ColumnTypeEnumArray, crdb.Nullable()),
+			crdb.NewColumn(AuthRequestColumnPrompt, crdb.ColumnTypeEnumArray, crdb.Nullable()),
 			crdb.NewColumn(AuthRequestColumnUILocales, crdb.ColumnTypeTextArray, crdb.Nullable()),
 			crdb.NewColumn(AuthRequestColumnMaxAge, crdb.ColumnTypeInt64, crdb.Nullable()),
 			crdb.NewColumn(AuthRequestColumnLoginHint, crdb.ColumnTypeText, crdb.Default("")),
@@ -106,7 +106,7 @@ func (p *authRequestProjection) reduceAuthRequestAdded(event eventstore.Event) (
 			handler.NewCol(AuthRequestColumnClientID, e.ClientID),
 			handler.NewCol(AuthRequestColumnRedirectURI, e.RedirectURI),
 			handler.NewCol(AuthRequestColumnScope, e.Scope),
-			handler.NewCol(AuthRequestColumnPrompts, e.Prompts),
+			handler.NewCol(AuthRequestColumnPrompt, e.Prompt),
 			handler.NewCol(AuthRequestColumnUILocales, e.UILocales),
 			handler.NewCol(AuthRequestColumnMaxAge, e.MaxAge),
 			handler.NewCol(AuthRequestColumnLoginHint, e.LoginHint),

--- a/internal/query/projection/auth_request_test.go
+++ b/internal/query/projection/auth_request_test.go
@@ -29,7 +29,7 @@ func TestAuthRequestProjection_reduces(t *testing.T) {
 				event: getEvent(testEvent(
 					authrequest.AddedType,
 					authrequest.AggregateType,
-					[]byte(`{"login_client": "loginClient", "client_id":"clientId","redirect_uri": "redirectURI", "scope": ["openid"], "prompts": [1], "ui_locales": ["en","de"], "max_age": 0, "login_hint": "loginHint", "hint_user_id": "hintUserID"}`),
+					[]byte(`{"login_client": "loginClient", "client_id":"clientId","redirect_uri": "redirectURI", "scope": ["openid"], "prompt": [1], "ui_locales": ["en","de"], "max_age": 0, "login_hint": "loginHint", "hint_user_id": "hintUserID"}`),
 				), authrequest.AddedEventMapper),
 			},
 			reduce: (&authRequestProjection{}).reduceAuthRequestAdded,
@@ -40,7 +40,7 @@ func TestAuthRequestProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.auth_requests (id, instance_id, creation_date, change_date, resource_owner, sequence, login_client, client_id, redirect_uri, scope, prompts, ui_locales, max_age, login_hint, hint_user_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+							expectedStmt: "INSERT INTO projections.auth_requests (id, instance_id, creation_date, change_date, resource_owner, sequence, login_client, client_id, redirect_uri, scope, prompt, ui_locales, max_age, login_hint, hint_user_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"instance-id",

--- a/internal/repository/authrequest/auth_request.go
+++ b/internal/repository/authrequest/auth_request.go
@@ -25,10 +25,11 @@ type AddedEvent struct {
 	RedirectURI   string                    `json:"redirect_uri"`
 	State         string                    `json:"state,omitempty"`
 	Nonce         string                    `json:"nonce,omitempty"`
-	Scope         []string                  `json:"scope"`
+	Scope         []string                  `json:"scope,omitempty"`
+	Audience      []string                  `json:"audience,omitempty"`
 	ResponseType  domain.OIDCResponseType   `json:"response_type,omitempty"`
 	CodeChallenge *domain.OIDCCodeChallenge `json:"code_challenge,omitempty"`
-	Prompts       []domain.Prompt           `json:"prompts,omitempty"`
+	Prompt        []domain.Prompt           `json:"prompt,omitempty"`
 	UILocales     []string                  `json:"ui_locales,omitempty"`
 	MaxAge        *time.Duration            `json:"max_age,omitempty"`
 	LoginHint     string                    `json:"login_hint,omitempty"`
@@ -50,10 +51,11 @@ func NewAddedEvent(ctx context.Context,
 	redirectURI,
 	state,
 	nonce string,
-	scope []string,
+	scope,
+	audience []string,
 	responseType domain.OIDCResponseType,
 	codeChallenge *domain.OIDCCodeChallenge,
-	prompts []domain.Prompt,
+	prompt []domain.Prompt,
 	uiLocales []string,
 	maxAge *time.Duration,
 	loginHint,
@@ -71,9 +73,10 @@ func NewAddedEvent(ctx context.Context,
 		State:         state,
 		Nonce:         nonce,
 		Scope:         scope,
+		Audience:      audience,
 		ResponseType:  responseType,
 		CodeChallenge: codeChallenge,
-		Prompts:       prompts,
+		Prompt:        prompt,
 		UILocales:     uiLocales,
 		MaxAge:        maxAge,
 		LoginHint:     loginHint,


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
