### PR TITLE
fix: replace back button with <- in user register

### DIFF
--- a/internal/api/ui/login/static/templates/register.html
+++ b/internal/api/ui/login/static/templates/register.html
@@ -106,8 +106,8 @@
     {{template "error-message" .}}
 
     <div class="lgn-actions">
-        <a class="lgn-stroked-button" href="{{ loginNameChangeUrl .AuthReqID }}">
-            {{t "RegistrationUser.BackButtonText"}}
+        <a class="lgn-icon-button lgn-left-action" id="back" href="{{ loginNameChangeUrl .AuthReqID }}" formnovalidate>
+            <i class="lgn-icon-arrow-left-solid"></i>
         </a>
         <span class="fill-space"></span>
         <button class="lgn-raised-button lgn-primary" id="register-button" type="submit">{{t "RegistrationUser.NextButtonText"}}</button>


### PR DESCRIPTION
In #6491 @kbumsik noted that there was a missing ← left arrow it we try to register a user. This PR replaces the back button (login) in the bottom with the common left arrow.

![change_back_button_login](https://github.com/zitadel/zitadel/assets/30386061/1d398a4d-a7e5-4e70-8e95-fdd36d48387a)

Closes #6491 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
