### PR TITLE
fix: apple idp configuration

### DIFF
--- a/console/src/app/modules/providers/provider-apple/provider-apple.component.ts
+++ b/console/src/app/modules/providers/provider-apple/provider-apple.component.ts
@@ -246,7 +246,8 @@ export class ProviderAppleComponent {
           return (e) => {
             const keyBase64 = e.target?.result;
             if (keyBase64 && typeof keyBase64 === 'string') {
-              const cropped = keyBase64.replace('data:application/octet-stream;base64,', '');
+              const contentType = file.type || 'application/octet-stream';
+              const cropped = keyBase64.replace(`data:${contentType};base64,`, '');
               this.privateKey?.setValue(cropped);
             }
           };

--- a/docs/docs/guides/integrate/identity-providers/apple.mdx
+++ b/docs/docs/guides/integrate/identity-providers/apple.mdx
@@ -35,7 +35,6 @@ import TestSetup from './_test_setup.mdx';
 8. Add the redirect uri in the Return URLs
  - {your-domain}/ui/login/login/externalidp/callback/form
  - Example redirect url for the domain `https://acme-gzoe4x.zitadel.cloud` would look like this:  `https://acme-gzoe4x.zitadel.cloud/ui/login/login/externalidp/callback/form`
-9. Save the Client ID and Client secret
 
 ![Apple Service](/img/guides/apple_service_create.png)
 


### PR DESCRIPTION
### Definition of Ready

- [ X ] I am happy with the code
- [ X ] Short description of the feature/issue is added in the pr description
- [ X ] PR is linked to the corresponding user story
- [ X ] Acceptance criteria are met
- [ X ] All open todos and follow ups are defined in a new ticket and justified
- [ X ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ X ] No debug or dead code
- [ X ] My code has no repetitions
- [ X ] Critical parts are tested automatically
- [ X ] Where possible E2E tests are implemented
- [ X ] Documentation/examples are up-to-date
- [ X ] All non-functional requirements are met
- [ X ] Functionality of the acceptance criteria is checked manually on the dev system.


When adding Apple as identity provider, there was an error depending on the file type you got:
![Screenshot from 2023-09-15 22-19-05](https://github.com/zitadel/zitadel/assets/55233123/d06a733a-ee34-4d34-ab19-7bf69a3878fe)

After debugging this issue, I found that when reading the file an octect-stream is always expected as content type. This is not the case though. In my case with a *.p8 file, the file type was pksc8. this also affects the data url. Therefore I adjusted the code to read the content type from the file and use the octet stream as a fallback.

I also adjusted the documentation, as no client id or secret is necessary  when creating a Service ID.

@livio-a as this is your code, can you maybe review it? I was able to successfully test the configuration but I couldn't test, if the actual login works as Apple only allows to configure with https hosts. Do you have dev env where we can test this?