### PR TITLE
fix(oidc): refresh token for device authorization

### DIFF
--- a/internal/command/user_human_refresh_token.go
+++ b/internal/command/user_human_refresh_token.go
@@ -45,7 +45,7 @@ func (c *Commands) AddNewRefreshTokenAndAccessToken(
 	refreshIdleExpiration time.Duration,
 	authTime time.Time,
 ) (accessToken *domain.Token, newRefreshToken string, err error) {
-	if userID == "" || agentID == "" || clientID == "" {
+	if userID == "" || clientID == "" {
 		return nil, "", zerrors.ThrowInvalidArgument(nil, "COMMAND-adg4r", "Errors.IDMissing")
 	}
 	userWriteModel := NewUserWriteModel(userID, orgID)


### PR DESCRIPTION
Due to a mis-alignment of OIDC interface and concrete implementations in zitadel, requesting a refresh token for device authorization would fail.
This change adds the possibility to to use the op.IDTokenRequest directly.
Also, the UserAgentID is dropped as required parameter, as devices do not have a user agent.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
