### PR TITLE
docs: Update cockroach to v23.1.11

### DIFF
--- a/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
@@ -26,7 +26,7 @@ services:
     restart: 'always'
     networks:
       - 'zitadel'
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:v23.1.11'
     command: 'start-single-node --insecure'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/docs/docs/self-hosting/deploy/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     restart: 'always'
     networks:
       - 'zitadel'
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:v23.1.11'
     command: 'start-single-node --insecure'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]


### PR DESCRIPTION
Sample docker-compose does not work until cockroach is updated to v23.1.11. 

https://discord.com/channels/927474939156643850/1166399185021567106

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
