### PR TITLE
fix(postgres): delete unique constraints

### DIFF
--- a/internal/eventstore/v3/unique_constraints_delete_placeholders.sql
+++ b/internal/eventstore/v3/unique_constraints_delete_placeholders.sql
@@ -1,0 +1,13 @@
+-- the query is so complex because we accidentally stored unique constraint case sensitive
+-- the query checks first if there is a case sensitive match and afterwards if there is a case insensitive match
+(instance_id = $%[1]d AND unique_type = $%[2]d AND unique_field = (
+    SELECT unique_field from (
+    SELECT instance_id, unique_type, unique_field
+    FROM eventstore.unique_constraints
+    WHERE instance_id = $%[1]d AND unique_type = $%[2]d AND unique_field = $%[3]d
+    UNION ALL
+    SELECT instance_id, unique_type, unique_field
+    FROM eventstore.unique_constraints
+    WHERE instance_id = $%[1]d AND unique_type = $%[2]d AND unique_field = LOWER($%[3]d)
+    ) AS case_insensitive_constraints LIMIT 1)
+)


### PR DESCRIPTION
Fixes compatibility with Postgres when deleting unique constraints. The bug was introduced with #6961

![image](https://github.com/zitadel/zitadel/assets/12727842/e7de3393-44ae-4de8-9dde-44bf04e28ccf)

To reproduce, just setup a new ZITADEL DB with Postgres.

Adding the alias `AS case_insensitive_constraints` resolves the issue.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
