### PR TITLE
fix(defaults): uncomment Verifiers

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -415,7 +415,7 @@ SystemDefaults:
     # https://passlib.readthedocs.io/en/stable/modular_crypt_format.html
     #
     # Supported verifiers: (uncomment to enable)
-    # Verifiers:
+    Verifiers:
     #   - "argon2" # verifier for both argon2i and argon2id.
     #   - "bcrypt"
     #   - "md5"


### PR DESCRIPTION
Options that are completely commented-out in the yaml file(s) do not get parsed from the envionment variables.
This was also to the case for the
`ZITADEL_SYSTEMDEFAULTS_PASSWORDHASHER_VERIFIERS` option.
This change just uncomments the yaml option, so that users
can use the envorment variable to set a list of verifiers they wish to
enable.

 I've tested the fix locally by disabling `Verifiers` in my yaml and with docker compose where

```
    environment:
      ZITADEL_SYSTEMDEFAULTS_PASSWORDHASHER_VERIFIERS: pbkdf2
```

Imported a pbkdf2 password user and logged in succesfully.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
