### PR TITLE
feat(actions): `ctx.org.getMetadata()` in external authentication

### DIFF
--- a/docs/docs/apis/actions/external-authentication.md
+++ b/docs/docs/apis/actions/external-authentication.md
@@ -33,6 +33,8 @@ The first parameter contains the following fields
     - `providerInfo` *Any*  
       Returns the response of the provider. In case the provider is a Generic OAuth Provider, the information is accessible through:
       - `rawInfo`  *Any*
+    - `org`
+      - `getMetadata()` [*metadataResult*](./objects#metadata-result)
 - `api`  
   The second parameter contains the following fields
   - `v1`
@@ -76,6 +78,8 @@ The trigger is represented by the following Ids in the API: `TRIGGER_TYPE_PRE_CR
     - `user` [*human*](./objects#human-user)
     - `authRequest` [*auth request*](/docs/apis/actions/objects#auth-request)
     - `httpRequest` [*http request*](/docs/apis/actions/objects#http-request)
+    - `org`
+      - `getMetadata()` [*metadataResult*](./objects#metadata-result)
 - `api`  
   The second parameter contains the following fields
   - `metadata`  
@@ -122,6 +126,8 @@ The trigger is represented by the following Ids in the API: `TRIGGER_TYPE_POST_C
     - `getUser()` [*user*](./objects#user)
     - `authRequest` [*auth request*](/docs/apis/actions/objects#auth-request)
     - `httpRequest` [*http request*](/docs/apis/actions/objects#http-request)
+    - `org`
+      - `getMetadata()` [*metadataResult*](./objects#metadata-result)
 - `api`  
   The second parameter contains the following fields
   - `userGrants` Array of [*userGrant*](./objects#user-grant)'s

--- a/internal/api/ui/login/custom_action.go
+++ b/internal/api/ui/login/custom_action.go
@@ -122,6 +122,24 @@ func (l *Login) runPostExternalAuthenticationActions(
 				actions.SetFields("authRequest", object.AuthRequestField(authRequest)),
 				actions.SetFields("httpRequest", object.HTTPRequestField(httpRequest)),
 				actions.SetFields("authError", authErrStr),
+				actions.SetFields("org",
+					actions.SetFields("getMetadata", func(c *actions.FieldConfig) interface{} {
+						return func(goja.FunctionCall) goja.Value {
+							metadata, err := l.query.SearchOrgMetadata(
+								ctx,
+								true,
+								resourceOwner,
+								&query.OrgMetadataSearchQueries{},
+								false,
+							)
+							if err != nil {
+								logging.WithError(err).Info("unable to get org metadata in action")
+								panic(err)
+							}
+							return object.OrgMetadataListFromQuery(c, metadata)
+						}
+					}),
+				),
 			),
 		)
 
@@ -298,6 +316,24 @@ func (l *Login) runPreCreationActions(
 				}),
 				actions.SetFields("authRequest", object.AuthRequestField(authRequest)),
 				actions.SetFields("httpRequest", object.HTTPRequestField(httpRequest)),
+				actions.SetFields("org",
+					actions.SetFields("getMetadata", func(c *actions.FieldConfig) interface{} {
+						return func(goja.FunctionCall) goja.Value {
+							metadata, err := l.query.SearchOrgMetadata(
+								ctx,
+								true,
+								resourceOwner,
+								&query.OrgMetadataSearchQueries{},
+								false,
+							)
+							if err != nil {
+								logging.WithError(err).Info("unable to get org metadata in action")
+								panic(err)
+							}
+							return object.OrgMetadataListFromQuery(c, metadata)
+						}
+					}),
+				),
 			),
 		)
 
@@ -356,6 +392,24 @@ func (l *Login) runPostCreationActions(
 				}),
 				actions.SetFields("authRequest", object.AuthRequestField(authRequest)),
 				actions.SetFields("httpRequest", object.HTTPRequestField(httpRequest)),
+				actions.SetFields("org",
+					actions.SetFields("getMetadata", func(c *actions.FieldConfig) interface{} {
+						return func(goja.FunctionCall) goja.Value {
+							metadata, err := l.query.SearchOrgMetadata(
+								ctx,
+								true,
+								resourceOwner,
+								&query.OrgMetadataSearchQueries{},
+								false,
+							)
+							if err != nil {
+								logging.WithError(err).Info("unable to get org metadata in action")
+								panic(err)
+							}
+							return object.OrgMetadataListFromQuery(c, metadata)
+						}
+					}),
+				),
 			),
 		)
 


### PR DESCRIPTION
External authentication actions now provide `ctx.org.getMetadata()`-method

closes https://github.com/zitadel/zitadel/issues/7482

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
