### PR TITLE
fix: origin from proxies

### DIFF
--- a/internal/api/http/middleware/origin_interceptor_test.go
+++ b/internal/api/http/middleware/origin_interceptor_test.go
@@ -1,0 +1,114 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_composeOrigin(t *testing.T) {
+	type args struct {
+		h http.Header
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "no proxy headers",
+		want: "http://host.header",
+	}, {
+		name: "forwarded proto",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"proto=https"},
+			},
+		},
+		want: "https://host.header",
+	}, {
+		name: "forwarded host",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"host=forwarded.host"},
+			},
+		},
+		want: "http://forwarded.host",
+	}, {
+		name: "forwarded proto and host",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"proto=https;host=forwarded.host"},
+			},
+		},
+		want: "https://forwarded.host",
+	}, {
+		name: "forwarded proto and host with multiple complete entries",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"proto=https;host=forwarded.host, proto=http;host=forwarded.host2"},
+			},
+		},
+		want: "https://forwarded.host",
+	}, {
+		name: "forwarded proto and host with multiple incomplete entries",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"proto=https;host=forwarded.host, proto=http"},
+			},
+		},
+		want: "https://forwarded.host",
+	}, {
+		name: "x-forwarded-proto",
+		args: args{
+			h: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+			},
+		},
+		want: "https://host.header",
+	}, {
+		name: "x-forwarded-host",
+		args: args{
+			h: http.Header{
+				"X-Forwarded-Host": []string{"x-forwarded.host"},
+			},
+		},
+		want: "http://x-forwarded.host",
+	}, {
+		name: "x-forwarded-proto and x-forwarded-host",
+		args: args{
+			h: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Host":  []string{"x-forwarded.host"},
+			},
+		},
+		want: "https://x-forwarded.host",
+	}, {
+		name: "forwarded host and x-forwarded-host",
+		args: args{
+			h: http.Header{
+				"Forwarded":        []string{"host=forwarded.host"},
+				"X-Forwarded-Host": []string{"x-forwarded.host"},
+			},
+		},
+		want: "http://forwarded.host",
+	}, {
+		name: "forwarded host and x-forwarded-proto",
+		args: args{
+			h: http.Header{
+				"Forwarded":         []string{"host=forwarded.host"},
+				"X-Forwarded-Proto": []string{"https"},
+			},
+		},
+		want: "https://forwarded.host",
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, composeOrigin(&http.Request{
+				Host:   "host.header",
+				Header: tt.args.h,
+			}), "headers: %+v", tt.args.h)
+		})
+	}
+}

--- a/internal/api/http/middleware/origin_interceptor_test.go
+++ b/internal/api/http/middleware/origin_interceptor_test.go
@@ -59,6 +59,14 @@ func Test_composeOrigin(t *testing.T) {
 		},
 		want: "https://forwarded.host",
 	}, {
+		name: "forwarded proto and host with incomplete entries in different values",
+		args: args{
+			h: http.Header{
+				"Forwarded": []string{"proto=http", "proto=https;host=forwarded.host", "proto=http"},
+			},
+		},
+		want: "http://forwarded.host",
+	}, {
 		name: "x-forwarded-proto",
 		args: args{
 			h: http.Header{


### PR DESCRIPTION
The PR fixes issues introduced with #6628 and reported [on Discord](https://discord.com/channels/927474939156643850/1163733984224747582)

1. To construct a requests origin, reading the header values falls back to other headers by properties, not by existence of headers. Like this, for example the host can be defined with the *Forwarded* header and the protocol can be defined with the *X-Forwarded-Proto* header or it can also be omitted.
3. As proxies should [append their values to the forwarded header(s)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded#syntax), we now read the **first** value to get the **oldest** value instead of the last most recent value.
2. As non-default ports should be included in the *Forwarded* directive *host*, in the *X-Forwarded-Host* header as well as in the *Host* header, it doesn't need special treatment in the code.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
