### PR TITLE
fix: rename (t)otp to code in session checks

### DIFF
--- a/internal/api/grpc/session/v2/session.go
+++ b/internal/api/grpc/session/v2/session.go
@@ -275,13 +275,13 @@ func (s *Server) checksToCommand(ctx context.Context, checks *session.Checks) ([
 		sessionChecks = append(sessionChecks, s.command.CheckWebAuthN(passkey.GetCredentialAssertionData()))
 	}
 	if totp := checks.GetTotp(); totp != nil {
-		sessionChecks = append(sessionChecks, command.CheckTOTP(totp.GetTotp()))
+		sessionChecks = append(sessionChecks, command.CheckTOTP(totp.GetCode()))
 	}
 	if otp := checks.GetOtpSms(); otp != nil {
-		sessionChecks = append(sessionChecks, command.CheckOTPSMS(otp.GetOtp()))
+		sessionChecks = append(sessionChecks, command.CheckOTPSMS(otp.GetCode()))
 	}
 	if otp := checks.GetOtpEmail(); otp != nil {
-		sessionChecks = append(sessionChecks, command.CheckOTPEmail(otp.GetOtp()))
+		sessionChecks = append(sessionChecks, command.CheckOTPEmail(otp.GetCode()))
 	}
 	return sessionChecks, nil
 }

--- a/proto/zitadel/session/v2alpha/session_service.proto
+++ b/proto/zitadel/session/v2alpha/session_service.proto
@@ -458,7 +458,7 @@ message CheckIDPIntent {
 }
 
 message CheckTOTP {
-  string totp = 1 [
+  string code = 1 [
     (validate.rules).string = {min_len: 6, max_len: 6},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 6;
@@ -469,7 +469,7 @@ message CheckTOTP {
 }
 
 message CheckOTP {
-  string otp = 1 [
+  string code = 1 [
     (validate.rules).string = {min_len: 1},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1;


### PR DESCRIPTION
fixes #6444 