### PR TITLE
docs: don't propose setting a random masterkey to env

### DIFF
--- a/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
@@ -53,10 +53,10 @@ wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosti
 # Download and adjust the example configuration file containing database initialization configuration.
 wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-init-steps.yaml
 
-# A single ZITADEL instance always needs the same 32 characters long masterkey
-# To generate a new random string, you can for example use the following command:
-# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
-export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
+# A single ZITADEL instance always needs the same 32 bytes long masterkey
+# Generate one to a file if you haven't done so already and pass it as environment variable
+tr -dc A-Za-z0-9 </dev/urandom | head -c 32 > ./zitadel-masterkey
+export ZITADEL_MASTERKEY="$(cat ./zitadel-masterkey)"
 
 # Run the database and application containers
 docker compose up --detach

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
@@ -54,9 +54,9 @@ wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosti
 wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-init-steps.yaml
 
 # A single ZITADEL instance always needs the same 32 characters long masterkey
-# If you haven't done so already, you can generate a new one.
-# For example:
-export ZITADEL_MASTERKEY="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)"
+# To generate a new random string, you can for example use the following command:
+# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
+export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
 
 # Run the database and application containers
 docker compose up --detach

--- a/docs/docs/self-hosting/manage/configure/_compose.mdx
+++ b/docs/docs/self-hosting/manage/configure/_compose.mdx
@@ -34,10 +34,10 @@ wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosti
 # Download and adjust the example configuration file containing database initialization configuration.
 wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosting/manage/configure/example-zitadel-init-steps.yaml
 
-# A single ZITADEL instance always needs the same 32 characters long masterkey
-# To generate a new random string, you can for example use the following command:
-# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
-export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
+# A single ZITADEL instance always needs the same 32 bytes long masterkey
+# Generate one to a file if you haven't done so already and pass it as environment variable
+tr -dc A-Za-z0-9 </dev/urandom | head -c 32 > ./zitadel-masterkey
+export ZITADEL_MASTERKEY="$(cat ./zitadel-masterkey)"
 
 # Run the database and application containers
 docker compose up --detach

--- a/docs/docs/self-hosting/manage/configure/_compose.mdx
+++ b/docs/docs/self-hosting/manage/configure/_compose.mdx
@@ -35,9 +35,9 @@ wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosti
 wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosting/manage/configure/example-zitadel-init-steps.yaml
 
 # A single ZITADEL instance always needs the same 32 characters long masterkey
-# If you haven't done so already, you can generate a new one
-# For example:
-export ZITADEL_MASTERKEY="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)"
+# To generate a new random string, you can for example use the following command:
+# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
+export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
 
 # Run the database and application containers
 docker compose up --detach

--- a/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
+++ b/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
@@ -56,9 +56,9 @@ export ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME="root"
 export ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD="RootPassword1!"
 
 # A single ZITADEL instance always needs the same 32 characters long masterkey
-# If you haven't done so already, you can generate a new one
-# The key must be passed as argument
-export ZITADEL_MASTERKEY="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)"
+# To generate a new random string, you can for example use the following command:
+# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
+export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
 
 # Let the zitadel binary read configuration from environment variables
 zitadel start-from-init --masterkey "${ZITADEL_MASTERKEY}" --tlsMode disabled

--- a/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
+++ b/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
@@ -55,10 +55,10 @@ export ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable
 export ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME="root"
 export ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD="RootPassword1!"
 
-# A single ZITADEL instance always needs the same 32 characters long masterkey
-# To generate a new random string, you can for example use the following command:
-# tr -dc A-Za-z0-9 </dev/urandom | head -c 32
-export ZITADEL_MASTERKEY="MasterkeyNeedsToHave32Characters"
+# A single ZITADEL instance always needs the same 32 bytes long masterkey
+# Generate one to a file if you haven't done so already and pass it as environment variable
+tr -dc A-Za-z0-9 </dev/urandom | head -c 32 > ./zitadel-masterkey
+export ZITADEL_MASTERKEY="$(cat ./zitadel-masterkey)"
 
 # Let the zitadel binary read configuration from environment variables
 zitadel start-from-init --masterkey "${ZITADEL_MASTERKEY}" --tlsMode disabled

--- a/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
+++ b/docs/docs/self-hosting/manage/configure/_linuxunix.mdx
@@ -58,8 +58,7 @@ export ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD="RootPassword1!"
 # A single ZITADEL instance always needs the same 32 bytes long masterkey
 # Generate one to a file if you haven't done so already and pass it as environment variable
 tr -dc A-Za-z0-9 </dev/urandom | head -c 32 > ./zitadel-masterkey
-export ZITADEL_MASTERKEY="$(cat ./zitadel-masterkey)"
 
 # Let the zitadel binary read configuration from environment variables
-zitadel start-from-init --masterkey "${ZITADEL_MASTERKEY}" --tlsMode disabled
+zitadel start-from-init --masterkey "${ZITADEL_MASTERKEY}" --tlsMode disabled --masterkeyFile ./zitadel-masterkey
 ```


### PR DESCRIPTION
Setting a randomly generated masterkey as environment variable is bad, as this value is lost as soon as the environment is shut down. Therefore, we should not propose to do so in our docs.

This was reported on Discord: https://discord.com/channels/927474939156643850/927866013545025566/1213157574569107497

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
