### PR TITLE
fix(console): allow edit phone dropdown to be wider than trigger flag

### DIFF
--- a/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.html
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.html
@@ -1,13 +1,19 @@
 <h1 mat-dialog-title>
   <span class="title">{{ data.titleKey | translate }}</span>
 </h1>
-<p class="desc cnsl-secondary-text">{{ data.descriptionKey | translate }}</p>
+
 <div mat-dialog-content>
+  <p class="desc cnsl-secondary-text">{{ data.descriptionKey | translate }}</p>
   <form [formGroup]="dialogForm" (ngSubmit)="closeDialogWithValue()">
     <div class="phone-grid">
       <cnsl-form-field *ngIf="isPhone">
         <cnsl-label>{{ 'USER.PROFILE.COUNTRY' | translate }}</cnsl-label>
-        <mat-select [(value)]="selected" [compareWith]="compareCountries" (selectionChange)="setCountryCallingCode()">
+        <mat-select
+          panelClass="select-flag"
+          [(value)]="selected"
+          [compareWith]="compareCountries"
+          (selectionChange)="setCountryCallingCode()"
+        >
           <mat-select-trigger> <span class="fi fi-{{ selected?.countryCode | lowercase }}"></span></mat-select-trigger>
           <mat-option *ngFor="let country of countryPhoneCodes" [value]="country">
             <span class="fi fi-{{ country.countryCode | lowercase }}"></span>
@@ -44,7 +50,6 @@
 
   <button
     [disabled]="dialogForm.invalid"
-    cdkFocusInitial
     color="primary"
     mat-raised-button
     class="ok-button"

--- a/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.scss
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.scss
@@ -14,10 +14,6 @@
   display: flex;
   justify-content: flex-end;
 
-  .ok-button {
-    margin-left: 0.5rem;
-  }
-
   button {
     border-radius: 0.5rem;
   }

--- a/console/src/app/pages/users/user-detail/auth-user-detail/resend-email-dialog/resend-email-dialog.component.html
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/resend-email-dialog/resend-email-dialog.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>
   <span class="title">{{ 'USER.SENDEMAILDIALOG.TITLE' | translate }} {{ data?.number }}</span>
 </h1>
-<p class="desc cnsl-secondary-text">{{ 'USER.SENDEMAILDIALOG.DESCRIPTION' | translate }}</p>
 <div mat-dialog-content>
+  <p class="desc cnsl-secondary-text">{{ 'USER.SENDEMAILDIALOG.DESCRIPTION' | translate }}</p>
   <cnsl-form-field class="formfield">
     <cnsl-label>{{ 'USER.SENDEMAILDIALOG.NEWEMAIL' | translate }}</cnsl-label>
     <input cnslInput [(ngModel)]="email" />

--- a/console/src/app/pages/users/user-detail/auth-user-detail/resend-email-dialog/resend-email-dialog.component.scss
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/resend-email-dialog/resend-email-dialog.component.scss
@@ -10,10 +10,6 @@
   display: flex;
   justify-content: flex-end;
 
-  .ok-button {
-    margin-left: 0.5rem;
-  }
-
   button {
     border-radius: 0.5rem;
   }

--- a/console/src/styles.scss
+++ b/console/src/styles.scss
@@ -634,3 +634,9 @@ i {
   align-items: center;
   font-size: 14px !important;
 }
+
+// See https://github.com/angular/components/issues/26000 discussion about dropdown to be wider
+// than parent form-field like before v15 and flags use case
+.cdk-overlay-pane:has(> .select-flag) {
+  width: initial !important;
+}


### PR DESCRIPTION
This PR tries to fix an issue with material design components mat-select from version 15 onwards. As discussed in https://github.com/angular/components/issues/26000 there's some controversy about mat-select "new" or "expected" behavior. In that discussion the flag case would be a suitable case for dropdown to be wider than parent form-field but no changes have been made since.

This PR proposes a workaround where only mat-select components with  panelClass="select-flag" would override the mat-select width. @peintnermax if you accept this proposal we may change the UserCreateComponent as well... but as I've added a global style (and didn't want to use the deprecated ::ng-deep trick) I prefer that you decide which is best.

![Captura desde 2024-03-10 14-40-53](https://github.com/zitadel/zitadel/assets/30386061/a61258b3-90d4-47f4-927a-2bb2909e40ad)

This PR also fix a minor style issue in the edit email component as well.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.

Should fix #7509 
