### PR TITLE
docs(legal): clarify response time in free plan

### DIFF
--- a/docs/docs/legal/service-description/support-services.mdx
+++ b/docs/docs/legal/service-description/support-services.mdx
@@ -31,7 +31,7 @@ Support features for ZITADEL Cloud subscriptions are as follows:
 Subscription Plans | Free | Production | Enterprise Cloud
 --- | --- | --- | ---
 [Support hours](#support-hours) | Business hours | Business hours | bespoke (up to 24x7)
-[Response Time](#slo---initial-response-time) (Severity 1) | Best effort | 48 business hours | bespoke (as low as 30min)
+[Response Time](#slo---initial-response-time) (Severity 1) | n/a | 48 business hours | bespoke (as low as 30min)
 [Community support](#community-support) | yes | yes | yes
 [Professional support](#professional-support) | no | yes | yes
 [Enterprise supported features](/docs/support/software-release-cycles-support.md#enterprise-supported) |  no | no | yes
@@ -100,6 +100,9 @@ If we fail to provide the initial response time objective, you will be entitled 
 #### Community support
 
 Community support for ZITADEL is available on our website, our [public chat](https://zitadel.com/chat), and [GitHub](https://github.com/zitadel/).
+
+We do only guarantee response times to Tickets reported via [professional support](#professional-support) channels only.
+If you are an eligible customer, please use Tickets for critical or urgent issues.
 
 #### Professional support
 


### PR DESCRIPTION
With the last pricing change we removed professional support from the free plan. Customers in the free plan should turn to community support for help.
We had however a response time stated in the free plan, which is an error carried over from the previous plans. 
This PR removes 'best effort'. Also it mentiones in the community support section that time critical issues should be reported through professional support, if eligible.