### PR TITLE
fix(origin): fall back to ExternalSecure

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -325,7 +325,7 @@ func startAPIs(
 	}
 	oidcPrefixes := []string{"/.well-known/openid-configuration", "/oidc/v1", "/oauth/v2"}
 	// always set the origin in the context if available in the http headers, no matter for what protocol
-	router.Use(middleware.OriginHandler)
+	router.Use(middleware.OriginMiddleware(config.ExternalSecure))
 	systemTokenVerifier, err := internal_authz.StartSystemTokenVerifierFromConfig(http_util.BuildHTTP(config.ExternalDomain, config.ExternalPort, config.ExternalSecure), config.SystemAPIUsers)
 	if err != nil {
 		return err

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -325,7 +325,7 @@ func startAPIs(
 	}
 	oidcPrefixes := []string{"/.well-known/openid-configuration", "/oidc/v1", "/oauth/v2"}
 	// always set the origin in the context if available in the http headers, no matter for what protocol
-	router.Use(middleware.OriginMiddleware(config.ExternalSecure))
+	router.Use(middleware.WithOrigin(config.ExternalSecure))
 	systemTokenVerifier, err := internal_authz.StartSystemTokenVerifierFromConfig(http_util.BuildHTTP(config.ExternalDomain, config.ExternalPort, config.ExternalSecure), config.SystemAPIUsers)
 	if err != nil {
 		return err

--- a/internal/api/http/middleware/origin_interceptor.go
+++ b/internal/api/http/middleware/origin_interceptor.go
@@ -11,7 +11,7 @@ import (
 	http_util "github.com/zitadel/zitadel/internal/api/http"
 )
 
-func OriginMiddleware(fallBackToHttps bool) mux.MiddlewareFunc {
+func WithOrigin(fallBackToHttps bool) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := composeOrigin(r, fallBackToHttps)

--- a/internal/api/http/middleware/origin_interceptor.go
+++ b/internal/api/http/middleware/origin_interceptor.go
@@ -2,9 +2,9 @@ package middleware
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/muhlemmer/httpforwarded"
 	"github.com/zitadel/logging"
 

--- a/internal/api/http/middleware/origin_interceptor.go
+++ b/internal/api/http/middleware/origin_interceptor.go
@@ -39,10 +39,9 @@ func composeOrigin(r *http.Request, fallBackToHttps bool) string {
 		host = r.Header.Get("X-Forwarded-Host")
 	}
 	if proto == "" {
+		proto = "http"
 		if fallBackToHttps {
 			proto = "https"
-		} else {
-			proto = "http"
 		}
 	}
 	if host == "" {

--- a/internal/api/http/middleware/origin_interceptor_test.go
+++ b/internal/api/http/middleware/origin_interceptor_test.go
@@ -9,7 +9,8 @@ import (
 
 func Test_composeOrigin(t *testing.T) {
 	type args struct {
-		h http.Header
+		h               http.Header
+		fallBackToHttps bool
 	}
 	tests := []struct {
 		name string
@@ -24,6 +25,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"proto=https"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://host.header",
 	}, {
@@ -32,6 +34,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"host=forwarded.host"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "http://forwarded.host",
 	}, {
@@ -40,6 +43,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"proto=https;host=forwarded.host"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://forwarded.host",
 	}, {
@@ -48,6 +52,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"proto=https;host=forwarded.host, proto=http;host=forwarded.host2"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://forwarded.host",
 	}, {
@@ -56,6 +61,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"proto=https;host=forwarded.host, proto=http"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://forwarded.host",
 	}, {
@@ -64,14 +70,37 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"Forwarded": []string{"proto=http", "proto=https;host=forwarded.host", "proto=http"},
 			},
+			fallBackToHttps: true,
 		},
 		want: "http://forwarded.host",
 	}, {
-		name: "x-forwarded-proto",
+		name: "x-forwarded-proto https",
 		args: args{
 			h: http.Header{
 				"X-Forwarded-Proto": []string{"https"},
 			},
+			fallBackToHttps: false,
+		},
+		want: "https://host.header",
+	}, {
+		name: "x-forwarded-proto http",
+		args: args{
+			h: http.Header{
+				"X-Forwarded-Proto": []string{"http"},
+			},
+			fallBackToHttps: true,
+		},
+		want: "http://host.header",
+	}, {
+		name: "fallback to http",
+		args: args{
+			fallBackToHttps: false,
+		},
+		want: "http://host.header",
+	}, {
+		name: "fallback to https",
+		args: args{
+			fallBackToHttps: true,
 		},
 		want: "https://host.header",
 	}, {
@@ -80,6 +109,7 @@ func Test_composeOrigin(t *testing.T) {
 			h: http.Header{
 				"X-Forwarded-Host": []string{"x-forwarded.host"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "http://x-forwarded.host",
 	}, {
@@ -89,6 +119,7 @@ func Test_composeOrigin(t *testing.T) {
 				"X-Forwarded-Proto": []string{"https"},
 				"X-Forwarded-Host":  []string{"x-forwarded.host"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://x-forwarded.host",
 	}, {
@@ -98,6 +129,7 @@ func Test_composeOrigin(t *testing.T) {
 				"Forwarded":        []string{"host=forwarded.host"},
 				"X-Forwarded-Host": []string{"x-forwarded.host"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "http://forwarded.host",
 	}, {
@@ -107,16 +139,20 @@ func Test_composeOrigin(t *testing.T) {
 				"Forwarded":         []string{"host=forwarded.host"},
 				"X-Forwarded-Proto": []string{"https"},
 			},
+			fallBackToHttps: false,
 		},
 		want: "https://forwarded.host",
 	},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, composeOrigin(&http.Request{
-				Host:   "host.header",
-				Header: tt.args.h,
-			}), "headers: %+v", tt.args.h)
+			assert.Equalf(t, tt.want, composeOrigin(
+				&http.Request{
+					Host:   "host.header",
+					Header: tt.args.h,
+				},
+				tt.args.fallBackToHttps,
+			), "headers: %+v, fallBackToHttps: %t", tt.args.h, tt.args.fallBackToHttps)
 		})
 	}
 }


### PR DESCRIPTION
This PR ensures that if neither a Forwarded nor an X-Forwarded-Proto header is sent in requests to ZITADEL, links in messages like Email verifications use https if ExternalSecure is true or http if ExternalSecure is false.

Before this PR, the requests TLS config was used, which did not make sense. The TLS config does not tell if a client in front of a proxy used http or https. ExternalSecure does.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
