### PR TITLE
feat(backend): support proxy of smtp email data

### DIFF
--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/notification/channels"
+	"github.com/zitadel/zitadel/internal/notification/templates"
 )
 
 var (
@@ -26,6 +27,7 @@ type Email struct {
 	ReplyToAddress  string
 	Subject         string
 	Content         string
+	TemplateData    templates.TemplateData
 	TriggeringEvent eventstore.Event
 }
 

--- a/internal/notification/templates/templateData.go
+++ b/internal/notification/templates/templateData.go
@@ -33,6 +33,7 @@ type TemplateData struct {
 
 	IncludeFooter bool
 	FooterText    string
+	Data          map[string]interface{}
 }
 
 func (data *TemplateData) Translate(translator *i18n.Translator, msgType string, args map[string]interface{}, langs ...string) {
@@ -49,4 +50,5 @@ func (data *TemplateData) Translate(translator *i18n.Translator, msgType string,
 	// we'll include the footer if we have a custom non-empty string and if the string doesn't include the
 	// id of the string that could not be translated example InitCode.Footer
 	data.IncludeFooter = len(data.FooterText) > 0 && data.FooterText != footerText
+	data.Data = args
 }

--- a/internal/notification/types/notification.go
+++ b/internal/notification/types/notification.go
@@ -54,6 +54,7 @@ func SendEmail(
 			data.Subject,
 			template,
 			allowUnverifiedNotificationChannel,
+			data,
 			triggeringEvent,
 		)
 	}

--- a/internal/notification/types/user_email.go
+++ b/internal/notification/types/user_email.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/notification/messages"
+	"github.com/zitadel/zitadel/internal/notification/templates"
 	"github.com/zitadel/zitadel/internal/query"
 )
 
@@ -17,6 +18,7 @@ func generateEmail(
 	subject,
 	content string,
 	lastEmail bool,
+	templateData templates.TemplateData,
 	triggeringEvent eventstore.Event,
 ) error {
 	content = html.UnescapeString(content)
@@ -24,6 +26,7 @@ func generateEmail(
 		Recipients:      []string{user.VerifiedEmail},
 		Subject:         subject,
 		Content:         content,
+		TemplateData:    templateData,
 		TriggeringEvent: triggeringEvent,
 	}
 	if lastEmail {


### PR DESCRIPTION
Using env vars, redirects smtp email as JSON to an http(s) endpoint for relay. Widened Email struct to include `templates.TemplateData` for exterior message templating.

I need direction on how to add the HTTP Notification as a modular capability, rather than as a piggy-back on the SMTP Notification.  Form UI, Persistence of form data, registration of the functionality as a provider, support for configuration via the API.  All that stuff.  I've been through the codebase a fair bit, and it is not obvious to me.