### PR TITLE
docs: describe DefaultInstance vs FirstInstance

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -23,19 +23,20 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - uses: tspascoal/get-user-teams-membership@v3
         id: checkUserMember
+        if: github.actor != 'dependabot[bot]'
         with:
          username: ${{ github.actor }}
          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - name: add pr
         uses: actions/add-to-project@v0.5.0
-        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'engineers') && github.actor != 'app/dependabot'}}
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
       - uses: actions-ecosystem/action-add-labels@v1.1.0
-        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'staff') && github.actor != 'app/dependabot'}}
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
         with:
           github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labels: |

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -543,6 +543,10 @@ Eventstore:
   # Maximum amount of push retries in case of primary key violation on the sequence
   MaxRetries: 5 #ZITADEL_EVENTSTORE_MAXRETRIES
 
+# The DefaultInstance section defines the default values for each new virtual instance that is created.
+# For the initial setup, the default values are used to create the first instance.
+# However, you might want to have your first instance created by the setup job to have a different configuration.
+# To overwrite the default values for the initial setup, configure the FirstInstance yaml section and pass it using the --steps flag.
 DefaultInstance:
   InstanceName: ZITADEL # ZITADEL_DEFAULTINSTANCE_INSTANCENAME
   DefaultLanguage: en # ZITADEL_DEFAULTINSTANCE_DEFAULTLANGUAGE

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -544,6 +544,7 @@ Eventstore:
   MaxRetries: 5 #ZITADEL_EVENTSTORE_MAXRETRIES
 
 # The DefaultInstance section defines the default values for each new virtual instance that is created.
+# Check out https://zitadel.com/docs/concepts/structure/instance#multiple-virtual-instances for more information about virtual instances.
 # For the initial setup, the default values are used to create the first instance.
 # However, you might want to have your first instance created by the setup job to have a different configuration.
 # To overwrite the default values for the initial setup, configure the FirstInstance yaml section and pass it using the --steps flag.

--- a/cmd/setup/steps.yaml
+++ b/cmd/setup/steps.yaml
@@ -1,3 +1,4 @@
+# By using the FirstInstance section, you can overwrite the DefaultInstance configuration for the first instance created by zitadel setup.
 FirstInstance:
   # The machine key from the section FirstInstance.Org.Machine.MachineKey is written to the MachineKeyPath.
   MachineKeyPath: # ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH

--- a/docs/docs/self-hosting/manage/configure/configure.mdx
+++ b/docs/docs/self-hosting/manage/configure/configure.mdx
@@ -21,6 +21,11 @@ This guide assumes you are familiar with [running ZITADEL using the least amount
 You can configure the runtime using the `--config` flag of the `zitadel` binary.
 Also, you can use the environment variables listed in the defaults.yaml.
 
+:::tip
+For overwriting the default configuration for the first instance created by zitadel setup, use the FirstInstance section in the [database initialization file](#database-initialization-file).
+:::
+
+
 <details>
   <summary>defaults.yaml</summary>
   <CodeBlock language="yaml">{DefaultsYamlSource}</CodeBlock>

--- a/docs/docs/self-hosting/manage/configure/configure.mdx
+++ b/docs/docs/self-hosting/manage/configure/configure.mdx
@@ -32,6 +32,10 @@ ZITADEL uses a [different configuration file](https://github.com/zitadel/zitadel
 Use the `--steps` flag of the `zitadel` binary to provide this configuration file.
 Also, you can use the environment variables listed in the steps.yaml.
 
+:::tip
+By using the FirstInstance section, you can overwrite the DefaultInstance configuration for the first instance created by zitadel setup.
+:::
+
 <details>
   <summary>steps.yaml</summary>
   <CodeBlock language="yaml">{StepsYamlSource}</CodeBlock>

--- a/docs/docs/self-hosting/manage/configure/configure.mdx
+++ b/docs/docs/self-hosting/manage/configure/configure.mdx
@@ -38,7 +38,7 @@ Use the `--steps` flag of the `zitadel` binary to provide this configuration fil
 Also, you can use the environment variables listed in the steps.yaml.
 
 :::tip
-By using the FirstInstance section, you can overwrite the DefaultInstance configuration for the first instance created by zitadel setup.
+By using the FirstInstance section, you can overwrite the [DefaultInstance configuration](#runtime-configuration-file) for the first instance created by zitadel setup.
 :::
 
 <details>


### PR DESCRIPTION
Closes https://github.com/zitadel/zitadel-charts/issues/110

Makes it clearer how to use the DefaultInstance and the FirstInstance sections.
Especially for configuring a ZITADEL Helm chart, where we don't differentiate between setup and runtime config, this helps understanding the concepts.

### Definition of Ready

- [ ] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
