### PR TITLE
chore(workflow): stop previous GH action pipeline on new changes and move back to public runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ on:
     paths-ignore:
     - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [firefox, chrome]
-    runs-on:
-      group: zitadel-public
+    runs-on: ubuntu-latest
     steps:
       - 
         name: Checkout Repository


### PR DESCRIPTION
This PR changes the pipeline to stop the `ZITADEL CI/CD` and `Code Scanning` workflows is a new workflow is started, e.g. after new changes or remerge of main. Additionally e2e tests now run on the GH public runners again, since it does not make any difference in speed.
![image](https://github.com/zitadel/zitadel/assets/9405495/9466bff4-54de-4c86-a927-ee03b0091a68)
![image](https://github.com/zitadel/zitadel/assets/9405495/41027c5d-142e-4c61-9d96-a0013c935c18)

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
