### PR TITLE
fix(oidc): return bad request for base64 errors

### DIFF
--- a/internal/api/authz/session_token.go
+++ b/internal/api/authz/session_token.go
@@ -19,7 +19,7 @@ func SessionTokenVerifier(algorithm crypto.EncryptionAlgorithm) func(ctx context
 	return func(ctx context.Context, sessionToken, sessionID, tokenID string) (err error) {
 		decodedToken, err := base64.RawURLEncoding.DecodeString(sessionToken)
 		if err != nil {
-			return err
+			return zerrors.ThrowInvalidArgument(err, "COMMAND-hi6Ph", "Errors.Session.Token.Invalid")
 		}
 		_, spanPasswordComparison := tracing.NewNamedSpan(ctx, "crypto.CompareHash")
 		token, err := algorithm.DecryptString(decodedToken, algorithm.EncryptionKeyID())

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -157,7 +157,7 @@ func (o *OPStorage) AuthRequestByCode(ctx context.Context, code string) (_ op.Au
 
 	plainCode, err := o.decryptGrant(code)
 	if err != nil {
-		return nil, err
+		return nil, zerrors.ThrowInvalidArgument(err, "OIDC-ahLi2", "Errors.User.Code.Invalid")
 	}
 	if strings.HasPrefix(plainCode, command.IDPrefixV2) {
 		authReq, err := o.command.ExchangeAuthCode(ctx, plainCode)
@@ -311,7 +311,7 @@ func (o *OPStorage) TokenRequestByRefreshToken(ctx context.Context, refreshToken
 
 	plainToken, err := o.decryptGrant(refreshToken)
 	if err != nil {
-		return nil, err
+		return nil, op.ErrInvalidRefreshToken
 	}
 	if strings.HasPrefix(plainToken, command.IDPrefixV2) {
 		oidcSession, err := o.command.OIDCSessionByRefreshToken(ctx, plainToken)

--- a/internal/api/oidc/error.go
+++ b/internal/api/oidc/error.go
@@ -19,7 +19,9 @@ func oidcError(err error) error {
 	if err == nil {
 		return nil
 	}
-
+	if errors.Is(err, op.ErrInvalidRefreshToken) {
+		err = zerrors.ThrowInvalidArgument(err, "OIDCS-ef2Gi", "Errors.User.RefreshToken.Invalid")
+	}
 	var (
 		sError op.StatusError
 		oError *oidc.Error

--- a/internal/command/oidc_session.go
+++ b/internal/command/oidc_session.go
@@ -207,7 +207,7 @@ func (c *Commands) getResourceOwnerOfSessionUser(ctx context.Context, userID, in
 func (c *Commands) decryptRefreshToken(refreshToken string) (refreshTokenID string, err error) {
 	decoded, err := base64.RawURLEncoding.DecodeString(refreshToken)
 	if err != nil {
-		return "", err
+		return "", zerrors.ThrowInvalidArgument(err, "OIDCS-Cux9a", "Errors.User.RefreshToken.Invalid")
 	}
 	decrypted, err := c.keyAlgorithm.DecryptString(decoded, c.keyAlgorithm.EncryptionKeyID())
 	if err != nil {

--- a/internal/domain/refresh_token.go
+++ b/internal/domain/refresh_token.go
@@ -23,7 +23,7 @@ func RefreshToken(userID, tokenID, token string, algorithm crypto.EncryptionAlgo
 func FromRefreshToken(refreshToken string, algorithm crypto.EncryptionAlgorithm) (userID, tokenID, token string, err error) {
 	decoded, err := base64.RawURLEncoding.DecodeString(refreshToken)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", zerrors.ThrowInvalidArgument(err, "DOMAIN-BGDhn", "Errors.User.RefreshToken.Invalid")
 	}
 	decrypted, err := algorithm.Decrypt(decoded, algorithm.EncryptionKeyID())
 	if err != nil {


### PR DESCRIPTION
We've recently noticed an increased amount of 500: internal server error status returns on zitadel cloud.
The source of these errors appear to be erroneous input in fields that are supposed to be bas64 formatted.

## Reproduce

```bash
curl --request POST \
  --url http://localhost:9000/oauth/v2/token \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data 'grant_type=refresh_token' \
  --data 'refresh_token&refresh_token=xxxxxxxxx' \
  --data 'client_id=257790446061813762@tests' | jq
```

Reponse:

```json
{
  "error": "server_error",
  "error_description": "Errors.Internal"
}
```

Printed zitadel logs:

```
time=2024-04-08T20:09:41.168Z level=ERROR msg="request error" oidc_error.parent="ID=OIDC-AhX2u Message=Errors.Internal Parent=(illegal base64 data at input byte 8)" oidc_error.description=Errors.Internal oidc_error.type=server_error status_code=500
```

Within the possible code paths of the token endpoint there are a couple of uses of base64.Encoding.DecodeString of which a returned error was not properly wrapped, but returned as-is.
This causes the oidc error handler to return a 500 with the `OIDC-AhX2u` ID.
We were not able to pinpoint the exact errors that are happening to any one call of `DecodeString`.

This fix wraps all errors from `DecodeString` so that proper 400: bad request is returned with information about the error. Each wrapper now has an unique error ID, so that logs will contain the source of the error as well.

## After fix

Response:

```json
{
  "error": "invalid_request",
  "error_description": "Errors.User.RefreshToken.Invalid"
}
```

Logs:

```
time=2024-04-08T20:22:25.930Z level=WARN msg="request error" oidc_error.parent="ID=OIDCS-ef2Gi Message=Errors.User.RefreshToken.Invalid Parent=(invalid_refresh_token)" oidc_error.description=Errors.User.RefreshToken.Invalid oidc_error.type=invalid_request status_code=400
```

This bug was reported internally by the ops team.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
