### PR TITLE
docs: fix environment variable name for steps

### DIFF
--- a/cmd/setup/steps.yaml
+++ b/cmd/setup/steps.yaml
@@ -35,8 +35,8 @@ FirstInstance:
     # If FirstInstance.Org.Machine.Machine is defined, a service user is created with the IAM_OWNER role, not a human user.
     Machine:
       Machine:
-        Username: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_USERNAME
-        Name: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_NAME
+        Username: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME
+        Name: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME
       MachineKey:
         # date format: 2023-01-01T00:00:00Z
         ExpirationDate: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_EXPIRATIONDATE


### PR DESCRIPTION
The yaml schema has a `Machine` object nested inside another one, which was improperly represented in the corresponding environment variable.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
