### PR TITLE
fix(query): optimise membership query

### DIFF
--- a/internal/query/search_query.go
+++ b/internal/query/search_query.go
@@ -43,6 +43,7 @@ func (req *SearchRequest) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
 type SearchQuery interface {
 	toQuery(sq.SelectBuilder) sq.SelectBuilder
 	comp() sq.Sqlizer
+	Col() Column
 }
 
 type NotNullQuery struct {
@@ -66,6 +67,10 @@ func (q *NotNullQuery) comp() sq.Sqlizer {
 	return sq.NotEq{q.Column.identifier(): nil}
 }
 
+func (q *NotNullQuery) Col() Column {
+	return q.Column
+}
+
 type IsNullQuery struct {
 	Column Column
 }
@@ -85,6 +90,10 @@ func (q *IsNullQuery) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
 
 func (q *IsNullQuery) comp() sq.Sqlizer {
 	return sq.Eq{q.Column.identifier(): nil}
+}
+
+func (q *IsNullQuery) Col() Column {
+	return q.Column
 }
 
 type orQuery struct {
@@ -108,6 +117,10 @@ func (q *orQuery) comp() sq.Sqlizer {
 		or[i] = query.comp()
 	}
 	return or
+}
+
+func (q *orQuery) Col() Column {
+	return Column{}
 }
 
 type ColumnComparisonQuery struct {
@@ -135,6 +148,10 @@ func NewColumnComparisonQuery(col1 Column, col2 Column, compare ColumnComparison
 
 func (q *ColumnComparisonQuery) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
 	return query.Where(q.comp())
+}
+
+func (q *ColumnComparisonQuery) Col() Column {
+	return Column{}
 }
 
 func (s *ColumnComparisonQuery) comp() sq.Sqlizer {
@@ -181,6 +198,10 @@ func NewTextQuery(col Column, value string, compare TextComparison) (*TextQuery,
 		Text:    value,
 		Compare: compare,
 	}, nil
+}
+
+func (q *TextQuery) Col() Column {
+	return q.Column
 }
 
 func (q *TextQuery) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
@@ -282,6 +303,10 @@ func NewNumberQuery(c Column, value interface{}, compare NumberComparison) (*Num
 
 func (q *NumberQuery) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
 	return query.Where(q.comp())
+}
+
+func (q *NumberQuery) Col() Column {
+	return q.Column
 }
 
 func (s *NumberQuery) comp() sq.Sqlizer {
@@ -400,6 +425,10 @@ func (s *ListQuery) comp() sq.Sqlizer {
 	return nil
 }
 
+func (q *ListQuery) Col() Column {
+	return q.Column
+}
+
 type ListComparison int
 
 const (
@@ -439,6 +468,10 @@ func (q *or) comp() sq.Sqlizer {
 	return sq.Or(queries)
 }
 
+func (q *or) Col() Column {
+	return Column{}
+}
+
 type BoolQuery struct {
 	Column Column
 	Value  bool
@@ -449,6 +482,10 @@ func NewBoolQuery(c Column, value bool) (*BoolQuery, error) {
 		Column: c,
 		Value:  value,
 	}, nil
+}
+
+func (q *BoolQuery) Col() Column {
+	return q.Column
 }
 
 func (q *BoolQuery) toQuery(query sq.SelectBuilder) sq.SelectBuilder {

--- a/internal/query/user_membership_test.go
+++ b/internal/query/user_membership_test.go
@@ -16,16 +16,16 @@ import (
 
 var (
 	membershipsStmt = regexp.QuoteMeta(
-		"SELECT memberships.user_id" +
-			", memberships.roles" +
-			", memberships.creation_date" +
-			", memberships.change_date" +
-			", memberships.sequence" +
-			", memberships.resource_owner" +
-			", memberships.org_id" +
-			", memberships.id" +
-			", memberships.project_id" +
-			", memberships.grant_id" +
+		"SELECT members.user_id" +
+			", members.roles" +
+			", members.creation_date" +
+			", members.change_date" +
+			", members.sequence" +
+			", members.resource_owner" +
+			", members.org_id" +
+			", members.id" +
+			", members.project_id" +
+			", members.grant_id" +
 			", projections.project_grants3.granted_org_id" +
 			", projections.projects3.name" +
 			", projections.orgs.name" +
@@ -86,10 +86,10 @@ var (
 			", members.grant_id" +
 			" FROM projections.project_grant_members3 AS members" +
 			" WHERE members.granted_org_removed = $7 AND members.owner_removed = $8 AND members.user_owner_removed = $9" +
-			") AS memberships" +
-			" LEFT JOIN projections.projects3 ON memberships.project_id = projections.projects3.id AND memberships.instance_id = projections.projects3.instance_id" +
-			" LEFT JOIN projections.orgs ON memberships.org_id = projections.orgs.id AND memberships.instance_id = projections.orgs.instance_id" +
-			" LEFT JOIN projections.project_grants3 ON memberships.grant_id = projections.project_grants3.grant_id AND memberships.instance_id = projections.project_grants3.instance_id" +
+			") AS members" +
+			" LEFT JOIN projections.projects3 ON members.project_id = projections.projects3.id AND members.instance_id = projections.projects3.instance_id" +
+			" LEFT JOIN projections.orgs ON members.org_id = projections.orgs.id AND members.instance_id = projections.orgs.instance_id" +
+			" LEFT JOIN projections.project_grants3 ON members.grant_id = projections.project_grants3.grant_id AND members.instance_id = projections.project_grants3.instance_id" +
 			` AS OF SYSTEM TIME '-1 ms'`)
 	membershipCols = []string{
 		"user_id",
@@ -456,7 +456,7 @@ func Test_MembershipPrepares(t *testing.T) {
 
 func prepareMembershipWrapper(withOwnerRemoved bool) func(ctx context.Context, db prepareDatabase) (sq.SelectBuilder, func(*sql.Rows) (*Memberships, error)) {
 	return func(ctx context.Context, db prepareDatabase) (sq.SelectBuilder, func(*sql.Rows) (*Memberships, error)) {
-		builder, _, fun := prepareMembershipsQuery(ctx, db, withOwnerRemoved)
+		builder, _, fun := prepareMembershipsQuery(ctx, db, withOwnerRemoved, &MembershipSearchQuery{})
 		return builder, fun
 	}
 }


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
