### PR TITLE
fix: improve autofill values

### DIFF
--- a/internal/api/ui/login/init_user_handler.go
+++ b/internal/api/ui/login/init_user_handler.go
@@ -121,9 +121,13 @@ func (l *Login) renderInitUser(w http.ResponseWriter, r *http.Request, authReq *
 		baseData:    l.getBaseData(r, authReq, "InitUser.Title", "InitUser.Description", errID, errMessage),
 		profileData: l.getProfileData(authReq),
 		UserID:      userID,
-		LoginName:   loginName,
 		Code:        code,
 		PasswordSet: passwordSet,
+	}
+	// if the user clicked on the link in the mail, we need to make sure the loginName is rendered
+	if authReq == nil {
+		data.LoginName = loginName
+		data.UserName = loginName
 	}
 	policy := l.getPasswordComplexityPolicyByUserID(r, userID)
 	if policy != nil {

--- a/internal/api/ui/login/static/templates/change_password.html
+++ b/internal/api/ui/login/static/templates/change_password.html
@@ -12,7 +12,7 @@
     {{ .CSRF }}
 
     <input type="hidden" name="authRequestID" value="{{ .AuthReqID }}" />
-    <input type="text" name="loginname" value="{{ .LoginName }}" autocomplete="username" class="hidden" />
+    <input type="text" name="loginName" value="{{if .DisplayLoginNameSuffix}}{{.LoginName}}{{else}}{{.UserName}}{{end}}" autocomplete="username" class="hidden" />
 
     <div class="fields">
         <div class="field">

--- a/internal/api/ui/login/static/templates/init_user.html
+++ b/internal/api/ui/login/static/templates/init_user.html
@@ -16,7 +16,7 @@
     <input type="hidden" name="userID" value="{{ .UserID }}" />
     <input type="hidden" name="passwordSet" value="{{ .PasswordSet }}" />
     <input type="hidden" name="orgID" value="{{ .OrgID }}" />
-    <input type="text" name="loginname" value="{{ .LoginName }}" autocomplete="username" class="hidden" />
+    <input type="text" name="loginName" value="{{if .DisplayLoginNameSuffix}}{{.LoginName}}{{else}}{{.UserName}}{{end}}" autocomplete="username" class="hidden" />
 
     <div class="fields">
         <div class="field">

--- a/internal/api/ui/login/static/templates/password.html
+++ b/internal/api/ui/login/static/templates/password.html
@@ -12,7 +12,7 @@
     {{ .CSRF }}
 
     <input type="hidden" name="authRequestID" value="{{ .AuthReqID }}" />
-    <input type="text" name="loginName" value="{{ .LoginName }}" autocomplete="username" class="hidden" />
+    <input type="text" name="loginName" value="{{if .DisplayLoginNameSuffix}}{{.LoginName}}{{else}}{{.UserName}}{{end}}" autocomplete="username" class="hidden" />
 
     <div class="fields">
         <label class="lgn-label" for="password">{{t "Password.PasswordLabel"}}</label>


### PR DESCRIPTION
A customer with 'Hide Loginname suffix' enabled reported, that the browser will try to save the suffixed login.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
