### PR TITLE
chore: trigger update homebrew tap on latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,24 @@ jobs:
         docker buildx imagetools create \
           --tag ${{ inputs.image_name }}:latest-debug \
           ${{ inputs.build_image_name }}-debug
+
+  homebrew-tap:
+    runs-on: ubuntu-22.04
+    needs: version
+    if: ${{ github.ref_name == 'next' }}
+    continue-on-error: true
+    steps:
+    - name: generate token
+      uses: tibdex/github-app-token@v2
+      id: generate-token
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.APP_PRIVATE_KEY }}
+    - name: Trigger Homebrew
+      if: ${{ github.ref_name == 'next' }}
+      env:
+        VERSION: ${{ needs.version.outputs.version }}
+        RUN_ID: ${{ github.run_id }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      run: |
+        gh workflow run -R zitadel/homebrew-tap update.yml -f runId=${RUN_ID} -f version=${VERSION}


### PR DESCRIPTION
Triggers the workflow in github.com/zitadel/homebrew-tap to update the versions of the tap

closes https://github.com/zitadel/zitadel/issues/6385

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
