### PR TITLE
fix(login): (re)allow HTML in custom login texts

### DIFF
--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -123,7 +123,7 @@ func (r *Renderer) registerTranslateFn(req *http.Request, translator *i18n.Trans
 	if translator == nil {
 		return funcs
 	}
-	funcs[TranslateFn] = func(id string, args ...interface{}) string {
+	funcs[TranslateFn] = func(id string, args ...interface{}) template.HTML {
 		m := map[string]interface{}{}
 		var key string
 		for i, arg := range args {
@@ -134,9 +134,9 @@ func (r *Renderer) registerTranslateFn(req *http.Request, translator *i18n.Trans
 			m[key] = arg
 		}
 		if r == nil {
-			return r.Localize(translator, id, m)
+			return template.HTML(r.Localize(translator, id, m))
 		}
-		return r.LocalizeFromRequest(translator, req, id, m)
+		return template.HTML(r.LocalizeFromRequest(translator, req, id, m))
 	}
 	return funcs
 }


### PR DESCRIPTION
When we fixed the template rendering to prevent HTML injection by queries, this changed also custom texts in the login UI, which include HTML. These are now rendered as raw strings.

This PR changes the behaviour back for custom texts to also render HTML.
To do so, the translation function (used to provide the texts in the login UI) returns now a `template.HTML` instead of a `string`.

closes #7556

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
