### PR TITLE
docs: fix naming of external port and domain envVars

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -41,10 +41,10 @@ Telemetry:
 Port: 8080 # ZITADEL_PORT
 # Port ZITADEL is exposed on, it can differ from port e.g. if you proxy the traffic
 # !!! Changing this after the initial setup breaks your system !!!
-ExternalPort: 8080 # ZITADEL_EXTERNAL_PORT
+ExternalPort: 8080 # ZITADEL_EXTERNALPORT
 # Domain/hostname ZITADEL is exposed externally
 # !!! Changing this after the initial setup breaks your system !!!
-ExternalDomain: localhost # ZITADEL_EXTERNAL_DOMAIN
+ExternalDomain: localhost # ZITADEL_EXTERNALDOMAIN
 # specifies if ZITADEL is exposed externally through TLS
 # this must be set to true even if TLS is not enabled on ZITADEL itself
 # but TLS traffic is terminated on a reverse proxy


### PR DESCRIPTION
I was trying to run Zitadel on fly.io, but had some issues getting the backend to use the right domain. It turns out, the docs had some incorrect naming of the `ZITADEL_EXTERNALPORT` and `ZITADEL_EXTERNALDOMAIN` environment variables.

This pull request fixes the naming of these variables.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
