### PR TITLE
fix: check the authRequest login client in command

### DIFF
--- a/internal/api/grpc/oidc/v2/oidc.go
+++ b/internal/api/grpc/oidc/v2/oidc.go
@@ -71,7 +71,7 @@ func promptToPb(p domain.Prompt) oidc_pb.Prompt {
 }
 
 func (s *Server) LinkSessionToAuthRequest(ctx context.Context, req *oidc_pb.LinkSessionToAuthRequestRequest) (*oidc_pb.LinkSessionToAuthRequestResponse, error) {
-	details, err := s.command.LinkSessionToAuthRequest(ctx, req.GetAuthRequestId(), req.GetSessionId(), req.GetSessionToken())
+	details, err := s.command.LinkSessionToAuthRequest(ctx, req.GetAuthRequestId(), req.GetSessionId(), req.GetSessionToken(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/auth_request.go
+++ b/internal/command/auth_request.go
@@ -76,10 +76,13 @@ func (c *Commands) getAuthRequestWriteModel(ctx context.Context, id string) (wri
 	return writeModel, nil
 }
 
-func (c *Commands) LinkSessionToAuthRequest(ctx context.Context, id, sessionID, sessionToken string) (*domain.ObjectDetails, error) {
+func (c *Commands) LinkSessionToAuthRequest(ctx context.Context, id, sessionID, sessionToken string, checkLoginClient bool) (*domain.ObjectDetails, error) {
 	writeModel, err := c.getAuthRequestWriteModel(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+	if checkLoginClient && authz.GetCtxData(ctx).UserID != writeModel.LoginClient {
+		return nil, errors.ThrowPermissionDenied(nil, "COMMAND-rai9Y", "Errors.AuthRequest.WrongLoginClient")
 	}
 	if writeModel.AuthRequestState != domain.AuthRequestStateAdded {
 		return nil, errors.ThrowPreconditionFailed(nil, "COMMAND-Sx208nt", "Errors.AuthRequest.AlreadyHandled")

--- a/internal/command/auth_request_model.go
+++ b/internal/command/auth_request_model.go
@@ -11,6 +11,7 @@ import (
 type AuthRequestWriteModel struct {
 	eventstore.WriteModel
 
+	LoginClient      string
 	ClientID         string
 	RedirectURI      string
 	State            string
@@ -40,6 +41,7 @@ func (m *AuthRequestWriteModel) Reduce() error {
 	for _, event := range m.Events {
 		switch e := event.(type) {
 		case *authrequest.AddedEvent:
+			m.LoginClient = e.LoginClient
 			m.ClientID = e.ClientID
 			m.RedirectURI = e.RedirectURI
 			m.State = e.State


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
