### PR TITLE
fix: project telemetry once for all instances

### DIFF
--- a/internal/notification/handlers/telemetry_pusher.go
+++ b/internal/notification/handlers/telemetry_pusher.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
@@ -57,6 +58,7 @@ func NewTelemetryPusher(
 	handlerCfg.ProjectionName = TelemetryProjectionTable
 	handlerCfg.Reducers = p.reducers()
 	p.cfg = telemetryCfg
+	handlerCfg.ConcurrentInstances = math.MaxInt
 	p.StatementHandler = crdb.NewStatementHandler(ctx, handlerCfg)
 	p.commands = commands
 	p.queries = queries


### PR DESCRIPTION
ConcurrentInstances is not customizable by configuration as it's missing here:
https://github.com/zitadel/zitadel/blob/main/internal/query/projection/projection.go#L174-L192

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
