### PR TITLE
fix(sessions/v2): resolve tOTP TODO for Auth Methods

### DIFF
--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -200,12 +200,9 @@ func authMethodsFromSession(session *query.Session) []domain.UserAuthMethodType 
 	if !session.IntentFactor.IntentCheckedAt.IsZero() {
 		types = append(types, domain.UserAuthMethodTypeIDP)
 	}
-	// TODO: add checks with https://github.com/zitadel/zitadel/issues/5477
-	/*
-		if !session.TOTPFactor.TOTPCheckedAt.IsZero() {
-			types = append(types, domain.UserAuthMethodTypeTOTP)
-		}
-	*/
+	if !session.TOTPFactor.TOTPCheckedAt.IsZero() {
+		types = append(types, domain.UserAuthMethodTypeTOTP)
+	}
 	if !session.OTPSMSFactor.OTPCheckedAt.IsZero() {
 		types = append(types, domain.UserAuthMethodTypeOTPSMS)
 	}


### PR DESCRIPTION
There was a comented TODO in authMethodsFromSession, resulting in users not getting a confirmed MFA when using password+TOTP in session v2 API.

Bug was verified on my local instance and also confirmed fixed after the change.

Fixes #6450

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
