### PR TITLE
docs(guides/integrate/service-users/private-key-jwt):

### DIFF
--- a/docs/docs/guides/integrate/service-users/private-key-jwt.md
+++ b/docs/docs/guides/integrate/service-users/private-key-jwt.md
@@ -118,21 +118,27 @@ import datetime
 # Replace with your service user ID and private key
 service_user_id = "your_service_user_id"
 private_key = "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----"
+key_id = "your_key_id"
 
 # ZITADEL API URL (replace if needed)
 api_url = "your_custom_domain"
 
 # Generate JWT claims
 payload = {
-    "iss": "your_zitadel_instance_id",
+    "iss": service_user_id,
     "sub": service_user_id,
     "aud": api_url,
-    "exp": datetime.utcnow() + datetime.timedelta(minutes=5),
-    "iat": datetime.utcnow()
+    "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=5),
+    "iat": datetime.datetime.now(datetime.timezone.utc)
+}
+
+header = {
+    "alg": "RS256",
+    "kid": key['keyId']
 }
 
 # Sign the JWT using RS256 algorithm
-encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
+encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256", headers=header)
 
 print(f"Generated JWT: {encoded_jwt}")
 ```

--- a/docs/docs/guides/integrate/service-users/private-key-jwt.md
+++ b/docs/docs/guides/integrate/service-users/private-key-jwt.md
@@ -134,7 +134,7 @@ payload = {
 
 header = {
     "alg": "RS256",
-    "kid": key['keyId']
+    "kid": key_id
 }
 
 # Sign the JWT using RS256 algorithm


### PR DESCRIPTION
adjust incomplete, outdated and incorrect parts of the python example.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
