### PR TITLE
fix: fill resourceowner of project into usergrant projection

### DIFF
--- a/internal/query/embed/userinfo_by_id.sql
+++ b/internal/query/embed/userinfo_by_id.sql
@@ -34,7 +34,7 @@ metadata as (
 -- get all user grants, needed for the orgs query
 user_grants as (
 	select id, grant_id, state, creation_date, change_date, sequence, user_id, roles, resource_owner, project_id
-	from projections.user_grants4
+	from projections.user_grants5
 	where user_id = $1
 	and instance_id = $2
 	and project_id = any($3)

--- a/internal/query/projection/user_grant.go
+++ b/internal/query/projection/user_grant.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	UserGrantProjectionTable = "projections.user_grants4"
+	UserGrantProjectionTable = "projections.user_grants5"
 
 	UserGrantID                   = "id"
 	UserGrantCreationDate         = "creation_date"
@@ -445,7 +445,8 @@ func getResourceOwners(ctx context.Context, es handler.EventStore, instanceID, u
 			EventData(map[string]interface{}{
 				"grantId": grantID,
 			})
-	} else if projectID != "" {
+	}
+	if projectID != "" {
 		builder = builder.Or().
 			AggregateTypes(project.AggregateType).
 			AggregateIDs(projectID).

--- a/internal/query/projection/user_grant_test.go
+++ b/internal/query/projection/user_grant_test.go
@@ -85,7 +85,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 			executer: &testExecuter{
 				executions: []execution{
 					{
-						expectedStmt: "INSERT INTO projections.user_grants4 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+						expectedStmt: "INSERT INTO projections.user_grants5 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
 						expectedArgs: []interface{}{
 							"agg-id",
 							"ro-id",
@@ -152,7 +152,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.user_grants4 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+							expectedStmt: "INSERT INTO projections.user_grants5 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"ro-id",
@@ -223,7 +223,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.user_grants4 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+							expectedStmt: "INSERT INTO projections.user_grants5 (id, resource_owner, instance_id, creation_date, change_date, sequence, user_id, resource_owner_user, project_id, resource_owner_project, grant_id, granted_org, roles, state) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
 							expectedArgs: []interface{}{
 								"agg-id",
 								"ro-id",
@@ -264,7 +264,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET (change_date, roles, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.user_grants5 SET (change_date, roles, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								database.TextArray[string]{"role"},
@@ -296,7 +296,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET (change_date, roles, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.user_grants5 SET (change_date, roles, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								database.TextArray[string]{"role"},
@@ -326,7 +326,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"instance-id",
@@ -353,7 +353,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},
@@ -379,7 +379,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"instance-id",
@@ -406,7 +406,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET (change_date, state, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.user_grants5 SET (change_date, state, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								domain.UserGrantStateInactive,
@@ -436,7 +436,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET (change_date, state, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.user_grants5 SET (change_date, state, sequence) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								domain.UserGrantStateActive,
@@ -466,7 +466,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (user_id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (user_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"instance-id",
@@ -493,7 +493,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (project_id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (project_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"instance-id",
@@ -520,7 +520,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (grant_id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (grant_id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"grantID",
 								"instance-id",
@@ -547,7 +547,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET roles = array_remove(roles, $1) WHERE (project_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.user_grants5 SET roles = array_remove(roles, $1) WHERE (project_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"key",
 								"agg-id",
@@ -575,7 +575,7 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.user_grants4 SET (roles) = (SELECT ARRAY( SELECT UNNEST(roles) INTERSECT SELECT UNNEST ($1::TEXT[]))) WHERE (grant_id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.user_grants5 SET (roles) = (SELECT ARRAY( SELECT UNNEST(roles) INTERSECT SELECT UNNEST ($1::TEXT[]))) WHERE (grant_id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								database.TextArray[string]{"key"},
 								"grantID",
@@ -603,28 +603,28 @@ func TestUserGrantProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (instance_id = $1) AND (resource_owner = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (instance_id = $1) AND (resource_owner = $2)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"agg-id",
 							},
 						},
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (instance_id = $1) AND (resource_owner_user = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (instance_id = $1) AND (resource_owner_user = $2)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"agg-id",
 							},
 						},
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (instance_id = $1) AND (resource_owner_project = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (instance_id = $1) AND (resource_owner_project = $2)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"agg-id",
 							},
 						},
 						{
-							expectedStmt: "DELETE FROM projections.user_grants4 WHERE (instance_id = $1) AND (granted_org = $2)",
+							expectedStmt: "DELETE FROM projections.user_grants5 WHERE (instance_id = $1) AND (granted_org = $2)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"agg-id",

--- a/internal/query/user_grant_test.go
+++ b/internal/query/user_grant_test.go
@@ -15,14 +15,14 @@ import (
 
 var (
 	userGrantStmt = regexp.QuoteMeta(
-		"SELECT projections.user_grants4.id" +
-			", projections.user_grants4.creation_date" +
-			", projections.user_grants4.change_date" +
-			", projections.user_grants4.sequence" +
-			", projections.user_grants4.grant_id" +
-			", projections.user_grants4.roles" +
-			", projections.user_grants4.state" +
-			", projections.user_grants4.user_id" +
+		"SELECT projections.user_grants5.id" +
+			", projections.user_grants5.creation_date" +
+			", projections.user_grants5.change_date" +
+			", projections.user_grants5.sequence" +
+			", projections.user_grants5.grant_id" +
+			", projections.user_grants5.roles" +
+			", projections.user_grants5.state" +
+			", projections.user_grants5.user_id" +
 			", projections.users10.username" +
 			", projections.users10.type" +
 			", projections.users10.resource_owner" +
@@ -32,21 +32,21 @@ var (
 			", projections.users10_humans.display_name" +
 			", projections.users10_humans.avatar_key" +
 			", projections.login_names3.login_name" +
-			", projections.user_grants4.resource_owner" +
+			", projections.user_grants5.resource_owner" +
 			", projections.orgs1.name" +
 			", projections.orgs1.primary_domain" +
-			", projections.user_grants4.project_id" +
+			", projections.user_grants5.project_id" +
 			", projections.projects4.name" +
 			", granted_orgs.id" +
 			", granted_orgs.name" +
 			", granted_orgs.primary_domain" +
-			" FROM projections.user_grants4" +
-			" LEFT JOIN projections.users10 ON projections.user_grants4.user_id = projections.users10.id AND projections.user_grants4.instance_id = projections.users10.instance_id" +
-			" LEFT JOIN projections.users10_humans ON projections.user_grants4.user_id = projections.users10_humans.user_id AND projections.user_grants4.instance_id = projections.users10_humans.instance_id" +
-			" LEFT JOIN projections.orgs1 ON projections.user_grants4.resource_owner = projections.orgs1.id AND projections.user_grants4.instance_id = projections.orgs1.instance_id" +
-			" LEFT JOIN projections.projects4 ON projections.user_grants4.project_id = projections.projects4.id AND projections.user_grants4.instance_id = projections.projects4.instance_id" +
+			" FROM projections.user_grants5" +
+			" LEFT JOIN projections.users10 ON projections.user_grants5.user_id = projections.users10.id AND projections.user_grants5.instance_id = projections.users10.instance_id" +
+			" LEFT JOIN projections.users10_humans ON projections.user_grants5.user_id = projections.users10_humans.user_id AND projections.user_grants5.instance_id = projections.users10_humans.instance_id" +
+			" LEFT JOIN projections.orgs1 ON projections.user_grants5.resource_owner = projections.orgs1.id AND projections.user_grants5.instance_id = projections.orgs1.instance_id" +
+			" LEFT JOIN projections.projects4 ON projections.user_grants5.project_id = projections.projects4.id AND projections.user_grants5.instance_id = projections.projects4.instance_id" +
 			" LEFT JOIN projections.orgs1 AS granted_orgs ON projections.users10.resource_owner = granted_orgs.id AND projections.users10.instance_id = granted_orgs.instance_id" +
-			" LEFT JOIN projections.login_names3 ON projections.user_grants4.user_id = projections.login_names3.user_id AND projections.user_grants4.instance_id = projections.login_names3.instance_id" +
+			" LEFT JOIN projections.login_names3 ON projections.user_grants5.user_id = projections.login_names3.user_id AND projections.user_grants5.instance_id = projections.login_names3.instance_id" +
 			` AS OF SYSTEM TIME '-1 ms' ` +
 			" WHERE projections.login_names3.is_primary = $1")
 	userGrantCols = []string{
@@ -77,14 +77,14 @@ var (
 		"primary_domain", // granted org domain
 	}
 	userGrantsStmt = regexp.QuoteMeta(
-		"SELECT projections.user_grants4.id" +
-			", projections.user_grants4.creation_date" +
-			", projections.user_grants4.change_date" +
-			", projections.user_grants4.sequence" +
-			", projections.user_grants4.grant_id" +
-			", projections.user_grants4.roles" +
-			", projections.user_grants4.state" +
-			", projections.user_grants4.user_id" +
+		"SELECT projections.user_grants5.id" +
+			", projections.user_grants5.creation_date" +
+			", projections.user_grants5.change_date" +
+			", projections.user_grants5.sequence" +
+			", projections.user_grants5.grant_id" +
+			", projections.user_grants5.roles" +
+			", projections.user_grants5.state" +
+			", projections.user_grants5.user_id" +
 			", projections.users10.username" +
 			", projections.users10.type" +
 			", projections.users10.resource_owner" +
@@ -94,22 +94,22 @@ var (
 			", projections.users10_humans.display_name" +
 			", projections.users10_humans.avatar_key" +
 			", projections.login_names3.login_name" +
-			", projections.user_grants4.resource_owner" +
+			", projections.user_grants5.resource_owner" +
 			", projections.orgs1.name" +
 			", projections.orgs1.primary_domain" +
-			", projections.user_grants4.project_id" +
+			", projections.user_grants5.project_id" +
 			", projections.projects4.name" +
 			", granted_orgs.id" +
 			", granted_orgs.name" +
 			", granted_orgs.primary_domain" +
 			", COUNT(*) OVER ()" +
-			" FROM projections.user_grants4" +
-			" LEFT JOIN projections.users10 ON projections.user_grants4.user_id = projections.users10.id AND projections.user_grants4.instance_id = projections.users10.instance_id" +
-			" LEFT JOIN projections.users10_humans ON projections.user_grants4.user_id = projections.users10_humans.user_id AND projections.user_grants4.instance_id = projections.users10_humans.instance_id" +
-			" LEFT JOIN projections.orgs1 ON projections.user_grants4.resource_owner = projections.orgs1.id AND projections.user_grants4.instance_id = projections.orgs1.instance_id" +
-			" LEFT JOIN projections.projects4 ON projections.user_grants4.project_id = projections.projects4.id AND projections.user_grants4.instance_id = projections.projects4.instance_id" +
+			" FROM projections.user_grants5" +
+			" LEFT JOIN projections.users10 ON projections.user_grants5.user_id = projections.users10.id AND projections.user_grants5.instance_id = projections.users10.instance_id" +
+			" LEFT JOIN projections.users10_humans ON projections.user_grants5.user_id = projections.users10_humans.user_id AND projections.user_grants5.instance_id = projections.users10_humans.instance_id" +
+			" LEFT JOIN projections.orgs1 ON projections.user_grants5.resource_owner = projections.orgs1.id AND projections.user_grants5.instance_id = projections.orgs1.instance_id" +
+			" LEFT JOIN projections.projects4 ON projections.user_grants5.project_id = projections.projects4.id AND projections.user_grants5.instance_id = projections.projects4.instance_id" +
 			" LEFT JOIN projections.orgs1 AS granted_orgs ON projections.users10.resource_owner = granted_orgs.id AND projections.users10.instance_id = granted_orgs.instance_id" +
-			" LEFT JOIN projections.login_names3 ON projections.user_grants4.user_id = projections.login_names3.user_id AND projections.user_grants4.instance_id = projections.login_names3.instance_id" +
+			" LEFT JOIN projections.login_names3 ON projections.user_grants5.user_id = projections.login_names3.user_id AND projections.user_grants5.instance_id = projections.login_names3.instance_id" +
 			` AS OF SYSTEM TIME '-1 ms' ` +
 			" WHERE projections.login_names3.is_primary = $1")
 	userGrantsCols = append(


### PR DESCRIPTION
Correct resourceowner of usergrant in reduce function and create new projection to fill everything.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
