### PR TITLE
fix(console): broken layout and colors in keyboard shortcuts modal

### DIFF
--- a/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.html
+++ b/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.html
@@ -1,49 +1,51 @@
-<h1 class="title" mat-dialog-title>{{ 'KEYBOARDSHORTCUTS.TITLE' | translate }}</h1>
-<div mat-dialog-content>
-  <div *ngIf="isNotOnSystem" class="keyboard-shortcuts-group">
-    <h2>{{ 'KEYBOARDSHORTCUTS.UNDERORGCONTEXT' | translate }}</h2>
-    <div class="keyboard-shortcuts-wrapper">
-      <div class="keyboard-shortcut" *ngFor="let shortcut of orgShortcuts">
-        <span class="keyboard-shortcut-name cnsl-secondary-text" [innerHTML]="shortcut.i18nKey | translate"></span>
-        <span class="fill-space"></span>
-        <template
-          *ngFor="let key of shortcut.keyboardKeys; index as i"
-          [ngTemplateOutlet]="actionkey"
-          [ngTemplateOutletContext]="{ key: key, last: i === shortcut.keyboardKeys.length - 1 }"
-        ></template>
+<div class="container">
+  <h1 class="title" mat-dialog-title>{{ 'KEYBOARDSHORTCUTS.TITLE' | translate }}</h1>
+  <div mat-dialog-content>
+    <div *ngIf="isNotOnSystem" class="keyboard-shortcuts-group">
+      <h2>{{ 'KEYBOARDSHORTCUTS.UNDERORGCONTEXT' | translate }}</h2>
+      <div class="keyboard-shortcuts-wrapper">
+        <div class="keyboard-shortcut" *ngFor="let shortcut of orgShortcuts">
+          <span class="keyboard-shortcut-name cnsl-secondary-text" [innerHTML]="shortcut.i18nKey | translate"></span>
+          <span class="fill-space"></span>
+          <template
+            *ngFor="let key of shortcut.keyboardKeys; index as i"
+            [ngTemplateOutlet]="actionkey"
+            [ngTemplateOutletContext]="{ key: key, last: i === shortcut.keyboardKeys.length - 1 }"
+          ></template>
+        </div>
+      </div>
+    </div>
+    <div class="keyboard-shortcuts-group">
+      <h2>{{ 'KEYBOARDSHORTCUTS.SIDEWIDE' | translate }}</h2>
+      <div class="keyboard-shortcuts-wrapper">
+        <ng-container *ngFor="let shortcut of shortcuts">
+          <ng-template cnslHasRole [hasRole]="shortcut.permissions">
+            <div class="keyboard-shortcut">
+              <span class="keyboard-shortcut-name cnsl-secondary-text" [innerHTML]="shortcut.i18nKey | translate"></span>
+              <span class="fill-space"></span>
+              <template
+                *ngFor="let key of shortcut.keyboardKeys; index as i"
+                [ngTemplateOutlet]="actionkey"
+                [ngTemplateOutletContext]="{ key: key, last: i === shortcut.keyboardKeys.length - 1 }"
+              ></template>
+            </div>
+          </ng-template>
+        </ng-container>
       </div>
     </div>
   </div>
-  <div class="keyboard-shortcuts-group">
-    <h2>{{ 'KEYBOARDSHORTCUTS.SIDEWIDE' | translate }}</h2>
-    <div class="keyboard-shortcuts-wrapper">
-      <ng-container *ngFor="let shortcut of shortcuts">
-        <ng-template cnslHasRole [hasRole]="shortcut.permissions">
-          <div class="keyboard-shortcut">
-            <span class="keyboard-shortcut-name cnsl-secondary-text" [innerHTML]="shortcut.i18nKey | translate"></span>
-            <span class="fill-space"></span>
-            <template
-              *ngFor="let key of shortcut.keyboardKeys; index as i"
-              [ngTemplateOutlet]="actionkey"
-              [ngTemplateOutletContext]="{ key: key, last: i === shortcut.keyboardKeys.length - 1 }"
-            ></template>
-          </div>
-        </ng-template>
-      </ng-container>
-    </div>
+  <div mat-dialog-actions class="action">
+    <button cdkFocusInitial mat-stroked-button (click)="closeDialog()">
+      {{ 'ACTIONS.CLOSE' | translate }}
+    </button>
+    <span class="fill-space"></span>
   </div>
-</div>
-<div mat-dialog-actions class="action">
-  <button cdkFocusInitial mat-stroked-button (click)="closeDialog()">
-    {{ 'ACTIONS.CLOSE' | translate }}
-  </button>
-  <span class="fill-space"></span>
-</div>
 
-<ng-template #actionkey let-key="key" let-last="last">
-  <div class="keyboard-shortcuts-action-key">
-    <div class="keyboard-shortcuts-key-overlay"></div>
-    <span class="keyboard-shortcuts-span">{{ key }}</span>
-  </div>
-  <!-- <span *ngIf="!last" class="keyboard-shortcuts-plus cnsl-secondary-text">+</span> -->
-</ng-template>
+  <ng-template #actionkey let-key="key" let-last="last">
+    <div class="keyboard-shortcuts-action-key">
+      <div class="keyboard-shortcuts-key-overlay"></div>
+      <span class="keyboard-shortcuts-span">{{ key }}</span>
+    </div>
+    <!-- <span *ngIf="!last" class="keyboard-shortcuts-plus cnsl-secondary-text">+</span> -->
+  </ng-template>
+</div>

--- a/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.scss
+++ b/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.scss
@@ -99,6 +99,9 @@
   margin-top: 1rem;
   button {
     border-radius: 0.5rem;
+    .mat-mdc-button-persistent-ripple {
+      border-style: none !important;
+    }
   }
 
   .fill-space {

--- a/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.scss
+++ b/console/src/app/modules/keyboard-shortcuts/keyboard-shortcuts.component.scss
@@ -21,6 +21,7 @@
     h2 {
       font-size: 1rem;
       margin: 0 0 1rem 0;
+      color: $text-color;
     }
 
     .keyboard-shortcuts-wrapper {
@@ -85,16 +86,17 @@
   .keyboard-shortcuts-plus {
     font-size: 14px;
   }
-}
 
-.title {
-  font-size: 1.2rem;
-  margin-top: 0;
+  .title {
+    font-size: 1.2rem;
+    margin-top: 0;
+    color: $text-color;
+  }
 }
 
 .action {
   display: flex;
-
+  margin-top: 1rem;
   button {
     border-radius: 0.5rem;
   }
@@ -102,4 +104,9 @@
   .fill-space {
     flex: 1;
   }
+}
+
+.container {
+  padding: 1.5rem;
+  border-radius: 6px !important;
 }

--- a/e2e/cypress/e2e/organization/organizations.cy.ts
+++ b/e2e/cypress/e2e/organization/organizations.cy.ts
@@ -27,7 +27,7 @@ describe('organizations', () => {
       cy.visit(orgsPath);
       cy.contains('tr', newOrg).click();
       cy.get('[data-e2e="actions"]').click();
-      cy.get('[data-e2e="delete"]', { timeout: 1000 }).should('be.visible').click();
+      cy.get('[data-e2e="delete"]', { timeout: 3000 }).should('be.visible').click();
       cy.get('[data-e2e="confirm-dialog-input"]').focus().clear().type(newOrg);
       cy.get('[data-e2e="confirm-dialog-button"]').click();
       cy.shouldConfirmSuccess();


### PR DESCRIPTION
In #7167 @heikkilamarko detected some broken styles after moving Zitadel to MDC components. This PR adds some styles that reverts back the look and feel of the keyboard shortcuts model.

Here are a couple of screenshots with a new style:

![Captura desde 2024-01-22 19-55-54](https://github.com/zitadel/zitadel/assets/30386061/12aa12c0-7102-47d6-9bc8-c6813412f237)

![Captura desde 2024-01-22 19-55-40](https://github.com/zitadel/zitadel/assets/30386061/ad3d2152-3cd7-4355-8fe4-1d2071e26f0a)

Thanks @heikkilamarko for reporting this issue!

Closes #7167 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
