### PR TITLE
docs(10006): clarify required crdb versions

### DIFF
--- a/docs/docs/support/advisory/a10006.md
+++ b/docs/docs/support/advisory/a10006.md
@@ -12,6 +12,8 @@ Date: Calendar week 41/42 2023
 
 Versions >= 2.39.0 require the cockroach database user of ZITADEL to be granted to the `VIEWACTIVITY` grant. This can either be reached by grant the role manually or execute the `zitadel init` command.
 
+Cockroach versions 22.2 < 22.2.11 and 23.1 < 23.1.4 will fail the migration. Please make sure to upgrade to more recent versions first. ZITADEL recommends to use the latest stable version of Cockroachdb.
+
 ## Statement
 
 To query correct order of events the cockroach database user of ZITADEL needs additional privileges to query the `crdb_internal.cluster_transactions`-table
@@ -19,6 +21,8 @@ To query correct order of events the cockroach database user of ZITADEL needs ad
 ## Mitigation
 
 Before migrating to versions >= 2.39.0 make sure the cockroach database user has sufficient grants.
+
+Cockroachdb version is up to date.
 
 ## Impact
 


### PR DESCRIPTION
During migrations admins were facing issues if they used a too old database version. This change states the minimum required versions of crdb