### PR TITLE
feat(api/v2): implement TOTP session check

### DIFF
--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -100,7 +100,7 @@ func verifyFactors(t testing.TB, factors *session.Factors, window time.Duration,
 			assert.WithinRange(t, pf.GetVerifiedAt().AsTime(), time.Now().Add(-window), time.Now().Add(window))
 			assert.True(t, pf.GetUserVerified())
 		case wantTOTPFactor:
-			pf := factors.GetWebAuthN()
+			pf := factors.GetTotp()
 			assert.NotNil(t, pf)
 			assert.WithinRange(t, pf.GetVerifiedAt().AsTime(), time.Now().Add(-window), time.Now().Add(window))
 		case wantIntentFactor:

--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/muhlemmer/gu"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -45,6 +46,7 @@ func TestMain(m *testing.M) {
 }
 
 func verifyCurrentSession(t testing.TB, id, token string, sequence uint64, window time.Duration, metadata map[string][]byte, factors ...wantFactor) *session.Session {
+	t.Helper()
 	require.NotEmpty(t, id)
 	require.NotEmpty(t, token)
 
@@ -71,6 +73,7 @@ const (
 	wantPasswordFactor
 	wantWebAuthNFactor
 	wantWebAuthNFactorUserVerified
+	wantTOTPFactor
 	wantIntentFactor
 )
 
@@ -90,12 +93,16 @@ func verifyFactors(t testing.TB, factors *session.Factors, window time.Duration,
 			pf := factors.GetWebAuthN()
 			assert.NotNil(t, pf)
 			assert.WithinRange(t, pf.GetVerifiedAt().AsTime(), time.Now().Add(-window), time.Now().Add(window))
-			assert.False(t, pf.UserVerified)
+			assert.False(t, pf.GetUserVerified())
 		case wantWebAuthNFactorUserVerified:
 			pf := factors.GetWebAuthN()
 			assert.NotNil(t, pf)
 			assert.WithinRange(t, pf.GetVerifiedAt().AsTime(), time.Now().Add(-window), time.Now().Add(window))
-			assert.True(t, pf.UserVerified)
+			assert.True(t, pf.GetUserVerified())
+		case wantTOTPFactor:
+			pf := factors.GetWebAuthN()
+			assert.NotNil(t, pf)
+			assert.WithinRange(t, pf.GetVerifiedAt().AsTime(), time.Now().Add(-window), time.Now().Add(window))
 		case wantIntentFactor:
 			pf := factors.GetIntent()
 			assert.NotNil(t, pf)
@@ -338,6 +345,23 @@ func TestServer_CreateSession_startedIntentFalseToken(t *testing.T) {
 	require.Error(t, err)
 }
 
+func registerTOTP(ctx context.Context, t *testing.T, userID string) (secret string) {
+	resp, err := Tester.Client.UserV2.RegisterTOTP(ctx, &user.RegisterTOTPRequest{
+		UserId: userID,
+	})
+	require.NoError(t, err)
+	secret = resp.GetSecret()
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+
+	_, err = Tester.Client.UserV2.VerifyTOTPRegistration(ctx, &user.VerifyTOTPRegistrationRequest{
+		UserId: userID,
+		Code:   code,
+	})
+	require.NoError(t, err)
+	return secret
+}
+
 func TestServer_SetSession_flow(t *testing.T) {
 	// create new, empty session
 	createResp, err := Client.CreateSession(CTX, &session.CreateSessionRequest{})
@@ -346,7 +370,6 @@ func TestServer_SetSession_flow(t *testing.T) {
 	verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, createResp.GetDetails().GetSequence(), time.Minute, nil)
 
 	t.Run("check user", func(t *testing.T) {
-		wantFactors := []wantFactor{wantUserFactor}
 		resp, err := Client.SetSession(CTX, &session.SetSessionRequest{
 			SessionId:    createResp.GetSessionId(),
 			SessionToken: sessionToken,
@@ -360,7 +383,7 @@ func TestServer_SetSession_flow(t *testing.T) {
 		})
 		require.NoError(t, err)
 		sessionToken = resp.GetSessionToken()
-		verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantFactors...)
+		verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantUserFactor)
 	})
 
 	t.Run("check webauthn, user verified (passkey)", func(t *testing.T) {
@@ -378,7 +401,6 @@ func TestServer_SetSession_flow(t *testing.T) {
 		verifyCurrentSession(t, createResp.GetSessionId(), resp.GetSessionToken(), resp.GetDetails().GetSequence(), time.Minute, nil)
 		sessionToken = resp.GetSessionToken()
 
-		wantFactors := []wantFactor{wantUserFactor, wantWebAuthNFactorUserVerified}
 		assertionData, err := Tester.WebAuthN.CreateAssertionResponse(resp.GetChallenges().GetWebAuthN().GetPublicKeyCredentialRequestOptions(), true)
 		require.NoError(t, err)
 
@@ -393,14 +415,14 @@ func TestServer_SetSession_flow(t *testing.T) {
 		})
 		require.NoError(t, err)
 		sessionToken = resp.GetSessionToken()
-		verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantFactors...)
+		verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantUserFactor, wantWebAuthNFactorUserVerified)
 	})
 
+	userAuthCtx := Tester.WithAuthorizationToken(CTX, sessionToken)
+	Tester.RegisterUserU2F(userAuthCtx, User.GetUserId())
+	totpSecret := registerTOTP(userAuthCtx, t, User.GetUserId())
+
 	t.Run("check webauthn, user not verified (U2F)", func(t *testing.T) {
-		Tester.RegisterUserU2F(
-			Tester.WithAuthorizationToken(context.Background(), sessionToken),
-			User.GetUserId(),
-		)
 
 		for _, userVerificationRequirement := range []session.UserVerificationRequirement{
 			session.UserVerificationRequirement_USER_VERIFICATION_REQUIREMENT_PREFERRED,
@@ -421,7 +443,6 @@ func TestServer_SetSession_flow(t *testing.T) {
 				verifyCurrentSession(t, createResp.GetSessionId(), resp.GetSessionToken(), resp.GetDetails().GetSequence(), time.Minute, nil)
 				sessionToken = resp.GetSessionToken()
 
-				wantFactors := []wantFactor{wantUserFactor, wantWebAuthNFactor}
 				assertionData, err := Tester.WebAuthN.CreateAssertionResponse(resp.GetChallenges().GetWebAuthN().GetPublicKeyCredentialRequestOptions(), false)
 				require.NoError(t, err)
 
@@ -436,9 +457,26 @@ func TestServer_SetSession_flow(t *testing.T) {
 				})
 				require.NoError(t, err)
 				sessionToken = resp.GetSessionToken()
-				verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantFactors...)
+				verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantUserFactor, wantWebAuthNFactor)
 			})
 		}
+	})
+
+	t.Run("check TOTP", func(t *testing.T) {
+		code, err := totp.GenerateCode(totpSecret, time.Now())
+		require.NoError(t, err)
+		resp, err := Client.SetSession(CTX, &session.SetSessionRequest{
+			SessionId:    createResp.GetSessionId(),
+			SessionToken: sessionToken,
+			Checks: &session.Checks{
+				Totp: &session.CheckTOTP{
+					Totp: code,
+				},
+			},
+		})
+		require.NoError(t, err)
+		sessionToken = resp.GetSessionToken()
+		verifyCurrentSession(t, createResp.GetSessionId(), sessionToken, resp.GetDetails().GetSequence(), time.Minute, nil, wantUserFactor, wantWebAuthNFactor, wantTOTPFactor)
 	})
 }
 

--- a/internal/api/grpc/session/v2/session_test.go
+++ b/internal/api/grpc/session/v2/session_test.go
@@ -91,6 +91,26 @@ func Test_sessionsToPb(t *testing.T) {
 			},
 			Metadata: map[string][]byte{"hello": []byte("world")},
 		},
+		{ // totp factor
+			ID:            "999",
+			CreationDate:  now,
+			ChangeDate:    now,
+			Sequence:      123,
+			State:         domain.SessionStateActive,
+			ResourceOwner: "me",
+			Creator:       "he",
+			UserFactor: query.SessionUserFactor{
+				UserID:        "345",
+				UserCheckedAt: past,
+				LoginName:     "donald",
+				DisplayName:   "donald duck",
+				ResourceOwner: "org1",
+			},
+			TOTPFactor: query.SessionTOTPFactor{
+				TOTPCheckedAt: past,
+			},
+			Metadata: map[string][]byte{"hello": []byte("world")},
+		},
 	}
 
 	want := []*session.Session{
@@ -153,6 +173,25 @@ func Test_sessionsToPb(t *testing.T) {
 				WebAuthN: &session.WebAuthNFactor{
 					VerifiedAt:   timestamppb.New(past),
 					UserVerified: true,
+				},
+			},
+			Metadata: map[string][]byte{"hello": []byte("world")},
+		},
+		{ // totp factor
+			Id:           "999",
+			CreationDate: timestamppb.New(now),
+			ChangeDate:   timestamppb.New(now),
+			Sequence:     123,
+			Factors: &session.Factors{
+				User: &session.UserFactor{
+					VerifiedAt:     timestamppb.New(past),
+					Id:             "345",
+					LoginName:      "donald",
+					DisplayName:    "donald duck",
+					OrganisationId: "org1",
+				},
+				Totp: &session.TOTPFactor{
+					VerifiedAt: timestamppb.New(past),
 				},
 			},
 			Metadata: map[string][]byte{"hello": []byte("world")},

--- a/internal/command/session_test.go
+++ b/internal/command/session_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
@@ -691,6 +692,138 @@ func TestCommands_updateSession(t *testing.T) {
 			got, err := c.updateSession(tt.args.ctx, tt.args.checks, tt.args.metadata)
 			require.ErrorIs(t, err, tt.res.err)
 			assert.Equal(t, tt.res.want, got)
+		})
+	}
+}
+
+func TestCheckTOTP(t *testing.T) {
+	ctx := authz.NewMockContext("", "org1", "user1")
+
+	cryptoAlg := crypto.CreateMockEncryptionAlg(gomock.NewController(t))
+	key, secret, err := domain.NewTOTPKey("example.com", "user1", cryptoAlg)
+	require.NoError(t, err)
+
+	sessAgg := &session.NewAggregate("session1", "org1").Aggregate
+	userAgg := &user.NewAggregate("user1", "org1").Aggregate
+
+	code, err := totp.GenerateCode(key.Secret(), testNow)
+	require.NoError(t, err)
+
+	type fields struct {
+		sessionWriteModel *SessionWriteModel
+		eventstore        func(*testing.T) *eventstore.Eventstore
+	}
+
+	tests := []struct {
+		name              string
+		code              string
+		fields            fields
+		wantEventCommands []eventstore.Command
+		wantErr           error
+	}{
+		{
+			name: "missing userID",
+			code: code,
+			fields: fields{
+				sessionWriteModel: &SessionWriteModel{
+					aggregate: sessAgg,
+				},
+				eventstore: expectEventstore(),
+			},
+			wantErr: caos_errs.ThrowPreconditionFailed(nil, "COMMAND-Neil7", "Errors.User.UserIDMissing"),
+		},
+		{
+			name: "filter error",
+			code: code,
+			fields: fields{
+				sessionWriteModel: &SessionWriteModel{
+					UserID:        "user1",
+					UserCheckedAt: testNow,
+					aggregate:     sessAgg,
+				},
+				eventstore: expectEventstore(
+					expectFilterError(io.ErrClosedPipe),
+				),
+			},
+			wantErr: io.ErrClosedPipe,
+		},
+		{
+			name: "otp not ready error",
+			code: code,
+			fields: fields{
+				sessionWriteModel: &SessionWriteModel{
+					UserID:        "user1",
+					UserCheckedAt: testNow,
+					aggregate:     sessAgg,
+				},
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanOTPAddedEvent(ctx, userAgg, secret),
+						),
+					),
+				),
+			},
+			wantErr: caos_errs.ThrowPreconditionFailed(nil, "COMMAND-eej1U", "Errors.User.MFA.OTP.NotReady"),
+		},
+		{
+			name: "otp verify error",
+			code: "foobar",
+			fields: fields{
+				sessionWriteModel: &SessionWriteModel{
+					UserID:        "user1",
+					UserCheckedAt: testNow,
+					aggregate:     sessAgg,
+				},
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanOTPAddedEvent(ctx, userAgg, secret),
+						),
+						eventFromEventPusher(
+							user.NewHumanOTPVerifiedEvent(ctx, userAgg, "agent1"),
+						),
+					),
+				),
+			},
+			wantErr: caos_errs.ThrowInvalidArgument(nil, "EVENT-8isk2", "Errors.User.MFA.OTP.InvalidCode"),
+		},
+		{
+			name: "ok",
+			code: code,
+			fields: fields{
+				sessionWriteModel: &SessionWriteModel{
+					UserID:        "user1",
+					UserCheckedAt: testNow,
+					aggregate:     sessAgg,
+				},
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanOTPAddedEvent(ctx, userAgg, secret),
+						),
+						eventFromEventPusher(
+							user.NewHumanOTPVerifiedEvent(ctx, userAgg, "agent1"),
+						),
+					),
+				),
+			},
+			wantEventCommands: []eventstore.Command{
+				session.NewTOTPCheckedEvent(ctx, sessAgg, testNow),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &SessionCommands{
+				sessionWriteModel: tt.fields.sessionWriteModel,
+				eventstore:        tt.fields.eventstore(t),
+				totpAlg:           cryptoAlg,
+				now:               func() time.Time { return testNow },
+			}
+			err := CheckTOTP(tt.code)(ctx, cmd)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantEventCommands, cmd.eventCommands)
 		})
 	}
 }

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -239,7 +239,12 @@ func (s *Tester) WithInstanceAuthorization(ctx context.Context, u UserType, inst
 }
 
 func (s *Tester) WithAuthorizationToken(ctx context.Context, token string) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", token))
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = make(metadata.MD)
+	}
+	md.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	return metadata.NewOutgoingContext(ctx, md)
 }
 
 func (s *Tester) ensureSystemUser() {

--- a/internal/query/projection/session_test.go
+++ b/internal/query/projection/session_test.go
@@ -210,7 +210,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions3 SET (change_date, sequence, totp_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions4 SET (change_date, sequence, totp_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},

--- a/internal/query/projection/session_test.go
+++ b/internal/query/projection/session_test.go
@@ -192,6 +192,38 @@ func TestSessionProjection_reduces(t *testing.T) {
 			},
 		},
 		{
+			name: "instance reduceOTPChecked",
+			args: args{
+				event: getEvent(testEvent(
+					session.AddedType,
+					session.AggregateType,
+					[]byte(`{
+						"checkedAt": "2023-05-04T00:00:00Z"
+					}`),
+				), eventstore.GenericEventMapper[session.TOTPCheckedEvent]),
+			},
+			reduce: (&sessionProjection{}).reduceTOTPChecked,
+			want: wantReduce{
+				aggregateType:    eventstore.AggregateType("session"),
+				sequence:         15,
+				previousSequence: 10,
+				executer: &testExecuter{
+					executions: []execution{
+						{
+							expectedStmt: "UPDATE projections.sessions3 SET (change_date, sequence, totp_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedArgs: []interface{}{
+								anyArg{},
+								anyArg{},
+								time.Date(2023, time.May, 4, 0, 0, 0, 0, time.UTC),
+								"agg-id",
+								"instance-id",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "instance reduceTokenSet",
 			args: args{
 				event: getEvent(testEvent(

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -34,6 +34,7 @@ type Session struct {
 	PasswordFactor SessionPasswordFactor
 	IntentFactor   SessionIntentFactor
 	WebAuthNFactor SessionWebAuthNFactor
+	TOTPFactor     SessionTOTPFactor
 	Metadata       map[string][]byte
 }
 
@@ -56,6 +57,10 @@ type SessionIntentFactor struct {
 type SessionWebAuthNFactor struct {
 	WebAuthNCheckedAt time.Time
 	UserVerified      bool
+}
+
+type SessionTOTPFactor struct {
+	TOTPCheckedAt time.Time
 }
 
 type SessionsSearchQueries struct {
@@ -130,6 +135,10 @@ var (
 	}
 	SessionColumnWebAuthNUserVerified = Column{
 		name:  projection.SessionColumnWebAuthNUserVerified,
+		table: sessionsTable,
+	}
+	SessionColumnTOTPCheckedAt = Column{
+		name:  projection.SessionColumnTOTPCheckedAt,
 		table: sessionsTable,
 	}
 	SessionColumnMetadata = Column{
@@ -230,6 +239,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 			SessionColumnIntentCheckedAt.identifier(),
 			SessionColumnWebAuthNCheckedAt.identifier(),
 			SessionColumnWebAuthNUserVerified.identifier(),
+			SessionColumnTOTPCheckedAt.identifier(),
 			SessionColumnMetadata.identifier(),
 			SessionColumnToken.identifier(),
 		).From(sessionsTable.identifier()).
@@ -249,6 +259,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 				intentCheckedAt     sql.NullTime
 				webAuthNCheckedAt   sql.NullTime
 				webAuthNUserPresent sql.NullBool
+				totpCheckedAt       sql.NullTime
 				metadata            database.Map[[]byte]
 				token               sql.NullString
 			)
@@ -270,6 +281,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 				&intentCheckedAt,
 				&webAuthNCheckedAt,
 				&webAuthNUserPresent,
+				&totpCheckedAt,
 				&metadata,
 				&token,
 			)
@@ -290,6 +302,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 			session.IntentFactor.IntentCheckedAt = intentCheckedAt.Time
 			session.WebAuthNFactor.WebAuthNCheckedAt = webAuthNCheckedAt.Time
 			session.WebAuthNFactor.UserVerified = webAuthNUserPresent.Bool
+			session.TOTPFactor.TOTPCheckedAt = totpCheckedAt.Time
 			session.Metadata = metadata
 
 			return session, token.String, nil
@@ -314,6 +327,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 			SessionColumnIntentCheckedAt.identifier(),
 			SessionColumnWebAuthNCheckedAt.identifier(),
 			SessionColumnWebAuthNUserVerified.identifier(),
+			SessionColumnTOTPCheckedAt.identifier(),
 			SessionColumnMetadata.identifier(),
 			countColumn.identifier(),
 		).From(sessionsTable.identifier()).
@@ -336,6 +350,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 					intentCheckedAt     sql.NullTime
 					webAuthNCheckedAt   sql.NullTime
 					webAuthNUserPresent sql.NullBool
+					totpCheckedAt       sql.NullTime
 					metadata            database.Map[[]byte]
 				)
 
@@ -356,6 +371,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 					&intentCheckedAt,
 					&webAuthNCheckedAt,
 					&webAuthNUserPresent,
+					&totpCheckedAt,
 					&metadata,
 					&sessions.Count,
 				)
@@ -372,6 +388,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 				session.IntentFactor.IntentCheckedAt = intentCheckedAt.Time
 				session.WebAuthNFactor.WebAuthNCheckedAt = webAuthNCheckedAt.Time
 				session.WebAuthNFactor.UserVerified = webAuthNUserPresent.Bool
+				session.TOTPFactor.TOTPCheckedAt = totpCheckedAt.Time
 				session.Metadata = metadata
 
 				sessions.Sessions = append(sessions.Sessions, session)

--- a/internal/query/sessions_test.go
+++ b/internal/query/sessions_test.go
@@ -33,6 +33,7 @@ var (
 		` projections.sessions4.intent_checked_at,` +
 		` projections.sessions4.webauthn_checked_at,` +
 		` projections.sessions4.webauthn_user_verified,` +
+		` projections.sessions4.totp_checked_at,` +
 		` projections.sessions4.metadata,` +
 		` projections.sessions4.token_id` +
 		` FROM projections.sessions4` +
@@ -56,6 +57,7 @@ var (
 		` projections.sessions4.intent_checked_at,` +
 		` projections.sessions4.webauthn_checked_at,` +
 		` projections.sessions4.webauthn_user_verified,` +
+		` projections.sessions4.totp_checked_at,` +
 		` projections.sessions4.metadata,` +
 		` COUNT(*) OVER ()` +
 		` FROM projections.sessions4` +
@@ -81,6 +83,7 @@ var (
 		"intent_checked_at",
 		"webauthn_checked_at",
 		"webauthn_user_verified",
+		"totp_checked_at",
 		"metadata",
 		"token",
 	}
@@ -102,6 +105,7 @@ var (
 		"intent_checked_at",
 		"webauthn_checked_at",
 		"webauthn_user_verified",
+		"totp_checked_at",
 		"metadata",
 		"count",
 	}
@@ -155,6 +159,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							true,
+							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
 						},
 					},
@@ -190,6 +195,9 @@ func Test_SessionsPrepare(t *testing.T) {
 							WebAuthNCheckedAt: testNow,
 							UserVerified:      true,
 						},
+						TOTPFactor: SessionTOTPFactor{
+							TOTPCheckedAt: testNow,
+						},
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
 						},
@@ -222,6 +230,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							true,
+							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
 						},
 						{
@@ -241,6 +250,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							false,
+							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
 						},
 					},
@@ -276,6 +286,9 @@ func Test_SessionsPrepare(t *testing.T) {
 							WebAuthNCheckedAt: testNow,
 							UserVerified:      true,
 						},
+						TOTPFactor: SessionTOTPFactor{
+							TOTPCheckedAt: testNow,
+						},
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
 						},
@@ -304,6 +317,9 @@ func Test_SessionsPrepare(t *testing.T) {
 						WebAuthNFactor: SessionWebAuthNFactor{
 							WebAuthNCheckedAt: testNow,
 							UserVerified:      false,
+						},
+						TOTPFactor: SessionTOTPFactor{
+							TOTPCheckedAt: testNow,
 						},
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
@@ -390,6 +406,7 @@ func Test_SessionPrepare(t *testing.T) {
 						testNow,
 						testNow,
 						true,
+						testNow,
 						[]byte(`{"key": "dmFsdWU="}`),
 						"tokenID",
 					},
@@ -419,6 +436,9 @@ func Test_SessionPrepare(t *testing.T) {
 				WebAuthNFactor: SessionWebAuthNFactor{
 					WebAuthNCheckedAt: testNow,
 					UserVerified:      true,
+				},
+				TOTPFactor: SessionTOTPFactor{
+					TOTPCheckedAt: testNow,
 				},
 				Metadata: map[string][]byte{
 					"key": []byte("value"),

--- a/internal/repository/session/eventstore.go
+++ b/internal/repository/session/eventstore.go
@@ -9,6 +9,7 @@ func RegisterEventMappers(es *eventstore.Eventstore) {
 		RegisterFilterEventMapper(AggregateType, IntentCheckedType, IntentCheckedEventMapper).
 		RegisterFilterEventMapper(AggregateType, WebAuthNChallengedType, eventstore.GenericEventMapper[WebAuthNChallengedEvent]).
 		RegisterFilterEventMapper(AggregateType, WebAuthNCheckedType, eventstore.GenericEventMapper[WebAuthNCheckedEvent]).
+		RegisterFilterEventMapper(AggregateType, TOTPCheckedType, eventstore.GenericEventMapper[TOTPCheckedEvent]).
 		RegisterFilterEventMapper(AggregateType, TokenSetType, TokenSetEventMapper).
 		RegisterFilterEventMapper(AggregateType, MetadataSetType, MetadataSetEventMapper).
 		RegisterFilterEventMapper(AggregateType, TerminateType, TerminateEventMapper)

--- a/internal/repository/session/session.go
+++ b/internal/repository/session/session.go
@@ -292,7 +292,7 @@ func NewTOTPCheckedEvent(
 		BaseEvent: *eventstore.NewBaseEventForPush(
 			ctx,
 			aggregate,
-			PasswordCheckedType,
+			TOTPCheckedType,
 		),
 		CheckedAt: checkedAt,
 	}

--- a/internal/repository/session/session.go
+++ b/internal/repository/session/session.go
@@ -19,6 +19,7 @@ const (
 	IntentCheckedType      = sessionEventPrefix + "intent.checked"
 	WebAuthNChallengedType = sessionEventPrefix + "webAuthN.challenged"
 	WebAuthNCheckedType    = sessionEventPrefix + "webAuthN.checked"
+	TOTPCheckedType        = sessionEventPrefix + "totp.checked"
 	TokenSetType           = sessionEventPrefix + "token.set"
 	MetadataSetType        = sessionEventPrefix + "metadata.set"
 	TerminateType          = sessionEventPrefix + "terminated"
@@ -261,6 +262,39 @@ func NewWebAuthNCheckedEvent(
 		),
 		CheckedAt:    checkedAt,
 		UserVerified: userVerified,
+	}
+}
+
+type TOTPCheckedEvent struct {
+	eventstore.BaseEvent `json:"-"`
+
+	CheckedAt time.Time `json:"checkedAt"`
+}
+
+func (e *TOTPCheckedEvent) Data() interface{} {
+	return e
+}
+
+func (e *TOTPCheckedEvent) UniqueConstraints() []*eventstore.EventUniqueConstraint {
+	return nil
+}
+
+func (e *TOTPCheckedEvent) SetBaseEvent(base *eventstore.BaseEvent) {
+	e.BaseEvent = *base
+}
+
+func NewTOTPCheckedEvent(
+	ctx context.Context,
+	aggregate *eventstore.Aggregate,
+	checkedAt time.Time,
+) *TOTPCheckedEvent {
+	return &TOTPCheckedEvent{
+		BaseEvent: *eventstore.NewBaseEventForPush(
+			ctx,
+			aggregate,
+			PasswordCheckedType,
+		),
+		CheckedAt: checkedAt,
 	}
 }
 

--- a/proto/zitadel/session/v2alpha/session.proto
+++ b/proto/zitadel/session/v2alpha/session.proto
@@ -46,6 +46,7 @@ message Factors {
   PasswordFactor password = 2;
   WebAuthNFactor web_auth_n = 3;
   IntentFactor intent = 4;
+  TOTPFactor totp = 5;
 }
 
 message UserFactor {
@@ -99,6 +100,14 @@ message WebAuthNFactor {
     }
   ];
   bool user_verified = 2;
+}
+
+message TOTPFactor {
+  google.protobuf.Timestamp verified_at = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "\"time when the Time-based One-Time Password was last checked\"";
+    }
+  ];
 }
 
 message SearchQuery {

--- a/proto/zitadel/session/v2alpha/session_service.proto
+++ b/proto/zitadel/session/v2alpha/session_service.proto
@@ -346,6 +346,11 @@ message Checks {
       description: "\"Checks the intent. Requires that the userlink is already checked and a successful intent.\"";
     }
   ];
+  optional CheckTOTP totp = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "\"Checks the Time-based One-Time Password and updates the session on success. Requires that the user is already checked, either in the previous or the same request.\"";
+    }
+  ];
 }
 
 message CheckUser {
@@ -409,6 +414,17 @@ message CheckIntent {
       min_length: 1;
       max_length: 200;
       example: "\"SJKL3ioIDpo342ioqw98fjp3sdf32wahb=\"";
+    }
+  ];
+}
+
+message CheckTOTP {
+  string totp = 1 [
+    (validate.rules).string = {min_len: 6, max_len: 6},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      min_length: 6;
+      max_length: 6;
+      example: "\"323764\"";
     }
   ];
 }


### PR DESCRIPTION
This change implements Time-based One-Time Password (TOTP) on the v2alpha session API.

Closes #5477 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
