### PR TITLE
fix: allow webauthn checks for users of other orgs

### DIFF
--- a/internal/command/session.go
+++ b/internal/command/session.go
@@ -267,7 +267,7 @@ func (s *SessionCommands) gethumanWriteModel(ctx context.Context) (*HumanWriteMo
 	if s.sessionWriteModel.UserID == "" {
 		return nil, caos_errs.ThrowPreconditionFailed(nil, "COMMAND-eeR2e", "Errors.User.UserIDMissing")
 	}
-	humanWriteModel := NewHumanWriteModel(s.sessionWriteModel.UserID, s.sessionWriteModel.ResourceOwner)
+	humanWriteModel := NewHumanWriteModel(s.sessionWriteModel.UserID, "")
 	err := s.eventstore.FilterToQueryReducer(ctx, humanWriteModel)
 	if err != nil {
 		return nil, err

--- a/internal/command/session_webauhtn.go
+++ b/internal/command/session_webauhtn.go
@@ -29,9 +29,9 @@ func (s *SessionCommands) getHumanWebAuthNTokens(ctx context.Context, userVerifi
 }
 
 func (s *SessionCommands) getHumanWebAuthNTokenReadModel(ctx context.Context, userVerification domain.UserVerificationRequirement) (readModel HumanWebAuthNTokensReadModel, err error) {
-	readModel = NewHumanU2FTokensReadModel(s.sessionWriteModel.UserID, s.sessionWriteModel.ResourceOwner)
+	readModel = NewHumanU2FTokensReadModel(s.sessionWriteModel.UserID, "")
 	if userVerification == domain.UserVerificationRequirementRequired {
-		readModel = NewHumanPasswordlessTokensReadModel(s.sessionWriteModel.UserID, s.sessionWriteModel.ResourceOwner)
+		readModel = NewHumanPasswordlessTokensReadModel(s.sessionWriteModel.UserID, "")
 	}
 	err = s.eventstore.FilterToQueryReducer(ctx, readModel)
 	if err != nil {


### PR DESCRIPTION
closes #6784 by removing the resource owner restriction of a user when creating webauthn challenges.

https://github.com/zitadel/zitadel/issues/6623 will further improve the resource owner handling in the session.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
