### PR TITLE
chore: remove cockroach, clickhouse and add hubspot from third party sub-processors

### DIFF
--- a/docs/src/components/subprocessors.jsx
+++ b/docs/src/components/subprocessors.jsx
@@ -22,13 +22,6 @@ export function SubProcessorTable() {
       enduserdata: "Yes (transit)"
     },
     {
-      entity: "Cockroach Labs, Inc.",
-      purpose: "Managed database services: Dedicated CockroachDB clusters on Google Cloud",
-      hosting: "Region designated by Customer",
-      country: country_list.us,
-      enduserdata: "Yes (at rest)"
-    },
-    {
       entity: "Datadog, Inc.",
       purpose: "Infrastructure monitoring, log analytics, and alerting",
       hosting: country_list.eu,

--- a/docs/src/components/subprocessors.jsx
+++ b/docs/src/components/subprocessors.jsx
@@ -16,7 +16,7 @@ export function SubProcessorTable() {
   const processors = [
     {
       entity: "Google LLC",
-      purpose: "Cloud infrastructure provider (Google Cloud), business applications and collaboration (Workspace), Data warehouse services, Content delivery network, DDoS and bot prevention",
+      purpose: "Cloud infrastructure provider (Google Cloud), business applications and collaboration (Workspace), Data warehouse services, Content delivery network,  DDoS and bot prevention",
       hosting: "Region designated by Customer, United States",
       country: country_list.us,
       enduserdata: "Yes (transit)"
@@ -119,7 +119,14 @@ export function SubProcessorTable() {
       hosting: undefined,
       country: country_list.nl,
       enduserdata: false
-    }
+    },
+    {
+      entity: "HubSpot Inc.",
+      purpose: "Customer and sales management, Marketing automation, Support requests",
+      hosting: country_list.eu,
+      country: country_list.us,
+      enduserdata: false
+    },
   ]
 
   return (

--- a/docs/src/components/subprocessors.jsx
+++ b/docs/src/components/subprocessors.jsx
@@ -119,14 +119,7 @@ export function SubProcessorTable() {
       hosting: undefined,
       country: country_list.nl,
       enduserdata: false
-    },
-    {
-      entity: "Clickhouse, Inc.",
-      purpose: "Data warehouse services",
-      hosting: country_list.us,
-      country: country_list.us,
-      enduserdata: false
-    },
+    }
   ]
 
   return (

--- a/docs/src/components/subprocessors.jsx
+++ b/docs/src/components/subprocessors.jsx
@@ -19,7 +19,7 @@ export function SubProcessorTable() {
       purpose: "Cloud infrastructure provider (Google Cloud), business applications and collaboration (Workspace), Data warehouse services, Content delivery network,  DDoS and bot prevention",
       hosting: "Region designated by Customer, United States",
       country: country_list.us,
-      enduserdata: "Yes (transit)"
+      enduserdata: "Yes"
     },
     {
       entity: "Datadog, Inc.",


### PR DESCRIPTION
We have discontinued Cockroach Labs as subprocessor by moving managed database services to Google LLC. Clickhouse only used briefly and replaced by Google LLC for datawarehouse services. We have introduced Hubspot for handling customer management, marketing automation, and support services. Hubspot will not receive end-user data.

All existing customers will be informed.