### PR TITLE
fix: Cherry pick session

### DIFF
--- a/internal/api/grpc/management/user_integration_test.go
+++ b/internal/api/grpc/management/user_integration_test.go
@@ -5,11 +5,20 @@ package management_test
 import (
 	"context"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/zitadel/zitadel/internal/integration"
 	"github.com/zitadel/zitadel/pkg/grpc/management"
+	"github.com/zitadel/zitadel/pkg/grpc/user"
 )
 
 var (
@@ -38,8 +47,6 @@ func TestMain(m *testing.M) {
 // This test Imports a user and directly tries to Get it, 100 times in a loop.
 // When the bug still existed, some (between 1 to 7 out of 100)
 // Get calls would return a Not Found error.
-
-/* Test disabled because it breaks the pipeline.
 func TestImport_and_Get(t *testing.T) {
 	const N = 100
 	var misses int
@@ -84,4 +91,3 @@ func TestImport_and_Get(t *testing.T) {
 	}
 	assert.Zerof(t, misses, "Not Found errors %d out of %d", misses, N)
 }
-*/

--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -147,7 +147,7 @@ func (repo *TokenVerifierRepo) verifySessionToken(ctx context.Context, sessionID
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
-	session, err := repo.Query.SessionByID(ctx, false, sessionID, token)
+	session, err := repo.Query.SessionByID(ctx, true, sessionID, token)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/internal/eventstore/handler/handler_projection.go
+++ b/internal/eventstore/handler/handler_projection.go
@@ -140,8 +140,11 @@ func (h *ProjectionHandler) Trigger(ctx context.Context, instances ...string) co
 // by calling FetchEvents and Process until the amount of events is smaller than the BulkLimit.
 // If a bulk action was executed, the call timestamp in context will be reset for subsequent queries.
 // The returned context is never nil. It is either the original context or an updated context.
-func (h *ProjectionHandler) TriggerErr(ctx context.Context, instances ...string) (context.Context, error) {
+func (h *ProjectionHandler) TriggerErr(ctx context.Context, instances ...string) (outCtx context.Context, err error) {
 	instances = triggerInstances(ctx, instances)
+	defer func() {
+		outCtx = call.ResetTimestamp(ctx)
+	}()
 	for {
 		events, hasLimitExceeded, err := h.FetchEvents(ctx, instances...)
 		if err != nil {
@@ -151,7 +154,6 @@ func (h *ProjectionHandler) TriggerErr(ctx context.Context, instances ...string)
 			return ctx, nil
 		}
 		_, err = h.Process(ctx, events...)
-		ctx = call.ResetTimestamp(ctx)
 		if err != nil {
 			return ctx, err
 		}


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
