### PR TITLE
fix(console): reset events filter to initial values

### DIFF
--- a/console/src/app/modules/filter-events/filter-events.component.ts
+++ b/console/src/app/modules/filter-events/filter-events.component.ts
@@ -75,6 +75,8 @@ export class FilterEventsComponent implements OnInit {
     eventTypesList: new FormControl<EventType.AsObject[]>([]),
   });
 
+  private initialValues = this.form.getRawValue();
+
   constructor(
     private adminService: AdminService,
     private toast: ToastService,
@@ -172,6 +174,7 @@ export class FilterEventsComponent implements OnInit {
 
   public reset(): void {
     this.form.reset();
+    this.form.setValue(this.initialValues);
     this.emitChange();
   }
 


### PR DESCRIPTION
Resets the form to its initial values instead of empty values.

Before when reset was clicked:
![image](https://github.com/zitadel/zitadel/assets/12727842/7c4721e7-c87f-4534-a5e4-bac073e3e930)

After when reset was clilcked:
![image](https://github.com/zitadel/zitadel/assets/12727842/dd87ea63-5c24-4634-85e7-69160e4f45dc)

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
