### PR TITLE
docs: fix external domain and external key env var names

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -41,10 +41,10 @@ Telemetry:
 Port: 8080 # ZITADEL_PORT
 # Port ZITADEL is exposed on, it can differ from port e.g. if you proxy the traffic
 # !!! Changing this after the initial setup breaks your system !!!
-ExternalPort: 8080 # ZITADEL_EXTERNAL_PORT
+ExternalPort: 8080 # ZITADEL_EXTERNALPORT
 # Domain/hostname ZITADEL is exposed externally
 # !!! Changing this after the initial setup breaks your system !!!
-ExternalDomain: localhost # ZITADEL_EXTERNAL_DOMAIN
+ExternalDomain: localhost # ZITADEL_EXTERNALDOMAIN
 # specifies if ZITADEL is exposed externally through TLS
 # this must be set to true even if TLS is not enabled on ZITADEL itself
 # but TLS traffic is terminated on a reverse proxy


### PR DESCRIPTION
The ExternalDomain and ExternalPort config environmental variable settings are incorrectly listed - both have an underscore after `EXTERNAL`, which is not needed
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
