### PR TITLE
fix: correctly respect maxFailureCount

### DIFF
--- a/internal/authz/repository/eventsourcing/view/token.go
+++ b/internal/authz/repository/eventsourcing/view/token.go
@@ -4,11 +4,9 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
-	"github.com/zitadel/zitadel/internal/eventstore/v1/models"
 	"github.com/zitadel/zitadel/internal/query"
 	usr_view "github.com/zitadel/zitadel/internal/user/repository/view"
 	usr_view_model "github.com/zitadel/zitadel/internal/user/repository/view/model"
-	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 const (
@@ -17,26 +15,6 @@ const (
 
 func (v *View) TokenByIDs(tokenID, userID, instanceID string) (*usr_view_model.TokenView, error) {
 	return usr_view.TokenByIDs(v.Db, tokenTable, tokenID, userID, instanceID)
-}
-
-func (v *View) PutToken(token *usr_view_model.TokenView, event *models.Event) error {
-	return usr_view.PutToken(v.Db, tokenTable, token)
-}
-
-func (v *View) DeleteToken(tokenID, instanceID string, event *models.Event) error {
-	err := usr_view.DeleteToken(v.Db, tokenTable, tokenID, instanceID)
-	if err != nil && !zerrors.IsNotFound(err) {
-		return err
-	}
-	return nil
-}
-
-func (v *View) DeleteSessionTokens(agentID, userID, instanceID string, event *models.Event) error {
-	err := usr_view.DeleteSessionTokens(v.Db, tokenTable, agentID, userID, instanceID)
-	if err != nil && !zerrors.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 func (v *View) GetLatestState(ctx context.Context) (_ *query.CurrentState, err error) {

--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -454,7 +454,10 @@ func (h *Handler) executeStatement(ctx context.Context, tx *sql.Tx, currentState
 	}
 	var shouldContinue bool
 	defer func() {
-		_, err = tx.Exec("RELEASE SAVEPOINT exec")
+		_, errSave := tx.Exec("RELEASE SAVEPOINT exec")
+		if err == nil {
+			err = errSave
+		}
 	}()
 
 	if err = statement.Execute(tx, h.projection.Name()); err != nil {


### PR DESCRIPTION
While investigating an issue on production (missing loginnames on a user in the auth projection), we found out that the error is overwritten and thus the maxFailureCount gets ignored.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
