### PR TITLE
fix: projection version of restrictions

### DIFF
--- a/internal/query/projection/restrictions.go
+++ b/internal/query/projection/restrictions.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	RestrictionsProjectionTable = "projections.restrictions"
+	RestrictionsProjectionTable = "projections.restrictions2"
 
 	RestrictionsColumnAggregateID   = "aggregate_id"
 	RestrictionsColumnCreationDate  = "creation_date"

--- a/internal/query/projection/restrictions_test.go
+++ b/internal/query/projection/restrictions_test.go
@@ -35,7 +35,7 @@ func TestRestrictionsProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.restrictions (instance_id, resource_owner, creation_date, change_date, sequence, aggregate_id, disallow_public_org_registration) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (instance_id, resource_owner) DO UPDATE SET (creation_date, change_date, sequence, aggregate_id, disallow_public_org_registration) = (projections.restrictions.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.aggregate_id, EXCLUDED.disallow_public_org_registration)",
+							expectedStmt: "INSERT INTO projections.restrictions2 (instance_id, resource_owner, creation_date, change_date, sequence, aggregate_id, disallow_public_org_registration) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (instance_id, resource_owner) DO UPDATE SET (creation_date, change_date, sequence, aggregate_id, disallow_public_org_registration) = (projections.restrictions2.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.aggregate_id, EXCLUDED.disallow_public_org_registration)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"ro-id",
@@ -66,7 +66,7 @@ func TestRestrictionsProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.restrictions (instance_id, resource_owner, creation_date, change_date, sequence, aggregate_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, resource_owner) DO UPDATE SET (creation_date, change_date, sequence, aggregate_id) = (projections.restrictions.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.aggregate_id)",
+							expectedStmt: "INSERT INTO projections.restrictions2 (instance_id, resource_owner, creation_date, change_date, sequence, aggregate_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, resource_owner) DO UPDATE SET (creation_date, change_date, sequence, aggregate_id) = (projections.restrictions2.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.aggregate_id)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"ro-id",

--- a/internal/query/restrictions_test.go
+++ b/internal/query/restrictions_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	expectedRestrictionsQuery = regexp.QuoteMeta("SELECT projections.restrictions.aggregate_id," +
-		" projections.restrictions.creation_date," +
-		" projections.restrictions.change_date," +
-		" projections.restrictions.resource_owner," +
-		" projections.restrictions.sequence," +
-		" projections.restrictions.disallow_public_org_registration," +
-		" projections.restrictions.allowed_languages" +
-		" FROM projections.restrictions" +
+	expectedRestrictionsQuery = regexp.QuoteMeta("SELECT projections.restrictions2.aggregate_id," +
+		" projections.restrictions2.creation_date," +
+		" projections.restrictions2.change_date," +
+		" projections.restrictions2.resource_owner," +
+		" projections.restrictions2.sequence," +
+		" projections.restrictions2.disallow_public_org_registration," +
+		" projections.restrictions2.allowed_languages" +
+		" FROM projections.restrictions2" +
 		" AS OF SYSTEM TIME '-1 ms'",
 	)
 


### PR DESCRIPTION
updates the version of the `projections.restrictions` table, so the new column will be added

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
