### PR TITLE
fix(eventstore): prevent allocation of filtered events

### DIFF
--- a/internal/command/existing_label_policies_model.go
+++ b/internal/command/existing_label_policies_model.go
@@ -38,7 +38,7 @@ func (rm *ExistingLabelPoliciesReadModel) Reduce() error {
 			}
 		}
 	}
-	return nil
+	return rm.WriteModel.Reduce()
 }
 
 func (rm *ExistingLabelPoliciesReadModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/command/instance_domain_model.go
+++ b/internal/command/instance_domain_model.go
@@ -55,7 +55,7 @@ func (wm *InstanceDomainWriteModel) Reduce() error {
 			wm.State = domain.InstanceDomainStateRemoved
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *InstanceDomainWriteModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/command/instance_model.go
+++ b/internal/command/instance_model.go
@@ -60,7 +60,7 @@ func (wm *InstanceWriteModel) Reduce() error {
 			wm.DefaultLanguage = e.Language
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *InstanceWriteModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/command/instance_test.go
+++ b/internal/command/instance_test.go
@@ -234,6 +234,7 @@ func TestCommandSide_RemoveInstance(t *testing.T) {
 				err: caos_errs.IsNotFound,
 			},
 		},
+		/* why this fails?
 		{
 			name: "instance remove, ok",
 			fields: fields{
@@ -286,6 +287,7 @@ func TestCommandSide_RemoveInstance(t *testing.T) {
 				},
 			},
 		},
+		*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/instance_test.go
+++ b/internal/command/instance_test.go
@@ -187,54 +187,53 @@ func TestCommandSide_RemoveInstance(t *testing.T) {
 		args   args
 		res    res
 	}{
-		{
-			name: "instance not existing, not found error",
-			fields: fields{
-				eventstore: eventstoreExpect(
-					t,
-					expectFilter(),
-				),
-			},
-			args: args{
-				ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
-				instanceID: "INSTANCE",
-			},
-			res: res{
-				err: caos_errs.IsNotFound,
-			},
-		},
-		{
-			name: "instance removed, not found error",
-			fields: fields{
-				eventstore: eventstoreExpect(
-					t,
-					expectFilter(
-						eventFromEventPusher(
-							instance.NewInstanceAddedEvent(
-								context.Background(),
-								&instance.NewAggregate("INSTANCE").Aggregate,
-								"INSTANCE",
-							),
-						),
-						eventFromEventPusher(
-							instance.NewInstanceRemovedEvent(context.Background(),
-								&instance.NewAggregate("INSTANCE").Aggregate,
-								"INSTANCE",
-								nil,
-							),
-						),
-					),
-				),
-			},
-			args: args{
-				ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
-				instanceID: "INSTANCE",
-			},
-			res: res{
-				err: caos_errs.IsNotFound,
-			},
-		},
-		/* why this fails?
+		// {
+		// 	name: "instance not existing, not found error",
+		// 	fields: fields{
+		// 		eventstore: eventstoreExpect(
+		// 			t,
+		// 			expectFilter(),
+		// 		),
+		// 	},
+		// 	args: args{
+		// 		ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
+		// 		instanceID: "INSTANCE",
+		// 	},
+		// 	res: res{
+		// 		err: caos_errs.IsNotFound,
+		// 	},
+		// },
+		// {
+		// 	name: "instance removed, not found error",
+		// 	fields: fields{
+		// 		eventstore: eventstoreExpect(
+		// 			t,
+		// 			expectFilter(
+		// 				eventFromEventPusher(
+		// 					instance.NewInstanceAddedEvent(
+		// 						context.Background(),
+		// 						&instance.NewAggregate("INSTANCE").Aggregate,
+		// 						"INSTANCE",
+		// 					),
+		// 				),
+		// 				eventFromEventPusher(
+		// 					instance.NewInstanceRemovedEvent(context.Background(),
+		// 						&instance.NewAggregate("INSTANCE").Aggregate,
+		// 						"INSTANCE",
+		// 						nil,
+		// 					),
+		// 				),
+		// 			),
+		// 		),
+		// 	},
+		// 	args: args{
+		// 		ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
+		// 		instanceID: "INSTANCE",
+		// 	},
+		// 	res: res{
+		// 		err: caos_errs.IsNotFound,
+		// 	},
+		// },
 		{
 			name: "instance remove, ok",
 			fields: fields{
@@ -287,7 +286,6 @@ func TestCommandSide_RemoveInstance(t *testing.T) {
 				},
 			},
 		},
-		*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/instance_test.go
+++ b/internal/command/instance_test.go
@@ -187,53 +187,53 @@ func TestCommandSide_RemoveInstance(t *testing.T) {
 		args   args
 		res    res
 	}{
-		// {
-		// 	name: "instance not existing, not found error",
-		// 	fields: fields{
-		// 		eventstore: eventstoreExpect(
-		// 			t,
-		// 			expectFilter(),
-		// 		),
-		// 	},
-		// 	args: args{
-		// 		ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
-		// 		instanceID: "INSTANCE",
-		// 	},
-		// 	res: res{
-		// 		err: caos_errs.IsNotFound,
-		// 	},
-		// },
-		// {
-		// 	name: "instance removed, not found error",
-		// 	fields: fields{
-		// 		eventstore: eventstoreExpect(
-		// 			t,
-		// 			expectFilter(
-		// 				eventFromEventPusher(
-		// 					instance.NewInstanceAddedEvent(
-		// 						context.Background(),
-		// 						&instance.NewAggregate("INSTANCE").Aggregate,
-		// 						"INSTANCE",
-		// 					),
-		// 				),
-		// 				eventFromEventPusher(
-		// 					instance.NewInstanceRemovedEvent(context.Background(),
-		// 						&instance.NewAggregate("INSTANCE").Aggregate,
-		// 						"INSTANCE",
-		// 						nil,
-		// 					),
-		// 				),
-		// 			),
-		// 		),
-		// 	},
-		// 	args: args{
-		// 		ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
-		// 		instanceID: "INSTANCE",
-		// 	},
-		// 	res: res{
-		// 		err: caos_errs.IsNotFound,
-		// 	},
-		// },
+		{
+			name: "instance not existing, not found error",
+			fields: fields{
+				eventstore: eventstoreExpect(
+					t,
+					expectFilter(),
+				),
+			},
+			args: args{
+				ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
+				instanceID: "INSTANCE",
+			},
+			res: res{
+				err: caos_errs.IsNotFound,
+			},
+		},
+		{
+			name: "instance removed, not found error",
+			fields: fields{
+				eventstore: eventstoreExpect(
+					t,
+					expectFilter(
+						eventFromEventPusher(
+							instance.NewInstanceAddedEvent(
+								context.Background(),
+								&instance.NewAggregate("INSTANCE").Aggregate,
+								"INSTANCE",
+							),
+						),
+						eventFromEventPusher(
+							instance.NewInstanceRemovedEvent(context.Background(),
+								&instance.NewAggregate("INSTANCE").Aggregate,
+								"INSTANCE",
+								nil,
+							),
+						),
+					),
+				),
+			},
+			args: args{
+				ctx:        authz.WithInstanceID(context.Background(), "INSTANCE"),
+				instanceID: "INSTANCE",
+			},
+			res: res{
+				err: caos_errs.IsNotFound,
+			},
+		},
 		{
 			name: "instance remove, ok",
 			fields: fields{

--- a/internal/command/org_domain_model.go
+++ b/internal/command/org_domain_model.go
@@ -84,7 +84,7 @@ func (wm *OrgDomainWriteModel) Reduce() error {
 			wm.ValidationCode = nil
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *OrgDomainWriteModel) Query() *eventstore.SearchQueryBuilder {
@@ -154,7 +154,7 @@ func (wm *OrgDomainsWriteModel) Reduce() error {
 			}
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *OrgDomainsWriteModel) Query() *eventstore.SearchQueryBuilder {
@@ -216,7 +216,7 @@ func (wm *OrgDomainVerifiedWriteModel) Reduce() error {
 			wm.Verified = false
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *OrgDomainVerifiedWriteModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/command/preparation/command.go
+++ b/internal/command/preparation/command.go
@@ -25,6 +25,8 @@ var (
 )
 
 // PrepareCommands checks the passed validations and if ok creates the commands
+//
+// Deprecated: filter causes unneeded allocation. Use [eventstore.FilterToQueryReducer] instead.
 func PrepareCommands(ctx context.Context, filter FilterToQueryReducer, validations ...Validation) (cmds []eventstore.Command, err error) {
 	commanders, err := validate(validations)
 	if err != nil {

--- a/internal/command/quota_model.go
+++ b/internal/command/quota_model.go
@@ -79,7 +79,7 @@ func (wm *quotaWriteModel) Reduce() error {
 	}
 	// wm.WriteModel.Reduce() sets the aggregateID to the first event's aggregateID, but we need the last one
 	wm.AggregateID = wm.rollingAggregateID
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 // NewChanges returns all changes that need to be applied to the aggregate.

--- a/internal/command/system_model.go
+++ b/internal/command/system_model.go
@@ -94,7 +94,7 @@ func (wm *SystemConfigWriteModel) Reduce() error {
 			}
 		}
 	}
-	return nil
+	return wm.WriteModel.Reduce()
 }
 
 func (wm *SystemConfigWriteModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/command/unique_constraints_model.go
+++ b/internal/command/unique_constraints_model.go
@@ -183,7 +183,7 @@ func (rm *UniqueConstraintReadModel) Reduce() error {
 			rm.removeUniqueConstraint(e.Aggregate().ID, e.UserID, member.UniqueMember)
 		}
 	}
-	return nil
+	return rm.WriteModel.Reduce()
 }
 
 func (rm *UniqueConstraintReadModel) Query() *eventstore.SearchQueryBuilder {

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -12,6 +12,8 @@ import (
 // Eventstore abstracts all functions needed to store valid events
 // and filters the stored events
 type Eventstore struct {
+	// TODO: get rid of this mutex,
+	// or if we scale to >4vCPU use a sync.Map
 	interceptorMutex  sync.RWMutex
 	eventInterceptors map[EventType]eventTypeInterceptors
 	eventTypes        []string
@@ -130,6 +132,14 @@ func (es *Eventstore) mapEventLocked(event Event) (Event, error) {
 	}
 	return interceptors.eventMapper(event)
 }
+
+// TODO: refactor so we can change to the following interface:
+/*
+type reducer interface {
+	// Reduce applies an event on the object.
+	Reduce(Event) error
+}
+*/
 
 type reducer interface {
 	//Reduce handles the events of the internal events list

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -12,7 +12,6 @@ import (
 // Eventstore abstracts all functions needed to store valid events
 // and filters the stored events
 type Eventstore struct {
-	interceptorMutex  sync.Mutex
 	eventInterceptors map[EventType]eventTypeInterceptors
 	eventTypes        []string
 	aggregateTypes    []string
@@ -33,7 +32,6 @@ type eventTypeInterceptors struct {
 func NewEventstore(config *Config) *Eventstore {
 	return &Eventstore{
 		eventInterceptors: map[EventType]eventTypeInterceptors{},
-		interceptorMutex:  sync.Mutex{},
 		PushTimeout:       config.PushTimeout,
 
 		pusher:  config.Pusher,
@@ -83,25 +81,27 @@ func (es *Eventstore) AggregateTypes() []string {
 
 // Filter filters the stored events based on the searchQuery
 // and maps the events to the defined event structs
-func (es *Eventstore) Filter(ctx context.Context, queryFactory *SearchQueryBuilder) ([]Event, error) {
-	// make sure that the instance id is always set
-	if queryFactory.instanceID == nil && authz.GetInstance(ctx).InstanceID() != "" {
-		queryFactory.InstanceID(authz.GetInstance(ctx).InstanceID())
-	}
-
-	events, err := es.querier.Filter(ctx, queryFactory)
+//
+// Deprecated: Use [FilterToQueryReducer] instead to avoid allocations.
+func (es *Eventstore) Filter(ctx context.Context, searchQuery *SearchQueryBuilder) ([]Event, error) {
+	events := make([]Event, 0, searchQuery.GetLimit())
+	searchQuery.ensureInstanceID(ctx)
+	err := es.querier.FilterToReducer(ctx, searchQuery, func(event Event) error {
+		event, err := es.mapEvent(event)
+		if err != nil {
+			return err
+		}
+		events = append(events, event)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	return es.mapEvents(events)
+	return events, nil
 }
 
 func (es *Eventstore) mapEvents(events []Event) (mappedEvents []Event, err error) {
 	mappedEvents = make([]Event, len(events))
-
-	es.interceptorMutex.Lock()
-	defer es.interceptorMutex.Unlock()
 
 	for i, event := range events {
 		mappedEvents[i], err = es.mapEvent(event)
@@ -131,14 +131,15 @@ type reducer interface {
 
 // FilterToReducer filters the events based on the search query, appends all events to the reducer and calls it's reduce function
 func (es *Eventstore) FilterToReducer(ctx context.Context, searchQuery *SearchQueryBuilder, r reducer) error {
-	events, err := es.Filter(ctx, searchQuery)
-	if err != nil {
-		return err
-	}
-
-	r.AppendEvents(events...)
-
-	return r.Reduce()
+	searchQuery.ensureInstanceID(ctx)
+	return es.querier.FilterToReducer(ctx, searchQuery, func(event Event) error {
+		event, err := es.mapEvent(event)
+		if err != nil {
+			return err
+		}
+		r.AppendEvents(event)
+		return r.Reduce()
+	})
 }
 
 // LatestSequence filters the latest sequence for the given search query
@@ -180,13 +181,7 @@ type QueryReducer interface {
 // FilterToQueryReducer filters the events based on the search query of the query function,
 // appends all events to the reducer and calls it's reduce function
 func (es *Eventstore) FilterToQueryReducer(ctx context.Context, r QueryReducer) error {
-	events, err := es.Filter(ctx, r.Query())
-	if err != nil {
-		return err
-	}
-	r.AppendEvents(events...)
-
-	return r.Reduce()
+	return es.FilterToReducer(ctx, r.Query(), r)
 }
 
 // RegisterFilterEventMapper registers a function for mapping an eventstore event to an event
@@ -194,8 +189,6 @@ func (es *Eventstore) RegisterFilterEventMapper(aggregateType AggregateType, eve
 	if mapper == nil || eventType == "" {
 		return es
 	}
-	es.interceptorMutex.Lock()
-	defer es.interceptorMutex.Unlock()
 
 	es.appendEventType(eventType)
 	es.appendAggregateType(aggregateType)
@@ -207,11 +200,13 @@ func (es *Eventstore) RegisterFilterEventMapper(aggregateType AggregateType, eve
 	return es
 }
 
+type Reducer func(event Event) error
+
 type Querier interface {
 	// Health checks if the connection to the storage is available
 	Health(ctx context.Context) error
-	// Filter returns all events matching the given search query
-	Filter(ctx context.Context, searchQuery *SearchQueryBuilder) (events []Event, err error)
+	// FilterToReducer returns all events matching the given search query
+	FilterToReducer(ctx context.Context, searchQuery *SearchQueryBuilder, r Reducer) error
 	// LatestSequence returns the latest sequence found by the search query
 	LatestSequence(ctx context.Context, queryFactory *SearchQueryBuilder) (float64, error)
 	// InstanceIDs returns the instance ids found by the search query

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -227,7 +227,7 @@ type Reducer func(event Event) error
 type Querier interface {
 	// Health checks if the connection to the storage is available
 	Health(ctx context.Context) error
-	// FilterToReducer returns all events matching the given search query
+	// FilterToReducer calls r for every event returned from the storage
 	FilterToReducer(ctx context.Context, searchQuery *SearchQueryBuilder, r Reducer) error
 	// LatestSequence returns the latest sequence found by the search query
 	LatestSequence(ctx context.Context, queryFactory *SearchQueryBuilder) (float64, error)

--- a/internal/eventstore/repository/mock/repository.mock.go
+++ b/internal/eventstore/repository/mock/repository.mock.go
@@ -35,19 +35,18 @@ func (m *MockQuerier) EXPECT() *MockQuerierMockRecorder {
 	return m.recorder
 }
 
-// Filter mocks base method.
-func (m *MockQuerier) Filter(arg0 context.Context, arg1 *eventstore.SearchQueryBuilder) ([]eventstore.Event, error) {
+// FilterToReducer mocks base method.
+func (m *MockQuerier) FilterToReducer(arg0 context.Context, arg1 *eventstore.SearchQueryBuilder, arg2 eventstore.Reducer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Filter", arg0, arg1)
-	ret0, _ := ret[0].([]eventstore.Event)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "FilterToReducer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// Filter indicates an expected call of Filter.
-func (mr *MockQuerierMockRecorder) Filter(arg0, arg1 interface{}) *gomock.Call {
+// FilterToReducer indicates an expected call of FilterToReducer.
+func (mr *MockQuerierMockRecorder) FilterToReducer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*MockQuerier)(nil).Filter), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterToReducer", reflect.TypeOf((*MockQuerier)(nil).FilterToReducer), arg0, arg1, arg2)
 }
 
 // Health mocks base method.

--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -173,7 +173,6 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 			return z_errors.ThrowInvalidArgumentf(nil, "SQL-4GP6F", "events scanner: invalid type %T", dest)
 		}
 		event := new(repository.Event)
-		data := sql.RawBytes{}
 		position := new(sql.NullFloat64)
 
 		if useV1 {
@@ -181,7 +180,7 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 				&event.CreationDate,
 				&event.Typ,
 				&event.Seq,
-				&data,
+				&event.Data,
 				&event.EditorUser,
 				&event.ResourceOwner,
 				&event.InstanceID,
@@ -196,7 +195,7 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 				&event.Typ,
 				&event.Seq,
 				position,
-				&data,
+				&event.Data,
 				&event.EditorUser,
 				&event.ResourceOwner,
 				&event.InstanceID,
@@ -212,7 +211,6 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 			return z_errors.ThrowInternal(err, "SQL-M0dsf", "unable to scan row")
 		}
 		event.Pos = position.Float64
-		event.Data = data
 		return reduce(event)
 	}
 }

--- a/internal/eventstore/repository/sql/query_test.go
+++ b/internal/eventstore/repository/sql/query_test.go
@@ -181,7 +181,6 @@ func Test_prepareColumns(t *testing.T) {
 				},
 			},
 			fields: fields{
-				// TO BE DISCUSSED: why is sql.Bytes nil in the tests? And why isn't a nil returned for Data if it nil?
 				dbRow: []interface{}{time.Time{}, eventstore.EventType(""), uint64(5), sql.NullFloat64{Float64: 42, Valid: true}, sql.RawBytes(nil), "", sql.NullString{}, "", eventstore.AggregateType("user"), "hodor", uint8(1)},
 			},
 		},

--- a/internal/eventstore/repository/sql/query_test.go
+++ b/internal/eventstore/repository/sql/query_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/database/cockroach"
@@ -74,6 +75,8 @@ func Test_getCondition(t *testing.T) {
 }
 
 func Test_prepareColumns(t *testing.T) {
+	var reducedEvents []eventstore.Event
+
 	type fields struct {
 		dbRow []interface{}
 	}
@@ -146,13 +149,16 @@ func Test_prepareColumns(t *testing.T) {
 			name: "events",
 			args: args{
 				columns: eventstore.ColumnsEvent,
-				dest:    &[]eventstore.Event{},
-				useV1:   true,
+				dest: eventstore.Reducer(func(event eventstore.Event) error {
+					reducedEvents = append(reducedEvents, event)
+					return nil
+				}),
+				useV1: true,
 			},
 			res: res{
 				query: `SELECT creation_date, event_type, event_sequence, event_data, editor_user, resource_owner, instance_id, aggregate_type, aggregate_id, aggregate_version FROM eventstore.events`,
 				expected: []eventstore.Event{
-					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Data: make(sql.RawBytes, 0)},
+					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Data: nil},
 				},
 			},
 			fields: fields{
@@ -163,15 +169,19 @@ func Test_prepareColumns(t *testing.T) {
 			name: "events v2",
 			args: args{
 				columns: eventstore.ColumnsEvent,
-				dest:    &[]eventstore.Event{},
+				dest: eventstore.Reducer(func(event eventstore.Event) error {
+					reducedEvents = append(reducedEvents, event)
+					return nil
+				}),
 			},
 			res: res{
 				query: `SELECT created_at, event_type, "sequence", "position", payload, creator, "owner", instance_id, aggregate_type, aggregate_id, revision FROM eventstore.events2`,
 				expected: []eventstore.Event{
-					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Pos: 42, Data: make(sql.RawBytes, 0), Version: "v1"},
+					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Pos: 42, Data: nil, Version: "v1"},
 				},
 			},
 			fields: fields{
+				// TO BE DISCUSSED: why is sql.Bytes nil in the tests? And why isn't a nil returned for Data if it nil?
 				dbRow: []interface{}{time.Time{}, eventstore.EventType(""), uint64(5), sql.NullFloat64{Float64: 42, Valid: true}, sql.RawBytes(nil), "", sql.NullString{}, "", eventstore.AggregateType("user"), "hodor", uint8(1)},
 			},
 		},
@@ -179,12 +189,15 @@ func Test_prepareColumns(t *testing.T) {
 			name: "event null position",
 			args: args{
 				columns: eventstore.ColumnsEvent,
-				dest:    &[]eventstore.Event{},
+				dest: eventstore.Reducer(func(event eventstore.Event) error {
+					reducedEvents = append(reducedEvents, event)
+					return nil
+				}),
 			},
 			res: res{
 				query: `SELECT created_at, event_type, "sequence", "position", payload, creator, "owner", instance_id, aggregate_type, aggregate_id, revision FROM eventstore.events2`,
 				expected: []eventstore.Event{
-					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Pos: 0, Data: make(sql.RawBytes, 0), Version: "v1"},
+					&repository.Event{AggregateID: "hodor", AggregateType: "user", Seq: 5, Pos: 0, Data: nil, Version: "v1"},
 				},
 			},
 			fields: fields{
@@ -207,9 +220,12 @@ func Test_prepareColumns(t *testing.T) {
 			name: "event query error",
 			args: args{
 				columns: eventstore.ColumnsEvent,
-				dest:    &[]eventstore.Event{},
-				dbErr:   sql.ErrConnDone,
-				useV1:   true,
+				dest: eventstore.Reducer(func(event eventstore.Event) error {
+					reducedEvents = append(reducedEvents, event)
+					return nil
+				}),
+				dbErr: sql.ErrConnDone,
+				useV1: true,
 			},
 			res: res{
 				query: `SELECT creation_date, event_type, event_sequence, event_data, editor_user, resource_owner, instance_id, aggregate_type, aggregate_id, aggregate_version FROM eventstore.events`,
@@ -242,6 +258,12 @@ func Test_prepareColumns(t *testing.T) {
 				equalizer.Equal(tt.args.dest.(*sql.NullTime).Time)
 				return
 			}
+			if _, ok := tt.args.dest.(eventstore.Reducer); ok {
+				assert.Equal(t, tt.res.expected, reducedEvents)
+				reducedEvents = nil
+				return
+			}
+
 			got := reflect.Indirect(reflect.ValueOf(tt.args.dest)).Interface()
 			if !reflect.DeepEqual(got, tt.res.expected) {
 				t.Errorf("unexpected result from rowScanner \nwant: %+v \ngot: %+v", tt.res.expected, got)
@@ -625,7 +647,10 @@ func Test_query_events_with_crdb(t *testing.T) {
 			}
 
 			events := []eventstore.Event{}
-			if err := query(context.Background(), db, tt.args.searchQuery, &events, true); (err != nil) != tt.wantErr {
+			if err := query(context.Background(), db, tt.args.searchQuery, eventstore.Reducer(func(event eventstore.Event) error {
+				events = append(events, event)
+				return nil
+			}), true); (err != nil) != tt.wantErr {
 				t.Errorf("CRDB.query() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/eventstore/search_query.go
+++ b/internal/eventstore/search_query.go
@@ -1,9 +1,11 @@
 package eventstore
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/errors"
 )
 
@@ -80,6 +82,13 @@ func (q SearchQueryBuilder) GetEventSequenceGreater() uint64 {
 
 func (q SearchQueryBuilder) GetCreationDateAfter() time.Time {
 	return q.creationDateAfter
+}
+
+// ensureInstanceID makes sure that the instance id is always set
+func (b *SearchQueryBuilder) ensureInstanceID(ctx context.Context) {
+	if b.instanceID == nil && authz.GetInstance(ctx).InstanceID() != "" {
+		b.InstanceID(authz.GetInstance(ctx).InstanceID())
+	}
 }
 
 type SearchQuery struct {


### PR DESCRIPTION
Directly reduce each event obtained from a sql.Rows scan, so that we do not have to allocate all events in a slice.

### Follow-up

We can can further optimize this solution by:

1. Port all functions that use `eventstore.Filter()` to `eventstore.FilterToReducer()` or `eventstore.FilterToQueryReducer()` . Currently there are 161 uses in Zitadel and most of them through the `preparation` package.
2. Refactor the `eventstore.reducer` interface so that every Event can be directly reduced, without calling `AppendEvents` first. This means that for all implementations we can get merge the `AppendEvents` with `Reduce` and can get rid of each `for` loop.
3. See if we can get rid of the `Eventstore.interceptorMutex`. It seems only needed for parallel tasks during startup and the map doesn't change during requests.
4. We can see if it's worth to recycle memory by using a [`sync.Pool`](https://pkg.go.dev/sync#Pool) for `*repository.Event` in which we reset and `Put()` Events that were reduced and `Get()` during scanning.

If the current change is validated, we can move the above to follow-up issues.


### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
