### PR TITLE
fix(login): error case for unknown usernames correctly

### DIFF
--- a/internal/auth/repository/eventsourcing/eventstore/auth_request.go
+++ b/internal/auth/repository/eventsourcing/eventstore/auth_request.go
@@ -756,9 +756,9 @@ func (repo *AuthRequestRepo) checkLoginName(ctx context.Context, request *domain
 	}
 	// the user was either not found or not active
 	// so check if the loginname suffix matches a verified org domain
-	ok, err := repo.checkDomainDiscovery(ctx, request, loginName)
-	if err != nil || ok {
-		return err
+	ok, errDomainDiscovery := repo.checkDomainDiscovery(ctx, request, loginName)
+	if errDomainDiscovery != nil || ok {
+		return errDomainDiscovery
 	}
 	// let's once again check if the user was just inactive
 	if user != nil && user.State == int32(domain.UserStateInactive) {


### PR DESCRIPTION
while testing 2.38.0 on QA i ran into a panic. the following PR will fix the issuer where the error (user not found) was overwritten by the domain discovery (nil) and therefore later checks to error would not work as expected

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
