### PR TITLE
fix(api): correct mapping of metadata queries

### DIFF
--- a/internal/api/grpc/auth/metadata_converter.go
+++ b/internal/api/grpc/auth/metadata_converter.go
@@ -21,7 +21,7 @@ func BulkSetMetadataToDomain(req *auth.BulkSetMyMetadataRequest) []*domain.Metad
 
 func ListUserMetadataToQuery(req *auth.ListMyMetadataRequest) (*query.UserMetadataSearchQueries, error) {
 	offset, limit, asc := object.ListQueryToModel(req.Query)
-	queries, err := metadata.MetadataQueriesToQuery(req.Queries)
+	queries, err := metadata.UserMetadataQueriesToQuery(req.Queries)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/management/org_converter.go
+++ b/internal/api/grpc/management/org_converter.go
@@ -110,7 +110,7 @@ func BulkSetOrgMetadataToDomain(req *mgmt_pb.BulkSetOrgMetadataRequest) []*domai
 
 func ListOrgMetadataToDomain(req *mgmt_pb.ListOrgMetadataRequest) (*query.OrgMetadataSearchQueries, error) {
 	offset, limit, asc := object.ListQueryToModel(req.Query)
-	queries, err := metadata.MetadataQueriesToQuery(req.Queries)
+	queries, err := metadata.OrgMetadataQueriesToQuery(req.Queries)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/management/user_converter.go
+++ b/internal/api/grpc/management/user_converter.go
@@ -76,7 +76,7 @@ func BulkSetUserMetadataToDomain(req *mgmt_pb.BulkSetUserMetadataRequest) []*dom
 
 func ListUserMetadataToDomain(req *mgmt_pb.ListUserMetadataRequest) (*query.UserMetadataSearchQueries, error) {
 	offset, limit, asc := object.ListQueryToModel(req.Query)
-	queries, err := metadata.MetadataQueriesToQuery(req.Queries)
+	queries, err := metadata.UserMetadataQueriesToQuery(req.Queries)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/metadata/metadata.go
+++ b/internal/api/grpc/metadata/metadata.go
@@ -49,10 +49,10 @@ func OrgMetadataToPb(data *query.OrgMetadata) *meta_pb.Metadata {
 	}
 }
 
-func MetadataQueriesToQuery(queries []*meta_pb.MetadataQuery) (_ []query.SearchQuery, err error) {
+func OrgMetadataQueriesToQuery(queries []*meta_pb.MetadataQuery) (_ []query.SearchQuery, err error) {
 	q := make([]query.SearchQuery, len(queries))
 	for i, query := range queries {
-		q[i], err = MetadataQueryToQuery(query)
+		q[i], err = OrgMetadataQueryToQuery(query)
 		if err != nil {
 			return nil, err
 		}
@@ -60,15 +60,31 @@ func MetadataQueriesToQuery(queries []*meta_pb.MetadataQuery) (_ []query.SearchQ
 	return q, nil
 }
 
-func MetadataQueryToQuery(query *meta_pb.MetadataQuery) (query.SearchQuery, error) {
-	switch q := query.Query.(type) {
+func OrgMetadataQueryToQuery(metadataQuery *meta_pb.MetadataQuery) (query.SearchQuery, error) {
+	switch q := metadataQuery.Query.(type) {
 	case *meta_pb.MetadataQuery_KeyQuery:
-		return MetadataKeyQueryToQuery(q.KeyQuery)
+		return query.NewOrgMetadataKeySearchQuery(q.KeyQuery.Key, object.TextMethodToQuery(q.KeyQuery.Method))
 	default:
 		return nil, zerrors.ThrowInvalidArgument(nil, "METAD-fdg23", "List.Query.Invalid")
 	}
 }
 
-func MetadataKeyQueryToQuery(q *meta_pb.MetadataKeyQuery) (query.SearchQuery, error) {
-	return query.NewOrgMetadataKeySearchQuery(q.Key, object.TextMethodToQuery(q.Method))
+func UserMetadataQueriesToQuery(queries []*meta_pb.MetadataQuery) (_ []query.SearchQuery, err error) {
+	q := make([]query.SearchQuery, len(queries))
+	for i, query := range queries {
+		q[i], err = UserMetadataQueryToQuery(query)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return q, nil
+}
+
+func UserMetadataQueryToQuery(metadataQuery *meta_pb.MetadataQuery) (query.SearchQuery, error) {
+	switch q := metadataQuery.Query.(type) {
+	case *meta_pb.MetadataQuery_KeyQuery:
+		return query.NewUserMetadataKeySearchQuery(q.KeyQuery.Key, object.TextMethodToQuery(q.KeyQuery.Method))
+	default:
+		return nil, zerrors.ThrowInvalidArgument(nil, "METAD-Vn7qy", "List.Query.Invalid")
+	}
 }


### PR DESCRIPTION
Corrects the mapping of metadata queries. 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
