### PR TITLE
docs(legal): update address of EU representative

### DIFF
--- a/docs/docs/legal/privacy-policy.mdx
+++ b/docs/docs/legal/privacy-policy.mdx
@@ -21,7 +21,7 @@ Switzerland
 
 Our representative in the EU is
 
-**VGS Datenschutzpartner UG**  
+**VGS Datenschutzpartner GmbH**  
 Am Kaiserkai 69  
 20457 Hamburg  
 Germany  


### PR DESCRIPTION
The legal form of our EU representative has changed from UG to GmbH. With this change we update the address in our privacy policy.