### PR TITLE
fix: Update url to redirect to name change url

### DIFF
--- a/docs/docs/guides/migrate/sources/keycloak.md
+++ b/docs/docs/guides/migrate/sources/keycloak.md
@@ -262,8 +262,7 @@ Ensure `my-realm-users-0.json` is in the same directory for the tool to process 
 Now copy the following portion to a separate file and name the file `zitadel-users-file.json`.
 
 ```bash
-"userId": "826731b2-bf17-4bd9-b45c-6a26c76ddaae",
-"user": {
+{
   "userName": "test-user",
   "profile": {
     "firstName": "John",

--- a/internal/api/ui/login/static/templates/register_option.html
+++ b/internal/api/ui/login/static/templates/register_option.html
@@ -42,7 +42,7 @@
     {{template "error-message" .}}
 
     <div class="lgn-actions">
-        <a class="lgn-stroked-button" href="{{ loginNameChangeUrl .AuthReqID }}">
+        <a class="lgn-stroked-button" href="{{ loginUrl .AuthReqID }}">
             {{t "RegisterOption.LoginButtonText"}}
         </a>
     </div>

--- a/internal/api/ui/login/static/templates/register_option.html
+++ b/internal/api/ui/login/static/templates/register_option.html
@@ -42,7 +42,7 @@
     {{template "error-message" .}}
 
     <div class="lgn-actions">
-        <a class="lgn-stroked-button" href="{{ loginUrl }}">
+        <a class="lgn-stroked-button" href="{{ loginNameChangeUrl .AuthReqID }}">
             {{t "RegisterOption.LoginButtonText"}}
         </a>
     </div>

--- a/internal/api/ui/login/static/templates/register_option.html
+++ b/internal/api/ui/login/static/templates/register_option.html
@@ -40,12 +40,6 @@
     </div>
 
     {{template "error-message" .}}
-
-    <div class="lgn-actions">
-        <a class="lgn-stroked-button" href="{{ loginUrl .AuthReqID }}">
-            {{t "RegisterOption.LoginButtonText"}}
-        </a>
-    </div>
 </form>
 
 


### PR DESCRIPTION
### Definition of Ready
Solves #7456 . Given an admin had configured at least one external IdP, when a user clicked on the Register button to register as a new user, the user would be redirected to the Register Options page. However, while clicking on the back arrow returns the user back to the original page to either log in or register, clicking on the Login page redirects to the default instance page, since the authRequestId is not included as a param.

Instead, it should redirect to the correct login page accordingly.

The changes add the authRequestID within the href of the Login button as well.

https://github.com/zitadel/zitadel/assets/68676914/cec4e09f-634a-48cc-bf41-019d531c7245

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
