### PR TITLE
fix: add Date header to email headers RFC822

### DIFF
--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/notification/channels"
@@ -37,6 +38,7 @@ func (msg *Email) GetContent() (string, error) {
 	headers["Return-Path"] = msg.SenderEmail
 	headers["To"] = strings.Join(msg.Recipients, ", ")
 	headers["Cc"] = strings.Join(msg.CC, ", ")
+	headers["Date"] = time.Now().Format(time.RFC1123Z)
 
 	message := ""
 	for k, v := range headers {


### PR DESCRIPTION
@pulsar256 stated that "Date header is not present when sending E-Mail verification and password reset E-Mails."

This PR adds Date header and sets the time using RFC1123Z  https://pkg.go.dev/time#pkg-constants 

The following screenshot shows how this new header is added to the message header:

![image](https://github.com/zitadel/zitadel/assets/30386061/465e5008-960e-4aa0-bc41-f4028fd4323c)


Closes #6293 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
