### PR TITLE
fix(oidc): return bad request for an invalid refresh token

### DIFF
--- a/internal/command/user_human_refresh_token.go
+++ b/internal/command/user_human_refresh_token.go
@@ -147,7 +147,7 @@ func (c *Commands) renewRefreshToken(ctx context.Context, userID, orgID, refresh
 
 	tokenUserID, tokenID, token, err := domain.FromRefreshToken(refreshToken, c.keyAlgorithm)
 	if err != nil {
-		return nil, "", "", zerrors.ThrowInvalidArgument(err, "COMMAND-Dbfe4", "Errors.User.RefreshToken.Invalid")
+		return nil, "", "", err
 	}
 	if tokenUserID != userID {
 		return nil, "", "", zerrors.ThrowInvalidArgument(nil, "COMMAND-Ht2g2", "Errors.User.RefreshToken.Invalid")

--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -31,7 +31,7 @@ func FromRefreshToken(refreshToken string, algorithm crypto.EncryptionAlgorithm)
 	}
 	split := strings.Split(string(decrypted), ":")
 	if len(split) != 3 {
-		return "", "", "", zerrors.ThrowInternal(nil, "DOMAIN-BGDhn", "Errors.User.RefreshToken.Invalid")
+		return "", "", "", zerrors.ThrowInvalidArgument(nil, "DOMAIN-BGDhn", "Errors.User.RefreshToken.Invalid")
 	}
 	return split[0], split[1], split[2], nil
 }


### PR DESCRIPTION
A refresh token that is encoded as valid base64 and of sufficient length would still pass decryption, as we use a symetric cypher. The resulting payload would be garbage and the following string-splitting would fail.

When the string split would fail, a internal server error was returned. This causes the logs to fill with unnecesary 500s when throwing garbage refresh tokens at zitadel. This change considers the error an Invalid Argumant and status bad request is returned to the calling client.

### Steps to reproduce

On a current zitadel installation (adjust domain and client ID if you want to try this):

```bash
curl -o - -I "http://localhost:9000/oauth/v2/token?grant_type=refresh_token&refresh_token=DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF&client_id=236646457053085698@tests"

HTTP/1.1 500 Internal Server Error
Cache-Control: no-store
Content-Type: application/json
Expires: Tue, 20 Feb 2024 12:27:15 GMT
Pragma: no-cache
Set-Cookie: zitadel.useragent=MTcwODQzNTYzNXxGWTBMM3ZxbThvMHJXZUo1bFF5SXFqc2hBem0wMkYxQVI5YmRTbmRERkFubXZ0WHdtSzFkSHRRcFhYOFJxSnlGTEZZRzc1alpKNnROOVZrRlFQVW8xcjJwVmxPdlJRPT18zAPxg1CTjJMUtMsazmn-Do6hwwvWKKvFFYVhcCBLxdo=; Path=/; Domain=localhost; Max-Age=31536000; HttpOnly; SameSite=Lax
Vary: Origin
Vary: Cookie
X-Robots-Tag: none
Date: Tue, 20 Feb 2024 13:27:15 GMT
Content-Length: 80
```

In the logs:

```bash
time=2024-02-20T13:27:15.671Z level=ERROR msg="request error" oidc_error.parent="ID=DOMAIN-BGDhn Message=Errors.User.RefreshToken.Invalid" oidc_error.description=Errors.User.RefreshToken.Invalid oidc_error.type=server_error status_code=500
```

### After fix

```bash
curl -o - -I "http://localhost:9000/oauth/v2/token?grant_type=refresh_token&refresh_token=DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF&client_id=236646457053085698@tests"

HTTP/1.1 400 Bad Request
Cache-Control: no-store
Content-Type: application/json
Expires: Tue, 20 Feb 2024 12:29:50 GMT
Pragma: no-cache
Set-Cookie: zitadel.useragent=MTcwODQzNTc5MHxCeDVuSnVkN1JhRVNQSDgwZ1BhSnpWU0ExVE9UMExMaTBGaGs3ZDB0YjRxY24xdC1nVHFDWU1JVEdEQ00yZE5JNFZZUzRXWnZrbDFtcXJIWEVQakVxMWt6eGM3YmJ3PT18vYehGhIhV-sDUgLTVZfyayIM_7V59WFrJ9Uy_trcbWU=; Path=/; Domain=localhost; Max-Age=31536000; HttpOnly; SameSite=Lax
Vary: Origin
Vary: Cookie
X-Robots-Tag: none
Date: Tue, 20 Feb 2024 13:29:50 GMT
Content-Length: 83
```

Logs:

```bash
time=2024-02-20T13:29:50.798Z level=WARN msg="request error" oidc_error.parent="ID=DOMAIN-BGDhn Message=Errors.User.RefreshToken.Invalid" oidc_error.description=Errors.User.RefreshToken.Invalid oidc_error.type=invalid_request status_code=400
```

Closes https://github.com/zitadel/DevOps/issues/40

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
