### PR TITLE
fix: assign instance ID to aggregate ID when converting from v1 to v2 feature

### DIFF
--- a/internal/command/instance_features_model.go
+++ b/internal/command/instance_features_model.go
@@ -48,7 +48,6 @@ func (m *InstanceFeaturesWriteModel) Query() *eventstore.SearchQueryBuilder {
 		AwaitOpenTransactions().
 		AddQuery().
 		AggregateTypes(feature_v2.AggregateType).
-		AggregateIDs(m.AggregateID).
 		EventTypes(
 			feature_v1.DefaultLoginInstanceEventType,
 			feature_v2.InstanceResetEventType,

--- a/internal/query/instance_by_domain.sql
+++ b/internal/query/instance_by_domain.sql
@@ -8,7 +8,7 @@ with domain as (
 	) features
 	from domain d
 	cross join projections.system_features s
-	full outer join projections.instance_features i using (key, instance_id)
+	full outer join projections.instance_features2 i using (key, instance_id)
 	group by instance_id
 )
 select

--- a/internal/query/instance_by_id.sql
+++ b/internal/query/instance_by_id.sql
@@ -5,7 +5,7 @@ with features as (
 	) features
 	from (select $1::text instance_id) x
 	cross join projections.system_features s
-	full outer join projections.instance_features i using (key, instance_id)
+	full outer join projections.instance_features2 i using (key, instance_id)
 	group by instance_id
 )
 select

--- a/internal/query/instance_features_model.go
+++ b/internal/query/instance_features_model.go
@@ -54,7 +54,6 @@ func (m *InstanceFeaturesReadModel) Query() *eventstore.SearchQueryBuilder {
 		AwaitOpenTransactions().
 		AddQuery().
 		AggregateTypes(feature_v2.AggregateType).
-		AggregateIDs(m.AggregateID).
 		EventTypes(
 			feature_v1.DefaultLoginInstanceEventType,
 			feature_v2.InstanceResetEventType,

--- a/internal/query/projection/instance_features.go
+++ b/internal/query/projection/instance_features.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	InstanceFeatureTable = "projections.instance_features"
+	InstanceFeatureTable = "projections.instance_features2"
 
 	InstanceFeatureInstanceIDCol   = "instance_id"
 	InstanceFeatureKeyCol          = "key"

--- a/internal/query/projection/instance_features_test.go
+++ b/internal/query/projection/instance_features_test.go
@@ -38,7 +38,7 @@ func TestInstanceFeaturesProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.instance_features (instance_id, key, creation_date, change_date, sequence, value) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, key) DO UPDATE SET (creation_date, change_date, sequence, value) = (projections.instance_features.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.value)",
+							expectedStmt: "INSERT INTO projections.instance_features2 (instance_id, key, creation_date, change_date, sequence, value) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, key) DO UPDATE SET (creation_date, change_date, sequence, value) = (projections.instance_features2.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.value)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"legacy_introspection",
@@ -69,7 +69,7 @@ func TestInstanceFeaturesProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.instance_features (instance_id, key, creation_date, change_date, sequence, value) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, key) DO UPDATE SET (creation_date, change_date, sequence, value) = (projections.instance_features.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.value)",
+							expectedStmt: "INSERT INTO projections.instance_features2 (instance_id, key, creation_date, change_date, sequence, value) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (instance_id, key) DO UPDATE SET (creation_date, change_date, sequence, value) = (projections.instance_features2.creation_date, EXCLUDED.change_date, EXCLUDED.sequence, EXCLUDED.value)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"login_default_org",
@@ -100,7 +100,7 @@ func TestInstanceFeaturesProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.instance_features WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.instance_features2 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},
@@ -126,7 +126,7 @@ func TestInstanceFeaturesProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.instance_features WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.instance_features2 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},

--- a/internal/repository/feature/feature.go
+++ b/internal/repository/feature/feature.go
@@ -22,6 +22,10 @@ func DefaultLoginInstanceEventToV2(e *SetEvent[Boolean]) *feature_v2.SetEvent[bo
 		BaseEvent: e.BaseEvent,
 		Value:     e.Value.Boolean,
 	}
+
+	// v1 used a random aggregate ID.
+	// v2 uses the instance ID as aggregate ID.
+	v2e.BaseEvent.Agg.ID = e.Agg.InstanceID
 	v2e.BaseEvent.EventType = feature_v2.InstanceLoginDefaultOrgEventType
 	return v2e
 }


### PR DESCRIPTION
This change fixes a mismatch between v1 and v2 aggregate IDs for instance feature events.
The old v1 used a random aggregate ID, while v2 uses the instance ID as aggregate ID.
The adapter was not correctly mapping, which resulted in the projections.instance_features table being filled with wrong instance IDs.

Closes #7501

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
