### PR TITLE
fix(authz): add logging to access token verification errors

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/api/grpc"
 	http_util "github.com/zitadel/zitadel/internal/api/http"
 	zitadel_errors "github.com/zitadel/zitadel/internal/errors"
@@ -107,6 +110,7 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		return CtxData{}, err
 	}
 	if err != nil {
+		logging.WithError(err).WithFields(logrus.Fields{"org_id": orgID, "org_domain": orgDomain}).Warn("authz: verify access token")
 		var sysTokenErr error
 		sysMemberships, userID, sysTokenErr = t.VerifySystemToken(ctx, tokenWOBearer, orgID)
 		if sysTokenErr != nil || sysMemberships == nil {

--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -263,9 +263,11 @@ func (repo *TokenVerifierRepo) getTokenIDAndSubject(ctx context.Context, accessT
 	// let's try opaque first:
 	tokenIDSubject, err := repo.decryptAccessToken(accessToken)
 	if err != nil {
+		logging.WithError(err).Warn("token verifier repo: decrypt access token")
 		// if decryption did not work, it might be a JWT
 		accessTokenClaims, err := op.VerifyAccessToken[*oidc.AccessTokenClaims](ctx, accessToken, repo.jwtTokenVerifier(ctx))
 		if err != nil {
+			logging.WithError(err).Warn("token verifier repo: verify JWT access token")
 			return "", "", false
 		}
 		return accessTokenClaims.JWTID, accessTokenClaims.Subject, true


### PR DESCRIPTION
Related to #6949

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
