### PR TITLE
fix(system-api): use distinct in intances filter query

### DIFF
--- a/internal/query/instance.go
+++ b/internal/query/instance.go
@@ -291,7 +291,7 @@ func prepareInstancesQuery(ctx context.Context, db prepareDatabase) (sq.SelectBu
 	return sq.Select(
 			InstanceColumnID.identifier(),
 			countColumn.identifier(),
-		).From(instanceTable.identifier()).
+		).Distinct().From(instanceTable.identifier()).
 			LeftJoin(join(InstanceDomainInstanceIDCol, InstanceColumnID)),
 		func(builder sq.SelectBuilder) sq.SelectBuilder {
 			return sq.Select(

--- a/internal/query/instance_test.go
+++ b/internal/query/instance_test.go
@@ -55,7 +55,7 @@ var (
 		` projections.instance_domains.creation_date,` +
 		` projections.instance_domains.change_date, ` +
 		` projections.instance_domains.sequence` +
-		` FROM (SELECT projections.instances.id, COUNT(*) OVER () FROM projections.instances` +
+		` FROM (SELECT DISTINCT projections.instances.id, COUNT(*) OVER () FROM projections.instances` +
 		` LEFT JOIN projections.instance_domains ON projections.instances.id = projections.instance_domains.instance_id) AS f` +
 		` LEFT JOIN projections.instances ON f.id = projections.instances.id` +
 		` LEFT JOIN projections.instance_domains ON f.id = projections.instance_domains.instance_id` +


### PR DESCRIPTION
Some users reported multiple intances that were returned in the dashboard.

This was caused by the filter-sub query, where each domain results in an instance ID in the join so multiple domains on an instance returns that instance multiple times. The second join then quantifies the problem.

This PR fixes that by using a `distinct` clause on the filter table.

### Definition of Ready

- [ ] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [ ] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
