### PR TITLE
fix: handle metadata from post authentication on auto creation

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -410,7 +410,7 @@ func (l *Login) externalUserNotExisting(w http.ResponseWriter, r *http.Request, 
 		l.renderExternalNotFoundOption(w, r, authReq, orgIAMPolicy, human, idpLink, err)
 		return
 	}
-	if changed {
+	if changed || len(externalUser.Metadatas) > 0 {
 		if err := l.authRepo.SetLinkingUser(r.Context(), authReq, externalUser); err != nil {
 			l.renderError(w, r, authReq, err)
 			return


### PR DESCRIPTION
bug reported in [Discord](https://discord.com/channels/927474939156643850/1135929532394766397) where metadata set in action would not be applied when the user is created at the same time

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
