### PR TITLE
fix: set samesite mode for CSRF cookie based on security policy

### DIFF
--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -130,11 +130,16 @@ func createCSRFInterceptor(cookieName string, csrfCookieKey []byte, externalSecu
 				handler.ServeHTTP(w, r)
 				return
 			}
+			sameSiteMode := csrf.SameSiteLaxMode
+			if len(authz.GetInstance(r.Context()).SecurityPolicyAllowedOrigins()) > 0 {
+				sameSiteMode = csrf.SameSiteNoneMode
+			}
 			csrf.Protect(csrfCookieKey,
 				csrf.Secure(externalSecure),
 				csrf.CookieName(http_utils.SetCookiePrefix(cookieName, "", path, externalSecure)),
 				csrf.Path(path),
 				csrf.ErrorHandler(errorHandler),
+				csrf.SameSite(sameSiteMode),
 			)(handler).ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
Raised by multiple people (https://discord.com/channels/927474939156643850/1172633019060858890, https://github.com/zitadel/zitadel/discussions/6911, ...) that the CSRF cookie will always set a SameSite `Lax` cookie even when the `iframe allowed` option was activated in the `Security Settings` of the instance.

This PR adds a missing check and changes the default `Lax` mode to `None` if the option mentioned above is active.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
