### PR TITLE
fix(query): optimize instance by domain query

### DIFF
--- a/internal/query/instance_by_domain.sql
+++ b/internal/query/instance_by_domain.sql
@@ -1,6 +1,10 @@
 with domain as (
 	select instance_id from projections.instance_domains
 	where domain = $1
+), instance_features as (
+	select i.*
+	from domain d
+	join projections.instance_features2 i on d.instance_id = i.instance_id
 ), features as (
 	select instance_id, json_object_agg(
 		coalesce(i.key, s.key),
@@ -8,7 +12,7 @@ with domain as (
 	) features
 	from domain d
 	cross join projections.system_features s
-	full outer join projections.instance_features2 i using (key, instance_id)
+	full outer join instance_features i using (instance_id, key)
 	group by instance_id
 )
 select


### PR DESCRIPTION
On zitadel cloud we noticed an increase in database CPU usage and slightly higher response times.
By analyzes we found that the instance by domain query was wrongly joining all instance_feature rows against all instances.
This PR adds an additional CTE to limit the join set to only the features that apply to the found instance.

The query was introduced with https://github.com/zitadel/zitadel/pull/7356 and part of the v2.47 release.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
