### PR TITLE
fix(handler): allow uint32 offset for migration scenarios

### DIFF
--- a/internal/eventstore/handler/v2/state.go
+++ b/internal/eventstore/handler/v2/state.go
@@ -19,7 +19,7 @@ type state struct {
 	aggregateType  eventstore.AggregateType
 	aggregateID    string
 	sequence       uint64
-	offset         uint16
+	offset         uint32
 }
 
 var (
@@ -46,7 +46,7 @@ func (h *Handler) currentState(ctx context.Context, tx *sql.Tx, config *triggerC
 		sequence      = new(sql.NullInt64)
 		timestamp     = new(sql.NullTime)
 		position      = new(sql.NullFloat64)
-		offset        = new(sql.NullInt16)
+		offset        = new(sql.NullInt64)
 	)
 
 	stateQuery := currentStateStmt
@@ -76,7 +76,8 @@ func (h *Handler) currentState(ctx context.Context, tx *sql.Tx, config *triggerC
 	currentState.sequence = uint64(sequence.Int64)
 	currentState.eventTimestamp = timestamp.Time
 	currentState.position = position.Float64
-	currentState.offset = uint16(offset.Int16)
+	// psql does not provide unsigned numbers so we work around it
+	currentState.offset = uint32(offset.Int64)
 	return currentState, nil
 }
 

--- a/internal/eventstore/handler/v2/statement.go
+++ b/internal/eventstore/handler/v2/statement.go
@@ -65,7 +65,7 @@ type Statement struct {
 	CreationDate  time.Time
 	InstanceID    string
 
-	offset uint16
+	offset uint32
 
 	Execute Exec
 }

--- a/internal/eventstore/repository/search_query.go
+++ b/internal/eventstore/repository/search_query.go
@@ -17,7 +17,7 @@ type SearchQuery struct {
 	AllowTimeTravel       bool
 	AwaitOpenTransactions bool
 	Limit                 uint64
-	Offset                uint16
+	Offset                uint32
 	Desc                  bool
 
 	InstanceID        *Filter

--- a/internal/eventstore/search_query.go
+++ b/internal/eventstore/search_query.go
@@ -14,7 +14,7 @@ import (
 type SearchQueryBuilder struct {
 	columns               Columns
 	limit                 uint64
-	offset                uint16
+	offset                uint32
 	desc                  bool
 	resourceOwner         string
 	instanceID            *string
@@ -38,7 +38,7 @@ func (b *SearchQueryBuilder) GetLimit() uint64 {
 	return b.limit
 }
 
-func (b *SearchQueryBuilder) GetOffset() uint16 {
+func (b *SearchQueryBuilder) GetOffset() uint32 {
 	return b.offset
 }
 
@@ -160,7 +160,7 @@ func (builder *SearchQueryBuilder) Matches(commands ...Command) []Command {
 		if builder.limit > 0 && builder.limit <= uint64(len(matches)) {
 			break
 		}
-		if builder.offset > 0 && uint16(i) < builder.offset {
+		if builder.offset > 0 && uint32(i) < builder.offset {
 			continue
 		}
 
@@ -213,7 +213,7 @@ func (builder *SearchQueryBuilder) Limit(limit uint64) *SearchQueryBuilder {
 }
 
 // Limit defines how many events are returned maximally.
-func (builder *SearchQueryBuilder) Offset(offset uint16) *SearchQueryBuilder {
+func (builder *SearchQueryBuilder) Offset(offset uint32) *SearchQueryBuilder {
 	builder.offset = offset
 	return builder
 }


### PR DESCRIPTION
For future migrations positions can get bigger and needs a higher offset in the handler. The datatype of the offset is changed to an uint32
