### PR TITLE
docs(complement token): clarify when `pre userinfo creation` is executed

### DIFF
--- a/docs/docs/apis/actions/complement-token.md
+++ b/docs/docs/apis/actions/complement-token.md
@@ -4,9 +4,9 @@ title: Complement Token Flow
 
 This flow is executed during the creation of tokens and token introspection.
 
-## Pre Userinfo creation
+## Pre Userinfo creation (id_token / userinfo / introspection endpoint)
 
-This trigger is called before userinfo are set in the token or response.
+This trigger is called before userinfo are set in the id_token or userinfo and introspection endpoint response.
 
 ### Parameters of Pre Userinfo creation
 


### PR DESCRIPTION
During a TAM session, it was noted that it is not clear to customers that the `pre userinfo creation` is not only executed for the userinfo endpoint, but among others also for the id_token

