### PR TITLE
fix: ensure no events are skipped on token check

### DIFF
--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -45,16 +45,19 @@ func (repo *TokenVerifierRepo) tokenByID(ctx context.Context, tokenID, userID st
 	defer func() { span.EndWithError(err) }()
 
 	instanceID := authz.GetInstance(ctx).InstanceID()
+
+	// always load the latest sequence first, so in case the token was not found by id,
+	// the sequence will be equal or lower than the actual projection and no events are lost
+	sequence, err := repo.View.GetLatestTokenSequence(ctx, instanceID)
+	logging.WithFields("instanceID", instanceID, "userID", userID, "tokenID", tokenID).
+		OnError(err).
+		Errorf("could not get current sequence for token check")
+
 	token, viewErr := repo.View.TokenByIDs(tokenID, userID, instanceID)
 	if viewErr != nil && !caos_errs.IsNotFound(viewErr) {
 		return nil, viewErr
 	}
 	if caos_errs.IsNotFound(viewErr) {
-		sequence, err := repo.View.GetLatestTokenSequence(ctx, instanceID)
-		logging.WithFields("instanceID", instanceID, "userID", userID, "tokenID", tokenID).
-			OnError(err).
-			Errorf("could not get current sequence for token check")
-
 		token = new(model.TokenView)
 		token.ID = tokenID
 		token.UserID = userID


### PR DESCRIPTION
a customer reported, that he would randomly get "APP-BxUSiL: invalid token" errors.

it seems that when querying the token (call _1_), it's not yet present in the database, therefore the latest token sequence will be loaded (call _2_). in some cases, the sequence might have been updated in the meantime (after call _1_), resulting in the loss of events for the current check.

to fix potential loss, this PR changes the order of the both calls and always load the sequence (previously _2_) first and only us that if the token was not found (previously _1_)