### PR TITLE
fix: handle context when locking for trigger

### DIFF
--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -257,24 +257,36 @@ func (h *Handler) Trigger(ctx context.Context, opts ...triggerOpt) (_ context.Co
 // lockInstances tries to lock the instance.
 // If the instance is already locked from another process no cancel function is returned
 // the instance can be skipped then
-// If the instance is locked, an unlock deferable function is returned
+// If the instance is locked, an unlock deferrable function is returned
 func (h *Handler) lockInstance(ctx context.Context, config *triggerConfig) func() {
 	instanceID := authz.GetInstance(ctx).InstanceID()
 
-	// Check that the instance has a mutex to lock
-	instanceMu, _ := h.triggeredInstancesSync.LoadOrStore(instanceID, new(sync.Mutex))
-	unlock := func() {
-		instanceMu.(*sync.Mutex).Unlock()
-	}
-	if !instanceMu.(*sync.Mutex).TryLock() {
-		instanceMu.(*sync.Mutex).Lock()
-		if config.awaitRunning {
-			return unlock
+	// Check that the instance has a lock
+	instanceLock, _ := h.triggeredInstancesSync.LoadOrStore(instanceID, make(chan bool, 1))
+
+	// in case we don't want to wait for a running trigger / lock (e.g. spooler),
+	// we can directly return if we cannot lock
+	if !config.awaitRunning {
+		select {
+		case instanceLock.(chan bool) <- true:
+			return func() {
+				<-instanceLock.(chan bool)
+			}
+		default:
+			return nil
 		}
-		defer unlock()
+	}
+
+	// in case we want to wait for a running trigger / lock (e.g. query),
+	// we try to lock as long as the context is not cancelled
+	select {
+	case instanceLock.(chan bool) <- true:
+		return func() {
+			<-instanceLock.(chan bool)
+		}
+	case <-ctx.Done():
 		return nil
 	}
-	return unlock
 }
 
 func (h *Handler) processEvents(ctx context.Context, config *triggerConfig) (additionalIteration bool, err error) {


### PR DESCRIPTION
A customer reached out to support as he experienced multiple outages. During the analyzation we discovered in the tracing, that multiple `Trigger` functions where running for several minutes! and then return an error `context canceled`.

This PR will change the locking mechanism used to make sure there's single trigger running at a time the following way:
First of all it will change `sync.Mutex` to a `chan bool` to be able to check for canceled context, while waiting to lock.
Further it will also no longer wait for the lock if `awaitRunning` is false. (It used to wait and directly unlock again).


### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
