### PR TITLE
fix(oidc): prefer x-zitadel-forwarded over forwarded header

### DIFF
--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -119,7 +119,7 @@ func NewServer(
 	provider, err := op.NewProvider(
 		opConfig,
 		storage,
-		op.IssuerFromForwardedOrHost("", op.WithIssuerFromCustomHeaders("forwarded", "x-zitadel-forwarded")),
+		op.IssuerFromForwardedOrHost("", op.WithIssuerFromCustomHeaders("x-zitadel-forwarded", "forwarded")),
 		options...,
 	)
 	if err != nil {


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
