### PR TITLE
fix: handle project deactivate and remove correctly on tokens

### DIFF
--- a/internal/auth/repository/eventsourcing/handler/token.go
+++ b/internal/auth/repository/eventsourcing/handler/token.go
@@ -219,7 +219,7 @@ func (t *Token) Reduce(event eventstore.Event) (_ *handler.Statement, err error)
 			}
 			applicationIDs := make([]string, 0, len(project.Applications))
 			for _, app := range project.Applications {
-				if app.OIDCConfig != nil {
+				if app.OIDCConfig != nil && app.OIDCConfig.ClientID != "" {
 					applicationIDs = append(applicationIDs, app.OIDCConfig.ClientID)
 				}
 			}

--- a/internal/project/repository/eventsourcing/model/project.go
+++ b/internal/project/repository/eventsourcing/model/project.go
@@ -99,7 +99,7 @@ func (p *Project) appendRemovedEvent() error {
 
 func (p *Project) appendOIDCConfig(event eventstore.Event) error {
 	appEvent := new(oidcApp)
-	if err := event.Unmarshal(p); err != nil {
+	if err := event.Unmarshal(appEvent); err != nil {
 		return err
 	}
 	p.OIDCApplications = append(p.OIDCApplications, appEvent)


### PR DESCRIPTION
A Customer reported, that after some time a PAT would just stop working. It was discovered, that project deactivations and removals would lead to PAT invalidations.

This PR fixes the event handling of project deactivate and remove events (unmarshalling) and further checks that no empty ids are passed to the handler afterwards.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
