### PR TITLE
fix(api): use (provided) organisation instead of resourceOwner of caller

### DIFF
--- a/internal/api/grpc/user/v2/otp.go
+++ b/internal/api/grpc/user/v2/otp.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Server) AddOTPSMS(ctx context.Context, req *user.AddOTPSMSRequest) (*user.AddOTPSMSResponse, error) {
-	details, err := s.command.AddHumanOTPSMS(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner)
+	details, err := s.command.AddHumanOTPSMS(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -18,7 +18,7 @@ func (s *Server) AddOTPSMS(ctx context.Context, req *user.AddOTPSMSRequest) (*us
 }
 
 func (s *Server) RemoveOTPSMS(ctx context.Context, req *user.RemoveOTPSMSRequest) (*user.RemoveOTPSMSResponse, error) {
-	objectDetails, err := s.command.RemoveHumanOTPSMS(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner)
+	objectDetails, err := s.command.RemoveHumanOTPSMS(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func (s *Server) RemoveOTPSMS(ctx context.Context, req *user.RemoveOTPSMSRequest
 }
 
 func (s *Server) AddOTPEmail(ctx context.Context, req *user.AddOTPEmailRequest) (*user.AddOTPEmailResponse, error) {
-	details, err := s.command.AddHumanOTPEmail(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner)
+	details, err := s.command.AddHumanOTPEmail(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (s *Server) AddOTPEmail(ctx context.Context, req *user.AddOTPEmailRequest) 
 }
 
 func (s *Server) RemoveOTPEmail(ctx context.Context, req *user.RemoveOTPEmailRequest) (*user.RemoveOTPEmailResponse, error) {
-	objectDetails, err := s.command.RemoveHumanOTPEmail(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner)
+	objectDetails, err := s.command.RemoveHumanOTPEmail(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/user/v2/passkey.go
+++ b/internal/api/grpc/user/v2/passkey.go
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) RegisterPasskey(ctx context.Context, req *user.RegisterPasskeyRequest) (resp *user.RegisterPasskeyResponse, err error) {
 	var (
-		resourceOwner = authz.GetCtxData(ctx).ResourceOwner
+		resourceOwner = authz.GetCtxData(ctx).OrgID
 		authenticator = passkeyAuthenticatorToDomain(req.GetAuthenticator())
 	)
 	if code := req.GetCode(); code != nil {
@@ -65,7 +65,7 @@ func passkeyRegistrationDetailsToPb(details *domain.WebAuthNRegistrationDetails,
 }
 
 func (s *Server) VerifyPasskeyRegistration(ctx context.Context, req *user.VerifyPasskeyRegistrationRequest) (*user.VerifyPasskeyRegistrationResponse, error) {
-	resourceOwner := authz.GetCtxData(ctx).ResourceOwner
+	resourceOwner := authz.GetCtxData(ctx).OrgID
 	pkc, err := req.GetPublicKeyCredential().MarshalJSON()
 	if err != nil {
 		return nil, caos_errs.ThrowInternal(err, "USERv2-Pha2o", "Errors.Internal")
@@ -80,7 +80,7 @@ func (s *Server) VerifyPasskeyRegistration(ctx context.Context, req *user.Verify
 }
 
 func (s *Server) CreatePasskeyRegistrationLink(ctx context.Context, req *user.CreatePasskeyRegistrationLinkRequest) (resp *user.CreatePasskeyRegistrationLinkResponse, err error) {
-	resourceOwner := authz.GetCtxData(ctx).ResourceOwner
+	resourceOwner := authz.GetCtxData(ctx).OrgID
 
 	switch medium := req.Medium.(type) {
 	case nil:

--- a/internal/api/grpc/user/v2/password.go
+++ b/internal/api/grpc/user/v2/password.go
@@ -48,7 +48,7 @@ func notificationTypeToDomain(notificationType user.NotificationType) domain.Not
 }
 
 func (s *Server) SetPassword(ctx context.Context, req *user.SetPasswordRequest) (_ *user.SetPasswordResponse, err error) {
-	var resourceOwner = authz.GetCtxData(ctx).ResourceOwner
+	var resourceOwner = authz.GetCtxData(ctx).OrgID
 	var details *domain.ObjectDetails
 
 	switch v := req.GetVerification().(type) {

--- a/internal/api/grpc/user/v2/totp.go
+++ b/internal/api/grpc/user/v2/totp.go
@@ -11,7 +11,7 @@ import (
 
 func (s *Server) RegisterTOTP(ctx context.Context, req *user.RegisterTOTPRequest) (*user.RegisterTOTPResponse, error) {
 	return totpDetailsToPb(
-		s.command.AddUserTOTP(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner),
+		s.command.AddUserTOTP(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID),
 	)
 
 }
@@ -28,7 +28,7 @@ func totpDetailsToPb(totp *domain.TOTP, err error) (*user.RegisterTOTPResponse, 
 }
 
 func (s *Server) VerifyTOTPRegistration(ctx context.Context, req *user.VerifyTOTPRegistrationRequest) (*user.VerifyTOTPRegistrationResponse, error) {
-	objectDetails, err := s.command.CheckUserTOTP(ctx, req.GetUserId(), req.GetCode(), authz.GetCtxData(ctx).ResourceOwner)
+	objectDetails, err := s.command.CheckUserTOTP(ctx, req.GetUserId(), req.GetCode(), authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/user/v2/u2f.go
+++ b/internal/api/grpc/user/v2/u2f.go
@@ -12,7 +12,7 @@ import (
 
 func (s *Server) RegisterU2F(ctx context.Context, req *user.RegisterU2FRequest) (*user.RegisterU2FResponse, error) {
 	return u2fRegistrationDetailsToPb(
-		s.command.RegisterUserU2F(ctx, req.GetUserId(), authz.GetCtxData(ctx).ResourceOwner, req.GetDomain()),
+		s.command.RegisterUserU2F(ctx, req.GetUserId(), authz.GetCtxData(ctx).OrgID, req.GetDomain()),
 	)
 }
 
@@ -29,7 +29,7 @@ func u2fRegistrationDetailsToPb(details *domain.WebAuthNRegistrationDetails, err
 }
 
 func (s *Server) VerifyU2FRegistration(ctx context.Context, req *user.VerifyU2FRegistrationRequest) (*user.VerifyU2FRegistrationResponse, error) {
-	resourceOwner := authz.GetCtxData(ctx).ResourceOwner
+	resourceOwner := authz.GetCtxData(ctx).OrgID
 	pkc, err := req.GetPublicKeyCredential().MarshalJSON()
 	if err != nil {
 		return nil, caos_errs.ThrowInternal(err, "USERv2-IeTh4", "Errors.Internal")


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
