### PR TITLE
fix(org): query eventstore instead of table for exists and by id

### DIFF
--- a/internal/query/org_projection.go
+++ b/internal/query/org_projection.go
@@ -1,0 +1,77 @@
+package query
+
+import (
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/repository/instance"
+	"github.com/zitadel/zitadel/internal/repository/org"
+)
+
+var _ eventstore.QueryReducer = (*OrgProjection)(nil)
+
+type OrgProjection struct {
+	*eventstore.ReadModel
+	Org
+}
+
+func newOrgProjection(instanceID, orgID string) *OrgProjection {
+	return &OrgProjection{
+		ReadModel: &eventstore.ReadModel{
+			AggregateID: orgID,
+			InstanceID:  instanceID,
+		},
+	}
+}
+
+// Query implements eventstore.QueryReducer.
+func (p *OrgProjection) Query() *eventstore.SearchQueryBuilder {
+	return eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
+		InstanceID(p.ReadModel.InstanceID).
+		OrderAsc().
+		AddQuery().
+		AggregateTypes(org.AggregateType).
+		AggregateIDs(p.ReadModel.AggregateID).
+		EventTypes(
+			org.OrgAddedEventType,
+			org.OrgChangedEventType,
+			org.OrgDeactivatedEventType,
+			org.OrgReactivatedEventType,
+			org.OrgRemovedEventType,
+			org.OrgDomainPrimarySetEventType,
+		).
+		Or().
+		AggregateTypes(instance.AggregateType).
+		AggregateIDs(p.InstanceID).
+		EventTypes(
+			instance.InstanceRemovedEventType,
+		).
+		Builder()
+}
+
+func (p *OrgProjection) Reduce() error {
+	for _, event := range p.Events {
+		p.Org.ChangeDate = event.CreatedAt()
+		p.Org.Sequence = event.Sequence()
+		switch e := event.(type) {
+		case *org.OrgAddedEvent:
+			p.Org.ID = event.Aggregate().ID
+			p.Org.CreationDate = event.CreatedAt()
+			p.Org.ResourceOwner = event.Aggregate().InstanceID
+			p.Org.State = domain.OrgStateActive
+			p.Org.Name = e.Name
+		case *org.OrgChangedEvent:
+			p.Org.Name = e.Name
+		case *org.OrgDeactivatedEvent:
+			p.Org.State = domain.OrgStateInactive
+		case *org.OrgReactivatedEvent:
+			p.Org.State = domain.OrgStateActive
+		case *org.OrgRemovedEvent:
+			p.Org.State = domain.OrgStateRemoved
+		case *org.DomainPrimarySetEvent:
+			p.Org.Domain = e.Domain
+		case *instance.InstanceRemovedEvent:
+			p.Org.State = domain.OrgStateRemoved
+		}
+	}
+	return p.ReadModel.Reduce()
+}

--- a/internal/query/org_state_projection.go
+++ b/internal/query/org_state_projection.go
@@ -1,0 +1,67 @@
+package query
+
+import (
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/repository/instance"
+	"github.com/zitadel/zitadel/internal/repository/org"
+)
+
+var _ eventstore.QueryReducer = (*OrgStateProjection)(nil)
+
+type OrgStateProjection struct {
+	*eventstore.ReadModel
+	state domain.OrgState
+}
+
+func (p *OrgStateProjection) Exists() bool {
+	return p.state != domain.OrgStateRemoved && p.state != domain.OrgStateUnspecified
+}
+
+func newOrgStateProjection(instanceID, orgID string) *OrgStateProjection {
+	return &OrgStateProjection{
+		ReadModel: &eventstore.ReadModel{
+			AggregateID: orgID,
+			InstanceID:  instanceID,
+		},
+	}
+}
+
+// Query implements eventstore.QueryReducer.
+func (p *OrgStateProjection) Query() *eventstore.SearchQueryBuilder {
+	return eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
+		InstanceID(p.InstanceID).
+		OrderAsc().
+		AddQuery().
+		AggregateTypes(org.AggregateType).
+		AggregateIDs(p.AggregateID).
+		EventTypes(
+			org.OrgAddedEventType,
+			org.OrgDeactivatedEventType,
+			org.OrgReactivatedEventType,
+			org.OrgRemovedEventType,
+		).
+		Or().
+		AggregateTypes(instance.AggregateType).
+		AggregateIDs(p.InstanceID).
+		EventTypes(
+			instance.InstanceRemovedEventType,
+		).
+		Builder()
+}
+
+func (p *OrgStateProjection) Reduce() error {
+	for _, event := range p.Events {
+		switch event.Type() {
+		case org.OrgAddedEventType:
+			p.state = domain.OrgStateActive
+		case org.OrgDeactivatedEventType:
+			p.state = domain.OrgStateInactive
+		case org.OrgReactivatedEventType:
+			p.state = domain.OrgStateActive
+		case org.OrgRemovedEventType, instance.InstanceRemovedEventType:
+			p.state = domain.OrgStateRemoved
+		}
+	}
+	return p.ReadModel.Reduce()
+}


### PR DESCRIPTION
This PR is a first draft to replace the `handler.Trigger`-calls in the `query`-package.

Following list is missing:

- [ ] **Feature flags from config**: especially for testing it would help if we can use feature flags. Also for deployments I'd prefer to enable a feature flag if I want to use the new implementation
- [ ] **Testing**: It's currently not tested if the behaviour of the calls would change. I would add a unit test which calls both implementations and asserts the two results
- [ ] **Structure**: We should define better interfaces and objects in the eventstore.
- [ ] **Terminology**: Clarify the difference between projection and read/write model