### PR TITLE
chore(workflow): run e2e on non standard runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         browser: [firefox, chrome]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: zitadel-public
     steps:
       - 
         name: Checkout Repository


### PR DESCRIPTION
Since moving the e2e tests to the GH runners, they randomly fail, which seems to relate the performance of the runners.
So as of now, the easiest solution is to just move them back to non standard runners.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
