### PR TITLE
fix: payload (de)serialization of some events

### DIFF
--- a/internal/repository/deviceauth/device_auth.go
+++ b/internal/repository/deviceauth/device_auth.go
@@ -17,7 +17,7 @@ const (
 )
 
 type AddedEvent struct {
-	*eventstore.BaseEvent
+	*eventstore.BaseEvent `json:"-"`
 
 	ClientID   string
 	DeviceCode string
@@ -56,7 +56,7 @@ func NewAddedEvent(
 }
 
 type ApprovedEvent struct {
-	*eventstore.BaseEvent
+	*eventstore.BaseEvent `json:"-"`
 
 	Subject string
 }
@@ -87,7 +87,8 @@ func NewApprovedEvent(
 }
 
 type CanceledEvent struct {
-	*eventstore.BaseEvent
+	*eventstore.BaseEvent `json:"-"`
+
 	Reason domain.DeviceAuthCanceled
 }
 
@@ -108,7 +109,7 @@ func NewCanceledEvent(ctx context.Context, aggregate *eventstore.Aggregate, reas
 }
 
 type RemovedEvent struct {
-	*eventstore.BaseEvent
+	*eventstore.BaseEvent `json:"-"`
 
 	ClientID   string
 	DeviceCode string

--- a/internal/repository/feature/feature.go
+++ b/internal/repository/feature/feature.go
@@ -17,7 +17,7 @@ func EventTypeFromFeature(feature domain.Feature) eventstore.EventType {
 }
 
 type SetEvent[T SetEventType] struct {
-	*eventstore.BaseEvent
+	*eventstore.BaseEvent `json:"-"`
 
 	Value T
 }

--- a/internal/repository/flow/flow.go
+++ b/internal/repository/flow/flow.go
@@ -15,7 +15,7 @@ const (
 )
 
 type TriggerActionsSetEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	FlowType    domain.FlowType    `json:"flowType"`
 	TriggerType domain.TriggerType `json:"triggerType"`
@@ -58,7 +58,7 @@ func TriggerActionsSetEventMapper(event eventstore.Event) (eventstore.Event, err
 }
 
 type TriggerActionsCascadeRemovedEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	FlowType    domain.FlowType    `json:"flowType"`
 	TriggerType domain.TriggerType `json:"triggerType"`
@@ -99,7 +99,7 @@ func TriggerActionsCascadeRemovedEventMapper(event eventstore.Event) (eventstore
 }
 
 type FlowClearedEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	FlowType domain.FlowType `json:"flowType"`
 }

--- a/internal/repository/policy/policy_login_identity_provider.go
+++ b/internal/repository/policy/policy_login_identity_provider.go
@@ -14,7 +14,7 @@ const (
 )
 
 type IdentityProviderAddedEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	IDPConfigID     string                      `json:"idpConfigId,omitempty"`
 	IDPProviderType domain.IdentityProviderType `json:"idpProviderType,omitempty"`
@@ -55,7 +55,7 @@ func IdentityProviderAddedEventMapper(event eventstore.Event) (eventstore.Event,
 }
 
 type IdentityProviderRemovedEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	IDPConfigID string `json:"idpConfigId"`
 }
@@ -92,7 +92,7 @@ func IdentityProviderRemovedEventMapper(event eventstore.Event) (eventstore.Even
 }
 
 type IdentityProviderCascadeRemovedEvent struct {
-	eventstore.BaseEvent
+	eventstore.BaseEvent `json:"-"`
 
 	IDPConfigID string `json:"idpConfigId"`
 }


### PR DESCRIPTION
A customer reported to support, that on some organisation, the configured action flows would not be executed / listed in the UI.

This PR fixes the serialization of the Flow events as well as others, by omitting the BaseEvent data in the payload. The data was never meant to be part of the payload. With the eventstore optimizations (Version [2.39.0](https://github.com/zitadel/zitadel/releases/tag/v2.39.0), resp.  [PR #5940](https://github.com/zitadel/zitadel/pull/5940)) EventMappers were changed to no longer use `json.Unmarshal` the event data directly but rather use the provided `Unmarshal` function on the passed event. This resulted in an overwrite of the `baseEvent`

https://github.com/zitadel/zitadel/pull/5940/files#diff-834871e35a5a7fad01386720d0583439c94e97b26421a44398a3ae7a1e200e2dL50-R58:
```diff
- func TriggerActionsSetEventMapper(event *repository.Event) (eventstore.Event, error) {
+ func TriggerActionsSetEventMapper(event eventstore.Event) (eventstore.Event, error) {
	e := &TriggerActionsSetEvent{
		BaseEvent: *eventstore.BaseEventFromRepo(event),
	}

-	err := json.Unmarshal(event.Data, e)
+	err := event.Unmarshal(e)
	if err != nil {
		return nil, errors.ThrowInternal(err, "FLOW-4n8vs", "unable to unmarshal trigger actions")
	}
	return e, nil
}
```

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
