### PR TITLE
chore: pin crdb version for unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       go_version: "1.21"
       core_cache_key: ${{ needs.core.outputs.cache_key }}
       core_cache_path: ${{ needs.core.outputs.cache_path }}
-      crdb_version: "23.1"
+      crdb_version: "23.1.14"
 
   core-integration-test:
     needs: core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
       go_version: "1.21"
       core_cache_key: ${{ needs.core.outputs.cache_key }}
       core_cache_path: ${{ needs.core.outputs.cache_path }}
+      crdb_version: "23.1"
 
   core-integration-test:
     needs: core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       go_version: "1.21"
       core_cache_key: ${{ needs.core.outputs.cache_key }}
       core_cache_path: ${{ needs.core.outputs.cache_path }}
-      crdb_version: "23.1.14"
+      crdb_version: "23.1.13"
 
   core-integration-test:
     needs: core

--- a/.github/workflows/core-unit-test.yml
+++ b/.github/workflows/core-unit-test.yml
@@ -12,6 +12,9 @@ on:
       core_cache_path:
         required: true
         type: string
+      crdb_version:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -51,7 +54,7 @@ jobs:
       - 
         name: test
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: make core_unit_test
+        run: export ZITADEL_CRDB_VERSION="${{ inputs.crdb_version }}" && make core_unit_test
       - 
         name: publish coverage
         uses: codecov/codecov-action@v3.1.4

--- a/internal/eventstore/local_crdb_test.go
+++ b/internal/eventstore/local_crdb_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ts, err := testserver.NewTestServer()
+	ts, err := testserver.NewTestServer(testserver.CustomVersionOpt(os.Getenv("ZITADEL_CRDB_VERSION")))
 	if err != nil {
 		logging.WithFields("error", err).Fatal("unable to start db")
 	}

--- a/internal/eventstore/repository/sql/local_crdb_test.go
+++ b/internal/eventstore/repository/sql/local_crdb_test.go
@@ -20,7 +20,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ts, err := testserver.NewTestServer()
+	ts, err := testserver.NewTestServer(testserver.CustomVersionOpt(os.Getenv("ZITADEL_CRDB_VERSION")))
 	if err != nil {
 		logging.WithFields("error", err).Fatal("unable to start db")
 	}


### PR DESCRIPTION
Cockroach created new versions (23.2.0 and 23.1.14), which are not yet publicly available, but the testserver used in the eventstore unit tests, checks for the latests stable version (which returns 23.2.0).

This PR allows to specify a specific version to use in the pipeline for unit tests and sets it currently to 23.1.13.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
