### PR TITLE
fix(oidc): add missing fields to introspection

### DIFF
--- a/internal/api/oidc/client_integration_test.go
+++ b/internal/api/oidc/client_integration_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	"github.com/zitadel/oidc/v3/pkg/client/rs"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"golang.org/x/text/language"
 
+	oidc_api "github.com/zitadel/zitadel/internal/api/oidc"
 	"github.com/zitadel/zitadel/pkg/grpc/authn"
 	"github.com/zitadel/zitadel/pkg/grpc/management"
 	oidc_pb "github.com/zitadel/zitadel/pkg/grpc/oidc/v2beta"
@@ -65,7 +67,7 @@ func TestServer_Introspect(t *testing.T) {
 	resourceServer, err := Tester.CreateResourceServer(CTX, keyResp.GetKeyDetails())
 	require.NoError(t, err)
 
-	scope := []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, oidc.ScopeOfflineAccess}
+	scope := []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, oidc.ScopeOfflineAccess, oidc_api.ScopeResourceOwner}
 	authRequestID := createAuthRequest(t, app.GetClientId(), redirectURI, scope...)
 	sessionID, sessionToken, startTime, changeTime := Tester.CreateVerifiedWebAuthNSession(t, CTXLOGIN, User.GetUserId())
 	linkResp, err := Tester.Client.OIDCv2.CreateCallback(CTXLOGIN, &oidc_pb.CreateCallbackRequest{
@@ -129,7 +131,14 @@ func assertIntrospection(
 	assert.Equal(t, "Mickey", introspection.GivenName)
 	assert.Equal(t, "Mouse", introspection.FamilyName)
 	assert.Equal(t, "Mickey Mouse", introspection.Name)
+	assert.Equal(t, oidc.Gender("male"), introspection.Gender)
+	assert.Equal(t, oidc.NewLocale(language.Dutch), introspection.Locale)
 	assert.Equal(t, introspection.Username, introspection.Email)
 	assert.False(t, bool(introspection.EmailVerified))
 	assertOIDCTime(t, introspection.UpdatedAt, User.GetDetails().GetChangeDate().AsTime())
+
+	require.NotNil(t, introspection.Claims)
+	assert.Equal(t, User.Details.ResourceOwner, introspection.Claims[oidc_api.ClaimResourceOwner+"id"])
+	assert.NotEmpty(t, introspection.Claims[oidc_api.ClaimResourceOwner+"name"])
+	assert.NotEmpty(t, introspection.Claims[oidc_api.ClaimResourceOwner+"primary_domain"])
 }

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	crewjam_saml "github.com/crewjam/saml"
+	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/logging"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -90,8 +91,10 @@ func (s *Tester) CreateHumanUser(ctx context.Context) *user.AddHumanUserResponse
 			},
 		},
 		Profile: &user.SetHumanProfile{
-			GivenName:  "Mickey",
-			FamilyName: "Mouse",
+			GivenName:         "Mickey",
+			FamilyName:        "Mouse",
+			PreferredLanguage: gu.Ptr("nl"),
+			Gender:            gu.Ptr(user.Gender_GENDER_MALE),
 		},
 		Email: &user.SetHumanEmail{
 			Email: fmt.Sprintf("%d@mouse.com", time.Now().UnixNano()),

--- a/internal/query/embed/userinfo_by_id.sql
+++ b/internal/query/embed/userinfo_by_id.sql
@@ -1,6 +1,3 @@
--- deallocate q;
--- prepare q (text, text, text[]) as
-
 with usr as (
 	select u.id, u.creation_date, u.change_date, u.sequence, u.state, u.resource_owner, u.username, n.login_name as preferred_login_name
 	from projections.users9 u
@@ -11,7 +8,7 @@ with usr as (
 ),
 human as (
 	select $1 as user_id, row_to_json(r) as human from (
-		select first_name, last_name, nick_name, display_name, avatar_key, email, is_email_verified, phone, is_phone_verified
+		select first_name, last_name, nick_name, display_name, avatar_key, preferred_language, gender, email, is_email_verified, phone, is_phone_verified
 		from projections.users9_humans
 		where user_id = $1
 		and instance_id = $2
@@ -56,7 +53,7 @@ orgs as (
 -- find the user's org
 user_org as (
 	select row_to_json(r) as organization from (
-		select name, primary_domain
+		select o.id, o.name, o.primary_domain
 		from orgs o
 		join usr u on o.id = u.resource_owner
 	) r
@@ -88,5 +85,3 @@ select json_build_object(
 	'metadata', (select metadata from metadata),
 	'user_grants', (select grants from grants)
 );
-
--- execute q('231965491734773762','230690539048009730', '{"236645808328409090","240762134579904514"}')

--- a/internal/query/testdata/userinfo_human.json
+++ b/internal/query/testdata/userinfo_human.json
@@ -14,6 +14,8 @@
       "nick_name": "muhlemmer",
       "display_name": "Tim Mohlmann",
       "avatar_key": null,
+      "preferred_language": "en",
+      "gender": 2,
       "email": "tim+tesmail@zitadel.com",
       "is_email_verified": true,
       "phone": "+40123456789",
@@ -22,6 +24,7 @@
     "machine": null
   },
   "org": {
+    "id": "231848297847848962",
     "name": "demo",
     "primary_domain": "demo.localhost"
   },

--- a/internal/query/testdata/userinfo_human_grants.json
+++ b/internal/query/testdata/userinfo_human_grants.json
@@ -14,6 +14,8 @@
       "nick_name": "muhlemmer",
       "display_name": "Tim Mohlmann",
       "avatar_key": null,
+      "preferred_language": "en",
+      "gender": 2,
       "email": "tim+tesmail@zitadel.com",
       "is_email_verified": true,
       "phone": "+40123456789",
@@ -22,6 +24,7 @@
     "machine": null
   },
   "org": {
+    "id": "231848297847848962",
     "name": "demo",
     "primary_domain": "demo.localhost"
   },

--- a/internal/query/testdata/userinfo_human_no_md.json
+++ b/internal/query/testdata/userinfo_human_no_md.json
@@ -14,6 +14,8 @@
       "nick_name": "muhlemmer",
       "display_name": "Tim Mohlmann",
       "avatar_key": null,
+      "preferred_language": "en",
+      "gender": 2,
       "email": "tim+tesmail@zitadel.com",
       "is_email_verified": true,
       "phone": "+40123456789",
@@ -22,6 +24,7 @@
     "machine": null
   },
   "org": {
+    "id": "231848297847848962",
     "name": "demo",
     "primary_domain": "demo.localhost"
   },

--- a/internal/query/testdata/userinfo_machine.json
+++ b/internal/query/testdata/userinfo_machine.json
@@ -15,6 +15,7 @@
     }
   },
   "org": {
+    "id": "231848297847848962",
     "name": "demo",
     "primary_domain": "demo.localhost"
   },

--- a/internal/query/userinfo_test.go
+++ b/internal/query/userinfo_test.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/errors"
 )
 
@@ -99,19 +101,22 @@ func TestQueries_GetOIDCUserInfo(t *testing.T) {
 					Username:           "tim+tesmail@zitadel.com",
 					PreferredLoginName: "tim+tesmail@zitadel.com@demo.localhost",
 					Human: &Human{
-						FirstName:       "Tim",
-						LastName:        "Mohlmann",
-						NickName:        "muhlemmer",
-						DisplayName:     "Tim Mohlmann",
-						AvatarKey:       "",
-						Email:           "tim+tesmail@zitadel.com",
-						IsEmailVerified: true,
-						Phone:           "+40123456789",
-						IsPhoneVerified: false,
+						FirstName:         "Tim",
+						LastName:          "Mohlmann",
+						NickName:          "muhlemmer",
+						DisplayName:       "Tim Mohlmann",
+						AvatarKey:         "",
+						PreferredLanguage: language.English,
+						Gender:            domain.GenderMale,
+						Email:             "tim+tesmail@zitadel.com",
+						IsEmailVerified:   true,
+						Phone:             "+40123456789",
+						IsPhoneVerified:   false,
 					},
 					Machine: nil,
 				},
 				Org: &UserInfoOrg{
+					ID:            "231848297847848962",
 					Name:          "demo",
 					PrimaryDomain: "demo.localhost",
 				},
@@ -135,19 +140,22 @@ func TestQueries_GetOIDCUserInfo(t *testing.T) {
 					Username:           "tim+tesmail@zitadel.com",
 					PreferredLoginName: "tim+tesmail@zitadel.com@demo.localhost",
 					Human: &Human{
-						FirstName:       "Tim",
-						LastName:        "Mohlmann",
-						NickName:        "muhlemmer",
-						DisplayName:     "Tim Mohlmann",
-						AvatarKey:       "",
-						Email:           "tim+tesmail@zitadel.com",
-						IsEmailVerified: true,
-						Phone:           "+40123456789",
-						IsPhoneVerified: false,
+						FirstName:         "Tim",
+						LastName:          "Mohlmann",
+						NickName:          "muhlemmer",
+						DisplayName:       "Tim Mohlmann",
+						AvatarKey:         "",
+						PreferredLanguage: language.English,
+						Gender:            domain.GenderMale,
+						Email:             "tim+tesmail@zitadel.com",
+						IsEmailVerified:   true,
+						Phone:             "+40123456789",
+						IsPhoneVerified:   false,
 					},
 					Machine: nil,
 				},
 				Org: &UserInfoOrg{
+					ID:            "231848297847848962",
 					Name:          "demo",
 					PrimaryDomain: "demo.localhost",
 				},
@@ -193,19 +201,22 @@ func TestQueries_GetOIDCUserInfo(t *testing.T) {
 					Username:           "tim+tesmail@zitadel.com",
 					PreferredLoginName: "tim+tesmail@zitadel.com@demo.localhost",
 					Human: &Human{
-						FirstName:       "Tim",
-						LastName:        "Mohlmann",
-						NickName:        "muhlemmer",
-						DisplayName:     "Tim Mohlmann",
-						AvatarKey:       "",
-						Email:           "tim+tesmail@zitadel.com",
-						IsEmailVerified: true,
-						Phone:           "+40123456789",
-						IsPhoneVerified: false,
+						FirstName:         "Tim",
+						LastName:          "Mohlmann",
+						NickName:          "muhlemmer",
+						DisplayName:       "Tim Mohlmann",
+						AvatarKey:         "",
+						PreferredLanguage: language.English,
+						Gender:            domain.GenderMale,
+						Email:             "tim+tesmail@zitadel.com",
+						IsEmailVerified:   true,
+						Phone:             "+40123456789",
+						IsPhoneVerified:   false,
 					},
 					Machine: nil,
 				},
 				Org: &UserInfoOrg{
+					ID:            "231848297847848962",
 					Name:          "demo",
 					PrimaryDomain: "demo.localhost",
 				},
@@ -292,6 +303,7 @@ func TestQueries_GetOIDCUserInfo(t *testing.T) {
 					},
 				},
 				Org: &UserInfoOrg{
+					ID:            "231848297847848962",
 					Name:          "demo",
 					PrimaryDomain: "demo.localhost",
 				},


### PR DESCRIPTION
during QA I found some user info and org ID was missing.
This change adds those missing fields.

Included the missing fields to the integration test as well.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
