### PR TITLE
fix: creation date argument in search events filters

### DIFF
--- a/internal/api/grpc/admin/event.go
+++ b/internal/api/grpc/admin/event.go
@@ -62,19 +62,19 @@ func eventRequestToFilter(ctx context.Context, req *admin_pb.ListEventsRequest) 
 		EditorUser(req.EditorUserId).
 		SequenceGreater(req.Sequence)
 
-	if req.GetAsc() {
-		builder.OrderAsc()
-		builder.CreationDateAfter(req.CreationDate.AsTime())
-	} else {
-		builder.CreationDateBefore(req.CreationDate.AsTime())
-	}
-
 	if len(aggregateIDs) > 0 || len(aggregateTypes) > 0 || len(eventTypes) > 0 {
 		builder.AddQuery().
 			AggregateIDs(aggregateIDs...).
 			AggregateTypes(aggregateTypes...).
 			EventTypes(eventTypes...).
 			Builder()
+	}
+
+	if req.GetAsc() {
+		builder.OrderAsc()
+		builder.CreationDateAfter(req.CreationDate.AsTime())
+	} else {
+		builder.CreationDateBefore(req.CreationDate.AsTime())
 	}
 
 	return builder, nil

--- a/internal/api/grpc/admin/event.go
+++ b/internal/api/grpc/admin/event.go
@@ -60,8 +60,20 @@ func eventRequestToFilter(ctx context.Context, req *admin_pb.ListEventsRequest) 
 		AwaitOpenTransactions().
 		ResourceOwner(req.ResourceOwner).
 		EditorUser(req.EditorUserId).
-		CreationDateAfter(req.CreationDate.AsTime()).
 		SequenceGreater(req.Sequence)
+
+	asc := req.GetAsc()
+	if asc {
+		builder.OrderAsc()
+	}
+
+	if !req.CreationDate.AsTime().IsZero() {
+		if asc {
+			builder.CreationDateAfter(req.CreationDate.AsTime())
+		} else {
+			builder.CreationDateBefore(req.CreationDate.AsTime())
+		}
+	}
 
 	if len(aggregateIDs) > 0 || len(aggregateTypes) > 0 || len(eventTypes) > 0 {
 		builder.AddQuery().
@@ -69,10 +81,6 @@ func eventRequestToFilter(ctx context.Context, req *admin_pb.ListEventsRequest) 
 			AggregateTypes(aggregateTypes...).
 			EventTypes(eventTypes...).
 			Builder()
-	}
-
-	if req.Asc {
-		builder.OrderAsc()
 	}
 
 	return builder, nil

--- a/internal/api/grpc/admin/event.go
+++ b/internal/api/grpc/admin/event.go
@@ -62,17 +62,11 @@ func eventRequestToFilter(ctx context.Context, req *admin_pb.ListEventsRequest) 
 		EditorUser(req.EditorUserId).
 		SequenceGreater(req.Sequence)
 
-	asc := req.GetAsc()
-	if asc {
+	if req.GetAsc() {
 		builder.OrderAsc()
-	}
-
-	if !req.CreationDate.AsTime().IsZero() {
-		if asc {
-			builder.CreationDateAfter(req.CreationDate.AsTime())
-		} else {
-			builder.CreationDateBefore(req.CreationDate.AsTime())
-		}
+		builder.CreationDateAfter(req.CreationDate.AsTime())
+	} else {
+		builder.CreationDateBefore(req.CreationDate.AsTime())
 	}
 
 	if len(aggregateIDs) > 0 || len(aggregateTypes) > 0 || len(eventTypes) > 0 {

--- a/internal/api/grpc/auth/user.go
+++ b/internal/api/grpc/auth/user.go
@@ -68,7 +68,6 @@ func (s *Server) ListMyUserChanges(ctx context.Context, req *auth_pb.ListMyUserC
 		sequence = req.Query.Sequence
 		asc = req.Query.Asc
 	}
-
 	query := eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
 		AllowTimeTravel().
 		Limit(limit).

--- a/internal/api/grpc/auth/user.go
+++ b/internal/api/grpc/auth/user.go
@@ -68,6 +68,7 @@ func (s *Server) ListMyUserChanges(ctx context.Context, req *auth_pb.ListMyUserC
 		sequence = req.Query.Sequence
 		asc = req.Query.Asc
 	}
+
 	query := eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
 		AllowTimeTravel().
 		Limit(limit).

--- a/internal/eventstore/repository/search_query.go
+++ b/internal/eventstore/repository/search_query.go
@@ -25,7 +25,8 @@ type SearchQuery struct {
 	Owner             *Filter
 	Position          *Filter
 	Sequence          *Filter
-	CreatedAt         *Filter
+	CreatedAfter      *Filter
+	CreatedBefore     *Filter
 }
 
 // Filter represents all fields needed to compare a field of an event with a value
@@ -136,6 +137,7 @@ func QueryFromBuilder(builder *eventstore.SearchQueryBuilder) (*SearchQuery, err
 		positionAfterFilter,
 		eventSequenceGreaterFilter,
 		creationDateAfterFilter,
+		creationDateBeforeFilter,
 	} {
 		filter := f(builder, query)
 		if filter == nil {
@@ -191,8 +193,16 @@ func creationDateAfterFilter(builder *eventstore.SearchQueryBuilder, query *Sear
 	if builder.GetCreationDateAfter().IsZero() {
 		return nil
 	}
-	query.CreatedAt = NewFilter(FieldCreationDate, builder.GetCreationDateAfter(), OperationGreater)
-	return query.CreatedAt
+	query.CreatedAfter = NewFilter(FieldCreationDate, builder.GetCreationDateAfter(), OperationGreater)
+	return query.CreatedAfter
+}
+
+func creationDateBeforeFilter(builder *eventstore.SearchQueryBuilder, query *SearchQuery) *Filter {
+	if builder.GetCreationDateBefore().IsZero() {
+		return nil
+	}
+	query.CreatedBefore = NewFilter(FieldCreationDate, builder.GetCreationDateBefore(), OperationLess)
+	return query.CreatedBefore
 }
 
 func resourceOwnerFilter(builder *eventstore.SearchQueryBuilder, query *SearchQuery) *Filter {

--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -239,7 +239,14 @@ func prepareConditions(criteria querier, query *repository.SearchQuery, useV1 bo
 		clauses += "(" + strings.Join(subClauses, " OR ") + ")"
 	}
 
-	additionalClauses, additionalArgs := prepareQuery(criteria, useV1, query.Position, query.Owner, query.Sequence, query.CreatedAt, query.Creator)
+	additionalClauses, additionalArgs := prepareQuery(criteria, useV1,
+		query.Position,
+		query.Owner,
+		query.Sequence,
+		query.CreatedAfter,
+		query.CreatedBefore,
+		query.Creator,
+	)
 	if additionalClauses != "" {
 		if clauses != "" {
 			clauses += " AND "

--- a/internal/eventstore/search_query.go
+++ b/internal/eventstore/search_query.go
@@ -25,6 +25,7 @@ type SearchQueryBuilder struct {
 	positionAfter         float64
 	awaitOpenTransactions bool
 	creationDateAfter     time.Time
+	creationDateBefore    time.Time
 	eventSequenceGreater  uint64
 }
 
@@ -82,6 +83,10 @@ func (q SearchQueryBuilder) GetEventSequenceGreater() uint64 {
 
 func (q SearchQueryBuilder) GetCreationDateAfter() time.Time {
 	return q.creationDateAfter
+}
+
+func (q SearchQueryBuilder) GetCreationDateBefore() time.Time {
+	return q.creationDateBefore
 }
 
 // ensureInstanceID makes sure that the instance id is always set
@@ -253,6 +258,15 @@ func (builder *SearchQueryBuilder) CreationDateAfter(creationDate time.Time) *Se
 		return builder
 	}
 	builder.creationDateAfter = creationDate
+	return builder
+}
+
+// CreationDateBefore filters for events which happened before the specified time
+func (builder *SearchQueryBuilder) CreationDateBefore(creationDate time.Time) *SearchQueryBuilder {
+	if creationDate.IsZero() || creationDate.Unix() == 0 {
+		return builder
+	}
+	builder.creationDateBefore = creationDate
 	return builder
 }
 

--- a/internal/query/event.go
+++ b/internal/query/event.go
@@ -66,7 +66,13 @@ func filterAuditLogRetention(ctx context.Context, auditLogRetention time.Duratio
 	if callTime.IsZero() {
 		callTime = time.Now()
 	}
-	return builder.CreationDateAfter(callTime.Add(-auditLogRetention))
+	oldestAllowed := callTime.Add(-auditLogRetention)
+	// The audit log retention time should overwrite the creation date after query only if it is older
+	// For example API calls should still be able to restrict the creation date after to a more recent date
+	if builder.GetCreationDateAfter().Before(oldestAllowed) {
+		return builder.CreationDateAfter(oldestAllowed)
+	}
+	return builder
 }
 
 func (q *Queries) SearchEventTypes(ctx context.Context) []string {

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -7894,7 +7894,7 @@ message ListEventsRequest {
     google.protobuf.Timestamp creation_date = 9 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "\"2019-04-01T08:45:00.000000Z\"";
-            description: "If asc is false creation_date is used as less than filter If asc is true creation_date is used as greater than filter. If creation_date is not set the field is ignored.";
+            description: "If asc is false, the events returned are older than creation_date. If asc is true, the events returned are younger than creation_date. If creation_date is not set the field is ignored.";
         }
     ];
 }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/927474939156643850/1169210538157412452)
Fixes a bug introduced with #6744: If an audit log retention was configured, it overwrote the event queries creation_date filter.
Fixes the described behavior of the creation_date filter in relation to the asc ordering property. 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
