### PR TITLE
fix(eventstore): differentiate unique constraint error

### DIFF
--- a/internal/eventstore/v3/eventstore.go
+++ b/internal/eventstore/v3/eventstore.go
@@ -6,9 +6,10 @@ import (
 	"github.com/zitadel/zitadel/internal/database"
 )
 
-// pushPlaceholderFmt defines how data are inserted into the events table
 var (
-	pushPlaceholderFmt             string
+	// pushPlaceholderFmt defines how data are inserted into the events table
+	pushPlaceholderFmt string
+	// uniqueConstraintPlaceholderFmt defines the format of the unique constraint error returned from the database
 	uniqueConstraintPlaceholderFmt string
 )
 

--- a/internal/eventstore/v3/eventstore.go
+++ b/internal/eventstore/v3/eventstore.go
@@ -7,7 +7,10 @@ import (
 )
 
 // pushPlaceholderFmt defines how data are inserted into the events table
-var pushPlaceholderFmt string
+var (
+	pushPlaceholderFmt             string
+	uniqueConstraintPlaceholderFmt string
+)
 
 type Eventstore struct {
 	client *database.DB
@@ -17,8 +20,10 @@ func NewEventstore(client *database.DB) *Eventstore {
 	switch client.Type() {
 	case "cockroach":
 		pushPlaceholderFmt = "($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, hlc_to_timestamp(cluster_logical_timestamp()), cluster_logical_timestamp(), $%d)"
+		uniqueConstraintPlaceholderFmt = "('%s', '%s', '%s')"
 	case "postgres":
 		pushPlaceholderFmt = "($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, statement_timestamp(), EXTRACT(EPOCH FROM clock_timestamp()), $%d)"
+		uniqueConstraintPlaceholderFmt = "(%s, %s, %s)"
 	}
 
 	return &Eventstore{client: client}

--- a/internal/eventstore/v3/unique_constraints.go
+++ b/internal/eventstore/v3/unique_constraints.go
@@ -69,7 +69,7 @@ func handleUniqueConstraints(ctx context.Context, tx *sql.Tx, commands []eventst
 			if constraint := constraintFromErr(err, addConstraints); constraint != nil {
 				errMessage = constraint.ErrorMessage
 			}
-			return errs.ThrowInternal(err, "V3-DKcYh", errMessage)
+			return errs.ThrowAlreadyExists(err, "V3-DKcYh", errMessage)
 		}
 	}
 	return nil

--- a/internal/eventstore/v3/unique_constraints.go
+++ b/internal/eventstore/v3/unique_constraints.go
@@ -37,15 +37,15 @@ func handleUniqueConstraints(ctx context.Context, tx *sql.Tx, commands []eventst
 			case eventstore.UniqueConstraintAdd:
 				addPlaceholders = append(addPlaceholders, fmt.Sprintf("($%d, $%d, $%d)", len(addArgs)+1, len(addArgs)+2, len(addArgs)+3))
 				addArgs = append(addArgs, command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)
-				addConstraints[fmt.Sprintf("('%s', '%s', '%s')", command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
+				addConstraints[fmt.Sprintf(uniqueConstraintPlaceholderFmt, command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
 			case eventstore.UniqueConstraintRemove:
 				deletePlaceholders = append(deletePlaceholders, fmt.Sprintf("(instance_id = $%d AND unique_type = $%d AND unique_field = $%d)", len(deleteArgs)+1, len(deleteArgs)+2, len(deleteArgs)+3))
 				deleteArgs = append(deleteArgs, command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)
-				deleteConstraints[fmt.Sprintf("('%s', '%s', '%s')", command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
+				deleteConstraints[fmt.Sprintf(uniqueConstraintPlaceholderFmt, command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
 			case eventstore.UniqueConstraintInstanceRemove:
 				deletePlaceholders = append(deletePlaceholders, fmt.Sprintf("(instance_id = $%d)", len(deleteArgs)+1))
 				deleteArgs = append(deleteArgs, command.Aggregate().InstanceID)
-				deleteConstraints[fmt.Sprintf("('%s', '%s', '%s')", command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
+				deleteConstraints[fmt.Sprintf(uniqueConstraintPlaceholderFmt, command.Aggregate().InstanceID, constraint.UniqueType, constraint.UniqueField)] = constraint
 			}
 		}
 	}


### PR DESCRIPTION
Version 2.39.0 silently introduced a breaking change to the error type returned when pushing is not possible because of a unique constraint error, the previous error type is now returned.
Postgres and Cockroach return unique constraint errors in different formats. ZITADEL now is able to handle both formats.