### PR TITLE
docs: Update basic-auth.mdx - add syntax highlighting to code blocks

### DIFF
--- a/docs/docs/guides/integrate/token-introspection/basic-auth.mdx
+++ b/docs/docs/guides/integrate/token-introspection/basic-auth.mdx
@@ -75,7 +75,7 @@ Authorization: "Basic " + base64( formUrlEncode(client_id) + ":" + formUrlEncode
 
 The request from the API to the introspection endpoint should be in the following format:
 
-```
+```bash
 curl --request POST \
  --url {your_domain}/oauth/v2/introspect \
  --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -85,7 +85,7 @@ curl --request POST \
 
 Here's an example of how this is done in Python code:
 
-```
+```python
 def introspect_token(self, token_string):
     url = ZITADEL_INTROSPECTION_URL
     data = {'token': token_string, 'token_type_hint': 'access_token', 'scope': 'openid'}


### PR DESCRIPTION
### Definition of Ready

This just adds syntax highlighting to the code blocks on base-auth.mdx, which is this [page](https://zitadel.com/docs/guides/integrate/token-introspection/basic-auth) in the docs.

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
