### PR TITLE
docs: replace fix cockroachdb version with latest stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Self-Service
 - [Administration UI (Console)](https://zitadel.com/docs/guides/manage/console/overview)
 
 Deployment
-- [Postgres](https://zitadel.com/docs/self-hosting/manage/database#postgres) (version >= 14) or [CockroachDB](https://zitadel.com/docs/self-hosting/manage/database#cockroach) (version >= 22.0)
+- [Postgres](https://zitadel.com/docs/self-hosting/manage/database#postgres) (version >= 14) or [CockroachDB](https://zitadel.com/docs/self-hosting/manage/database#cockroach) (version latest stable)
 - [Zero Downtime Updates](https://zitadel.com/docs/concepts/architecture/solution#zero-downtime-updates)
 
 Track upcoming features on our [roadmap](https://zitadel.com/roadmap).

--- a/deploy/knative/cockroachdb-statefulset-single-node.yaml
+++ b/deploy/knative/cockroachdb-statefulset-single-node.yaml
@@ -98,7 +98,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.2
+        image: cockroachdb/cockroach:latest
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
@@ -26,7 +26,7 @@ services:
     restart: 'always'
     networks:
       - 'zitadel'
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest'
     command: 'start-single-node --insecure'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/docs/docs/self-hosting/deploy/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     restart: 'always'
     networks:
       - 'zitadel'
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest'
     command: 'start-single-node --insecure'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/docs/docs/self-hosting/deploy/linux.mdx
+++ b/docs/docs/self-hosting/deploy/linux.mdx
@@ -12,7 +12,7 @@ import NoteInstanceNotFound from './troubleshooting/_note_instance_not_found.mdx
 ## Install CockroachDB
 
 Download a `cockroach` binary as described [in the CockroachDB docs](https://www.cockroachlabs.com/docs/stable/install-cockroachdb).
-ZITADEL is tested against CockroachDB v22.2.2 and Ubuntu 20.04.
+ZITADEL is tested against CockroachDB latest stable tag and Ubuntu 20.04.
 
 ## Run CockroachDB
 

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - 'zitadel-certs:/crdb-certs:ro'
 
   certs:
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest'
     entrypoint: [ '/bin/bash', '-c' ]
     command: [ 'cp /certs/* /zitadel-certs/ && cockroach cert create-client --overwrite --certs-dir /zitadel-certs/ --ca-key /zitadel-certs/ca.key zitadel_user && chown 1000:1000 /zitadel-certs/*' ]
     volumes:
@@ -42,7 +42,7 @@ services:
     restart: 'always'
     networks:
       - 'zitadel'
-    image: 'cockroachdb/cockroach:v22.2.2'
+    image: 'cockroachdb/cockroach:latest'
     command: 'start-single-node --advertise-addr my-cockroach-db'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/docs/docs/self-hosting/deploy/macos.mdx
+++ b/docs/docs/self-hosting/deploy/macos.mdx
@@ -11,7 +11,7 @@ import NoteInstanceNotFound from './troubleshooting/_note_instance_not_found.mdx
 ## Install CockroachDB
 
 Download a `cockroach` binary as described [in the CockroachDB docs](https://www.cockroachlabs.com/docs/stable/install-cockroachdb).
-ZITADEL is tested against CockroachDB v22.2.2.
+ZITADEL is tested against CockroachDB latest stable tag.
 
 ## Run CockroachDB
 

--- a/docs/docs/self-hosting/manage/configure/docker-compose.yaml
+++ b/docs/docs/self-hosting/manage/configure/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "zitadel-certs:/crdb-certs:ro"
 
   certs:
-    image: "cockroachdb/cockroach:v22.2.2"
+    image: "cockroachdb/cockroach:latest"
     entrypoint: ["/bin/bash", "-c"]
     command:
       [
@@ -36,7 +36,7 @@ services:
     restart: "always"
     networks:
       - "zitadel"
-    image: "cockroachdb/cockroach:v22.2.2"
+    image: "cockroachdb/cockroach:latest"
     command: "start-single-node --advertise-addr my-cockroach-db"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/e2e/config/localhost/docker-compose.yaml
+++ b/e2e/config/localhost/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
 
   db:
     restart: 'always'
-    image: 'cockroachdb/cockroach:v22.2.10'
+    image: 'cockroachdb/cockroach:latest'
     command: 'start-single-node --insecure --http-addr :9090'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9090/health?ready=1']


### PR DESCRIPTION
ZITADEL always is tested agains the latest stable tag of cockroachdb. We should also advise our users to use this tag