### PR TITLE
docs: add technical advisory on `allow register`

### DIFF
--- a/docs/docs/support/advisory/a10000.md
+++ b/docs/docs/support/advisory/a10000.md
@@ -13,8 +13,8 @@ To address this, we are going to change this behavior so that users will be auto
 
 ## Statement
 
-This behaviour change is tracked in the following issue: [Reuse current session if no prompt is selected ](https://github.com/zitadel/zitadel/issues/4841)
-As soon as the release version is published, we will include the version here.
+This behaviour change was tracked in the following issue: [Reuse current session if no prompt is selected ](https://github.com/zitadel/zitadel/issues/4841)
+and release in Version [2.32.0](https://github.com/zitadel/zitadel/releases/tag/v2.32.0
 
 ## Mitigation
 

--- a/docs/docs/support/advisory/a10001.md
+++ b/docs/docs/support/advisory/a10001.md
@@ -1,0 +1,26 @@
+---
+title: Technical Advisory 10001
+---
+
+## Description
+
+Currently, disabling the `Allow Register` setting in the Login Policy, will disable any registration - local and through External Identity Providers (IDP). 
+This might be a good solution, if you manage all users yourself and do not want them to create any new account.
+If you on the other hand want users to be able to federate their accounts from another IDP and only want to disable local registration, there's currently no option to do so.
+
+Further ZITADEL provided the possibility to disable registration on each IDP with the introduction of IDP Templates.
+
+To address this, we are going to change the behavior of the setting mentioned above, so that if disable, it will only prevent local registration. Registration of a federated user will still be possible - if not disabled by the corresponding IDP Template.
+
+## Statement
+
+This behaviour change is tracked in the following PR: [Restrict AllowRegistration check to local registration](https://github.com/zitadel/zitadel/pull/5939).
+As soon as the release version is published, we will include the version here.
+
+## Mitigation
+
+If you want to prevent user creation / registration through an IDP, be sure to disable the `isCreationAllowed` option on the desired IDP Templates.
+
+## Impact
+
+Once this update has been released and deployed, the `Allow Register` setting in the Login Policy will only affect local registrations and users might be able to create a ZITADEL account through an IDP, depending on your IDP provider options.

--- a/docs/docs/support/technical_advisory.mdx
+++ b/docs/docs/support/technical_advisory.mdx
@@ -26,6 +26,14 @@ We understand that these advisories may include breaking changes, and we aim to 
     <td>2.32.0</td>
     <td>Calendar week 32</td>
   </tr>
+  <tr>
+    <td><a href="./advisory/a10001">A-10001</a></td>
+    <td>Login Policy - Allow Register</td>
+    <td>Breaking Behaviour Change</td>
+    <td>When disabling the option, users are currently not able to register locally and also not through an external IDP. With the upcoming change, the setting will only prevent local registration. Restriction to Identity Providers can be managed through the corresponding IDP Template. No action is required on your side if this is the intended behaviour or if you already disabled registration on your IDP.</td>
+    <td>2.34.0</td>
+    <td>Calendar week 35</td>
+  </tr>
 </table>
 
 ## Subscribe to our Mailing List


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
