### PR TITLE
fix(console): hide domains settings for unauthorized users

### DIFF
--- a/console/src/app/modules/settings-list/settings-list.component.html
+++ b/console/src/app/modules/settings-list/settings-list.component.html
@@ -18,7 +18,7 @@
   <ng-container *ngIf="currentSetting === 'login'">
     <cnsl-login-policy [serviceType]="serviceType"></cnsl-login-policy>
   </ng-container>
-  <ng-container *ngIf="currentSetting === 'domain'">
+  <ng-container *ngIf="currentSetting === 'domain' && (['iam.policy.write'] | hasRole | async) === true">
     <cnsl-domain-policy [serviceType]="serviceType"></cnsl-domain-policy>
   </ng-container>
   <ng-container *ngIf="currentSetting === 'idp'">

--- a/console/src/app/modules/settings-list/settings.ts
+++ b/console/src/app/modules/settings-list/settings.ts
@@ -48,8 +48,8 @@ export const DOMAIN: SidenavSetting = {
   i18nKey: 'SETTINGS.LIST.DOMAIN',
   groupI18nKey: 'SETTINGS.GROUPS.DOMAIN',
   requiredRoles: {
-    [PolicyComponentServiceType.MGMT]: ['policy.read'],
-    [PolicyComponentServiceType.ADMIN]: ['iam.policy.read'],
+    [PolicyComponentServiceType.MGMT]: ['iam.policy.write'],
+    [PolicyComponentServiceType.ADMIN]: ['iam.policy.write'],
   },
 };
 

--- a/console/src/app/modules/sidenav/sidenav.component.html
+++ b/console/src/app/modules/sidenav/sidenav.component.html
@@ -28,11 +28,6 @@
 
           <button
             (click)="value = setting.id"
-            *ngIf="
-              !setting.requiredRoles ||
-              (setting.requiredRoles.mgmt && (setting.requiredRoles.mgmt | hasRole | async)) ||
-              (setting.requiredRoles.admin && (setting.requiredRoles.admin | hasRole | async))
-            "
             class="sidenav-setting-list-element hide-on-mobile"
             [ngClass]="{ active: currentSetting === setting.id, show: currentSetting === undefined }"
             [attr.data-e2e]="'sidenav-element-' + setting.id"


### PR DESCRIPTION
In #6547 @hifabienne commented 

> I think for the moment we should completaly hide the domain settings from the organization if the user only has ORG_OWNER permissions

As this issue is focused on Domain Settings and the related AddCustomDomainPolicy GRPC call requires iam.policy.write permission, this code checks if the user has this permission in order to show the setting. 

Also an additional check is added in case the user tries to visit /org-settings?id=domain so the component is not loaded without permissions.

The following screenshot shows how Zitadel Admin can visit Domain Settings and update the settings 

![image](https://github.com/zitadel/zitadel/assets/30386061/ea216b05-bc4e-4707-86b7-97ac8b6dd66b)

while a user which has ORG_OWNER role has no clue about domain settings.

![image](https://github.com/zitadel/zitadel/assets/30386061/5772a646-1163-41d8-bce5-0df564816ddd)

## A note for code review:

I've created a checkSettingsPermissions function that recieves a settings list (admin or mgmt), check for every setting if the user is allowed to use that setting and returns and
array of Observable<boolean> that once all calls are finished (forkJoin) I subscribe to get the results and remove every setting that cannot be visited. Why?

Because in sidenav component we pass settingList and use ngFor to loop the settings and while there's a ngIf to only show allowed settings, there's an issue with the logic that decides if setting.groupI18nKey is shown in a span as the title for the group of settings. The ngFor index is used to check if we have a new group key, but if a group has only one setting that is not allowed, that logic shows the group key even if we don't have settings, so I decided to filter first in ngOnInit thos settings so that logic works fine.

Maybe it's too complex or it's not coded fine but as I'm a beginner with RxJS I hope you can help me to get that code neat and efficient :smile:

Closes #6547 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
