### PR TITLE
feat(login): Hide Available External IDPs (#6761)  

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -338,6 +338,7 @@ Login:
     # 168h is 7 days, one week
     SharedMaxAge: 168h # ZITADEL_LOGIN_CACHE_SHAREDMAXAGE
   DefaultOTPEmailURLV2: "/otp/verify?loginName={{.LoginName}}&code={{.Code}}" # ZITADEL_LOGIN_CACHE_DEFAULTOTPEMAILURLV2
+  DisableExternalIDPPanel: false # ZITADEL_LOGIN_DISABLEEXTERNALIDPPANEL
 
 Console:
   ShortCache:

--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -42,6 +42,7 @@ type Login struct {
 	idpConfigAlg        crypto.EncryptionAlgorithm
 	userCodeAlg         crypto.EncryptionAlgorithm
 	featureCheck        feature.Checker
+	config              *Config
 }
 
 type Config struct {
@@ -52,6 +53,9 @@ type Config struct {
 
 	// LoginV2
 	DefaultOTPEmailURLV2 string
+
+	// Advanced Settings
+	DisableExternalIDPPanel bool
 }
 
 const (
@@ -105,6 +109,7 @@ func CreateLogin(config Config,
 	login.router = CreateRouter(login, statikFS, middleware.TelemetryHandler(IgnoreInstanceEndpoints...), oidcInstanceHandler, samlInstanceHandler, csrfInterceptor, cacheInterceptor, security, userAgentCookie, issuerInterceptor, accessHandler)
 	login.renderer = CreateRenderer(HandlerPrefix, statikFS, staticStorage, config.LanguageCookieName)
 	login.parser = form.NewParser()
+	login.config = &config
 	return login, nil
 }
 

--- a/internal/api/ui/login/login_handler.go
+++ b/internal/api/ui/login/login_handler.go
@@ -105,6 +105,13 @@ func (l *Login) renderLogin(w http.ResponseWriter, r *http.Request, authReq *dom
 			return authReq != nil && authReq.LoginPolicy != nil && authReq.LoginPolicy.AllowUsernamePassword
 		},
 		"hasExternalLogin": func() bool {
+			// global disable
+			// TODO: Specific IDPs for an org will be available and optionally hidden.
+			// The ExternalIDPs will not show up in the list if they are hidden.
+			// However they can still be used, if available, by passing the idp scope in the auth request.
+			if l.config.DisableExternalIDPPanel {
+				return false
+			}
 			return authReq != nil && authReq.LoginPolicy != nil && authReq.LoginPolicy.AllowExternalIDP && authReq.AllowedExternalIDPs != nil && len(authReq.AllowedExternalIDPs) > 0
 		},
 		"hasRegistration": func() bool {


### PR DESCRIPTION
[optional config]
DisableExternalIDPPanel: false # ZITADEL_LOGIN_DISABLEEXTERNALIDPPANEL

This will GLOBALLY disable the external IDP panel. The main use case is that there may be thousands of external idps available for a given org. The Login UI should not show these but instead an auth request passing the idp scope can be used to cherry pick which external IDP a user is challenged with.

### Definition of Ready

- [ x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
