### PR TITLE
test(postgres): always test against latest release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,8 +219,9 @@ docker compose --file ./e2e/config/host.docker.internal/docker-compose.yaml down
 In order to run the integrations tests for the gRPC API, PostgreSQL and CockroachDB must be started and initialized:
 
 ```bash
-export INTEGRATION_DB_FLAVOR="cockroach" ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
 docker compose -f internal/integration/config/docker-compose.yaml up --wait ${INTEGRATION_DB_FLAVOR}
+export INTEGRATION_DB_FLAVOR="cockroach" ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
+docker compose -f internal/integration/config/docker-compose.yaml up --pull always --wait ${INTEGRATION_DB_FLAVOR}
 make core_integration_test
 docker compose -f internal/integration/config/docker-compose.yaml down
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,6 @@ docker compose --file ./e2e/config/host.docker.internal/docker-compose.yaml down
 In order to run the integrations tests for the gRPC API, PostgreSQL and CockroachDB must be started and initialized:
 
 ```bash
-docker compose -f internal/integration/config/docker-compose.yaml up --wait ${INTEGRATION_DB_FLAVOR}
 export INTEGRATION_DB_FLAVOR="cockroach" ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
 docker compose -f internal/integration/config/docker-compose.yaml up --pull always --wait ${INTEGRATION_DB_FLAVOR}
 make core_integration_test

--- a/internal/integration/config/docker-compose.yaml
+++ b/internal/integration/config/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
   
   postgres:
     restart: 'always'
-    image: 'postgres:15'
+    image: 'postgres'
     environment:
       - POSTGRES_USER=zitadel
       - PGUSER=zitadel

--- a/internal/integration/config/docker-compose.yaml
+++ b/internal/integration/config/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
   
   postgres:
     restart: 'always'
-    image: 'postgres'
+    image: 'postgres:latest'
     environment:
       - POSTGRES_USER=zitadel
       - PGUSER=zitadel


### PR DESCRIPTION
Let's locally test against the latest DB versions.
Like we do in the Pipelines.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
