### PR TITLE
chore(workflow): exclude console dist folder from cache

### DIFF
--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -32,7 +32,7 @@ jobs:
           timeout-minutes: 1
           id: cache
           with:
-            key: console-${{ hashFiles('console', 'proto') }}
+            key: console-${{ hashFiles('console', 'proto', '!console/dist') }}
             restore-keys: |
               console-
             path: ${{ env.cache_path }}

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ See the exact licensing terms [here](./LICENSE)
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -167,4 +167,3 @@ See the exact licensing terms [here](./LICENSE)
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
-


### PR DESCRIPTION
excludes the `dist` folder when building the cache-key, so we're able to get a primary cache hit and do not need to rebuild console everytime even if there aren't any changes