### PR TITLE
fix(eventstore): retry push on primary key sequence violation

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -546,6 +546,8 @@ Quotas:
 Eventstore:
   # Sets the maximum duration of transactions pushing events
   PushTimeout: 15s #ZITADEL_EVENTSTORE_PUSHTIMEOUT
+  # Maximum amount of push retries in case of primary key violation on the sequence
+  MaxRetries: 5 #ZITADEL_EVENTSTORE_MAXRETRIES
 
 DefaultInstance:
   InstanceName: ZITADEL # ZITADEL_DEFAULTINSTANCE_INSTANCENAME

--- a/internal/eventstore/config.go
+++ b/internal/eventstore/config.go
@@ -6,6 +6,7 @@ import (
 
 type Config struct {
 	PushTimeout time.Duration
+	MaxRetries  uint32
 
 	Pusher  Pusher
 	Querier Querier

--- a/internal/eventstore/eventstore_test.go
+++ b/internal/eventstore/eventstore_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgconn"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/service"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -329,7 +331,7 @@ func Test_eventData(t *testing.T) {
 
 type testPusher struct {
 	events []Event
-	err    error
+	errs   []error
 
 	t *testing.T
 }
@@ -339,8 +341,9 @@ func (repo *testPusher) Health(ctx context.Context) error {
 }
 
 func (repo *testPusher) Push(ctx context.Context, commands ...Command) (events []Event, err error) {
-	if repo.err != nil {
-		return nil, repo.err
+	if len(repo.errs) != 0 {
+		err, repo.errs = repo.errs[0], repo.errs[1:]
+		return nil, err
 	}
 
 	if len(repo.events) != len(commands) {
@@ -439,6 +442,7 @@ func TestEventstore_Push(t *testing.T) {
 		events []Command
 	}
 	type fields struct {
+		maxRetries  int
 		pusher      *testPusher
 		eventMapper map[EventType]func(Event) (Event, error)
 	}
@@ -465,6 +469,51 @@ func TestEventstore_Push(t *testing.T) {
 				},
 			},
 			fields: fields{
+				maxRetries: 1,
+				pusher: &testPusher{
+					t: t,
+					events: []Event{
+						&BaseEvent{
+							Agg: &Aggregate{
+								ID:            "1",
+								Type:          "test.aggregate",
+								ResourceOwner: "caos",
+								InstanceID:    "zitadel",
+							},
+							Data:      []byte(nil),
+							User:      "editorUser",
+							EventType: "test.event",
+						},
+					},
+				},
+				eventMapper: map[EventType]func(Event) (Event, error){
+					"test.event": func(e Event) (Event, error) {
+						return &testEvent{
+							BaseEvent: BaseEvent{
+								Agg: &Aggregate{
+									Type: e.Aggregate().Type,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+		},
+		{
+			name: "one aggregate one event, retry disabled",
+			args: args{
+				events: []Command{
+					newTestEvent(
+						"1",
+						"",
+						func() interface{} {
+							return []byte(nil)
+						},
+						false),
+				},
+			},
+			fields: fields{
+				maxRetries: 0,
 				pusher: &testPusher{
 					t: t,
 					events: []Event{
@@ -515,6 +564,7 @@ func TestEventstore_Push(t *testing.T) {
 				},
 			},
 			fields: fields{
+				maxRetries: 1,
 				pusher: &testPusher{
 					t: t,
 					events: []Event{
@@ -586,6 +636,7 @@ func TestEventstore_Push(t *testing.T) {
 				},
 			},
 			fields: fields{
+				maxRetries: 1,
 				pusher: &testPusher{
 					t: t,
 					events: combineEventLists(
@@ -658,9 +709,10 @@ func TestEventstore_Push(t *testing.T) {
 				},
 			},
 			fields: fields{
+				maxRetries: 1,
 				pusher: &testPusher{
-					t:   t,
-					err: zerrors.ThrowInternal(nil, "V2-qaa4S", "test err"),
+					t:    t,
+					errs: []error{zerrors.ThrowInternal(nil, "V2-qaa4S", "test err")},
 				},
 			},
 			res: res{
@@ -681,21 +733,179 @@ func TestEventstore_Push(t *testing.T) {
 				},
 			},
 			fields: fields{
+				maxRetries: 1,
 				pusher: &testPusher{
-					t:   t,
-					err: zerrors.ThrowInternal(nil, "V2-qaa4S", "test err"),
+					t:    t,
+					errs: []error{zerrors.ThrowInternal(nil, "V2-qaa4S", "test err")},
 				},
 			},
 			res: res{
 				wantErr: true,
 			},
 		},
+		{
+			name: "retry succeeds",
+			args: args{
+				events: []Command{
+					newTestEvent(
+						"1",
+						"",
+						func() interface{} {
+							return []byte(nil)
+						},
+						false),
+				},
+			},
+			fields: fields{
+				maxRetries: 1,
+				pusher: &testPusher{
+					t: t,
+					events: []Event{
+						&BaseEvent{
+							Agg: &Aggregate{
+								ID:            "1",
+								Type:          "test.aggregate",
+								ResourceOwner: "caos",
+								InstanceID:    "zitadel",
+							},
+							Data:      []byte(nil),
+							User:      "editorUser",
+							EventType: "test.event",
+						},
+					},
+					errs: []error{
+						zerrors.ThrowInternal(&pgconn.PgError{
+							ConstraintName: "events2_pkey",
+							Code:           "23505",
+						}, "foo-err", "Errors.Internal"),
+					},
+				},
+				eventMapper: map[EventType]func(Event) (Event, error){
+					"test.event": func(e Event) (Event, error) {
+						return &testEvent{
+							BaseEvent: BaseEvent{
+								Agg: &Aggregate{
+									Type: e.Aggregate().Type,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+		},
+		{
+			name: "retry fails",
+			args: args{
+				events: []Command{
+					newTestEvent(
+						"1",
+						"",
+						func() interface{} {
+							return []byte(nil)
+						},
+						false),
+				},
+			},
+			fields: fields{
+				maxRetries: 1,
+				pusher: &testPusher{
+					t: t,
+					events: []Event{
+						&BaseEvent{
+							Agg: &Aggregate{
+								ID:            "1",
+								Type:          "test.aggregate",
+								ResourceOwner: "caos",
+								InstanceID:    "zitadel",
+							},
+							Data:      []byte(nil),
+							User:      "editorUser",
+							EventType: "test.event",
+						},
+					},
+					errs: []error{
+						zerrors.ThrowInternal(&pgconn.PgError{
+							ConstraintName: "events2_pkey",
+							Code:           "23505",
+						}, "foo-err", "Errors.Internal"),
+						zerrors.ThrowInternal(&pgconn.PgError{
+							ConstraintName: "events2_pkey",
+							Code:           "23505",
+						}, "foo-err", "Errors.Internal"),
+					},
+				},
+				eventMapper: map[EventType]func(Event) (Event, error){
+					"test.event": func(e Event) (Event, error) {
+						return &testEvent{
+							BaseEvent: BaseEvent{
+								Agg: &Aggregate{
+									Type: e.Aggregate().Type,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			res: res{wantErr: true},
+		},
+		{
+			name: "retry disabled",
+			args: args{
+				events: []Command{
+					newTestEvent(
+						"1",
+						"",
+						func() interface{} {
+							return []byte(nil)
+						},
+						false),
+				},
+			},
+			fields: fields{
+				maxRetries: 0,
+				pusher: &testPusher{
+					t: t,
+					events: []Event{
+						&BaseEvent{
+							Agg: &Aggregate{
+								ID:            "1",
+								Type:          "test.aggregate",
+								ResourceOwner: "caos",
+								InstanceID:    "zitadel",
+							},
+							Data:      []byte(nil),
+							User:      "editorUser",
+							EventType: "test.event",
+						},
+					},
+					errs: []error{
+						zerrors.ThrowInternal(&pgconn.PgError{
+							ConstraintName: "events2_pkey",
+							Code:           "23505",
+						}, "foo-err", "Errors.Internal"),
+					},
+				},
+				eventMapper: map[EventType]func(Event) (Event, error){
+					"test.event": func(e Event) (Event, error) {
+						return &testEvent{
+							BaseEvent: BaseEvent{
+								Agg: &Aggregate{
+									Type: e.Aggregate().Type,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			res: res{wantErr: true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eventInterceptors = map[EventType]eventTypeInterceptors{}
 			es := &Eventstore{
-				pusher: tt.fields.pusher,
+				maxRetries: tt.fields.maxRetries,
+				pusher:     tt.fields.pusher,
 			}
 			for eventType, mapper := range tt.fields.eventMapper {
 				RegisterFilterEventMapper("test", eventType, mapper)


### PR DESCRIPTION
This change retries pushing of events if there is an unique constraint violation on the primary key of the eventstore.

Because we do a `SELECT .. FOR UPDATE` to establish the latest sequence number, many concurent pushes on the same aggregate ID might result in duplicate sequence numbers and the push will fail. We will now retry the complete push transaction, only if the error was created by the specific constraint `events2_pkey` with SQL state `23505`.

A `MaxRetries` field is added to the event store config to prevent endless retries is the context timeout is not set. `defaults.yaml` sets the value to 5. As during reproduction of the issue, the bug seems to occur a few times out of 1000 requests, 5 retries should be more than enough. If the unique constraint error still exists after 5 retries, there might be another issue worth investigating.

Closes #7202

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
