### PR TITLE
fix(smtp): support UTF-8 subjects

### DIFF
--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"fmt"
+	"mime"
 	"regexp"
 	"strings"
 	"time"
@@ -54,7 +55,7 @@ func (msg *Email) GetContent() (string, error) {
 	if !isHTML(msg.Content) {
 		mime = "MIME-version: 1.0;" + lineBreak + "Content-Type: text/plain; charset=\"UTF-8\";" + lineBreak + lineBreak
 	}
-	subject := "Subject: " + qEncodeSubject(msg.Subject) + lineBreak
+	subject := "Subject: " + bEncodeSubject(msg.Subject) + lineBreak
 	message += subject + mime + lineBreak + msg.Content
 
 	return message, nil
@@ -68,7 +69,7 @@ func isHTML(input string) bool {
 	return isHTMLRgx.MatchString(input)
 }
 
-// returns a RFC1342 "Q" encoded string to allow non-ascii characters
-func qEncodeSubject(subject string) string {
-	return "=?utf-8?q?" + subject + "?="
+// returns a RFC1342 "B" encoded string to allow non-ascii characters
+func bEncodeSubject(subject string) string {
+	return mime.BEncoding.Encode("UTF-8", subject)
 }


### PR DESCRIPTION
A customer had an issue where the email was received by the end-user. They noted that the user's SMTP provider did not support `SMTPUTF8`.

This PR changes the encoding for the subject from "Q" to "B" (base64).

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
