### PR TITLE
perf(ListEvents): add aggregate types to filter if not set

### DIFF
--- a/internal/api/grpc/admin/event.go
+++ b/internal/api/grpc/admin/event.go
@@ -3,16 +3,10 @@ package admin
 import (
 	"context"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-	"github.com/zitadel/zitadel/internal/repository/deviceauth"
-	"github.com/zitadel/zitadel/internal/repository/instance"
-	"github.com/zitadel/zitadel/internal/repository/session"
-	"github.com/zitadel/zitadel/internal/repository/user"
-	"github.com/zitadel/zitadel/internal/repository/usergrant"
 	admin_pb "github.com/zitadel/zitadel/pkg/grpc/admin"
 )
 

--- a/internal/api/grpc/admin/event.go
+++ b/internal/api/grpc/admin/event.go
@@ -119,30 +119,8 @@ func aggregateTypesFromEventTypes(eventTypes []eventstore.EventType) []eventstor
 	aggregateTypes := make([]eventstore.AggregateType, 0, len(eventTypes))
 
 	for _, eventType := range eventTypes {
-		if types, ok := specialEventTypeMappings[eventType]; ok {
-			aggregateTypes = append(aggregateTypes, types...)
-			continue
-		}
-		aggregateTypes = append(aggregateTypes, eventstore.AggregateType(strings.Split(string(eventType), ".")[0]))
+		aggregateTypes = append(aggregateTypes, eventstore.AggregateTypeFromEventType(eventType))
 	}
 
 	return aggregateTypes
-}
-
-var specialEventTypeMappings = map[eventstore.EventType][]eventstore.AggregateType{
-	"device.authorization.added":                      []eventstore.AggregateType{deviceauth.AggregateType},
-	"device.authorization.approved":                   []eventstore.AggregateType{deviceauth.AggregateType},
-	"iam.idp.config.added":                            []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.config.changed":                          []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.config.deactivated":                      []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.config.reactivated":                      []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.config.removed":                          []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.oidc.config.added":                       []eventstore.AggregateType{instance.AggregateType},
-	"iam.idp.oidc.config.changed":                     []eventstore.AggregateType{instance.AggregateType},
-	"user.grant.added":                                []eventstore.AggregateType{usergrant.AggregateType},
-	"user.grant.cascade.changed":                      []eventstore.AggregateType{usergrant.AggregateType},
-	"user.grant.cascade.removed":                      []eventstore.AggregateType{usergrant.AggregateType},
-	"user.grant.changed":                              []eventstore.AggregateType{usergrant.AggregateType},
-	"user.grant.removed":                              []eventstore.AggregateType{usergrant.AggregateType},
-	"user.human.passwordless.token.signcount.changed": []eventstore.AggregateType{user.AggregateType, session.AggregateType},
 }

--- a/internal/api/grpc/admin/event_test.go
+++ b/internal/api/grpc/admin/event_test.go
@@ -1,0 +1,58 @@
+package admin
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/repository/deviceauth"
+	"github.com/zitadel/zitadel/internal/repository/org"
+	"github.com/zitadel/zitadel/internal/repository/user"
+)
+
+func Test_aggregateTypesFromEventTypes(t *testing.T) {
+	type args struct {
+		eventTypes []eventstore.EventType
+	}
+	tests := []struct {
+		name string
+		args args
+		want []eventstore.AggregateType
+	}{
+		{
+			name: "no event types",
+			args: args{
+				eventTypes: []eventstore.EventType{},
+			},
+			want: []eventstore.AggregateType{},
+		},
+		{
+			name: "only by prefix",
+			args: args{
+				eventTypes: []eventstore.EventType{user.MachineAddedEventType, org.OrgAddedEventType},
+			},
+			want: []eventstore.AggregateType{user.AggregateType, org.AggregateType},
+		},
+		{
+			name: "with special",
+			args: args{
+				eventTypes: []eventstore.EventType{deviceauth.ApprovedEventType, org.OrgAddedEventType},
+			},
+			want: []eventstore.AggregateType{deviceauth.AggregateType, org.AggregateType},
+		},
+		{
+			name: "duplicates",
+			args: args{
+				eventTypes: []eventstore.EventType{org.OrgAddedEventType, org.OrgChangedEventType},
+			},
+			want: []eventstore.AggregateType{org.AggregateType, org.AggregateType},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aggregateTypesFromEventTypes(tt.args.eventTypes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("aggregateTypesFromEventTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -31,6 +31,7 @@ var (
 	eventInterceptors map[EventType]eventTypeInterceptors
 	eventTypes        []string
 	aggregateTypes    []string
+	eventTypeMapping  = map[EventType]AggregateType{}
 )
 
 // RegisterFilterEventMapper registers a function for mapping an eventstore event to an event
@@ -45,9 +46,11 @@ func RegisterFilterEventMapper(aggregateType AggregateType, eventType EventType,
 	if eventInterceptors == nil {
 		eventInterceptors = make(map[EventType]eventTypeInterceptors)
 	}
+
 	interceptor := eventInterceptors[eventType]
 	interceptor.eventMapper = mapper
 	eventInterceptors[eventType] = interceptor
+	eventTypeMapping[eventType] = aggregateType
 }
 
 type eventTypeInterceptors struct {
@@ -110,6 +113,10 @@ retry:
 	}
 	es.notify(mappedEvents)
 	return mappedEvents, nil
+}
+
+func AggregateTypeFromEventType(typ EventType) AggregateType {
+	return eventTypeMapping[typ]
 }
 
 func (es *Eventstore) EventTypes() []string {


### PR DESCRIPTION
To optimise response times and database load aggregate types are added to the query if needed and not defined the request payload.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
