### PR TITLE
feature: generic oauth configurable prompt

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -3,6 +3,7 @@ package login
 import (
 	"context"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/crewjam/saml/samlsp"
@@ -870,8 +871,14 @@ func (l *Login) oidcProvider(ctx context.Context, identityProvider *query.IDPTem
 	if err != nil {
 		return nil, err
 	}
-	opts := make([]openid.ProviderOpts, 1, 2)
-	opts[0] = openid.WithSelectAccount()
+	opts := make([]openid.ProviderOpts, 0, 2)
+	switch prompt := os.Getenv("ZITADEL_GENERIC_OAUTH_AUTH_PROMPT"); prompt {
+	case "PROMPT_UNSPECIFIED":
+		// When set to "UNSPECIFIED" send no "prompt" param
+	default:
+		// previous behavior must be default to prevent a breaking change
+		opts = append(opts, openid.WithSelectAccount())
+	}
 	if identityProvider.OIDCIDPTemplate.IsIDTokenMapping {
 		opts = append(opts, openid.WithIDTokenMapping())
 	}

--- a/internal/idp/providers/oauth/oauth2.go
+++ b/internal/idp/providers/oauth/oauth2.go
@@ -92,13 +92,16 @@ func (p *Provider) BeginAuth(ctx context.Context, state string, params ...any) (
 	opts := []rp.AuthURLOpt{}
 	// https://github.com/zitadel/zitadel/blob/main/proto/zitadel/oidc/v2beta/authorization.proto
 	switch prompt := os.Getenv("ZITADEL_GENERIC_OAUTH_AUTH_PROMPT"); prompt {
-	case "0":
-	case "1":
+	case "PROMPT_UNSPECIFIED":
+		// When set to "UNSPECIFIED" send no "prompt" param
+	case "PROMPT_NONE":
 		opts = append(opts, rp.WithPrompt(oidc.PromptNone))
-	case "2":
+	case "PROMPT_LOGIN":
 		opts = append(opts, rp.WithPrompt(oidc.PromptLogin))
-	case "3":
+	case "PROMPT_CONSENT":
 		opts = append(opts, rp.WithPrompt(oidc.PromptConsent))
+	case "PROMPT_SELECT_ACCOUNT":
+		opts = append(opts, rp.WithPrompt(oidc.PromptSelectAccount))
 	default:
 		// previous behavior must be default to prevent a breaking change
 		opts = append(opts, rp.WithPrompt(oidc.PromptSelectAccount))


### PR DESCRIPTION
There seem to be major oauth companies that throw an error when the authorizer is passed a "prompt" value.  Oauth Applications created within PingOne exhibit this deviation/disagreement with spec.

Consistent with the authorization.proto constants defined in oidc v2beta, this commit uses an env var to drive a prompt value selection.  The choice is "PROMPT_UNSPECIFIED" in the case of Ping.  This commit does not add a Select Menu in the UI of the Generic Oauth form, nor augment the API.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
