### PR TITLE
fix(oidc): correctly return new refresh token on refresh token grant

### DIFF
--- a/internal/api/oidc/token_exchange_integration_test.go
+++ b/internal/api/oidc/token_exchange_integration_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
 	oidc_api "github.com/zitadel/zitadel/internal/api/oidc"
 	"github.com/zitadel/zitadel/internal/integration"
 	"github.com/zitadel/zitadel/pkg/grpc/admin"
 	feature "github.com/zitadel/zitadel/pkg/grpc/feature/v2beta"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 func setTokenExchangeFeature(t *testing.T, value bool) {
@@ -107,6 +108,7 @@ func refreshTokenVerifier(ctx context.Context, provider rp.RelyingParty, subject
 			require.NotNil(t, tokens.IDTokenClaims.Actor)
 			assert.Equal(t, actorSubject, tokens.IDTokenClaims.Actor.Subject)
 		}
+		assert.NotEmpty(t, tokens.RefreshToken)
 	}
 }
 

--- a/internal/api/oidc/token_exchange_integration_test.go
+++ b/internal/api/oidc/token_exchange_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/client/tokenexchange"
 	"github.com/zitadel/oidc/v3/pkg/crypto"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"

--- a/internal/command/user_human_refresh_token.go
+++ b/internal/command/user_human_refresh_token.go
@@ -99,7 +99,7 @@ func (c *Commands) RenewRefreshTokenAndAccessToken(
 	if err != nil {
 		return nil, "", err
 	}
-	return accessToken, newRefreshToken, nil
+	return accessToken, renewed.token, nil
 }
 
 func (c *Commands) RevokeRefreshToken(ctx context.Context, userID, orgID, tokenID string) (*domain.ObjectDetails, error) {


### PR DESCRIPTION
A customer noticed that on token refresh, no new refresh token was returned. This PR corrects this behaviour (accidentally changed in 2.49.0)  and returns the refresh_token again.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
