### PR TITLE
fix: use enum for instance feature in system api

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -19,6 +19,7 @@ lint:
     - zitadel/auth.proto
     - zitadel/change.proto
     - zitadel/event.proto
+    - zitadel/feature.proto
     - zitadel/idp.proto
     - zitadel/instance.proto
     - zitadel/management.proto

--- a/proto/zitadel/feature.proto
+++ b/proto/zitadel/feature.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package zitadel.feature.v1;
+
+option go_package ="github.com/zitadel/zitadel/pkg/grpc/feature";
+
+enum InstanceFeature {
+  INSTANCE_FEATURE_UNSPECIFIED = 0;
+  INSTANCE_FEATURE_LOGIN_DEFAULT_ORG = 1;
+}

--- a/proto/zitadel/system.proto
+++ b/proto/zitadel/system.proto
@@ -6,6 +6,7 @@ import "zitadel/instance.proto";
 import "zitadel/member.proto";
 import "zitadel/quota.proto";
 import "zitadel/auth_n_key.proto";
+import "zitadel/feature.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
@@ -894,8 +895,7 @@ message FailedEvent {
 
 message SetInstanceFeatureRequest {
   string instance_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
-  // the feature (id) according to [internal/domain/feature.go]
-  int32 feature_id = 2 [(validate.rules).int32 = {gt: 0}];
+  zitadel.feature.v1.InstanceFeature feature_id = 2 [(validate.rules).enum = {not_in: 0, defined_only: true}];
   // value based on the feature type
   oneof value {
     option (validate.required) = true;


### PR DESCRIPTION
following up the short discussion during the sprint review, i've changed the int to a enum

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
