### PR TITLE
fix: detect autofill in chrome to enable login buttons

### DIFF
--- a/internal/api/ui/login/static/resources/scripts/form_submit.js
+++ b/internal/api/ui/login/static/resources/scripts/form_submit.js
@@ -1,58 +1,87 @@
-function disableSubmit(checks, button) {
-    let form = document.getElementsByTagName('form')[0];
-    let inputs = form.getElementsByTagName('input');
-    if (button) {
-        button.disabled = true;
-    }
-    addRequiredEventListener(inputs, checks, form, button);
-    disableDoubleSubmit(form, button);
+// if an autofilled input is deleted we remove the attribute
+function detectDelete(event) {
+  const key = event.key;
+  if (key === "Backspace" || key === "Delete") {
+    event.target.isAutofilled = false;
+  }
+}
 
+// if the autofill associated animation is detected we add a property
+// and check if submit button should be disabled or not
+function autofill(target, checks, form, inputs, button) {
+  if (!target.isAutofilled) {
+    target.isAutofilled = true;
+    target.dispatchEvent(new CustomEvent("autofill", { bubbles: true }));
     toggleButton(checks, form, inputs, button);
+  }
+}
+
+function disableSubmit(checks, button) {
+  let form = document.getElementsByTagName("form")[0];
+  let inputs = form.getElementsByTagName("input");
+  if (button) {
+    button.disabled = true;
+  }
+  addRequiredEventListener(inputs, checks, form, button);
+  disableDoubleSubmit(form, button);
+
+  toggleButton(checks, form, inputs, button);
 }
 
 function addRequiredEventListener(inputs, checks, form, button) {
-    let eventType = 'input';
-    for (i = 0; i < inputs.length; i++) {
-        if (inputs[i].required) {
-            eventType = 'input';
-            if (inputs[i].type === 'checkbox') {
-                eventType = 'click';
-            }
-            inputs[i].addEventListener(eventType, function () {
-                toggleButton(checks, form, inputs, button);
-            });
-        }
+  let eventType = "input";
+  for (i = 0; i < inputs.length; i++) {
+    if (inputs[i].required) {
+      eventType = "input";
+      if (inputs[i].type === "checkbox") {
+        eventType = "click";
+      }
+
+      inputs[i].addEventListener(eventType, function () {
+        toggleButton(checks, form, inputs, button);
+      });
+
+      if (inputs[i].type !== "checkbox") {
+        // hack for Chrome, add an animationstart event listener
+        // if input is autofilled: https://gist.github.com/jonathantneal/d462fc2bf761a10c9fca60eb634f6977?permalink_comment_id=2901919
+        inputs[i].addEventListener("animationstart", (event) =>
+          autofill(event.target, checks, form, inputs, button)
+        );
+
+        inputs[i].addEventListener("keydown", detectDelete);
+      }
     }
+  }
 }
 
 function disableDoubleSubmit(form, button) {
-    form.addEventListener('submit', function () {
-        document.body.classList.add('waiting');
-        button.disabled = true;
-    });
+  form.addEventListener("submit", function () {
+    document.body.classList.add("waiting");
+    button.disabled = true;
+  });
 }
 
 function toggleButton(checks, form, inputs, button) {
-    if (checks !== undefined) {
-        if (checks() === false) {
-            button.disabled = true;
-            return;
-        }
+  if (checks !== undefined) {
+    if (checks() === false) {
+      button.disabled = true;
+      return;
     }
-    const targetValue = !allRequiredDone(form, inputs);
-    button.disabled = targetValue;
+  }
+  const targetValue = !allRequiredDone(form, inputs);
+  button.disabled = targetValue;
 }
 
 function allRequiredDone(form, inputs) {
-    for (i = 0; i < inputs.length; i++) {
-        if (inputs[i].required) {
-            if (inputs[i].type === 'checkbox' && !inputs[i].checked) {
-                return false;
-            }
-            if (inputs[i].value === '') {
-                return false;
-            }
-        }
+  for (i = 0; i < inputs.length; i++) {
+    if (inputs[i].required) {
+      if (inputs[i].type === "checkbox" && !inputs[i].checked) {
+        return false;
+      }
+      if (inputs[i].value === "" && !inputs[i].isAutofilled) {
+        return false;
+      }
     }
-    return true;
+  }
+  return true;
 }

--- a/internal/api/ui/login/static/resources/themes/scss/styles/input/input_base.scss
+++ b/internal/api/ui/login/static/resources/themes/scss/styles/input/input_base.scss
@@ -7,26 +7,36 @@ $lgn-input-border-width: 1px !default;
 $lgn-input-placeholder-font-size: 14px !default;
 
 @mixin lgn-input-base {
-    display: block;
-    box-sizing: border-box;
-    padding-inline-start: $lgn-input-padding-start;
-    outline: none;
-    display: inline-block;
-    text-align: start;
-    cursor: text;
-    border-radius: $lgn-input-border-radius;
-    transform: all .2 linear;
-    font-size: 1rem;
-    border-style: solid;
-    border-width: $lgn-input-border-width;
-    height: $lgn-input-line-height;
-    padding: $lgn-input-padding;
-    transition: border-color .2s ease-in-out;
-    width: 100%;
-    margin: $lgn-input-margin;
+  display: block;
+  box-sizing: border-box;
+  padding-inline-start: $lgn-input-padding-start;
+  outline: none;
+  display: inline-block;
+  text-align: start;
+  cursor: text;
+  border-radius: $lgn-input-border-radius;
+  transform: all 0.2 linear;
+  font-size: 1rem;
+  border-style: solid;
+  border-width: $lgn-input-border-width;
+  height: $lgn-input-line-height;
+  padding: $lgn-input-padding;
+  transition: border-color 0.2s ease-in-out;
+  width: 100%;
+  margin: $lgn-input-margin;
 
-    &::placeholder {
-        font-size: $lgn-input-placeholder-font-size;
-        font-style: italic;
-    }
+  &::placeholder {
+    font-size: $lgn-input-placeholder-font-size;
+    font-style: italic;
+  }
+
+  &:autofill {
+    animation-duration: 50000s;
+    animation-name: onautofillstart;
+  }
+}
+
+@keyframes onautofillstart {
+  from {
+  }
 }


### PR DESCRIPTION
In #7024 @Koen-Nocore reported an issue about login submit buttons (next, submit) to shown as disabled when inputs are autofilled. 

Indeed, I reproduced the issue with Chrome + Linux (not in Firefox + Linux). This question in Stack Overflow: https://stackoverflow.com/questions/11708092/detecting-browser-autofill explains the issue. It seems that if Chrome autofills an input the value of that input is empty until the user interacts with the page (e.g click) so Zitadel login JS helpers detect those inputs as empty and then the button is shown as disabled (but you can click on it).

I've added some of the suggested hack (https://gist.github.com/jonathantneal/d462fc2bf761a10c9fca60eb634f6977?permalink_comment_id=2901919) to the code. Now if a required input is autofilled an attribute isAutofilled is added to the input and the button is not disabled if that input is autofilled although its value is temporarily empty. Also that attribute is removed if we delete the autofilled input.

This is a video showing the proposed behavior:

https://github.com/zitadel/zitadel/assets/30386061/3c50a13e-bc29-46b2-971a-da0c17e76cc1

Hope this hack is good enough

Should close #7024 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
