### PR TITLE
refactor: copy only required frameworks icons from docs in console

### DIFF
--- a/console/angular.json
+++ b/console/angular.json
@@ -27,7 +27,7 @@
               "src/favicon.ico",
               "src/assets",
               "src/manifest.webmanifest",
-              { "glob": "**/*", "input": "../docs/static/img", "output": "assets/docs/img" }
+              { "glob": "**/*", "input": "../docs/static/img/tech", "output": "assets/docs/img/tech" }
             ],
             "styles": ["src/styles.scss"],
             "scripts": ["./node_modules/tinycolor2/dist/tinycolor-min.js"],


### PR DESCRIPTION
Developers noted that the size of the ZITADEL image / binary suddenly increased by a lot.
This was due to the copied images from docs to include the frameworks in console.
This PR changes the path to use the frameworks folder only.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
