### PR TITLE
chore: add database questions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -33,6 +33,20 @@ body:
   attributes:
     label: Version
     description: Which version of ZITADEL are you using.
+- type: dropdown
+  id: database
+  attributes:
+    label: Database
+    description: What database are you using? (self-hosters only)
+    options:
+    - CockroachDB
+    - PostgreSQL
+    - Other (describe below!)
+- type: input
+  id: Database version
+  attributes:
+    label: Database Version
+    description: Which version of the selected database are you using? (self-hosters only)
 - type: textarea
   id: impact
   attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -43,7 +43,7 @@ body:
     - PostgreSQL
     - Other (describe below!)
 - type: input
-  id: Database version
+  id: database-version
   attributes:
     label: Database Version
     description: Which version of the selected database are you using? (self-hosters only)


### PR DESCRIPTION
Sometimes we get bug reports that are only reproducible when zitadel is running against a certain database. This change adds database related questions to the issue template, as it is something people don't tend to describe in the detail fields.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
