### PR TITLE
fix(account-selection): use font color as color for labels

### DIFF
--- a/internal/admin/repository/eventsourcing/handler/styling.go
+++ b/internal/admin/repository/eventsourcing/handler/styling.go
@@ -207,6 +207,7 @@ func (m *Styling) writeFile(policy *iam_model.LabelPolicyView) (io.Reader, int64
 		}
 	}
 	if policy.FontColor != "" {
+		cssContent += fmt.Sprintf("--zitadel-color-label: %s;", policy.FontColor)
 		palette := m.generateColorPaletteRGBA255(policy.FontColor)
 		for i, color := range palette {
 			cssContent += fmt.Sprintf("--zitadel-color-text-%v: %s;", i, color)
@@ -242,6 +243,7 @@ func (m *Styling) writeFile(policy *iam_model.LabelPolicyView) (io.Reader, int64
 		}
 	}
 	if policy.FontColorDark != "" {
+		cssContent += fmt.Sprintf("--zitadel-color-label: %s;", policy.FontColorDark)
 		palette := m.generateColorPaletteRGBA255(policy.FontColorDark)
 		for i, color := range palette {
 			cssContent += fmt.Sprintf("--zitadel-color-text-%v: %s;", i, color)


### PR DESCRIPTION
### Definition of Ready

- [ X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [X] All open todos and follow ups are defined in a new ticket and justified
- [X] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [X] Critical parts are tested automatically
- [X] Where possible E2E tests are implemented
- [X] Documentation/examples are up-to-date
- [X] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.

The colors configured in the instance resp. project settings for the font were not used for labels. See #5505 for more infos.
