### PR TITLE
fix: allow unused keys in hasher config

### DIFF
--- a/internal/crypto/passwap.go
+++ b/internal/crypto/passwap.go
@@ -147,7 +147,7 @@ func (c *HasherConfig) buildHasher() (hasher passwap.Hasher, prefixes []string, 
 
 func (c *HasherConfig) decodeParams(dst any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: true,
+		ErrorUnused: false,
 		ErrorUnset:  true,
 		Result:      dst,
 	})

--- a/internal/crypto/passwap_test.go
+++ b/internal/crypto/passwap_test.go
@@ -379,7 +379,10 @@ func TestHasherConfig_decodeParams(t *testing.T) {
 				"b": 2,
 				"c": 3,
 			},
-			wantErr: true,
+			want: dst{
+				A: 1,
+				B: 2,
+			},
 		},
 		{
 			name: "unset",


### PR DESCRIPTION
In `defaults.yam` we specify bcrypt with a default `Cost` parameter. When a hasher that does not take a `Cost` parameter is used, (like Argon2), the `Cost` parameter remains present in the config map. This because viper is merging the config map recursively. During startup we let the decoder error on unused keys. Hence, it is impossible to start zitadel with an argon2 hasher.

To reproduce, start a released or `main` version of zitadel (locally) with the following in a config file (not `defaults.yaml`):

```yaml
SystemDefaults:
  PasswordHasher:
    Hasher:
      Algorithm: "argon2id"
      Time: 1
      Memory: 65536
      Threads: 4
```

Zitadel will fail to start with an error

This PR fixes the behavior by allowing unused keys.

Reported through discord: https://discord.com/channels/927474939156643850/1153179401169686600

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
