### PR TITLE
fix: use username with external idp linking

### DIFF
--- a/internal/auth/repository/eventsourcing/eventstore/auth_request.go
+++ b/internal/auth/repository/eventsourcing/eventstore/auth_request.go
@@ -1586,7 +1586,7 @@ func linkExternalIDPs(ctx context.Context, userCommandProvider userCommandProvid
 			ObjectRoot:     es_models.ObjectRoot{AggregateID: request.UserID},
 			IDPConfigID:    linkingUser.IDPConfigID,
 			ExternalUserID: linkingUser.ExternalUserID,
-			DisplayName:    linkingUser.DisplayName,
+			DisplayName:    linkingUser.PreferredUsername,
 		}
 		externalIDPs[i] = externalIDP
 	}


### PR DESCRIPTION
Closes #6731 , changes used attribute for display_name in the user link from DisplayName to PreferredUsername.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
