### PR TITLE
ci: publish sha to docker registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       pull-requests: write
     needs:
       [version, core-unit-test, core-integration-test, lint, container, e2e]
-    if: ${{ needs.version.outputs.published == 'true' && github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     secrets:
       GCR_JSON_KEY_BASE64: ${{ secrets.GCR_JSON_KEY_BASE64 }}
     with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -47,4 +47,4 @@ jobs:
       name: output
       id: output
       run:
-        if [[ ! -z "${{ steps.semantic.outputs.new_release_version }}" ]]; then echo "VERSION=v${{ steps.semantic.outputs.new_release_version }}" >> "$GITHUB_OUTPUT"; else echo "VERSION=" >> "$GITHUB_OUTPUT";fi
+        if [[ ! -z "${{ steps.semantic.outputs.new_release_version }}" ]]; then echo "VERSION=v${{ steps.semantic.outputs.new_release_version }}" >> "$GITHUB_OUTPUT"; else echo "VERSION=${{ github.sha }}" >> "$GITHUB_OUTPUT";fi


### PR DESCRIPTION
Allows to push sha versions to docker registry on workflow dispatch