### PR TITLE
chore(user/v2): solve test TODO that depended on session tokens

### DIFF
--- a/internal/api/grpc/user/v2/passkey_integration_test.go
+++ b/internal/api/grpc/user/v2/passkey_integration_test.go
@@ -24,6 +24,10 @@ func TestServer_RegisterPasskey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// We also need a user session
+	Tester.RegisterUserPasskey(CTX, userID)
+	_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
+
 	type args struct {
 		ctx context.Context
 		req *user.RegisterPasskeyRequest
@@ -95,14 +99,12 @@ func TestServer_RegisterPasskey(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		/* TODO: after we are able to obtain a Bearer token for a human user
-		https://github.com/zitadel/zitadel/issues/6022
 		{
-			name: "human user",
+			name: "user setting its own passkey",
 			args: args{
-				ctx: CTX,
+				ctx: Tester.WithAuthorizationToken(CTX, sessionToken),
 				req: &user.RegisterPasskeyRequest{
-					UserId: humanUserID,
+					UserId: userID,
 				},
 			},
 			want: &user.RegisterPasskeyResponse{
@@ -111,7 +113,6 @@ func TestServer_RegisterPasskey(t *testing.T) {
 				},
 			},
 		},
-		*/
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #6022

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ x No debug or dead code
- [x] My code has no repetitions
- [ x Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
