### PR TITLE
fix: use configured binding on SAML IDPs and make sure CSP doesn't block POST binding

### DIFF
--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -105,7 +105,7 @@ func csp() *middleware.CSP {
 	csp := middleware.DefaultSCP
 	csp.ObjectSrc = middleware.CSPSourceOptsSelf()
 	csp.StyleSrc = csp.StyleSrc.AddNonce()
-	csp.ScriptSrc = csp.ScriptSrc.AddNonce()
+	csp.ScriptSrc = csp.ScriptSrc.AddNonce().AddHash("sha256", "AjPdJSbZmeWHnEc5ykvJFay8FTWeTeRbs9dutfZ0HqE=")
 	return &csp
 }
 

--- a/internal/idp/providers/saml/saml.go
+++ b/internal/idp/providers/saml/saml.go
@@ -159,6 +159,9 @@ func (p *Provider) GetSP() (*samlsp.Middleware, error) {
 	if p.requestTracker != nil {
 		sp.RequestTracker = p.requestTracker
 	}
+	if p.binding != "" {
+		sp.Binding = p.binding
+	}
 	return sp, nil
 }
 


### PR DESCRIPTION
[A customer noted](https://github.com/zitadel/zitadel/discussions/7286#discussioncomment-8340193), that the auto form submit for POST binding was blocked due to the CSP. While testing we also noticed, that the configured binding is not used, but rather the (first) from the metadata.

This PR therefore adds the hash of the form submit JS to the CSP of the login UI and further makes sure to set the binding if set.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
