### PR TITLE
docs:  update headings for custom login ui

### DIFF
--- a/docs/docs/guides/integrate/login-ui/external-login.mdx
+++ b/docs/docs/guides/integrate/login-ui/external-login.mdx
@@ -1,5 +1,5 @@
 ---
-title: Handle External Logins in ZITADEL
+title: Handle External Logins in a Custom Login UI
 sidebar_label: External Identity Provider
 ---
 

--- a/docs/docs/guides/integrate/login-ui/logout.mdx
+++ b/docs/docs/guides/integrate/login-ui/logout.mdx
@@ -1,5 +1,5 @@
 ---
-title: Logging Out via ZITADEL
+title: Logging Out via a Custom Login UI
 sidebar_label: Logout
 ---
 

--- a/docs/docs/guides/integrate/login-ui/mfa.mdx
+++ b/docs/docs/guides/integrate/login-ui/mfa.mdx
@@ -1,6 +1,6 @@
 ---
-title: Multi-Factor Authentication(MFA) in ZITADEL
-sidebar_label: Multi-Factor Authentication(MFA)
+title: Multi-Factor Authentication (MFA) in a Custom Login UI
+sidebar_label: Multi-Factor Authentication (MFA)
 ---
 
 import MfaOptions from './_list-mfa-options.mdx';

--- a/docs/docs/guides/integrate/login-ui/oidc-standard.mdx
+++ b/docs/docs/guides/integrate/login-ui/oidc-standard.mdx
@@ -1,5 +1,5 @@
 ---
-title: Support for the OpenID Connect(OIDC) Standard in ZITADEL
+title: Support for the OpenID Connect(OIDC) Standard in a Custom Login UI
 sidebar_label: OIDC Standard
 ---
 

--- a/docs/docs/guides/integrate/login-ui/passkey.mdx
+++ b/docs/docs/guides/integrate/login-ui/passkey.mdx
@@ -1,5 +1,5 @@
 ---
-title: Passkeys in ZITADEL
+title: Using Passkeys in a Custom Login UI
 sidebar_label: Passkeys
 ---
 

--- a/docs/docs/guides/integrate/login-ui/password-reset.mdx
+++ b/docs/docs/guides/integrate/login-ui/password-reset.mdx
@@ -1,5 +1,5 @@
 ---
-title: Password Reset/Change in ZITADEL
+title: Password Reset/Change in a Custom Login UI
 sidebar_label: Password Reset/Change 
 ---
 

--- a/docs/docs/guides/integrate/login-ui/select-account.mdx
+++ b/docs/docs/guides/integrate/login-ui/select-account.mdx
@@ -1,5 +1,5 @@
 ---
-title: Select Account
+title: Select Account in a Custom Login UI
 ---
 
 import SelectAccount from './_select-account.mdx';

--- a/docs/docs/guides/integrate/login-ui/username-password.mdx
+++ b/docs/docs/guides/integrate/login-ui/username-password.mdx
@@ -1,5 +1,5 @@
 ---
-title: Register and Login User with Password in ZITADEL
+title: Register and Login User with Password in a Custom Login UI
 sidebar_label: Username and Password
 ---
 

--- a/proto/zitadel/session/v2beta/session_service.proto
+++ b/proto/zitadel/session/v2beta/session_service.proto
@@ -20,7 +20,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Session Service";
     version: "2.0-beta";
-    description: "This API is intended to manage sessions in a ZITADEL instance. This project is in beta state. It can AND will continue breaking until the services provide the same functionality as the current login.";
+    description: "This API is intended to manage sessions in a ZITADEL instance. Follow the guides on how to [build your own Login UI](/docs/guides/integrate/login-ui) and learn how to use the Session API. This project is in beta state. It can AND will continue breaking until the services provide the same functionality as the current login.";
     contact:{
       name: "ZITADEL"
       url: "https://zitadel.com"


### PR DESCRIPTION
The headings for the custom login UI are confusing. "Passkeys in ZITADEL" means in fact how to use passkeys when building a custom login UI with ZITADEL. The PR updates the headings to reflect the actual intent. 

Also x-ref from Session API to the guides.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
