### PR TITLE
docs: correct usage of key parameter in go login example

### DIFF
--- a/docs/docs/examples/login/go.md
+++ b/docs/docs/examples/login/go.md
@@ -28,7 +28,7 @@ We recommend that you use [Proof Key for Code Exchange (PKCE)](/apis/openidoauth
 The Redirect URIs field tells ZITADEL where it's allowed to redirect users after authentication. For development, you can set dev mode to `true` to enable insecure HTTP and redirect to a `localhost` URI.
 The Post-logout redirect send the users back to a route on your application after they have logged out.
 
-> If you are following along with the [example](https://github.com/zitadel/zitadel-go), set the dev mode to `true`, the Redirect URIs to <http://localhost:8089/auth/callback> and Post redirect URI to <http://localhost:8089/>.
+> If you are following along with the [example](https://github.com/zitadel/zitadel-go), set the dev mode to `true`, the Redirect URIs to <http://localhost:8089/auth/callback> and Post-logout redirect URI to <http://localhost:8089/>.
 
 ![Create app in console - set redirectURI](/img/go/app-create-redirect.png)
 
@@ -70,7 +70,7 @@ The SDK itself will then register three routes on that to be able to:
  - start the authentication process and redirect to the Login UI (`/auth/login`)
  - continue with the authentication process after the login UI (`/auth/callback`)
  - terminate the session (`/auth/logout`)
- - 
+
 ```go
 router.Handle("/auth/", z.Authentication)
 ```
@@ -119,7 +119,7 @@ https://github.com/zitadel/zitadel-go/blob/next/example/app/templates/profile.ht
 
 You will need to provide some values for the program to run:
 - `domain`: Your ZITADEL instance domain, e.g. my-domain.zitadel.cloud
-- `key`: The path to the downloaded key.json
+- `key`: Random secret string. Used for symmetric encryption of state parameters, cookies and PCKE. 
 - `clientID`: The clientID provided by ZITADEL
 - `redirectURI`: The redirectURI registered at ZITADEL
 - `port`: The port on which the API will be accessible, default it 8089


### PR DESCRIPTION
The example was falsely stating that the key was used for a json private key, obtained from zitadel.
This lead to confusion as we do not use JWT assertion in the example, but PKCE.
Instead, the key is used for symmetric encryption.

https://stackoverflow.com/questions/78080163/zitadel-example-go-webapp-encryption-key/78087242#78087242

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
