### PR TITLE
fix: reduce origin check to tokens issued through code and implicit flow

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -78,9 +78,12 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		if err != nil {
 			return CtxData{}, errors.ThrowPermissionDenied(err, "AUTH-GHpw2", "could not read projectid by clientid")
 		}
-	}
-	if err := checkOrigin(ctx, origins); err != nil {
-		return CtxData{}, err
+		// We used to check origins for every token, but service users shouldn't be used publicly (native app / SPA).
+		// Therefore, mostly won't send an origin and aren't able to configure them anyway.
+		// For the current time we will only check origins for tokens issued to users through apps (code / implicit flow).
+		if err := checkOrigin(ctx, origins); err != nil {
+			return CtxData{}, err
+		}
 	}
 	if orgID == "" && orgDomain == "" {
 		orgID = resourceOwner


### PR DESCRIPTION
There were many request in discord from developers, that send an origin header either when using a PAT or some other service user based token. Current checks would deny such requests.
With this PR, we will only check origin for tokens issued to users through apps (Code / Implicit Flow) and ignore on tokens for service accounts (Client Credentials / JWT Profile / PAT)

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
