### PR TITLE
fix: rendering of TOTP QR code

### DIFF
--- a/internal/api/ui/login/mfa_init_verify_handler.go
+++ b/internal/api/ui/login/mfa_init_verify_handler.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"bytes"
+	"html/template"
 	"net/http"
 
 	"github.com/zitadel/zitadel/internal/domain"
@@ -76,7 +77,7 @@ func (l *Login) renderMFAInitVerify(w http.ResponseWriter, r *http.Request, auth
 	if data.MFAType == domain.MFATypeTOTP {
 		code, err := generateQrCode(data.totpData.Url)
 		if err == nil {
-			data.totpData.QrCode = code
+			data.totpData.QrCode = template.HTML(code)
 		}
 	}
 

--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -706,5 +706,5 @@ type mfaDoneData struct {
 type totpData struct {
 	Url    string
 	Secret string
-	QrCode string
+	QrCode template.HTML
 }


### PR DESCRIPTION
Customers reported, that the QR Code for the TOTP setup was not rendered anymore, but rather plain HTML was displayed.

This was due to the recent change to sanitize the HTML of the login pages. This PR explicitly switches the `QrCode` field of the `totpData` from `string` to `template.HTML` to allow the rendering again. 

closes #7542

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
