### PR TITLE
fix: rest path for StartIdentityProviderIntent

### DIFF
--- a/docs/docs/guides/integrate/login-ui/external-login.mdx
+++ b/docs/docs/guides/integrate/login-ui/external-login.mdx
@@ -26,7 +26,7 @@ In the response, you will get an authentication URL of the provider you like.
 
 ```bash
 curl --request POST \
-  --url https://$ZITADEL_DOMAIN/v2alpha/idp_intents/start \
+  --url https://$ZITADEL_DOMAIN/v2alpha/idp_intents \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer '"$TOKEN"''\
   --header 'Content-Type: application/json' \

--- a/proto/zitadel/user/v2alpha/user_service.proto
+++ b/proto/zitadel/user/v2alpha/user_service.proto
@@ -490,7 +490,7 @@ service UserService {
   // Start an IDP authentication (for external login, registration or linking)
   rpc StartIdentityProviderIntent (StartIdentityProviderIntentRequest) returns (StartIdentityProviderIntentResponse) {
     option (google.api.http) = {
-      post: "/v2alpha/idp_intents/start"
+      post: "/v2alpha/idp_intents"
       body: "*"
     };
 


### PR DESCRIPTION
Fixes #6436 by removing the `/start` from the REST path of the StartIdentityProviderIntent and therefore ensuring the correct binding again.