### PR TITLE
fix: change force local mfa on org

### DIFF
--- a/internal/command/org_policy_login.go
+++ b/internal/command/org_policy_login.go
@@ -473,6 +473,7 @@ func prepareChangeLoginPolicy(a *org.Aggregate, policy *ChangeLoginPolicy) prepa
 				policy.AllowRegister,
 				policy.AllowExternalIDP,
 				policy.ForceMFA,
+				policy.ForceMFALocalOnly,
 				policy.HidePasswordReset,
 				policy.IgnoreUnknownUsernames,
 				policy.AllowDomainDiscovery,

--- a/internal/command/org_policy_login_model.go
+++ b/internal/command/org_policy_login_model.go
@@ -67,6 +67,7 @@ func (wm *OrgLoginPolicyWriteModel) NewChangedEvent(
 	allowRegister,
 	allowExternalIDP,
 	forceMFA,
+	forceMFALocalOnly,
 	hidePasswordReset,
 	ignoreUnknownUsernames,
 	allowDomainDiscovery,
@@ -93,6 +94,9 @@ func (wm *OrgLoginPolicyWriteModel) NewChangedEvent(
 	}
 	if wm.ForceMFA != forceMFA {
 		changes = append(changes, policy.ChangeForceMFA(forceMFA))
+	}
+	if wm.ForceMFALocalOnly != forceMFALocalOnly {
+		changes = append(changes, policy.ChangeForceMFALocalOnly(forceMFALocalOnly))
 	}
 	if wm.HidePasswordReset != hidePasswordReset {
 		changes = append(changes, policy.ChangeHidePasswordReset(hidePasswordReset))

--- a/internal/command/org_policy_login_test.go
+++ b/internal/command/org_policy_login_test.go
@@ -574,6 +574,7 @@ func TestCommandSide_ChangeLoginPolicy(t *testing.T) {
 									false,
 									false,
 									false,
+									false,
 									domain.PasswordlessTypeNotAllowed,
 									"",
 									&duration10,
@@ -2196,7 +2197,7 @@ func TestCommandSide_RemoveMultiFactorLoginPolicy(t *testing.T) {
 }
 
 func newLoginPolicyChangedEvent(ctx context.Context, orgID string,
-	usernamePassword, register, externalIDP, mfa, passwordReset, ignoreUnknownUsernames, allowDomainDiscovery, disableLoginWithEmail, disableLoginWithPhone bool,
+	usernamePassword, register, externalIDP, mfa, mfaLocalOnly, passwordReset, ignoreUnknownUsernames, allowDomainDiscovery, disableLoginWithEmail, disableLoginWithPhone bool,
 	passwordlessType domain.PasswordlessType,
 	redirectURI string,
 	passwordLifetime, externalLoginLifetime, mfaInitSkipLifetime, secondFactorLifetime, multiFactorLifetime *time.Duration) *org.LoginPolicyChangedEvent {
@@ -2205,6 +2206,7 @@ func newLoginPolicyChangedEvent(ctx context.Context, orgID string,
 		policy.ChangeAllowRegister(register),
 		policy.ChangeAllowExternalIDP(externalIDP),
 		policy.ChangeForceMFA(mfa),
+		policy.ChangeForceMFALocalOnly(mfaLocalOnly),
 		policy.ChangeHidePasswordReset(passwordReset),
 		policy.ChangeIgnoreUnknownUsernames(ignoreUnknownUsernames),
 		policy.ChangeAllowDomainDiscovery(allowDomainDiscovery),


### PR DESCRIPTION
Finishes #6234 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
