### PR TITLE
feat(OIDC): support token revocation with V2 tokens

### DIFF
--- a/internal/command/oidc_session.go
+++ b/internal/command/oidc_session.go
@@ -3,8 +3,11 @@ package command
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/crypto"
@@ -15,6 +18,14 @@ import (
 	"github.com/zitadel/zitadel/internal/repository/authrequest"
 	"github.com/zitadel/zitadel/internal/repository/oidcsession"
 	"github.com/zitadel/zitadel/internal/repository/user"
+)
+
+const (
+	TokenDelimiter            = "-"
+	AccessTokenPrefix         = "at_"
+	RefreshTokenPrefix        = "rt_"
+	oidcTokenSubjectDelimiter = ":"
+	oidcTokenFormat           = "%s" + oidcTokenSubjectDelimiter + "%s"
 )
 
 // AddOIDCSessionAccessToken creates a new OIDC Session, creates an access token and returns its id and expiration.
@@ -71,19 +82,68 @@ func (c *Commands) ExchangeOIDCSessionRefreshAndAccessToken(ctx context.Context,
 // OIDCSessionByRefreshToken computes the current state of an existing OIDCSession by a refresh_token (to start a Refresh Token Grant).
 // If either the session is not active, the token is invalid or expired (incl. idle expiration) an invalid refresh token error will be returned.
 func (c *Commands) OIDCSessionByRefreshToken(ctx context.Context, refreshToken string) (*OIDCSessionWriteModel, error) {
-	split := strings.Split(refreshToken, ":")
-	if len(split) != 2 {
-		return nil, caos_errs.ThrowPreconditionFailed(nil, "OIDCS-JOI23", "Errors.OIDCSession.RefreshTokenInvalid")
+	oidcSessionID, refreshTokenID, err := parseRefreshToken(refreshToken)
+	if err != nil {
+		return nil, err
 	}
-	writeModel := NewOIDCSessionWriteModel(split[0], "")
-	err := c.eventstore.FilterToQueryReducer(ctx, writeModel)
+	writeModel := NewOIDCSessionWriteModel(oidcSessionID, "")
+	err = c.eventstore.FilterToQueryReducer(ctx, writeModel)
 	if err != nil {
 		return nil, caos_errs.ThrowPreconditionFailed(err, "OIDCS-SAF31", "Errors.OIDCSession.RefreshTokenInvalid")
 	}
-	if err = writeModel.CheckRefreshToken(split[1]); err != nil {
+	if err = writeModel.CheckRefreshToken(refreshTokenID); err != nil {
 		return nil, err
 	}
 	return writeModel, nil
+}
+
+func oidcSessionTokenIDsFromToken(token string) (oidcSessionID, refreshTokenID, accessTokenID string, err error) {
+	split := strings.Split(token, TokenDelimiter)
+	if len(split) != 2 {
+		return "", "", "", caos_errs.ThrowPreconditionFailed(nil, "OIDCS-S87kl", "Errors.OIDCSession.Token.Invalid")
+	}
+	if strings.HasPrefix(split[1], RefreshTokenPrefix) {
+		return split[0], split[1], "", nil
+	}
+	if strings.HasPrefix(split[1], AccessTokenPrefix) {
+		return split[0], "", split[1], nil
+	}
+	return "", "", "", caos_errs.ThrowPreconditionFailed(nil, "OIDCS-S87kl", "Errors.OIDCSession.Token.Invalid")
+}
+
+// RevokeOIDCSessionToken revokes an access_token or refresh_token
+// if the OIDCSession cannot be retrieved by the provided token, is not active or if the token is already revoked,
+// then no error will be returned.
+// The only possible error (except db connection or other internal errors) occurs if a client tries to revoke a token,
+// which was not part of the audience.
+func (c *Commands) RevokeOIDCSessionToken(ctx context.Context, token, clientID string) (err error) {
+	oidcSessionID, refreshTokenID, accessTokenID, err := oidcSessionTokenIDsFromToken(token)
+	if err != nil {
+		logging.WithError(err).Info("token revocation with invalid token format")
+		return nil
+	}
+	writeModel := NewOIDCSessionWriteModel(oidcSessionID, "")
+	err = c.eventstore.FilterToQueryReducer(ctx, writeModel)
+	if err != nil {
+		return caos_errs.ThrowInternal(err, "OIDCS-NB3t2", "Errors.Internal")
+	}
+	if err = writeModel.CheckClient(clientID); err != nil {
+		return err
+	}
+	if refreshTokenID != "" {
+		if err = writeModel.CheckRefreshToken(refreshTokenID); err != nil {
+			logging.WithFields("oidcSessionID", oidcSessionID, "refreshTokenID", refreshTokenID).WithError(err).
+				Info("refresh token revocation with invalid token")
+			return nil
+		}
+		return c.pushAppendAndReduce(ctx, writeModel, oidcsession.NewRefreshTokenRevokedEvent(ctx, writeModel.aggregate))
+	}
+	if err = writeModel.CheckAccessToken(accessTokenID); err != nil {
+		logging.WithFields("oidcSessionID", oidcSessionID, "accessTokenID", accessTokenID).WithError(err).
+			Info("access token revocation with invalid token")
+		return nil
+	}
+	return c.pushAppendAndReduce(ctx, writeModel, oidcsession.NewAccessTokenRevokedEvent(ctx, writeModel.aggregate))
 }
 
 func (c *Commands) newOIDCSessionAddEvents(ctx context.Context, authRequestID string) (*OIDCSessionEvents, error) {
@@ -153,11 +213,18 @@ func (c *Commands) decryptRefreshToken(refreshToken string) (refreshTokenID stri
 	if err != nil {
 		return "", err
 	}
-	split := strings.Split(decrypted, ":")
-	if len(split) != 2 {
-		return "", caos_errs.ThrowPreconditionFailed(nil, "OIDCS-Sj3lk", "Errors.OIDCSession.RefreshTokenInvalid")
+	_, refreshTokenID, err = parseRefreshToken(decrypted)
+	return refreshTokenID, err
+}
+
+func parseRefreshToken(refreshToken string) (oidcSessionID, refreshTokenID string, err error) {
+	split := strings.Split(refreshToken, TokenDelimiter)
+	if len(split) < 2 || !strings.HasPrefix(split[1], RefreshTokenPrefix) {
+		return "", "", caos_errs.ThrowPreconditionFailed(nil, "OIDCS-JOI23", "Errors.OIDCSession.RefreshTokenInvalid")
 	}
-	return split[1], nil
+	// the oidc library requires that every token has the format of <tokenID>:<userID>
+	// the V2 tokens don't use the userID anymore, so let's just remove it
+	return split[0], strings.Split(split[1], oidcTokenSubjectDelimiter)[0], nil
 }
 
 func (c *Commands) newOIDCSessionUpdateEvents(ctx context.Context, oidcSessionID, refreshToken string) (*OIDCSessionEvents, error) {
@@ -224,18 +291,19 @@ func (c *OIDCSessionEvents) SetAuthRequestSuccessful(ctx context.Context) {
 	c.events = append(c.events, authrequest.NewSucceededEvent(ctx, c.authRequestWriteModel.aggregate))
 }
 
-func (c *OIDCSessionEvents) AddAccessToken(ctx context.Context, scope []string) (err error) {
-	c.accessTokenID, err = c.idGenerator.Next()
+func (c *OIDCSessionEvents) AddAccessToken(ctx context.Context, scope []string) error {
+	accessTokenID, err := c.idGenerator.Next()
 	if err != nil {
 		return err
 	}
+	c.accessTokenID = AccessTokenPrefix + accessTokenID
 	c.events = append(c.events, oidcsession.NewAccessTokenAddedEvent(ctx, c.oidcSessionWriteModel.aggregate, c.accessTokenID, scope, c.accessTokenLifetime))
 	return nil
 }
 
 func (c *OIDCSessionEvents) AddRefreshToken(ctx context.Context) (err error) {
 	var refreshTokenID string
-	refreshTokenID, c.refreshToken, err = c.generateRefreshToken()
+	refreshTokenID, c.refreshToken, err = c.generateRefreshToken(c.sessionWriteModel.UserID)
 	if err != nil {
 		return err
 	}
@@ -245,7 +313,7 @@ func (c *OIDCSessionEvents) AddRefreshToken(ctx context.Context) (err error) {
 
 func (c *OIDCSessionEvents) RenewRefreshToken(ctx context.Context) (err error) {
 	var refreshTokenID string
-	refreshTokenID, c.refreshToken, err = c.generateRefreshToken()
+	refreshTokenID, c.refreshToken, err = c.generateRefreshToken(c.oidcSessionWriteModel.UserID)
 	if err != nil {
 		return err
 	}
@@ -253,12 +321,13 @@ func (c *OIDCSessionEvents) RenewRefreshToken(ctx context.Context) (err error) {
 	return nil
 }
 
-func (c *OIDCSessionEvents) generateRefreshToken() (refreshTokenID, refreshToken string, err error) {
+func (c *OIDCSessionEvents) generateRefreshToken(userID string) (refreshTokenID, refreshToken string, err error) {
 	refreshTokenID, err = c.idGenerator.Next()
 	if err != nil {
 		return "", "", err
 	}
-	token, err := c.encryptionAlg.Encrypt([]byte(c.oidcSessionWriteModel.AggregateID + ":" + refreshTokenID))
+	refreshTokenID = RefreshTokenPrefix + refreshTokenID
+	token, err := c.encryptionAlg.Encrypt([]byte(fmt.Sprintf(oidcTokenFormat, c.oidcSessionWriteModel.OIDCRefreshTokenID(refreshTokenID), userID)))
 	if err != nil {
 		return "", "", err
 	}
@@ -276,7 +345,7 @@ func (c *OIDCSessionEvents) PushEvents(ctx context.Context) (accessTokenID strin
 	}
 	// prefix the returned id with the oidcSessionID so that we can retrieve it later on
 	// we need to use `-` as a delimiter because the OIDC library uses `:` and will check for a length of 2 parts
-	return c.oidcSessionWriteModel.AggregateID + "-" + c.accessTokenID, c.refreshToken, c.oidcSessionWriteModel.AccessTokenExpiration, nil
+	return c.oidcSessionWriteModel.AggregateID + TokenDelimiter + c.accessTokenID, c.refreshToken, c.oidcSessionWriteModel.AccessTokenExpiration, nil
 }
 
 func (c *Commands) tokenTokenLifetimes(ctx context.Context) (accessTokenLifetime time.Duration, refreshTokenLifetime time.Duration, refreshTokenIdleLifetime time.Duration, err error) {

--- a/internal/command/oidc_session_model.go
+++ b/internal/command/oidc_session_model.go
@@ -20,9 +20,11 @@ type OIDCSessionWriteModel struct {
 	AuthMethods                []domain.UserAuthMethodType
 	AuthTime                   time.Time
 	State                      domain.OIDCSessionState
+	AccessTokenID              string
 	AccessTokenCreation        time.Time
 	AccessTokenExpiration      time.Time
 	RefreshTokenID             string
+	RefreshToken               string
 	RefreshTokenExpiration     time.Time
 	RefreshTokenIdleExpiration time.Time
 
@@ -46,10 +48,14 @@ func (wm *OIDCSessionWriteModel) Reduce() error {
 			wm.reduceAdded(e)
 		case *oidcsession.AccessTokenAddedEvent:
 			wm.reduceAccessTokenAdded(e)
+		case *oidcsession.AccessTokenRevokedEvent:
+			wm.reduceAccessTokenRevoked(e)
 		case *oidcsession.RefreshTokenAddedEvent:
 			wm.reduceRefreshTokenAdded(e)
 		case *oidcsession.RefreshTokenRenewedEvent:
 			wm.reduceRefreshTokenRenewed(e)
+		case *oidcsession.RefreshTokenRevokedEvent:
+			wm.reduceRefreshTokenRevoked(e)
 		}
 	}
 	return wm.WriteModel.Reduce()
@@ -65,6 +71,7 @@ func (wm *OIDCSessionWriteModel) Query() *eventstore.SearchQueryBuilder {
 			oidcsession.AccessTokenAddedType,
 			oidcsession.RefreshTokenAddedType,
 			oidcsession.RefreshTokenRenewedType,
+			oidcsession.RefreshTokenRevokedType,
 		).
 		Builder()
 
@@ -91,7 +98,13 @@ func (wm *OIDCSessionWriteModel) reduceAdded(e *oidcsession.AddedEvent) {
 }
 
 func (wm *OIDCSessionWriteModel) reduceAccessTokenAdded(e *oidcsession.AccessTokenAddedEvent) {
+	wm.AccessTokenID = e.ID
 	wm.AccessTokenExpiration = e.CreationDate().Add(e.Lifetime)
+}
+
+func (wm *OIDCSessionWriteModel) reduceAccessTokenRevoked(e *oidcsession.AccessTokenRevokedEvent) {
+	wm.AccessTokenID = ""
+	wm.AccessTokenExpiration = e.CreationDate()
 }
 
 func (wm *OIDCSessionWriteModel) reduceRefreshTokenAdded(e *oidcsession.RefreshTokenAddedEvent) {
@@ -103,6 +116,14 @@ func (wm *OIDCSessionWriteModel) reduceRefreshTokenAdded(e *oidcsession.RefreshT
 func (wm *OIDCSessionWriteModel) reduceRefreshTokenRenewed(e *oidcsession.RefreshTokenRenewedEvent) {
 	wm.RefreshTokenID = e.ID
 	wm.RefreshTokenIdleExpiration = e.CreationDate().Add(e.IdleLifetime)
+}
+
+func (wm *OIDCSessionWriteModel) reduceRefreshTokenRevoked(e *oidcsession.RefreshTokenRevokedEvent) {
+	wm.RefreshTokenID = ""
+	wm.RefreshTokenExpiration = e.CreationDate()
+	wm.RefreshTokenIdleExpiration = e.CreationDate()
+	wm.AccessTokenID = ""
+	wm.AccessTokenExpiration = e.CreationDate()
 }
 
 func (wm *OIDCSessionWriteModel) CheckRefreshToken(refreshTokenID string) error {
@@ -117,4 +138,30 @@ func (wm *OIDCSessionWriteModel) CheckRefreshToken(refreshTokenID string) error 
 		return caos_errs.ThrowPreconditionFailed(nil, "OIDCS-3jt2w", "Errors.OIDCSession.RefreshTokenInvalid")
 	}
 	return nil
+}
+
+func (wm *OIDCSessionWriteModel) CheckAccessToken(accessTokenID string) error {
+	if wm.State != domain.OIDCSessionStateActive {
+		return caos_errs.ThrowPreconditionFailed(nil, "OIDCS-KL2pk", "Errors.OIDCSession.Token.Invalid")
+	}
+	if wm.AccessTokenID != accessTokenID {
+		return caos_errs.ThrowPreconditionFailed(nil, "OIDCS-JLKW2", "Errors.OIDCSession.Token.Invalid")
+	}
+	if wm.AccessTokenExpiration.Before(time.Now()) {
+		return caos_errs.ThrowPreconditionFailed(nil, "OIDCS-3j3md", "Errors.OIDCSession.Token.Invalid")
+	}
+	return nil
+}
+
+func (wm *OIDCSessionWriteModel) CheckClient(clientID string) error {
+	for _, aud := range wm.Audience {
+		if aud == clientID {
+			return nil
+		}
+	}
+	return caos_errs.ThrowPreconditionFailed(nil, "OIDCS-SKjl3", "Errors.OIDCSession.InvalidClient")
+}
+
+func (wm *OIDCSessionWriteModel) OIDCRefreshTokenID(refreshTokenID string) string {
+	return wm.AggregateID + TokenDelimiter + refreshTokenID
 }

--- a/internal/command/oidc_session_test.go
+++ b/internal/command/oidc_session_test.go
@@ -191,7 +191,7 @@ func TestCommands_AddOIDCSessionAccessToken(t *testing.T) {
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-									"accessTokenID", []string{"openid"}, time.Hour),
+									"at_accessTokenID", []string{"openid"}, time.Hour),
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								authrequest.NewSucceededEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate),
@@ -207,7 +207,7 @@ func TestCommands_AddOIDCSessionAccessToken(t *testing.T) {
 				authRequestID: "V2_authRequestID",
 			},
 			res{
-				id:         "V2_oidcSessionID-accessTokenID",
+				id:         "V2_oidcSessionID-at_accessTokenID",
 				expiration: tokenCreationNow.Add(time.Hour),
 			},
 		},
@@ -392,11 +392,11 @@ func TestCommands_AddOIDCSessionRefreshAndAccessToken(t *testing.T) {
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-									"accessTokenID", []string{"openid", "offline_access"}, time.Hour),
+									"at_accessTokenID", []string{"openid", "offline_access"}, time.Hour),
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-									"refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+									"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								authrequest.NewSucceededEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate),
@@ -415,8 +415,8 @@ func TestCommands_AddOIDCSessionRefreshAndAccessToken(t *testing.T) {
 				authRequestID: "V2_authRequestID",
 			},
 			res{
-				id:           "V2_oidcSessionID-accessTokenID",
-				refreshToken: "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRA", //V2_oidcSessionID:refreshTokenID
+				id:           "V2_oidcSessionID-at_accessTokenID",
+				refreshToken: "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID-rt_refreshTokenID:userID
 				expiration:   tokenCreationNow.Add(time.Hour),
 			},
 		},
@@ -476,10 +476,10 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 			args{
 				ctx:           authz.WithInstanceID(context.Background(), "instanceID"),
 				oidcSessionID: "V2_oidcSessionID",
-				refreshToken:  "aW52YWxpZA",
+				refreshToken:  "aW52YWxpZA", //invalid
 			},
 			res{
-				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-Sj3lk", "Errors.OIDCSession.RefreshTokenInvalid"),
+				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-JOI23", "Errors.OIDCSession.RefreshTokenInvalid"),
 			},
 		},
 		{
@@ -493,7 +493,7 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 			args{
 				ctx:           authz.WithInstanceID(context.Background(), "instanceID"),
 				oidcSessionID: "V2_oidcSessionID",
-				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRA",
+				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID:rt_refreshTokenID:userID
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-s3hjk", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -519,7 +519,7 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 			args{
 				ctx:           authz.WithInstanceID(context.Background(), "instanceID"),
 				oidcSessionID: "V2_oidcSessionID",
-				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRA",
+				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID:rt_refreshTokenID:userID
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-28ubl", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -536,11 +536,11 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 						),
 						eventFromEventPusher(
 							oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
+								"at_accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
 						),
 						eventFromEventPusher(
 							oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+								"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
 						),
 					),
 				),
@@ -549,7 +549,7 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 			args{
 				ctx:           authz.WithInstanceID(context.Background(), "instanceID"),
 				oidcSessionID: "V2_oidcSessionID",
-				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRA",
+				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID:rt_refreshTokenID:userID
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-3jt2w", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -566,11 +566,11 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 						),
 						eventFromEventPusherWithCreationDateNow(
 							oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
+								"at_accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
 						),
 						eventFromEventPusherWithCreationDateNow(
 							oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+								"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
 						),
 					),
 					expectFilter(), // token lifetime
@@ -578,11 +578,11 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 						[]*repository.Event{
 							eventFromEventPusherWithInstanceID("instanceID",
 								oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-									"accessTokenID", []string{"openid", "offline_access"}, time.Hour),
+									"at_accessTokenID", []string{"openid", "offline_access"}, time.Hour),
 							),
 							eventFromEventPusherWithInstanceID("instanceID",
 								oidcsession.NewRefreshTokenRenewedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-									"refreshTokenID2", 24*time.Hour),
+									"rt_refreshTokenID2", 24*time.Hour),
 							),
 						},
 					),
@@ -596,12 +596,12 @@ func TestCommands_ExchangeOIDCSessionRefreshAndAccessToken(t *testing.T) {
 			args{
 				ctx:           authz.WithInstanceID(context.Background(), "instanceID"),
 				oidcSessionID: "V2_oidcSessionID",
-				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRA",
+				refreshToken:  "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID:rt_refreshTokenID:userID
 				scope:         []string{"openid", "offline_access"},
 			},
 			res{
-				id:           "V2_oidcSessionID-accessTokenID",
-				refreshToken: "VjJfb2lkY1Nlc3Npb25JRDpyZWZyZXNoVG9rZW5JRDI",
+				id:           "V2_oidcSessionID-at_accessTokenID",
+				refreshToken: "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDI6dXNlcklE", // V2_oidcSessionID-rt_refreshTokenID2:userID%
 				expiration:   time.Time{}.Add(time.Hour),
 			},
 		},
@@ -672,7 +672,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 			},
 			args{
 				ctx:          authz.WithInstanceID(context.Background(), "instanceID"),
-				refreshToken: "V2_oidcSessionID:refreshTokenID",
+				refreshToken: "V2_oidcSessionID-rt_refreshTokenID:userID",
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-s3hjk", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -689,7 +689,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 						),
 						eventFromEventPusher(
 							oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
+								"at_accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
 						),
 					),
 				),
@@ -697,7 +697,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 			},
 			args{
 				ctx:          authz.WithInstanceID(context.Background(), "instanceID"),
-				refreshToken: "V2_oidcSessionID:refreshTokenID",
+				refreshToken: "V2_oidcSessionID-rt_refreshTokenID:userID",
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-28ubl", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -714,11 +714,11 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 						),
 						eventFromEventPusher(
 							oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
+								"at_accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
 						),
 						eventFromEventPusher(
 							oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+								"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
 						),
 					),
 				),
@@ -726,7 +726,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 			},
 			args{
 				ctx:          authz.WithInstanceID(context.Background(), "instanceID"),
-				refreshToken: "V2_oidcSessionID:refreshTokenID",
+				refreshToken: "V2_oidcSessionID-rt_refreshTokenID:userID",
 			},
 			res{
 				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-3jt2w", "Errors.OIDCSession.RefreshTokenInvalid"),
@@ -743,11 +743,11 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 						),
 						eventFromEventPusherWithCreationDateNow(
 							oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
+								"at_accessTokenID", []string{"openid", "profile", "offline_access"}, time.Hour),
 						),
 						eventFromEventPusherWithCreationDateNow(
 							oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
-								"refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+								"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
 						),
 					),
 				),
@@ -755,7 +755,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 			},
 			args{
 				ctx:          authz.WithInstanceID(context.Background(), "instanceID"),
-				refreshToken: "V2_oidcSessionID:refreshTokenID",
+				refreshToken: "V2_oidcSessionID-rt_refreshTokenID:userID",
 			},
 			res{
 				model: &OIDCSessionWriteModel{
@@ -771,7 +771,7 @@ func TestCommands_OIDCSessionByRefreshToken(t *testing.T) {
 					AuthMethods:                []domain.UserAuthMethodType{domain.UserAuthMethodTypePassword},
 					AuthTime:                   testNow,
 					State:                      domain.OIDCSessionStateActive,
-					RefreshTokenID:             "refreshTokenID",
+					RefreshTokenID:             "rt_refreshTokenID",
 					RefreshTokenExpiration:     testNow.Add(7 * 24 * time.Hour),
 					RefreshTokenIdleExpiration: testNow.Add(24 * time.Hour),
 				},

--- a/internal/repository/oidcsession/eventstore.go
+++ b/internal/repository/oidcsession/eventstore.go
@@ -1,11 +1,15 @@
 package oidcsession
 
-import "github.com/zitadel/zitadel/internal/eventstore"
+import (
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
 
 func RegisterEventMappers(es *eventstore.Eventstore) {
-	es.RegisterFilterEventMapper(AggregateType, AddedType, AddedEventMapper).
-		RegisterFilterEventMapper(AggregateType, AccessTokenAddedType, AccessTokenAddedEventMapper).
-		RegisterFilterEventMapper(AggregateType, RefreshTokenAddedType, RefreshTokenAddedEventMapper).
-		RegisterFilterEventMapper(AggregateType, RefreshTokenRenewedType, RefreshTokenRenewedEventMapper)
+	es.RegisterFilterEventMapper(AggregateType, AddedType, eventstore.GenericEventMapper[AddedEvent]).
+		RegisterFilterEventMapper(AggregateType, AccessTokenAddedType, eventstore.GenericEventMapper[AccessTokenAddedEvent]).
+		RegisterFilterEventMapper(AggregateType, AccessTokenRevokedType, eventstore.GenericEventMapper[AccessTokenRevokedEvent]).
+		RegisterFilterEventMapper(AggregateType, RefreshTokenAddedType, eventstore.GenericEventMapper[RefreshTokenAddedEvent]).
+		RegisterFilterEventMapper(AggregateType, RefreshTokenRenewedType, eventstore.GenericEventMapper[RefreshTokenRenewedEvent]).
+		RegisterFilterEventMapper(AggregateType, RefreshTokenRevokedType, eventstore.GenericEventMapper[RefreshTokenRevokedEvent])
 
 }

--- a/internal/repository/oidcsession/oidc_session.go
+++ b/internal/repository/oidcsession/oidc_session.go
@@ -2,21 +2,20 @@ package oidcsession
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/zitadel/zitadel/internal/domain"
-	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
-	"github.com/zitadel/zitadel/internal/eventstore/repository"
 )
 
 const (
 	oidcSessionEventPrefix  = "oidc_session."
 	AddedType               = oidcSessionEventPrefix + "added"
 	AccessTokenAddedType    = oidcSessionEventPrefix + "access_token.added"
+	AccessTokenRevokedType  = oidcSessionEventPrefix + "access_token.revoked"
 	RefreshTokenAddedType   = oidcSessionEventPrefix + "refresh_token.added"
 	RefreshTokenRenewedType = oidcSessionEventPrefix + "refresh_token.renewed"
+	RefreshTokenRevokedType = oidcSessionEventPrefix + "refresh_token.revoked"
 )
 
 type AddedEvent struct {
@@ -37,6 +36,10 @@ func (e *AddedEvent) Data() interface{} {
 
 func (e *AddedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
 	return nil
+}
+
+func (e *AddedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
 }
 
 func NewAddedEvent(ctx context.Context,
@@ -65,18 +68,6 @@ func NewAddedEvent(ctx context.Context,
 	}
 }
 
-func AddedEventMapper(event *repository.Event) (eventstore.Event, error) {
-	added := &AddedEvent{
-		BaseEvent: *eventstore.BaseEventFromRepo(event),
-	}
-	err := json.Unmarshal(event.Data, added)
-	if err != nil {
-		return nil, errors.ThrowInternal(err, "OIDCS-DG4gn", "unable to unmarshal oidc session added")
-	}
-
-	return added, nil
-}
-
 type AccessTokenAddedEvent struct {
 	eventstore.BaseEvent `json:"-"`
 
@@ -91,6 +82,10 @@ func (e *AccessTokenAddedEvent) Data() interface{} {
 
 func (e *AccessTokenAddedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
 	return nil
+}
+
+func (e *AccessTokenAddedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
 }
 
 func NewAccessTokenAddedEvent(
@@ -112,16 +107,33 @@ func NewAccessTokenAddedEvent(
 	}
 }
 
-func AccessTokenAddedEventMapper(event *repository.Event) (eventstore.Event, error) {
-	added := &AccessTokenAddedEvent{
-		BaseEvent: *eventstore.BaseEventFromRepo(event),
-	}
-	err := json.Unmarshal(event.Data, added)
-	if err != nil {
-		return nil, errors.ThrowInternal(err, "OIDCS-DSGn5", "unable to unmarshal access token added")
-	}
+type AccessTokenRevokedEvent struct {
+	eventstore.BaseEvent `json:"-"`
+}
 
-	return added, nil
+func (e *AccessTokenRevokedEvent) Data() interface{} {
+	return e
+}
+
+func (e *AccessTokenRevokedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
+	return nil
+}
+
+func (e *AccessTokenRevokedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
+}
+
+func NewAccessTokenRevokedEvent(
+	ctx context.Context,
+	aggregate *eventstore.Aggregate,
+) *AccessTokenAddedEvent {
+	return &AccessTokenAddedEvent{
+		BaseEvent: *eventstore.NewBaseEventForPush(
+			ctx,
+			aggregate,
+			AccessTokenRevokedType,
+		),
+	}
 }
 
 type RefreshTokenAddedEvent struct {
@@ -138,6 +150,10 @@ func (e *RefreshTokenAddedEvent) Data() interface{} {
 
 func (e *RefreshTokenAddedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
 	return nil
+}
+
+func (e *RefreshTokenAddedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
 }
 
 func NewRefreshTokenAddedEvent(
@@ -159,18 +175,6 @@ func NewRefreshTokenAddedEvent(
 	}
 }
 
-func RefreshTokenAddedEventMapper(event *repository.Event) (eventstore.Event, error) {
-	added := &RefreshTokenAddedEvent{
-		BaseEvent: *eventstore.BaseEventFromRepo(event),
-	}
-	err := json.Unmarshal(event.Data, added)
-	if err != nil {
-		return nil, errors.ThrowInternal(err, "OIDCS-aW3gqq", "unable to unmarshal refresh token added")
-	}
-
-	return added, nil
-}
-
 type RefreshTokenRenewedEvent struct {
 	eventstore.BaseEvent `json:"-"`
 
@@ -184,6 +188,10 @@ func (e *RefreshTokenRenewedEvent) Data() interface{} {
 
 func (e *RefreshTokenRenewedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
 	return nil
+}
+
+func (e *RefreshTokenRenewedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
 }
 
 func NewRefreshTokenRenewedEvent(
@@ -203,14 +211,31 @@ func NewRefreshTokenRenewedEvent(
 	}
 }
 
-func RefreshTokenRenewedEventMapper(event *repository.Event) (eventstore.Event, error) {
-	added := &RefreshTokenRenewedEvent{
-		BaseEvent: *eventstore.BaseEventFromRepo(event),
-	}
-	err := json.Unmarshal(event.Data, added)
-	if err != nil {
-		return nil, errors.ThrowInternal(err, "OIDCS-SF3fc", "unable to unmarshal refresh token renewed")
-	}
+type RefreshTokenRevokedEvent struct {
+	eventstore.BaseEvent `json:"-"`
+}
 
-	return added, nil
+func (e *RefreshTokenRevokedEvent) Data() interface{} {
+	return e
+}
+
+func (e *RefreshTokenRevokedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
+	return nil
+}
+
+func (e *RefreshTokenRevokedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
+	e.BaseEvent = *event
+}
+
+func NewRefreshTokenRevokedEvent(
+	ctx context.Context,
+	aggregate *eventstore.Aggregate,
+) *RefreshTokenRevokedEvent {
+	return &RefreshTokenRevokedEvent{
+		BaseEvent: *eventstore.NewBaseEventForPush(
+			ctx,
+			aggregate,
+			RefreshTokenRevokedType,
+		),
+	}
 }


### PR DESCRIPTION
This PR adds support for OAuth2 token revocation of V2 tokens.
 
Unlike with V1 tokens, it's now possible to revoke a token not only from the authorized client / client which the token was issued to, but rather from all trusted clients (audience):  #5276

relates to #5468



### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
