### PR TITLE
feat: add possibility to set an expiration to a session

### DIFF
--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -629,7 +629,7 @@ func Test_ZITADEL_API_missing_mfa(t *testing.T) {
 }
 
 func Test_ZITADEL_API_success(t *testing.T) {
-	id, token, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, User.GetUserId())
+	id, token, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, User.GetUserId())
 
 	ctx := Tester.WithAuthorizationToken(context.Background(), token)
 	sessionResp, err := Tester.Client.SessionV2.GetSession(ctx, &session.GetSessionRequest{SessionId: id})
@@ -641,7 +641,7 @@ func Test_ZITADEL_API_success(t *testing.T) {
 }
 
 func Test_ZITADEL_API_session_not_found(t *testing.T) {
-	id, token, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, User.GetUserId())
+	id, token, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, User.GetUserId())
 
 	// test session token works
 	ctx := Tester.WithAuthorizationToken(context.Background(), token)

--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -611,7 +611,7 @@ func TestServer_SetSession_flow(t *testing.T) {
 
 func TestServer_SetSession_expired(t *testing.T) {
 	createResp, err := Client.CreateSession(CTX, &session.CreateSessionRequest{
-		Lifetime: durationpb.New(10 * time.Second),
+		Lifetime: durationpb.New(20 * time.Second),
 	})
 	require.NoError(t, err)
 
@@ -619,20 +619,16 @@ func TestServer_SetSession_expired(t *testing.T) {
 	sessionResp, err := Tester.Client.SessionV2.SetSession(CTX, &session.SetSessionRequest{
 		SessionId:    createResp.GetSessionId(),
 		SessionToken: createResp.GetSessionToken(),
-		Metadata: map[string][]byte{
-			"key": []byte("value"),
-		},
+		Lifetime:     durationpb.New(20 * time.Second),
 	})
 	require.NoError(t, err)
 
 	// ensure session expires and does not work anymore
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 	_, err = Tester.Client.SessionV2.SetSession(CTX, &session.SetSessionRequest{
 		SessionId:    createResp.GetSessionId(),
 		SessionToken: sessionResp.GetSessionToken(),
-		Metadata: map[string][]byte{
-			"key": []byte("value"),
-		},
+		Lifetime:     durationpb.New(20 * time.Second),
 	})
 	require.Error(t, err)
 }
@@ -689,7 +685,7 @@ func Test_ZITADEL_API_session_not_found(t *testing.T) {
 }
 
 func Test_ZITADEL_API_session_expired(t *testing.T) {
-	id, token, _, _ := Tester.CreateVerifiedWebAuthNSessionWithLifetime(t, CTX, User.GetUserId(), 30*time.Second)
+	id, token, _, _ := Tester.CreateVerifiedWebAuthNSessionWithLifetime(t, CTX, User.GetUserId(), 20*time.Second)
 
 	// test session token works
 	ctx := Tester.WithAuthorizationToken(context.Background(), token)
@@ -697,7 +693,7 @@ func Test_ZITADEL_API_session_expired(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure session expires and does not work anymore
-	time.Sleep(30 * time.Second)
+	time.Sleep(20 * time.Second)
 	sessionResp, err := Tester.Client.SessionV2.GetSession(ctx, &session.GetSessionRequest{SessionId: id})
 	require.Error(t, err)
 	require.Nil(t, sessionResp)

--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -658,3 +658,18 @@ func Test_ZITADEL_API_session_not_found(t *testing.T) {
 	_, err = Tester.Client.SessionV2.GetSession(ctx, &session.GetSessionRequest{SessionId: id})
 	require.Error(t, err)
 }
+
+func Test_ZITADEL_API_session_expired(t *testing.T) {
+	id, token, _, _ := Tester.CreateVerifiedWebAuthNSessionWithLifetime(t, CTX, User.GetUserId(), 30*time.Second)
+
+	// test session token works
+	ctx := Tester.WithAuthorizationToken(context.Background(), token)
+	_, err := Tester.Client.SessionV2.GetSession(ctx, &session.GetSessionRequest{SessionId: id})
+	require.NoError(t, err)
+
+	// ensure session expires and does not work anymore
+	time.Sleep(30 * time.Second)
+	sessionResp, err := Tester.Client.SessionV2.GetSession(ctx, &session.GetSessionRequest{SessionId: id})
+	require.Error(t, err)
+	require.Nil(t, sessionResp)
+}

--- a/internal/api/grpc/session/v2/session_integration_test.go
+++ b/internal/api/grpc/session/v2/session_integration_test.go
@@ -190,6 +190,14 @@ func TestServer_CreateSession(t *testing.T) {
 			},
 		},
 		{
+			name: "negative lifetime",
+			req: &session.CreateSessionRequest{
+				Metadata: map[string][]byte{"foo": []byte("bar")},
+				Lifetime: durationpb.New(-5 * time.Minute),
+			},
+			wantErr: true,
+		},
+		{
 			name: "lifetime",
 			req: &session.CreateSessionRequest{
 				Metadata: map[string][]byte{"foo": []byte("bar")},

--- a/internal/api/grpc/session/v2/session_test.go
+++ b/internal/api/grpc/session/v2/session_test.go
@@ -27,7 +27,7 @@ func Test_sessionsToPb(t *testing.T) {
 	past := now.Add(-time.Hour)
 
 	sessions := []*query.Session{
-		{ // no factor, with user agent
+		{ // no factor, with user agent and expiration
 			ID:            "999",
 			CreationDate:  now,
 			ChangeDate:    now,
@@ -42,6 +42,7 @@ func Test_sessionsToPb(t *testing.T) {
 				IP:            net.IPv4(1, 2, 3, 4),
 				Header:        http.Header{"foo": []string{"foo", "bar"}},
 			},
+			Expiration: now,
 		},
 		{ // user factor
 			ID:            "999",
@@ -124,7 +125,7 @@ func Test_sessionsToPb(t *testing.T) {
 	}
 
 	want := []*session.Session{
-		{ // no factor, with user agent
+		{ // no factor, with user agent and expiration
 			Id:           "999",
 			CreationDate: timestamppb.New(now),
 			ChangeDate:   timestamppb.New(now),
@@ -139,6 +140,7 @@ func Test_sessionsToPb(t *testing.T) {
 					"foo": {Values: []string{"foo", "bar"}},
 				},
 			},
+			ExpirationDate: timestamppb.New(now),
 		},
 		{ // user factor
 			Id:           "999",

--- a/internal/api/grpc/user/v2/otp_integration_test.go
+++ b/internal/api/grpc/user/v2/otp_integration_test.go
@@ -16,13 +16,13 @@ import (
 func TestServer_AddOTPSMS(t *testing.T) {
 	userID := Tester.CreateHumanUser(CTX).GetUserId()
 	Tester.RegisterUserPasskey(CTX, userID)
-	_, sessionToken, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userID)
+	_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
 
 	// TODO: add when phone can be added to user
 	/*
 		userIDPhone := Tester.CreateHumanUser(CTX).GetUserId()
 		Tester.RegisterUserPasskey(CTX, userIDPhone)
-		_, sessionTokenPhone, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userIDPhone)
+		_, sessionTokenPhone, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userIDPhone)
 	*/
 	type args struct {
 		ctx context.Context
@@ -99,7 +99,7 @@ func TestServer_RemoveOTPSMS(t *testing.T) {
 	/*
 		userID := Tester.CreateHumanUser(CTX).GetUserId()
 		Tester.RegisterUserPasskey(CTX, userID)
-		_, sessionToken, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userID)
+		_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
 	*/
 
 	type args struct {
@@ -157,7 +157,7 @@ func TestServer_RemoveOTPSMS(t *testing.T) {
 func TestServer_AddOTPEmail(t *testing.T) {
 	userID := Tester.CreateHumanUser(CTX).GetUserId()
 	Tester.RegisterUserPasskey(CTX, userID)
-	_, sessionToken, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userID)
+	_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
 
 	userVerified := Tester.CreateHumanUser(CTX)
 	_, err := Tester.Client.UserV2.VerifyEmail(CTX, &user.VerifyEmailRequest{
@@ -166,7 +166,7 @@ func TestServer_AddOTPEmail(t *testing.T) {
 	})
 	require.NoError(t, err)
 	Tester.RegisterUserPasskey(CTX, userVerified.GetUserId())
-	_, sessionTokenVerified, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userVerified.GetUserId())
+	_, sessionTokenVerified, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userVerified.GetUserId())
 
 	type args struct {
 		ctx context.Context
@@ -238,11 +238,11 @@ func TestServer_AddOTPEmail(t *testing.T) {
 func TestServer_RemoveOTPEmail(t *testing.T) {
 	userID := Tester.CreateHumanUser(CTX).GetUserId()
 	Tester.RegisterUserPasskey(CTX, userID)
-	_, sessionToken, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userID)
+	_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
 
 	userVerified := Tester.CreateHumanUser(CTX)
 	Tester.RegisterUserPasskey(CTX, userVerified.GetUserId())
-	_, sessionTokenVerified, _, _ := Tester.CreateVerfiedWebAuthNSession(t, CTX, userVerified.GetUserId())
+	_, sessionTokenVerified, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userVerified.GetUserId())
 	userVerifiedCtx := Tester.WithAuthorizationToken(context.Background(), sessionTokenVerified)
 	_, err := Tester.Client.UserV2.VerifyEmail(userVerifiedCtx, &user.VerifyEmailRequest{
 		UserId:           userVerified.GetUserId(),

--- a/internal/api/oidc/auth_request_integration_test.go
+++ b/internal/api/oidc/auth_request_integration_test.go
@@ -36,7 +36,7 @@ func TestOPStorage_CreateAuthRequest(t *testing.T) {
 func TestOPStorage_CreateAccessToken_code(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -75,7 +75,7 @@ func TestOPStorage_CreateAccessToken_code(t *testing.T) {
 func TestOPStorage_CreateAccessToken_implicit(t *testing.T) {
 	clientID := createImplicitClient(t)
 	authRequestID := createAuthRequestImplicit(t, clientID, redirectURIImplicit)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -125,7 +125,7 @@ func TestOPStorage_CreateAccessToken_implicit(t *testing.T) {
 func TestOPStorage_CreateAccessAndRefreshTokens_code(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -150,7 +150,7 @@ func TestOPStorage_CreateAccessAndRefreshTokens_refresh(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -186,7 +186,7 @@ func TestOPStorage_RevokeToken_access_token(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -229,7 +229,7 @@ func TestOPStorage_RevokeToken_access_token_invalid_token_hint_type(t *testing.T
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -266,7 +266,7 @@ func TestOPStorage_RevokeToken_refresh_token(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -309,7 +309,7 @@ func TestOPStorage_RevokeToken_refresh_token_invalid_token_type_hint(t *testing.
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -344,7 +344,7 @@ func TestOPStorage_RevokeToken_refresh_token_invalid_token_type_hint(t *testing.
 func TestOPStorage_RevokeToken_invalid_client(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -376,7 +376,7 @@ func TestOPStorage_TerminateSession(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -413,7 +413,7 @@ func TestOPStorage_TerminateSession_refresh_grant(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -457,7 +457,7 @@ func TestOPStorage_TerminateSession_empty_id_token_hint(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{

--- a/internal/api/oidc/client_integration_test.go
+++ b/internal/api/oidc/client_integration_test.go
@@ -21,7 +21,7 @@ import (
 func TestOPStorage_SetUserinfoFromToken(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, oidc.ScopeOfflineAccess)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -67,7 +67,7 @@ func TestOPStorage_SetIntrospectionFromToken(t *testing.T) {
 
 	scope := []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, oidc.ScopeOfflineAccess}
 	authRequestID := createAuthRequest(t, app.GetClientId(), redirectURI, scope...)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{

--- a/internal/api/oidc/oidc_integration_test.go
+++ b/internal/api/oidc/oidc_integration_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 func Test_ZITADEL_API_missing_audience_scope(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -148,7 +148,7 @@ func Test_ZITADEL_API_missing_mfa(t *testing.T) {
 func Test_ZITADEL_API_success(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, zitadelAudienceScope)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -177,7 +177,7 @@ func Test_ZITADEL_API_success(t *testing.T) {
 func Test_ZITADEL_API_inactive_access_token(t *testing.T) {
 	clientID := createClient(t)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess, zitadelAudienceScope)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{
@@ -219,7 +219,7 @@ func Test_ZITADEL_API_terminated_session(t *testing.T) {
 	provider, err := Tester.CreateRelyingParty(CTX, clientID, redirectURI)
 	require.NoError(t, err)
 	authRequestID := createAuthRequest(t, clientID, redirectURI, oidc.ScopeOpenID, oidc.ScopeOfflineAccess, zitadelAudienceScope)
-	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerfiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
+	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
 		AuthRequestId: authRequestID,
 		CallbackKind: &oidc_pb.CreateCallbackRequest_Session{

--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -153,6 +153,9 @@ func (repo *TokenVerifierRepo) verifySessionToken(ctx context.Context, sessionID
 	if err != nil {
 		return "", "", "", err
 	}
+	if !session.Expiration.IsZero() && session.Expiration.Before(time.Now()) {
+		return "", "", "", caos_errs.ThrowPermissionDenied(nil, "AUTHZ-EGDo3", "session expired")
+	}
 	if err = repo.checkAuthentication(ctx, authMethodsFromSession(session), session.UserFactor.UserID); err != nil {
 		return "", "", "", err
 	}

--- a/internal/command/auth_request.go
+++ b/internal/command/auth_request.go
@@ -95,8 +95,8 @@ func (c *Commands) LinkSessionToAuthRequest(ctx context.Context, id, sessionID, 
 	if err != nil {
 		return nil, nil, err
 	}
-	if sessionWriteModel.State == domain.SessionStateUnspecified {
-		return nil, nil, errors.ThrowNotFound(nil, "COMMAND-x0099887", "Errors.Session.NotExisting")
+	if err = sessionWriteModel.CheckIsActive(); err != nil {
+		return nil, nil, err
 	}
 	if err := c.sessionPermission(ctx, sessionWriteModel, sessionToken, domain.PermissionSessionWrite); err != nil {
 		return nil, nil, err

--- a/internal/command/oidc_session.go
+++ b/internal/command/oidc_session.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/crypto"
-	"github.com/zitadel/zitadel/internal/domain"
 	caos_errs "github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/id"
@@ -159,8 +158,8 @@ func (c *Commands) newOIDCSessionAddEvents(ctx context.Context, authRequestID st
 	if err != nil {
 		return nil, err
 	}
-	if sessionWriteModel.State != domain.SessionStateActive {
-		return nil, caos_errs.ThrowPreconditionFailed(nil, "OIDCS-sjkl3", "Errors.Session.Terminated")
+	if err = sessionWriteModel.CheckIsActive(); err != nil {
+		return nil, err
 	}
 	resourceOwner, err := c.getResourceOwnerOfSessionUser(ctx, sessionWriteModel.UserID, sessionWriteModel.InstanceID)
 	if err != nil {

--- a/internal/command/oidc_session_test.go
+++ b/internal/command/oidc_session_test.go
@@ -119,7 +119,7 @@ func TestCommands_AddOIDCSessionAccessToken(t *testing.T) {
 				authRequestID: "V2_authRequestID",
 			},
 			res{
-				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-sjkl3", "Errors.Session.Terminated"),
+				err: caos_errs.ThrowPreconditionFailed(nil, "COMMAND-Flk38", "Errors.Session.NotExisting"),
 			},
 		},
 		{
@@ -320,7 +320,7 @@ func TestCommands_AddOIDCSessionRefreshAndAccessToken(t *testing.T) {
 				authRequestID: "V2_authRequestID",
 			},
 			res{
-				err: caos_errs.ThrowPreconditionFailed(nil, "OIDCS-sjkl3", "Errors.Session.Terminated"),
+				err: caos_errs.ThrowPreconditionFailed(nil, "COMMAND-Flk38", "Errors.Session.NotExisting"),
 			},
 		},
 		{

--- a/internal/command/session.go
+++ b/internal/command/session.go
@@ -350,11 +350,8 @@ func (c *Commands) terminateSession(ctx context.Context, sessionID, sessionToken
 
 // updateSession execute the [SessionCommands] where new events will be created and as well as for metadata (changes)
 func (c *Commands) updateSession(ctx context.Context, checks *SessionCommands, metadata map[string][]byte, lifetime time.Duration) (set *SessionChanged, err error) {
-	if checks.sessionWriteModel.State == domain.SessionStateTerminated {
-		return nil, caos_errs.ThrowPreconditionFailed(nil, "COMAND-SAjeh", "Errors.Session.Terminated")
-	}
-	if !checks.sessionWriteModel.Expiration.IsZero() && checks.sessionWriteModel.Expiration.Before(time.Now()) {
-		return nil, caos_errs.ThrowPreconditionFailed(nil, "COMAND-Gh5j3", "Errors.Session.Expired")
+	if err = checks.sessionWriteModel.CheckNotInvalidated(); err != nil {
+		return nil, err
 	}
 	if err := checks.Exec(ctx); err != nil {
 		// TODO: how to handle failed checks (e.g. pw wrong) https://github.com/zitadel/zitadel/issues/5807

--- a/internal/command/session.go
+++ b/internal/command/session.go
@@ -254,7 +254,7 @@ func (s *SessionCommands) ChangeMetadata(ctx context.Context, metadata map[strin
 
 func (s *SessionCommands) SetLifetime(ctx context.Context, lifetime time.Duration) error {
 	if lifetime < 0 {
-		return caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.InvalidLifetime")
+		return caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.NegativeLifetime")
 	}
 	if lifetime == 0 {
 		return nil

--- a/internal/command/session.go
+++ b/internal/command/session.go
@@ -254,7 +254,7 @@ func (s *SessionCommands) ChangeMetadata(ctx context.Context, metadata map[strin
 
 func (s *SessionCommands) SetLifetime(ctx context.Context, lifetime time.Duration) error {
 	if lifetime < 0 {
-		return caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.NegativeLifetime")
+		return caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.PositiveLifetime")
 	}
 	if lifetime == 0 {
 		return nil

--- a/internal/command/session.go
+++ b/internal/command/session.go
@@ -253,10 +253,9 @@ func (s *SessionCommands) ChangeMetadata(ctx context.Context, metadata map[strin
 }
 
 func (s *SessionCommands) SetLifetime(ctx context.Context, lifetime time.Duration) {
-	if lifetime == 0 {
-		return
+	if lifetime > 0 {
+		s.eventCommands = append(s.eventCommands, session.NewLifetimeSetEvent(ctx, s.sessionWriteModel.aggregate, lifetime))
 	}
-	s.eventCommands = append(s.eventCommands, session.NewLifetimeSetEvent(ctx, s.sessionWriteModel.aggregate, lifetime))
 }
 
 func (s *SessionCommands) gethumanWriteModel(ctx context.Context) (*HumanWriteModel, error) {

--- a/internal/command/session_model.go
+++ b/internal/command/session_model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/errors"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/session"
 )
@@ -48,6 +49,7 @@ type SessionWriteModel struct {
 	WebAuthNUserVerified bool
 	Metadata             map[string][]byte
 	State                domain.SessionState
+	Expiration           time.Time
 
 	WebAuthNChallenge     *WebAuthNChallengeModel
 	OTPSMSCodeChallenge   *OTPCode
@@ -94,6 +96,8 @@ func (wm *SessionWriteModel) Reduce() error {
 			wm.reduceOTPEmailChecked(e)
 		case *session.TokenSetEvent:
 			wm.reduceTokenSet(e)
+		case *session.LifetimeSetEvent:
+			wm.reduceLifetimeSet(e)
 		case *session.TerminateEvent:
 			wm.reduceTerminate()
 		}
@@ -120,6 +124,7 @@ func (wm *SessionWriteModel) Query() *eventstore.SearchQueryBuilder {
 			session.OTPEmailCheckedType,
 			session.TokenSetType,
 			session.MetadataSetType,
+			session.LifetimeSetType,
 			session.TerminateType,
 		).
 		Builder()
@@ -196,6 +201,10 @@ func (wm *SessionWriteModel) reduceTokenSet(e *session.TokenSetEvent) {
 	wm.TokenID = e.TokenID
 }
 
+func (wm *SessionWriteModel) reduceLifetimeSet(e *session.LifetimeSetEvent) {
+	wm.Expiration = e.CreationDate().Add(e.Lifetime)
+}
+
 func (wm *SessionWriteModel) reduceTerminate() {
 	wm.State = domain.SessionStateTerminated
 }
@@ -244,4 +253,17 @@ func (wm *SessionWriteModel) AuthMethodTypes() []domain.UserAuthMethodType {
 		types = append(types, domain.UserAuthMethodTypeOTPEmail)
 	}
 	return types
+}
+
+func (wm *SessionWriteModel) CheckIsActive() error {
+	if wm.State == domain.SessionStateUnspecified {
+		return errors.ThrowPreconditionFailed(nil, "COMMAND-Flk38", "Errors.Session.NotExisting")
+	}
+	if wm.State == domain.SessionStateTerminated {
+		return errors.ThrowPreconditionFailed(nil, "COMMAND-Hewfq", "Errors.Session.Terminated")
+	}
+	if !wm.Expiration.IsZero() && wm.Expiration.Before(time.Now()) {
+		return errors.ThrowPreconditionFailed(nil, "COMMAND-Hkl3d", "Errors.Session.Expired")
+	}
+	return nil
 }

--- a/internal/command/session_model.go
+++ b/internal/command/session_model.go
@@ -255,10 +255,9 @@ func (wm *SessionWriteModel) AuthMethodTypes() []domain.UserAuthMethodType {
 	return types
 }
 
-func (wm *SessionWriteModel) CheckIsActive() error {
-	if wm.State == domain.SessionStateUnspecified {
-		return errors.ThrowPreconditionFailed(nil, "COMMAND-Flk38", "Errors.Session.NotExisting")
-	}
+// CheckNotInvalidated checks that the session was not invalidated either manually ([session.TerminateType])
+// or automatically (expired).
+func (wm *SessionWriteModel) CheckNotInvalidated() error {
 	if wm.State == domain.SessionStateTerminated {
 		return errors.ThrowPreconditionFailed(nil, "COMMAND-Hewfq", "Errors.Session.Terminated")
 	}
@@ -266,4 +265,12 @@ func (wm *SessionWriteModel) CheckIsActive() error {
 		return errors.ThrowPreconditionFailed(nil, "COMMAND-Hkl3d", "Errors.Session.Expired")
 	}
 	return nil
+}
+
+// CheckIsActive checks that the session was not invalidated ([CheckNotInvalidated]) and actually already exists.
+func (wm *SessionWriteModel) CheckIsActive() error {
+	if wm.State == domain.SessionStateUnspecified {
+		return errors.ThrowPreconditionFailed(nil, "COMMAND-Flk38", "Errors.Session.NotExisting")
+	}
+	return wm.CheckNotInvalidated()
 }

--- a/internal/command/session_test.go
+++ b/internal/command/session_test.go
@@ -217,7 +217,7 @@ func TestCommands_CreateSession(t *testing.T) {
 				expectFilter(),
 			},
 			res{
-				err: caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.NegativeLifetime"),
+				err: caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.PositiveLifetime"),
 			},
 		},
 		{
@@ -520,7 +520,7 @@ func TestCommands_updateSession(t *testing.T) {
 				lifetime: -10 * time.Minute,
 			},
 			res{
-				err: caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.NegativeLifetime"),
+				err: caos_errs.ThrowInvalidArgument(nil, "COMMAND-asEG4", "Errors.Session.PositiveLifetime"),
 			},
 		},
 		{

--- a/internal/command/session_test.go
+++ b/internal/command/session_test.go
@@ -425,7 +425,7 @@ func TestCommands_updateSession(t *testing.T) {
 				},
 			},
 			res{
-				err: caos_errs.ThrowPreconditionFailed(nil, "COMAND-SAjeh", "Errors.Session.Terminated"),
+				err: caos_errs.ThrowPreconditionFailed(nil, "COMMAND-Hewfq", "Errors.Session.Terminated"),
 			},
 		},
 		{

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -330,6 +330,10 @@ func (s *Tester) CreateVerifiedWebAuthNSession(t *testing.T, ctx context.Context
 }
 
 func (s *Tester) CreateVerifiedWebAuthNSessionWithLifetime(t *testing.T, ctx context.Context, userID string, lifetime time.Duration) (id, token string, start, change time.Time) {
+	var sessionLifetime *durationpb.Duration
+	if lifetime > 0 {
+		sessionLifetime = durationpb.New(lifetime)
+	}
 	createResp, err := s.Client.SessionV2.CreateSession(ctx, &session.CreateSessionRequest{
 		Checks: &session.Checks{
 			User: &session.CheckUser{
@@ -342,7 +346,7 @@ func (s *Tester) CreateVerifiedWebAuthNSessionWithLifetime(t *testing.T, ctx con
 				UserVerificationRequirement: session.UserVerificationRequirement_USER_VERIFICATION_REQUIREMENT_REQUIRED,
 			},
 		},
-		Lifetime: durationpb.New(lifetime),
+		Lifetime: sessionLifetime,
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/text/language"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/command"
@@ -325,6 +326,10 @@ func (s *Tester) CreateSuccessfulSAMLIntent(t *testing.T, idpID, userID, idpUser
 }
 
 func (s *Tester) CreateVerfiedWebAuthNSession(t *testing.T, ctx context.Context, userID string) (id, token string, start, change time.Time) {
+	return s.CreateVerifiedWebAuthNSessionWithLifetime(t, ctx, userID, 0)
+}
+
+func (s *Tester) CreateVerifiedWebAuthNSessionWithLifetime(t *testing.T, ctx context.Context, userID string, lifetime time.Duration) (id, token string, start, change time.Time) {
 	createResp, err := s.Client.SessionV2.CreateSession(ctx, &session.CreateSessionRequest{
 		Checks: &session.Checks{
 			User: &session.CheckUser{
@@ -337,6 +342,7 @@ func (s *Tester) CreateVerfiedWebAuthNSession(t *testing.T, ctx context.Context,
 				UserVerificationRequirement: session.UserVerificationRequirement_USER_VERIFICATION_REQUIREMENT_REQUIRED,
 			},
 		},
+		Lifetime: durationpb.New(lifetime),
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -325,7 +325,7 @@ func (s *Tester) CreateSuccessfulSAMLIntent(t *testing.T, idpID, userID, idpUser
 	return intentID, token, writeModel.ChangeDate, writeModel.ProcessedSequence
 }
 
-func (s *Tester) CreateVerfiedWebAuthNSession(t *testing.T, ctx context.Context, userID string) (id, token string, start, change time.Time) {
+func (s *Tester) CreateVerifiedWebAuthNSession(t *testing.T, ctx context.Context, userID string) (id, token string, start, change time.Time) {
 	return s.CreateVerifiedWebAuthNSessionWithLifetime(t, ctx, userID, 0)
 }
 

--- a/internal/query/projection/session_test.go
+++ b/internal/query/projection/session_test.go
@@ -51,7 +51,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.sessions6 (id, instance_id, creation_date, change_date, resource_owner, state, sequence, creator, user_agent_fingerprint_id, user_agent_description, user_agent_ip, user_agent_header) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+							expectedStmt: "INSERT INTO projections.sessions7 (id, instance_id, creation_date, change_date, resource_owner, state, sequence, creator, user_agent_fingerprint_id, user_agent_description, user_agent_ip, user_agent_header) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"instance-id",
@@ -90,7 +90,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, user_id, user_checked_at) = ($1, $2, $3, $4) WHERE (id = $5) AND (instance_id = $6)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, user_id, user_checked_at) = ($1, $2, $3, $4) WHERE (id = $5) AND (instance_id = $6)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -122,7 +122,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, password_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, password_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -154,7 +154,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, webauthn_checked_at, webauthn_user_verified) = ($1, $2, $3, $4) WHERE (id = $5) AND (instance_id = $6)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, webauthn_checked_at, webauthn_user_verified) = ($1, $2, $3, $4) WHERE (id = $5) AND (instance_id = $6)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -186,7 +186,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, intent_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, intent_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -217,7 +217,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, totp_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, totp_checked_at) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -248,7 +248,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, token_id) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, token_id) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -281,13 +281,44 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET (change_date, sequence, metadata) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, metadata) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
 								map[string][]byte{
 									"key": []byte("value"),
 								},
+								"agg-id",
+								"instance-id",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "instance reduceLifetimeSet",
+			args: args{
+				event: getEvent(testEvent(
+					session.MetadataSetType,
+					session.AggregateType,
+					[]byte(`{
+						"lifetime": 600000000000
+					}`),
+				), eventstore.GenericEventMapper[session.LifetimeSetEvent]),
+			},
+			reduce: (&sessionProjection{}).reduceLifetimeSet,
+			want: wantReduce{
+				aggregateType: eventstore.AggregateType("session"),
+				sequence:      15,
+				executer: &testExecuter{
+					executions: []execution{
+						{
+							expectedStmt: "UPDATE projections.sessions7 SET (change_date, sequence, expiration) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedArgs: []interface{}{
+								anyArg{},
+								anyArg{},
+								anyArg{},
 								"agg-id",
 								"instance-id",
 							},
@@ -312,7 +343,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.sessions6 WHERE (id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.sessions7 WHERE (id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"instance-id",
@@ -339,7 +370,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.sessions6 WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.sessions7 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},
@@ -369,7 +400,7 @@ func TestSessionProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.sessions6 SET password_checked_at = $1 WHERE (user_id = $2) AND (password_checked_at < $3)",
+							expectedStmt: "UPDATE projections.sessions7 SET password_checked_at = $1 WHERE (user_id = $2) AND (password_checked_at < $3)",
 							expectedArgs: []interface{}{
 								nil,
 								"agg-id",

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -44,6 +44,7 @@ type Session struct {
 	OTPEmailFactor SessionOTPFactor
 	Metadata       map[string][]byte
 	UserAgent      domain.UserAgent
+	Expiration     time.Time
 }
 
 type SessionUserFactor struct {
@@ -185,6 +186,10 @@ var (
 		name:  projection.SessionColumnUserAgentHeader,
 		table: sessionsTable,
 	}
+	SessionColumnExpiration = Column{
+		name:  projection.SessionColumnExpiration,
+		table: sessionsTable,
+	}
 )
 
 func (q *Queries) SessionByID(ctx context.Context, shouldTriggerBulk bool, id, sessionToken string) (session *Session, err error) {
@@ -290,6 +295,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 			SessionColumnUserAgentIP.identifier(),
 			SessionColumnUserAgentDescription.identifier(),
 			SessionColumnUserAgentHeader.identifier(),
+			SessionColumnExpiration.identifier(),
 		).From(sessionsTable.identifier()).
 			LeftJoin(join(LoginNameUserIDCol, SessionColumnUserID)).
 			LeftJoin(join(HumanUserIDCol, SessionColumnUserID)).
@@ -314,6 +320,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 				token               sql.NullString
 				userAgentIP         sql.NullString
 				userAgentHeader     database.Map[[]string]
+				expiration          sql.NullTime
 			)
 
 			err := row.Scan(
@@ -342,6 +349,7 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 				&userAgentIP,
 				&session.UserAgent.Description,
 				&userAgentHeader,
+				&expiration,
 			)
 
 			if err != nil {
@@ -365,10 +373,10 @@ func prepareSessionQuery(ctx context.Context, db prepareDatabase) (sq.SelectBuil
 			session.OTPEmailFactor.OTPCheckedAt = otpEmailCheckedAt.Time
 			session.Metadata = metadata
 			session.UserAgent.Header = http.Header(userAgentHeader)
-
 			if userAgentIP.Valid {
 				session.UserAgent.IP = net.ParseIP(userAgentIP.String)
 			}
+			session.Expiration = expiration.Time
 			return session, token.String, nil
 		}
 }
@@ -395,6 +403,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 			SessionColumnOTPSMSCheckedAt.identifier(),
 			SessionColumnOTPEmailCheckedAt.identifier(),
 			SessionColumnMetadata.identifier(),
+			SessionColumnExpiration.identifier(),
 			countColumn.identifier(),
 		).From(sessionsTable.identifier()).
 			LeftJoin(join(LoginNameUserIDCol, SessionColumnUserID)).
@@ -420,6 +429,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 					otpSMSCheckedAt     sql.NullTime
 					otpEmailCheckedAt   sql.NullTime
 					metadata            database.Map[[]byte]
+					expiration          sql.NullTime
 				)
 
 				err := rows.Scan(
@@ -443,6 +453,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 					&otpSMSCheckedAt,
 					&otpEmailCheckedAt,
 					&metadata,
+					&expiration,
 					&sessions.Count,
 				)
 
@@ -462,6 +473,7 @@ func prepareSessionsQuery(ctx context.Context, db prepareDatabase) (sq.SelectBui
 				session.OTPSMSFactor.OTPCheckedAt = otpSMSCheckedAt.Time
 				session.OTPEmailFactor.OTPCheckedAt = otpEmailCheckedAt.Time
 				session.Metadata = metadata
+				session.Expiration = expiration.Time
 
 				sessions.Sessions = append(sessions.Sessions, session)
 			}

--- a/internal/query/sessions_test.go
+++ b/internal/query/sessions_test.go
@@ -20,61 +20,63 @@ import (
 )
 
 var (
-	expectedSessionQuery = regexp.QuoteMeta(`SELECT projections.sessions6.id,` +
-		` projections.sessions6.creation_date,` +
-		` projections.sessions6.change_date,` +
-		` projections.sessions6.sequence,` +
-		` projections.sessions6.state,` +
-		` projections.sessions6.resource_owner,` +
-		` projections.sessions6.creator,` +
-		` projections.sessions6.user_id,` +
-		` projections.sessions6.user_checked_at,` +
+	expectedSessionQuery = regexp.QuoteMeta(`SELECT projections.sessions7.id,` +
+		` projections.sessions7.creation_date,` +
+		` projections.sessions7.change_date,` +
+		` projections.sessions7.sequence,` +
+		` projections.sessions7.state,` +
+		` projections.sessions7.resource_owner,` +
+		` projections.sessions7.creator,` +
+		` projections.sessions7.user_id,` +
+		` projections.sessions7.user_checked_at,` +
 		` projections.login_names2.login_name,` +
 		` projections.users8_humans.display_name,` +
 		` projections.users8.resource_owner,` +
-		` projections.sessions6.password_checked_at,` +
-		` projections.sessions6.intent_checked_at,` +
-		` projections.sessions6.webauthn_checked_at,` +
-		` projections.sessions6.webauthn_user_verified,` +
-		` projections.sessions6.totp_checked_at,` +
-		` projections.sessions6.otp_sms_checked_at,` +
-		` projections.sessions6.otp_email_checked_at,` +
-		` projections.sessions6.metadata,` +
-		` projections.sessions6.token_id,` +
-		` projections.sessions6.user_agent_fingerprint_id,` +
-		` projections.sessions6.user_agent_ip,` +
-		` projections.sessions6.user_agent_description,` +
-		` projections.sessions6.user_agent_header` +
-		` FROM projections.sessions6` +
-		` LEFT JOIN projections.login_names2 ON projections.sessions6.user_id = projections.login_names2.user_id AND projections.sessions6.instance_id = projections.login_names2.instance_id` +
-		` LEFT JOIN projections.users8_humans ON projections.sessions6.user_id = projections.users8_humans.user_id AND projections.sessions6.instance_id = projections.users8_humans.instance_id` +
-		` LEFT JOIN projections.users8 ON projections.sessions6.user_id = projections.users8.id AND projections.sessions6.instance_id = projections.users8.instance_id` +
+		` projections.sessions7.password_checked_at,` +
+		` projections.sessions7.intent_checked_at,` +
+		` projections.sessions7.webauthn_checked_at,` +
+		` projections.sessions7.webauthn_user_verified,` +
+		` projections.sessions7.totp_checked_at,` +
+		` projections.sessions7.otp_sms_checked_at,` +
+		` projections.sessions7.otp_email_checked_at,` +
+		` projections.sessions7.metadata,` +
+		` projections.sessions7.token_id,` +
+		` projections.sessions7.user_agent_fingerprint_id,` +
+		` projections.sessions7.user_agent_ip,` +
+		` projections.sessions7.user_agent_description,` +
+		` projections.sessions7.user_agent_header,` +
+		` projections.sessions7.expiration` +
+		` FROM projections.sessions7` +
+		` LEFT JOIN projections.login_names2 ON projections.sessions7.user_id = projections.login_names2.user_id AND projections.sessions7.instance_id = projections.login_names2.instance_id` +
+		` LEFT JOIN projections.users8_humans ON projections.sessions7.user_id = projections.users8_humans.user_id AND projections.sessions7.instance_id = projections.users8_humans.instance_id` +
+		` LEFT JOIN projections.users8 ON projections.sessions7.user_id = projections.users8.id AND projections.sessions7.instance_id = projections.users8.instance_id` +
 		` AS OF SYSTEM TIME '-1 ms'`)
-	expectedSessionsQuery = regexp.QuoteMeta(`SELECT projections.sessions6.id,` +
-		` projections.sessions6.creation_date,` +
-		` projections.sessions6.change_date,` +
-		` projections.sessions6.sequence,` +
-		` projections.sessions6.state,` +
-		` projections.sessions6.resource_owner,` +
-		` projections.sessions6.creator,` +
-		` projections.sessions6.user_id,` +
-		` projections.sessions6.user_checked_at,` +
+	expectedSessionsQuery = regexp.QuoteMeta(`SELECT projections.sessions7.id,` +
+		` projections.sessions7.creation_date,` +
+		` projections.sessions7.change_date,` +
+		` projections.sessions7.sequence,` +
+		` projections.sessions7.state,` +
+		` projections.sessions7.resource_owner,` +
+		` projections.sessions7.creator,` +
+		` projections.sessions7.user_id,` +
+		` projections.sessions7.user_checked_at,` +
 		` projections.login_names2.login_name,` +
 		` projections.users8_humans.display_name,` +
 		` projections.users8.resource_owner,` +
-		` projections.sessions6.password_checked_at,` +
-		` projections.sessions6.intent_checked_at,` +
-		` projections.sessions6.webauthn_checked_at,` +
-		` projections.sessions6.webauthn_user_verified,` +
-		` projections.sessions6.totp_checked_at,` +
-		` projections.sessions6.otp_sms_checked_at,` +
-		` projections.sessions6.otp_email_checked_at,` +
-		` projections.sessions6.metadata,` +
+		` projections.sessions7.password_checked_at,` +
+		` projections.sessions7.intent_checked_at,` +
+		` projections.sessions7.webauthn_checked_at,` +
+		` projections.sessions7.webauthn_user_verified,` +
+		` projections.sessions7.totp_checked_at,` +
+		` projections.sessions7.otp_sms_checked_at,` +
+		` projections.sessions7.otp_email_checked_at,` +
+		` projections.sessions7.metadata,` +
+		` projections.sessions7.expiration,` +
 		` COUNT(*) OVER ()` +
-		` FROM projections.sessions6` +
-		` LEFT JOIN projections.login_names2 ON projections.sessions6.user_id = projections.login_names2.user_id AND projections.sessions6.instance_id = projections.login_names2.instance_id` +
-		` LEFT JOIN projections.users8_humans ON projections.sessions6.user_id = projections.users8_humans.user_id AND projections.sessions6.instance_id = projections.users8_humans.instance_id` +
-		` LEFT JOIN projections.users8 ON projections.sessions6.user_id = projections.users8.id AND projections.sessions6.instance_id = projections.users8.instance_id` +
+		` FROM projections.sessions7` +
+		` LEFT JOIN projections.login_names2 ON projections.sessions7.user_id = projections.login_names2.user_id AND projections.sessions7.instance_id = projections.login_names2.instance_id` +
+		` LEFT JOIN projections.users8_humans ON projections.sessions7.user_id = projections.users8_humans.user_id AND projections.sessions7.instance_id = projections.users8_humans.instance_id` +
+		` LEFT JOIN projections.users8 ON projections.sessions7.user_id = projections.users8.id AND projections.sessions7.instance_id = projections.users8.instance_id` +
 		` AS OF SYSTEM TIME '-1 ms'`)
 
 	sessionCols = []string{
@@ -103,6 +105,7 @@ var (
 		"user_agent_ip",
 		"user_agent_description",
 		"user_agent_header",
+		"expiration",
 	}
 
 	sessionsCols = []string{
@@ -126,6 +129,7 @@ var (
 		"otp_sms_checked_at",
 		"otp_email_checked_at",
 		"metadata",
+		"expiration",
 		"count",
 	}
 )
@@ -182,6 +186,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
+							testNow,
 						},
 					},
 				),
@@ -228,6 +233,7 @@ func Test_SessionsPrepare(t *testing.T) {
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
 						},
+						Expiration: testNow,
 					},
 				},
 			},
@@ -261,6 +267,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
+							testNow,
 						},
 						{
 							"session-id2",
@@ -283,6 +290,7 @@ func Test_SessionsPrepare(t *testing.T) {
 							testNow,
 							testNow,
 							[]byte(`{"key": "dmFsdWU="}`),
+							testNow,
 						},
 					},
 				),
@@ -329,6 +337,7 @@ func Test_SessionsPrepare(t *testing.T) {
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
 						},
+						Expiration: testNow,
 					},
 					{
 						ID:            "session-id2",
@@ -367,6 +376,7 @@ func Test_SessionsPrepare(t *testing.T) {
 						Metadata: map[string][]byte{
 							"key": []byte("value"),
 						},
+						Expiration: testNow,
 					},
 				},
 			},
@@ -458,6 +468,7 @@ func Test_SessionPrepare(t *testing.T) {
 						"1.2.3.4",
 						"agentDescription",
 						[]byte(`{"foo":["foo","bar"]}`),
+						testNow,
 					},
 				),
 			},
@@ -504,6 +515,7 @@ func Test_SessionPrepare(t *testing.T) {
 					Description:   gu.Ptr("agentDescription"),
 					Header:        http.Header{"foo": []string{"foo", "bar"}},
 				},
+				Expiration: testNow,
 			},
 		},
 		{

--- a/internal/repository/session/eventstore.go
+++ b/internal/repository/session/eventstore.go
@@ -18,5 +18,6 @@ func RegisterEventMappers(es *eventstore.Eventstore) {
 		RegisterFilterEventMapper(AggregateType, OTPEmailCheckedType, eventstore.GenericEventMapper[OTPEmailCheckedEvent]).
 		RegisterFilterEventMapper(AggregateType, TokenSetType, TokenSetEventMapper).
 		RegisterFilterEventMapper(AggregateType, MetadataSetType, MetadataSetEventMapper).
+		RegisterFilterEventMapper(AggregateType, LifetimeSetType, eventstore.GenericEventMapper[LifetimeSetEvent]).
 		RegisterFilterEventMapper(AggregateType, TerminateType, TerminateEventMapper)
 }

--- a/internal/repository/session/session.go
+++ b/internal/repository/session/session.go
@@ -28,6 +28,7 @@ const (
 	OTPEmailCheckedType    = sessionEventPrefix + "otp.email.checked"
 	TokenSetType           = sessionEventPrefix + "token.set"
 	MetadataSetType        = sessionEventPrefix + "metadata.set"
+	LifetimeSetType        = sessionEventPrefix + "lifetime.set"
 	TerminateType          = sessionEventPrefix + "terminated"
 )
 
@@ -605,6 +606,39 @@ func MetadataSetEventMapper(event eventstore.Event) (eventstore.Event, error) {
 	}
 
 	return added, nil
+}
+
+type LifetimeSetEvent struct {
+	eventstore.BaseEvent `json:"-"`
+
+	Lifetime time.Duration `json:"lifetime"`
+}
+
+func (e *LifetimeSetEvent) Payload() interface{} {
+	return e
+}
+
+func (e *LifetimeSetEvent) UniqueConstraints() []*eventstore.UniqueConstraint {
+	return nil
+}
+
+func (e *LifetimeSetEvent) SetBaseEvent(base *eventstore.BaseEvent) {
+	e.BaseEvent = *base
+}
+
+func NewLifetimeSetEvent(
+	ctx context.Context,
+	aggregate *eventstore.Aggregate,
+	lifetime time.Duration,
+) *LifetimeSetEvent {
+	return &LifetimeSetEvent{
+		BaseEvent: *eventstore.NewBaseEventForPush(
+			ctx,
+			aggregate,
+			LifetimeSetType,
+		),
+		Lifetime: lifetime,
+	}
 }
 
 type TerminateEvent struct {

--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -509,6 +509,7 @@ Errors:
   Session:
     NotExisting: Сесията не съществува
     Terminated: Сесията вече е прекратена
+    Expired: Сесията е изтекла
     Token:
       Invalid: Токенът на сесията е невалиден
     WebAuthN:

--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -510,6 +510,7 @@ Errors:
     NotExisting: Сесията не съществува
     Terminated: Сесията вече е прекратена
     Expired: Сесията е изтекла
+    NegativeLifetime: Животът на сесията не трябва да е по-малък от 0
     Token:
       Invalid: Токенът на сесията е невалиден
     WebAuthN:

--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -510,7 +510,7 @@ Errors:
     NotExisting: Сесията не съществува
     Terminated: Сесията вече е прекратена
     Expired: Сесията е изтекла
-    NegativeLifetime: Животът на сесията не трябва да е по-малък от 0
+    PositiveLifetime: Животът на сесията не трябва да е по-малък от 0
     Token:
       Invalid: Токенът на сесията е невалиден
     WebAuthN:

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: Session existiert nicht
     Terminated: Session bereits beendet
+    Expired: Session ist abgelaufen
     Token:
       Invalid: Session Token ist ungültig
     WebAuthN:

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: Session existiert nicht
     Terminated: Session bereits beendet
     Expired: Session ist abgelaufen
-    NegativeLifetime: Session Lebensdauer darf nicht kleiner als 0 sein
+    PositiveLifetime: Session Lebensdauer darf nicht kleiner als 0 sein
     Token:
       Invalid: Session Token ist ungültig
     WebAuthN:

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: Session existiert nicht
     Terminated: Session bereits beendet
     Expired: Session ist abgelaufen
+    NegativeLifetime: Session Lebensdauer darf nicht kleiner als 0 sein
     Token:
       Invalid: Session Token ist ungültig
     WebAuthN:

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: Session does not exist
     Terminated: Session already terminated
+    Expired: Session has expired
     Token:
       Invalid: Session Token is invalid
     WebAuthN:

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: Session does not exist
     Terminated: Session already terminated
     Expired: Session has expired
+    NegativeLifetime: Session lifetime must not be less than 0
     Token:
       Invalid: Session Token is invalid
     WebAuthN:

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: Session does not exist
     Terminated: Session already terminated
     Expired: Session has expired
-    NegativeLifetime: Session lifetime must not be less than 0
+    PositiveLifetime: Session lifetime must not be less than 0
     Token:
       Invalid: Session Token is invalid
     WebAuthN:

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -490,7 +490,8 @@ Errors:
       ScanFailed: La consulta de uso de los segundos de ejecuciónde acciones ha fallado
   Session:
     NotExisting: La sesión no existe
-    Terminated: Sesión ya terminada
+    Terminated: La Sesión ya terminada
+    Expired: La sesión ha expirado
     Token:
       Invalid: El identificador de sesión no es válido
     WebAuthN:

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: La sesión no existe
     Terminated: La Sesión ya terminada
     Expired: La sesión ha expirado
+    NegativeLifetime: La duración de la sesión no debe ser inferior a 0
     Token:
       Invalid: El identificador de sesión no es válido
     WebAuthN:

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: La sesión no existe
     Terminated: La Sesión ya terminada
     Expired: La sesión ha expirado
-    NegativeLifetime: La duración de la sesión no debe ser inferior a 0
+    PositiveLifetime: La duración de la sesión no debe ser inferior a 0
     Token:
       Invalid: El identificador de sesión no es válido
     WebAuthN:

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: La session n'existe pas
     Terminated: La session est déjà terminée
     Expired: La session a expiré
+    NegativeLifetime: La durée de vie de la session ne doit pas être inférieure à 0
     Token:
       Invalid: Le jeton de session n'est pas valide
     WebAuthN:

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: La session n'existe pas
     Terminated: La session est déjà terminée
+    Expired: La session a expiré
     Token:
       Invalid: Le jeton de session n'est pas valide
     WebAuthN:

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: La session n'existe pas
     Terminated: La session est déjà terminée
     Expired: La session a expiré
-    NegativeLifetime: La durée de vie de la session ne doit pas être inférieure à 0
+    PositiveLifetime: La durée de vie de la session ne doit pas être inférieure à 0
     Token:
       Invalid: Le jeton de session n'est pas valide
     WebAuthN:

--- a/internal/static/i18n/it.yaml
+++ b/internal/static/i18n/it.yaml
@@ -491,7 +491,8 @@ Errors:
       ScanFailed: La query dei secondi delle azioni utilizzate non è riuscita
   Session:
     NotExisting: La sessione non esiste
-    Terminated: Sessione già terminata
+    Terminated: La Sessione già terminata
+    Expired: La sessione è scaduta
     Token:
       Invalid: Il token della sessione non è valido
     WebAuthN:

--- a/internal/static/i18n/it.yaml
+++ b/internal/static/i18n/it.yaml
@@ -493,7 +493,7 @@ Errors:
     NotExisting: La sessione non esiste
     Terminated: La Sessione già terminata
     Expired: La sessione è scaduta
-    NegativeLifetime: La durata della sessione non deve essere inferiore a 0
+    PositiveLifetime: La durata della sessione non deve essere inferiore a 0
     Token:
       Invalid: Il token della sessione non è valido
     WebAuthN:

--- a/internal/static/i18n/it.yaml
+++ b/internal/static/i18n/it.yaml
@@ -493,6 +493,7 @@ Errors:
     NotExisting: La sessione non esiste
     Terminated: La Sessione già terminata
     Expired: La sessione è scaduta
+    NegativeLifetime: La durata della sessione non deve essere inferiore a 0
     Token:
       Invalid: Il token della sessione non è valido
     WebAuthN:

--- a/internal/static/i18n/ja.yaml
+++ b/internal/static/i18n/ja.yaml
@@ -480,6 +480,7 @@ Errors:
   Session:
     NotExisting: セッションが存在しない
     Terminated: セッションはすでに終了しています
+    Expired: セッションの有効期限が切れました
     Token:
       Invalid: セッショントークンが無効です
     WebAuthN:

--- a/internal/static/i18n/ja.yaml
+++ b/internal/static/i18n/ja.yaml
@@ -481,7 +481,7 @@ Errors:
     NotExisting: セッションが存在しない
     Terminated: セッションはすでに終了しています
     Expired: セッションの有効期限が切れました
-    NegativeLifetime: セッションの有効期間は 0 未満であってはなりません
+    PositiveLifetime: セッションの有効期間は 0 未満であってはなりません
     Token:
       Invalid: セッショントークンが無効です
     WebAuthN:

--- a/internal/static/i18n/ja.yaml
+++ b/internal/static/i18n/ja.yaml
@@ -481,6 +481,7 @@ Errors:
     NotExisting: セッションが存在しない
     Terminated: セッションはすでに終了しています
     Expired: セッションの有効期限が切れました
+    NegativeLifetime: セッションの有効期間は 0 未満であってはなりません
     Token:
       Invalid: セッショントークンが無効です
     WebAuthN:

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: Сесијата не постои
     Terminated: Сесијата е веќе завршена
     Expired: Сесијата истече
-    NegativeLifetime: Времетраењето на сесијата не смее да биде помало од 0
+    PositiveLifetime: Времетраењето на сесијата не смее да биде помало од 0
     Token:
       Invalid: Токенот за сесија е невалиден
     WebAuthN:

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: Сесијата не постои
     Terminated: Сесијата е веќе завршена
+    Expired: Сесијата истече
     Token:
       Invalid: Токенот за сесија е невалиден
     WebAuthN:

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: Сесијата не постои
     Terminated: Сесијата е веќе завршена
     Expired: Сесијата истече
+    NegativeLifetime: Времетраењето на сесијата не смее да биде помало од 0
     Token:
       Invalid: Токенот за сесија е невалиден
     WebAuthN:

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: Sesja nie istnieje
     Terminated: Sesja już zakończona
     Expired: Sesja wygasła
-    NegativeLifetime: Czas życia sesji nie może być krótszy niż 0
+    PositiveLifetime: Czas życia sesji nie może być krótszy niż 0
     Token:
       Invalid: Token sesji jest nieprawidłowy
     WebAuthN:

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: Sesja nie istnieje
     Terminated: Sesja już zakończona
     Expired: Sesja wygasła
+    NegativeLifetime: Czas życia sesji nie może być krótszy niż 0
     Token:
       Invalid: Token sesji jest nieprawidłowy
     WebAuthN:

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: Sesja nie istnieje
     Terminated: Sesja już zakończona
+    Expired: Sesja wygasła
     Token:
       Invalid: Token sesji jest nieprawidłowy
     WebAuthN:

--- a/internal/static/i18n/pt.yaml
+++ b/internal/static/i18n/pt.yaml
@@ -490,6 +490,7 @@ Errors:
     NotExisting: A sessão não existe
     Terminated: A sessão já foi encerrada
     Expired: A Sessão expirou
+    NegativeLifetime: O tempo de vida da sessão não deve ser inferior a 0
     Token:
       Invalid: O token da sessão é inválido
     WebAuthN:

--- a/internal/static/i18n/pt.yaml
+++ b/internal/static/i18n/pt.yaml
@@ -489,6 +489,7 @@ Errors:
   Session:
     NotExisting: A sessão não existe
     Terminated: A sessão já foi encerrada
+    Expired: A Sessão expirou
     Token:
       Invalid: O token da sessão é inválido
     WebAuthN:

--- a/internal/static/i18n/pt.yaml
+++ b/internal/static/i18n/pt.yaml
@@ -490,7 +490,7 @@ Errors:
     NotExisting: A sessão não existe
     Terminated: A sessão já foi encerrada
     Expired: A Sessão expirou
-    NegativeLifetime: O tempo de vida da sessão não deve ser inferior a 0
+    PositiveLifetime: O tempo de vida da sessão não deve ser inferior a 0
     Token:
       Invalid: O token da sessão é inválido
     WebAuthN:

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -491,6 +491,7 @@ Errors:
   Session:
     NotExisting: 会话不存在
     Terminated: 会话已经终止
+    Expired: 会话已过期
     Token:
       Invalid: 会话令牌是无效的
     WebAuthN:

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -492,7 +492,7 @@ Errors:
     NotExisting: 会话不存在
     Terminated: 会话已经终止
     Expired: 会话已过期
-    NegativeLifetime: 会话生存期不得小于 0
+    PositiveLifetime: 会话生存期不得小于 0
     Token:
       Invalid: 会话令牌是无效的
     WebAuthN:

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -492,6 +492,7 @@ Errors:
     NotExisting: 会话不存在
     Terminated: 会话已经终止
     Expired: 会话已过期
+    NegativeLifetime: 会话生存期不得小于 0
     Token:
       Invalid: 会话令牌是无效的
     WebAuthN:

--- a/proto/zitadel/session/v2beta/session.proto
+++ b/proto/zitadel/session/v2beta/session.proto
@@ -40,6 +40,11 @@ message Session {
     }
   ];
   UserAgent user_agent = 7;
+  optional google.protobuf.Timestamp expiration_date = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "\"time the session will be automatically invalidated\"";
+    }
+  ];
 }
 
 message Factors {

--- a/proto/zitadel/session/v2beta/session_service.proto
+++ b/proto/zitadel/session/v2beta/session_service.proto
@@ -277,6 +277,7 @@ message CreateSessionRequest{
   RequestChallenges challenges = 3;
   UserAgent user_agent = 4;
   optional google.protobuf.Duration lifetime = 5 [
+    (validate.rules).duration = {gt: {seconds: 0}},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "\"duration after which the session will be automatically invalidated\"";
     }
@@ -329,6 +330,7 @@ message SetSessionRequest{
   ];
   RequestChallenges challenges = 5;
   optional google.protobuf.Duration lifetime = 6 [
+    (validate.rules).duration = {gt: {seconds: 0}},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "\"duration after which the session will be automatically invalidated\"";
     }

--- a/proto/zitadel/session/v2beta/session_service.proto
+++ b/proto/zitadel/session/v2beta/session_service.proto
@@ -10,6 +10,7 @@ import "zitadel/session/v2beta/session.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/duration.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "validate/validate.proto";
 
@@ -275,6 +276,11 @@ message CreateSessionRequest{
   ];
   RequestChallenges challenges = 3;
   UserAgent user_agent = 4;
+  optional google.protobuf.Duration lifetime = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "\"duration after which the session will be automatically invalidated\"";
+    }
+  ];
 }
 
 message CreateSessionResponse{
@@ -322,6 +328,11 @@ message SetSessionRequest{
     }
   ];
   RequestChallenges challenges = 5;
+  optional google.protobuf.Duration lifetime = 6 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "\"duration after which the session will be automatically invalidated\"";
+    }
+  ];
 }
 
 message SetSessionResponse{


### PR DESCRIPTION
Adds a field lifetime to the create and update session api. On Session retrieval the expiration date will be returned.
Expired session cannot be updated and used (e.g. for OIDC authentication and API use)

closes #5807 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
