### PR TITLE
fix: filter events by instance ids

### DIFF
--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -221,7 +221,7 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 }
 
 func prepareConditions(criteria querier, query *repository.SearchQuery, useV1 bool) (string, []any) {
-	clauses, args := prepareQuery(criteria, useV1, query.InstanceID, query.ExcludedInstances)
+	clauses, args := prepareQuery(criteria, useV1, query.InstanceID, query.InstanceIDs, query.ExcludedInstances)
 	if clauses != "" && len(query.SubQueries) > 0 {
 		clauses += " AND "
 	}


### PR DESCRIPTION
This PR ensures that event queries over many instance ids are executed with the where clause `instance_id ANY(?)`

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
