### PR TITLE
fix(crypto): check for nil client secret

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -121,6 +121,9 @@ func Hash(value []byte, alg HashAlgorithm) (*CryptoValue, error) {
 }
 
 func CompareHash(value *CryptoValue, comparer []byte, alg HashAlgorithm) error {
+	if value == nil {
+		return zerrors.ThrowPreconditionFailed(nil, "CRYPT-Zei4o", "Errors.Project.App.ClientSecretNotSet")
+	}
 	if value.Algorithm != alg.Algorithm() {
 		return zerrors.ThrowInvalidArgument(nil, "CRYPT-HF32f", "value was hashed with a different algorithm")
 	}

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -259,7 +259,12 @@ func TestCompareHash(t *testing.T) {
 		},
 		{
 			"wrong",
-			args{&CryptoValue{CryptoType: TypeHash, Algorithm: "hash", Crypted: []byte("test")}, []byte("test2"), &mockHashCrypto{}},
+			args{&CryptoValue{CryptoType: TypeHash, Algorithm: "hash", Crypted: []byte("test")}, []byte("test"), &mockHashCrypto{}},
+			false,
+		},
+		{
+			"nil",
+			args{nil, []byte("test2"), &mockHashCrypto{}},
 			true,
 		},
 	}

--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -316,6 +316,7 @@ Errors:
       APIAuthMethodNoSecret: Избраният API Auth Method не изисква тайна
       AuthMethodNoPrivateKeyJWT: Избраният метод за удостоверяване не изисква ключ
       ClientSecretInvalid: Тайната на клиента е невалидна
+      ClientSecretNotSet: Тайната на клиента не е зададена
       Key:
         AlreadyExisting: Вече съществува ключ за приложение
         NotFound: Ключът на приложението не е намерен

--- a/internal/static/i18n/cs.yaml
+++ b/internal/static/i18n/cs.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: Vybraná API Auth metoda nevyžaduje tajný klíč
       AuthMethodNoPrivateKeyJWT: Vybraná metoda ověření nevyžaduje klíč
       ClientSecretInvalid: Tajný klíč klienta je neplatný
+      ClientSecretNotSet: Tajný klíč klienta není nastaven
       Key:
         AlreadyExisting: Klíč aplikace již existuje
         NotFound: Klíč aplikace nebyl nalezen

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: Gewählte API Auth Method benötigt kein Secret
       AuthMethodNoPrivateKeyJWT: Gewählte Auth Method benötigt keinen Key
       ClientSecretInvalid: Client Secret ist ungültig
+      ClientSecretNotSet: Das Client-Geheimnis ist nicht festgelegt
       Key:
         AlreadyExisting: Applikationsschlüssel existiert bereits
         NotFound: Applikationsschlüssel nicht gefunden

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: Chosen API Auth Method does not require a secret
       AuthMethodNoPrivateKeyJWT: Chosen Auth Method does not require a key
       ClientSecretInvalid: Client Secret is invalid
+      ClientSecretNotSet: Client Secret is not set
       Key:
         AlreadyExisting: Application key already existing
         NotFound: Application key not found

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: El método de autenticación de API elegido no requiere un secreto
       AuthMethodNoPrivateKeyJWT: El método de autenticación elegido no requiere una clave
       ClientSecretInvalid: El secreto del cliente no es válido
+      ClientSecretNotSet: El secreto del cliente no está establecido
       Key:
         AlreadyExisting: La clave de la aplicación ya existe
         NotFound: Clave de la aplicación no encontrada

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: La méthode d'authentification API choisie ne nécessite pas de secret.
       AuthMethodNoPrivateKeyJWT: La méthode d'authentification choisie ne nécessite pas de clé.
       ClientSecretInvalid: Le secret du client n'est pas valide
+      ClientSecretNotSet: Le secret client n'est pas défini
       Key:
         AlreadyExisting: Clé d'application déjà existante
         NotFound: Clé d'application non trouvée

--- a/internal/static/i18n/it.yaml
+++ b/internal/static/i18n/it.yaml
@@ -315,6 +315,7 @@ Errors:
       APIAuthMethodNoSecret: Il metodo di autorizzazione API scelto non richiede un segreto
       AuthMethodNoPrivateKeyJWT: Il metodo di autorizzazione scelto non richiede una chiave
       ClientSecretInvalid: Il segreto del cliente non è valido
+      ClientSecretNotSet: Le secret client n'est pas défini
       Key:
         AlreadyExisting: Chiave di applicazione già esistente
         NotFound: Chiave di applicazione non trovata

--- a/internal/static/i18n/ja.yaml
+++ b/internal/static/i18n/ja.yaml
@@ -303,6 +303,7 @@ Errors:
       APIAuthMethodNoSecret: 選択されたAPIメソッドには、シークレットを必要としません
       AuthMethodNoPrivateKeyJWT: 選択されたメソッドには、キーを必要としません
       ClientSecretInvalid: 無効なクライアントシークレットです
+      ClientSecretNotSet: クライアントシークレットが設定されていません
       Key:
         AlreadyExisting: すでに存在しているアプリケーションキーです
         NotFound: アプリケーションキーが見つかりません

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -313,6 +313,7 @@ Errors:
       APIAuthMethodNoSecret: Избраниот API метод за автентикација не бара таен клуч
       AuthMethodNoPrivateKeyJWT: Избраниот метод за автентикација не бара приватен клуч
       ClientSecretInvalid: Клиентскиот таен клуч е невалиден
+      ClientSecretNotSet: Тајната на клиентот не е поставена
       Key:
         AlreadyExisting: Клучот за апликацијата веќе постои
         NotFound: Клучот за апликацијата не е пронајден

--- a/internal/static/i18n/nl.yaml
+++ b/internal/static/i18n/nl.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: Gekozen API Auth Methode vereist geen geheim
       AuthMethodNoPrivateKeyJWT: Gekozen Auth Methode vereist geen sleutel
       ClientSecretInvalid: Client Geheim is ongeldig
+      ClientSecretNotSet: Client geheim is niet ingesteld
       Key:
         AlreadyExisting: Applicatie sleutel bestaat al
         NotFound: Applicatie sleutel niet gevonden

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: Wybrany metoda uwierzytelniania API nie wymaga tajnego
       AuthMethodNoPrivateKeyJWT: Wybrana metoda uwierzytelniania nie wymaga klucza
       ClientSecretInvalid: Tajne klienta jest nieprawidłowe
+      ClientSecretNotSet: Klucz tajny klienta nie jest ustawiony
       Key:
         AlreadyExisting: Klucz aplikacji już istnieje
         NotFound: Klucz aplikacji nie znaleziony

--- a/internal/static/i18n/pt.yaml
+++ b/internal/static/i18n/pt.yaml
@@ -312,6 +312,7 @@ Errors:
       APIAuthMethodNoSecret: O método de autenticação da API escolhido não requer um segredo
       AuthMethodNoPrivateKeyJWT: O método de autenticação escolhido não requer uma chave
       ClientSecretInvalid: O segredo do cliente é inválido
+      ClientSecretNotSet: O segredo do cliente não está definido
       Key:
         AlreadyExisting: Chave do aplicativo já existente
         NotFound: Chave do aplicativo não encontrada

--- a/internal/static/i18n/ru.yaml
+++ b/internal/static/i18n/ru.yaml
@@ -308,6 +308,7 @@ Errors:
       APIAuthMethodNoSecret: Выбранный метод аутентификации API не требует ключа
       AuthMethodNoPrivateKeyJWT: Выбранный метод аутентификации не требует ключа
       ClientSecretInvalid: Клиентский ключ недействителен
+      ClientSecretNotSet: Секрет клиента не установлен
       Key:
         AlreadyExisting: Ключ приложения уже существует
         NotFound: Ключ приложения не найден

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -314,6 +314,7 @@ Errors:
       APIAuthMethodNoSecret: 选择的 API 身份验证方法不需要秘钥
       AuthMethodNoPrivateKeyJWT: 选择的身份验证方法不需要 Key
       ClientSecretInvalid: Client Secret 无效
+      ClientSecretNotSet: 未设置客户端密码
       Key:
         AlreadyExisting: 已经存在的应用钥匙
         NotFound: 未找到应用钥匙


### PR DESCRIPTION
When creating an app without secret or other type of authentication method,
like JWT, and the authentication type is switched afterwards the app would remain without generated secret.
If then client authentication with secret is attempted, for example on the token endpoint, the handler would panic in the crypto.CompareHash function on the nile pointer to the CryptoValue.

This fix introduces a nil pointer check in crypt.CompareHash and returns a error.

The issue was reported over discord: https://discord.com/channels/927474939156643850/1222971118730875020
Possible fix was suggested here: https://github.com/zitadel/zitadel/pull/6999#discussion_r1553503088
This bug only applies to zitadel versions <=2.49.1.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
