### PR TITLE
fix: provide tokens in azuread idp session

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -967,6 +967,8 @@ func tokens(session idp.Session) *oidc.Tokens[*oidc.IDTokenClaims] {
 		return s.Tokens
 	case *oauth.Session:
 		return s.Tokens
+	case *azuread.Session:
+		return s.Tokens
 	}
 	return nil
 }

--- a/internal/command/idp_intent.go
+++ b/internal/command/idp_intent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/idp"
+	"github.com/zitadel/zitadel/internal/idp/providers/azuread"
 	"github.com/zitadel/zitadel/internal/idp/providers/jwt"
 	"github.com/zitadel/zitadel/internal/idp/providers/oauth"
 	openid "github.com/zitadel/zitadel/internal/idp/providers/oidc"
@@ -164,6 +165,8 @@ func tokensForSucceededIDPIntent(session idp.Session, encryptionAlg crypto.Encry
 	case *openid.Session:
 		tokens = s.Tokens
 	case *jwt.Session:
+		tokens = s.Tokens
+	case *azuread.Session:
 		tokens = s.Tokens
 	default:
 		return nil, "", nil

--- a/internal/command/idp_intent_test.go
+++ b/internal/command/idp_intent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zitadel/zitadel/internal/id"
 	"github.com/zitadel/zitadel/internal/id/mock"
 	"github.com/zitadel/zitadel/internal/idp"
+	"github.com/zitadel/zitadel/internal/idp/providers/azuread"
 	"github.com/zitadel/zitadel/internal/idp/providers/jwt"
 	"github.com/zitadel/zitadel/internal/idp/providers/ldap"
 	"github.com/zitadel/zitadel/internal/idp/providers/oauth"
@@ -743,6 +744,31 @@ func Test_tokensForSucceededIDPIntent(t *testing.T) {
 				accessToken: nil,
 				idToken:     "idToken",
 				err:         nil,
+			},
+		},
+		{
+			"azure tokens",
+			args{
+				&azuread.Session{
+					Session: &oauth.Session{
+						Tokens: &oidc.Tokens[*oidc.IDTokenClaims]{
+							Token: &oauth2.Token{
+								AccessToken: "accessToken",
+							},
+						},
+					},
+				},
+				crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+			},
+			res{
+				accessToken: &crypto.CryptoValue{
+					CryptoType: crypto.TypeEncryption,
+					Algorithm:  "enc",
+					KeyID:      "id",
+					Crypted:    []byte("accessToken"),
+				},
+				idToken: "",
+				err:     nil,
 			},
 		},
 	}


### PR DESCRIPTION
Issue reported by a customer, that after migrating to 2.31.5 the access_token was not provided in the postAuthentication action.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
