### PR TITLE
chore(fmt): run gci on complete project

### DIFF
--- a/cmd/initialise/helper.go
+++ b/cmd/initialise/helper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/jackc/pgconn"
+
 	"github.com/zitadel/zitadel/internal/database"
 )
 

--- a/cmd/initialise/init_test.go
+++ b/cmd/initialise/init_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/zitadel/zitadel/internal/database"
 )
 

--- a/cmd/start/flags.go
+++ b/cmd/start/flags.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/cmd/key"

--- a/internal/actions/http_module_config.go
+++ b/internal/actions/http_module_config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 

--- a/internal/api/grpc/admin/iam_member_integration_test.go
+++ b/internal/api/grpc/admin/iam_member_integration_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/zitadel/zitadel/internal/integration"
 	admin_pb "github.com/zitadel/zitadel/pkg/grpc/admin"
 	"github.com/zitadel/zitadel/pkg/grpc/member"

--- a/internal/api/grpc/admin/language.go
+++ b/internal/api/grpc/admin/language.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	"github.com/zitadel/zitadel/internal/domain"

--- a/internal/api/grpc/admin/milestone_converter.go
+++ b/internal/api/grpc/admin/milestone_converter.go
@@ -1,13 +1,14 @@
 package admin
 
 import (
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/repository/milestone"
 	"github.com/zitadel/zitadel/internal/zerrors"
 	admin_pb "github.com/zitadel/zitadel/pkg/grpc/admin"
 	milestone_pb "github.com/zitadel/zitadel/pkg/grpc/milestone"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func listMilestonesToModel(instanceID string, req *admin_pb.ListMilestonesRequest) (*query.MilestonesSearchQueries, error) {

--- a/internal/api/grpc/admin/restrictions_integration_allow_public_org_registrations_test.go
+++ b/internal/api/grpc/admin/restrictions_integration_allow_public_org_registrations_test.go
@@ -5,8 +5,6 @@ package admin_test
 import (
 	"bytes"
 	"context"
-	"github.com/muhlemmer/gu"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -14,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/muhlemmer/gu"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zitadel/zitadel/pkg/grpc/admin"

--- a/internal/api/grpc/auth/language.go
+++ b/internal/api/grpc/auth/language.go
@@ -2,9 +2,9 @@ package auth
 
 import (
 	"context"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/i18n"
-
 	auth_pb "github.com/zitadel/zitadel/pkg/grpc/auth"
 )
 

--- a/internal/api/grpc/auth/password.go
+++ b/internal/api/grpc/auth/password.go
@@ -3,9 +3,8 @@ package auth
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/api/grpc/object"
-
 	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	auth_pb "github.com/zitadel/zitadel/pkg/grpc/auth"
 )
 

--- a/internal/api/grpc/change/changes.go
+++ b/internal/api/grpc/change/changes.go
@@ -4,7 +4,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/zitadel/zitadel/internal/domain"
-
 	"github.com/zitadel/zitadel/internal/query"
 	change_pb "github.com/zitadel/zitadel/pkg/grpc/change"
 	"github.com/zitadel/zitadel/pkg/grpc/message"

--- a/internal/api/grpc/client/middleware/tracing.go
+++ b/internal/api/grpc/client/middleware/tracing.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 
-	grpc_utils "github.com/zitadel/zitadel/internal/api/grpc"
 	grpc_trace "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+
+	grpc_utils "github.com/zitadel/zitadel/internal/api/grpc"
 )
 
 type GRPCMethod string

--- a/internal/api/grpc/management/language.go
+++ b/internal/api/grpc/management/language.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/i18n"
 	mgmt_pb "github.com/zitadel/zitadel/pkg/grpc/management"

--- a/internal/api/grpc/management/user_converter.go
+++ b/internal/api/grpc/management/user_converter.go
@@ -7,18 +7,17 @@ import (
 	"github.com/zitadel/logging"
 	"golang.org/x/text/language"
 
-	"github.com/zitadel/zitadel/internal/command"
-	"github.com/zitadel/zitadel/pkg/grpc/user"
-
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/grpc/authn"
 	"github.com/zitadel/zitadel/internal/api/grpc/metadata"
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	user_grpc "github.com/zitadel/zitadel/internal/api/grpc/user"
+	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore/v1/models"
 	"github.com/zitadel/zitadel/internal/query"
 	mgmt_pb "github.com/zitadel/zitadel/pkg/grpc/management"
+	"github.com/zitadel/zitadel/pkg/grpc/user"
 )
 
 func ListUsersRequestToModel(req *mgmt_pb.ListUsersRequest) (*query.UserSearchQueries, error) {

--- a/internal/api/grpc/server/middleware/tracing.go
+++ b/internal/api/grpc/server/middleware/tracing.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 
-	grpc_utils "github.com/zitadel/zitadel/internal/api/grpc"
 	grpc_trace "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+
+	grpc_utils "github.com/zitadel/zitadel/internal/api/grpc"
 )
 
 type GRPCMethod string

--- a/internal/api/grpc/server/middleware/validation_interceptor.go
+++ b/internal/api/grpc/server/middleware/validation_interceptor.go
@@ -3,12 +3,12 @@ package middleware
 import (
 	"context"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	//import to make sure go.mod does not lose it
 	//because dependency is only needed for generated code
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func ValidationHandler() grpc.UnaryServerInterceptor {
@@ -17,8 +17,8 @@ func ValidationHandler() grpc.UnaryServerInterceptor {
 	}
 }
 
-//validator interface needed for github.com/envoyproxy/protoc-gen-validate
-//(it does not expose an interface itself)
+// validator interface needed for github.com/envoyproxy/protoc-gen-validate
+// (it does not expose an interface itself)
 type validator interface {
 	Validate() error
 }

--- a/internal/api/grpc/session/v2/session.go
+++ b/internal/api/grpc/session/v2/session.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/muhlemmer/gu"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/muhlemmer/gu"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/grpc/object/v2"

--- a/internal/api/grpc/system/instance_integration_test.go
+++ b/internal/api/grpc/system/instance_integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/zitadel/zitadel/pkg/grpc/instance"
 	"github.com/zitadel/zitadel/pkg/grpc/object"
 	system_pb "github.com/zitadel/zitadel/pkg/grpc/system"

--- a/internal/api/grpc/system/limits_integration_auditlogretention_test.go
+++ b/internal/api/grpc/system/limits_integration_auditlogretention_test.go
@@ -4,7 +4,6 @@ package system_test
 
 import (
 	"context"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"math/rand"
 	"sync"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/zitadel/zitadel/pkg/grpc/admin"
 	"github.com/zitadel/zitadel/pkg/grpc/auth"

--- a/internal/api/grpc/system/quota_converter.go
+++ b/internal/api/grpc/system/quota_converter.go
@@ -1,10 +1,11 @@
 package system
 
 import (
-	"github.com/zitadel/zitadel/internal/command"
-	"github.com/zitadel/zitadel/pkg/grpc/quota"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zitadel/zitadel/internal/command"
+	"github.com/zitadel/zitadel/pkg/grpc/quota"
 )
 
 type setQuotaRequest interface {

--- a/internal/api/grpc/user/v2/query_integration_test.go
+++ b/internal/api/grpc/user/v2/query_integration_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/muhlemmer/gu"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 

--- a/internal/api/http/middleware/metrics_interceptor.go
+++ b/internal/api/http/middleware/metrics_interceptor.go
@@ -3,9 +3,8 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/zitadel/zitadel/internal/telemetry/metrics"
-
 	http_utils "github.com/zitadel/zitadel/internal/api/http"
+	"github.com/zitadel/zitadel/internal/telemetry/metrics"
 )
 
 func DefaultMetricsHandler(handler http.Handler) http.Handler {

--- a/internal/api/http/middleware/telemetry_interceptor.go
+++ b/internal/api/http/middleware/telemetry_interceptor.go
@@ -3,9 +3,8 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/zitadel/zitadel/internal/telemetry"
-
 	http_utils "github.com/zitadel/zitadel/internal/api/http"
+	"github.com/zitadel/zitadel/internal/telemetry"
 )
 
 func DefaultTelemetryHandler(handler http.Handler) http.Handler {

--- a/internal/api/http/origin.go
+++ b/internal/api/http/origin.go
@@ -22,7 +22,7 @@ func IsOriginAllowed(allowList []string, origin string) bool {
 	return false
 }
 
-//IsOrigin checks if provided string is an origin (scheme://hostname[:port]) without path, query or fragment
+// IsOrigin checks if provided string is an origin (scheme://hostname[:port]) without path, query or fragment
 func IsOrigin(rawOrigin string) bool {
 	parsedUrl, err := url.Parse(rawOrigin)
 	if err != nil {

--- a/internal/api/ui/login/mfa_init_verify_handler.go
+++ b/internal/api/ui/login/mfa_init_verify_handler.go
@@ -5,12 +5,11 @@ import (
 	"html/template"
 	"net/http"
 
-	"github.com/zitadel/zitadel/internal/domain"
-
 	svg "github.com/ajstarks/svgo"
 	"github.com/boombuler/barcode/qr"
 
 	http_mw "github.com/zitadel/zitadel/internal/api/http/middleware"
+	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/qrcode"
 )
 

--- a/internal/api/ui/login/mfa_verify_u2f_handler.go
+++ b/internal/api/ui/login/mfa_verify_u2f_handler.go
@@ -4,9 +4,8 @@ import (
 	"encoding/base64"
 	"net/http"
 
-	"github.com/zitadel/zitadel/internal/domain"
-
 	http_mw "github.com/zitadel/zitadel/internal/api/http/middleware"
+	"github.com/zitadel/zitadel/internal/domain"
 )
 
 const (

--- a/internal/api/ui/login/select_user_handler.go
+++ b/internal/api/ui/login/select_user_handler.go
@@ -3,9 +3,8 @@ package login
 import (
 	"net/http"
 
-	"github.com/zitadel/zitadel/internal/domain"
-
 	http_mw "github.com/zitadel/zitadel/internal/api/http/middleware"
+	"github.com/zitadel/zitadel/internal/domain"
 )
 
 const (

--- a/internal/command/instance_custom_login_text_model.go
+++ b/internal/command/instance_custom_login_text_model.go
@@ -3,9 +3,9 @@ package command
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/api/authz"
 	"golang.org/x/text/language"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 )

--- a/internal/command/instance_custom_message_text_model.go
+++ b/internal/command/instance_custom_message_text_model.go
@@ -3,9 +3,9 @@ package command
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/api/authz"
 	"golang.org/x/text/language"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 )

--- a/internal/command/instance_idp_config_model.go
+++ b/internal/command/instance_idp_config_model.go
@@ -4,9 +4,8 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 )

--- a/internal/command/instance_idp_jwt_config_model.go
+++ b/internal/command/instance_idp_jwt_config_model.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 )

--- a/internal/command/instance_idp_oidc_config_model.go
+++ b/internal/command/instance_idp_oidc_config_model.go
@@ -5,10 +5,9 @@ import (
 	"reflect"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 )

--- a/internal/command/instance_policy_login_model.go
+++ b/internal/command/instance_policy_login_model.go
@@ -5,9 +5,8 @@ import (
 	"time"
 
 	"github.com/zitadel/zitadel/internal/api/authz"
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/instance_policy_mail_template_model.go
+++ b/internal/command/instance_policy_mail_template_model.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/instance_policy_mail_template_test.go
+++ b/internal/command/instance_policy_mail_template_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"

--- a/internal/command/instance_policy_password_age_model.go
+++ b/internal/command/instance_policy_password_age_model.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/instance_policy_password_complexity_model.go
+++ b/internal/command/instance_policy_password_complexity_model.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/instance_policy_password_lockout_model.go
+++ b/internal/command/instance_policy_password_lockout_model.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_idp_config_model.go
+++ b/internal/command/org_idp_config_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/org"
 )

--- a/internal/command/org_idp_jwt_config_model.go
+++ b/internal/command/org_idp_jwt_config_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/org"
 )

--- a/internal/command/org_idp_oidc_config_model.go
+++ b/internal/command/org_idp_oidc_config_model.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/idpconfig"
 	"github.com/zitadel/zitadel/internal/repository/org"
 )

--- a/internal/command/org_policy_label_model.go
+++ b/internal/command/org_policy_label_model.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_policy_lockout_model.go
+++ b/internal/command/org_policy_lockout_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_policy_login_model.go
+++ b/internal/command/org_policy_login_model.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_policy_mail_template_model.go
+++ b/internal/command/org_policy_mail_template_model.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_policy_password_age_model.go
+++ b/internal/command/org_policy_password_age_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/org_policy_password_complexity_model.go
+++ b/internal/command/org_policy_password_complexity_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/policy"
 )

--- a/internal/command/preparation_test.go
+++ b/internal/command/preparation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
 
-//Want represents the expected values for each step
+// Want represents the expected values for each step
 type Want struct {
 	ValidationErr error
 	CreateErr     error
@@ -22,7 +22,7 @@ type CommandVerifier interface {
 	Validate(eventstore.Command) bool
 }
 
-//AssertValidation checks if the validation works as inteded
+// AssertValidation checks if the validation works as inteded
 func AssertValidation(t *testing.T, ctx context.Context, validation preparation.Validation, filter preparation.FilterToQueryReducer, want Want) {
 	t.Helper()
 

--- a/internal/command/project_application_api_model.go
+++ b/internal/command/project_application_api_model.go
@@ -3,10 +3,9 @@ package command
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/project"
 )
 

--- a/internal/command/project_application_key_model.go
+++ b/internal/command/project_application_key_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/project"
 )
 

--- a/internal/command/project_application_key_test.go
+++ b/internal/command/project_application_key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"

--- a/internal/command/user_grant.go
+++ b/internal/command/user_grant.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-	"github.com/zitadel/zitadel/internal/zerrors"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/usergrant"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
+	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 func (c *Commands) AddUserGrant(ctx context.Context, usergrant *domain.UserGrant, resourceOwner string) (_ *domain.UserGrant, err error) {

--- a/internal/command/user_human_access_token_model.go
+++ b/internal/command/user_human_access_token_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_human_init_model.go
+++ b/internal/command/user_human_init_model.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_human_password_model.go
+++ b/internal/command/user_human_password_model.go
@@ -3,10 +3,9 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_human_phone_model.go
+++ b/internal/command/user_human_phone_model.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_human_profile_model.go
+++ b/internal/command/user_human_profile_model.go
@@ -3,11 +3,10 @@ package command
 import (
 	"context"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"golang.org/x/text/language"
 
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_human_refresh_token_model.go
+++ b/internal/command/user_human_refresh_token_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_machine_key_model.go
+++ b/internal/command/user_machine_key_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_machine_model.go
+++ b/internal/command/user_machine_model.go
@@ -4,9 +4,8 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/crypto"
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_model.go
+++ b/internal/command/user_model.go
@@ -1,9 +1,8 @@
 package command
 
 import (
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/command/user_personal_access_token_model.go
+++ b/internal/command/user_personal_access_token_model.go
@@ -3,9 +3,8 @@ package command
 import (
 	"time"
 
-	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/crypto/aes_test.go
+++ b/internal/crypto/aes_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//TODO: refactor test style
+// TODO: refactor test style
 func TestDecrypt_OK(t *testing.T) {
 	encryptedpw, err := EncryptAESString("ThisIsMySecretPw", "passphrasewhichneedstobe32bytes!")
 	assert.NoError(t, err)

--- a/internal/eventstore/handler/crdb/db_mock_test.go
+++ b/internal/eventstore/handler/crdb/db_mock_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/zitadel/zitadel/internal/database"
 )
 

--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/notification/channels/log/channel.go
+++ b/internal/notification/channels/log/channel.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/k3a/html2text"
-
 	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/notification/channels"
 )
 

--- a/internal/notification/handlers/queries.go
+++ b/internal/notification/handlers/queries.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+
 	"golang.org/x/text/language"
 
 	"github.com/zitadel/zitadel/internal/crypto"

--- a/internal/notification/handlers/user_notifier_test.go
+++ b/internal/notification/handlers/user_notifier_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zitadel/zitadel/internal/repository/session"
-
-	"github.com/zitadel/zitadel/internal/notification/messages"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/text/language"
@@ -24,9 +20,11 @@ import (
 	"github.com/zitadel/zitadel/internal/notification/channels/twilio"
 	"github.com/zitadel/zitadel/internal/notification/channels/webhook"
 	"github.com/zitadel/zitadel/internal/notification/handlers/mock"
+	"github.com/zitadel/zitadel/internal/notification/messages"
 	"github.com/zitadel/zitadel/internal/notification/senders"
 	"github.com/zitadel/zitadel/internal/notification/types"
 	"github.com/zitadel/zitadel/internal/query"
+	"github.com/zitadel/zitadel/internal/repository/session"
 	"github.com/zitadel/zitadel/internal/repository/user"
 )
 

--- a/internal/notification/senders/email.go
+++ b/internal/notification/senders/email.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/notification/channels"
 	"github.com/zitadel/zitadel/internal/notification/channels/fs"

--- a/internal/notification/senders/webhook.go
+++ b/internal/notification/senders/webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/notification/channels"
 	"github.com/zitadel/zitadel/internal/notification/channels/fs"

--- a/internal/notification/types/otp.go
+++ b/internal/notification/types/otp.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"time"
 
-	http_utils "github.com/zitadel/zitadel/internal/api/http"
-
 	"github.com/zitadel/zitadel/internal/api/authz"
-
+	http_utils "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/domain"
 )
 

--- a/internal/notification/types/templateData.go
+++ b/internal/notification/types/templateData.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	http_util "github.com/zitadel/zitadel/internal/api/http"
-
 	"github.com/zitadel/zitadel/internal/api/assets"
+	http_util "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/i18n"
 	"github.com/zitadel/zitadel/internal/notification/templates"
 	"github.com/zitadel/zitadel/internal/query"

--- a/internal/query/authn_key.go
+++ b/internal/query/authn_key.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/domain_policy.go
+++ b/internal/query/domain_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/idp.go
+++ b/internal/query/idp.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/idp_template.go
+++ b/internal/query/idp_template.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/lockout_policy.go
+++ b/internal/query/lockout_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/login_policy.go
+++ b/internal/query/login_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/member.go
+++ b/internal/query/member.go
@@ -3,10 +3,10 @@ package query
 import (
 	"time"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/domain"
-
-	sq "github.com/Masterminds/squirrel"
 )
 
 type MembersQuery struct {

--- a/internal/query/org.go
+++ b/internal/query/org.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/org_metadata.go
+++ b/internal/query/org_metadata.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/password_age_policy.go
+++ b/internal/query/password_age_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/password_complexity_policy.go
+++ b/internal/query/password_complexity_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/privacy_policy.go
+++ b/internal/query/privacy_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/project.go
+++ b/internal/query/project.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/project_grant.go
+++ b/internal/query/project_grant.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/project_role.go
+++ b/internal/query/project_role.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/projection/debug_notification.go
+++ b/internal/query/projection/debug_notification.go
@@ -4,12 +4,11 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/domain"
-	"github.com/zitadel/zitadel/internal/repository/settings"
-
 	"github.com/zitadel/zitadel/internal/eventstore"
 	old_handler "github.com/zitadel/zitadel/internal/eventstore/handler"
 	"github.com/zitadel/zitadel/internal/eventstore/handler/v2"
 	"github.com/zitadel/zitadel/internal/repository/instance"
+	"github.com/zitadel/zitadel/internal/repository/settings"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/user_grant.go
+++ b/internal/query/user_grant.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/user_metadata.go
+++ b/internal/query/user_metadata.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/query/user_personal_access_token.go
+++ b/internal/query/user_personal_access_token.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/authz"

--- a/internal/repository/user/human_profile.go
+++ b/internal/repository/user/human_profile.go
@@ -3,10 +3,11 @@ package user
 import (
 	"context"
 
+	"golang.org/x/text/language"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
-	"golang.org/x/text/language"
 )
 
 const (

--- a/internal/repository/usergrant/user_grant.go
+++ b/internal/repository/usergrant/user_grant.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
-
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 

--- a/internal/telemetry/http_handler.go
+++ b/internal/telemetry/http_handler.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/zitadel/zitadel/internal/telemetry/metrics"
-
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/zitadel/zitadel/internal/telemetry/metrics"
 )
 
 func shouldNotIgnore(endpoints ...string) func(r *http.Request) bool {

--- a/internal/test/filled_checker.go
+++ b/internal/test/filled_checker.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//testingT is a wrapper for testing.T
+// testingT is a wrapper for testing.T
 //
 // this wrapper is needed for internal testing
 type testingT interface {

--- a/internal/user/model/external_idp_view.go
+++ b/internal/user/model/external_idp_view.go
@@ -1,10 +1,10 @@
 package model
 
 import (
+	"time"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/zerrors"
-
-	"time"
 )
 
 type ExternalIDPView struct {

--- a/internal/user/model/refresh_token_view.go
+++ b/internal/user/model/refresh_token_view.go
@@ -1,10 +1,10 @@
 package model
 
 import (
+	"time"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/zerrors"
-
-	"time"
 )
 
 type RefreshTokenView struct {

--- a/internal/user/model/token_view.go
+++ b/internal/user/model/token_view.go
@@ -1,10 +1,10 @@
 package model
 
 import (
+	"time"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/zerrors"
-
-	"time"
 )
 
 type TokenView struct {

--- a/internal/user/model/user_membership_view.go
+++ b/internal/user/model/user_membership_view.go
@@ -1,10 +1,10 @@
 package model
 
 import (
+	"time"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/zerrors"
-
-	"time"
 )
 
 type UserMembershipView struct {

--- a/internal/user/repository/eventsourcing/model/profile_test.go
+++ b/internal/user/repository/eventsourcing/model/profile_test.go
@@ -3,8 +3,9 @@ package model
 import (
 	"testing"
 
-	user_model "github.com/zitadel/zitadel/internal/user/model"
 	"golang.org/x/text/language"
+
+	user_model "github.com/zitadel/zitadel/internal/user/model"
 )
 
 func TestProfileChanges(t *testing.T) {

--- a/internal/view/repository/db_mock_test.go
+++ b/internal/view/repository/db_mock_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/zitadel/zitadel/internal/domain"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jinzhu/gorm"
+
+	"github.com/zitadel/zitadel/internal/domain"
 )
 
 var (

--- a/internal/view/repository/query.go
+++ b/internal/view/repository/query.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/jinzhu/gorm"
-
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/database"

--- a/internal/view/repository/query_test.go
+++ b/internal/view/repository/query_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jinzhu/gorm"
+
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )

--- a/internal/zerrors/zerror_test.go
+++ b/internal/zerrors/zerror_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 


### PR DESCRIPTION
Fix global import formatting in go code by running the `gci` command. This allows us to just use the command directly, instead of fixing the import order manually for the linter, on each PR.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
