### PR TITLE
feat: search users by list of emails (users/_search)

### DIFF
--- a/internal/api/grpc/user/query.go
+++ b/internal/api/grpc/user/query.go
@@ -46,6 +46,8 @@ func UserQueryToQuery(query *user_pb.SearchQuery, level uint8) (query.SearchQuer
 		return ResourceOwnerQueryToQuery(q.ResourceOwner)
 	case *user_pb.SearchQuery_InUserIdsQuery:
 		return InUserIdsQueryToQuery(q.InUserIdsQuery)
+	case *user_pb.SearchQuery_InUserEmailsQuery:
+		return InUserEmailsQueryToQuery(q.InUserEmailsQuery)
 	case *user_pb.SearchQuery_OrQuery:
 		return OrQueryToQuery(q.OrQuery, level)
 	case *user_pb.SearchQuery_AndQuery:
@@ -100,6 +102,11 @@ func ResourceOwnerQueryToQuery(q *user_pb.ResourceOwnerQuery) (query.SearchQuery
 func InUserIdsQueryToQuery(q *user_pb.InUserIDQuery) (query.SearchQuery, error) {
 	return query.NewUserInUserIdsSearchQuery(q.UserIds)
 }
+
+func InUserEmailsQueryToQuery(q *user_pb.InUserEmailsQuery) (query.SearchQuery, error) {
+	return query.NewUserInUserEmailsSearchQuery(q.UserEmails)
+}
+
 func OrQueryToQuery(q *user_pb.OrQuery, level uint8) (query.SearchQuery, error) {
 	mappedQueries, err := UserQueriesToQuery(q.Queries, level+1)
 	if err != nil {

--- a/internal/query/user.go
+++ b/internal/query/user.go
@@ -591,6 +591,9 @@ func NewUserNotSearchQuery(value SearchQuery) (SearchQuery, error) {
 func NewUserInUserIdsSearchQuery(values []string) (SearchQuery, error) {
 	return NewInTextQuery(UserIDCol, values)
 }
+func NewUserInUserEmailsSearchQuery(values []string) (SearchQuery, error) {
+	return NewInTextQuery(HumanEmailCol, values)
+}
 
 func NewUserResourceOwnerSearchQuery(value string, comparison TextComparison) (SearchQuery, error) {
 	return NewTextQuery(UserResourceOwnerCol, value, comparison)

--- a/proto/zitadel/user.proto
+++ b/proto/zitadel/user.proto
@@ -188,6 +188,7 @@ message SearchQuery {
         OrQuery or_query = 11;
         AndQuery and_query = 12;
         NotQuery not_query = 13;
+        InUserEmailsQuery in_user_emails_query = 14;
     }
 }
 
@@ -219,6 +220,15 @@ message InUserIDQuery {
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {            
             description: "the ids of the users to include"
             example: "[\"69629023906488334\",\"69622366012355662\"]";
+        }
+    ];
+}
+
+message InUserEmailsQuery {
+    repeated string user_emails = 1 [        
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {            
+            description: "the emails of the users to include"
+            example: "[\"test@example.com\",\"test@example.org\"]";
         }
     ];
 }


### PR DESCRIPTION
In #6829 @mffap proposed that it should be possible to search users by a list of emails (/users/_search) in a similar way as we can use a list of user ids using inUserIdsQuery object.

This PR adds inUserEmailsQuery object so we can use userEmails to pass a list of emails that we want to search.

Here's a sample query:

![image](https://github.com/zitadel/zitadel/assets/30386061/ba1b88a9-b4bc-445d-bad6-6ce62c0ee8ee)

Closes #6829

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
