### PR TITLE
chore(oidc): add additional spans to userinfo code paths

### DIFF
--- a/internal/api/oidc/access_token.go
+++ b/internal/api/oidc/access_token.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/query"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/user/model"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -35,7 +36,10 @@ type accessToken struct {
 
 var ErrInvalidTokenFormat = errors.New("invalid token format")
 
-func (s *Server) verifyAccessToken(ctx context.Context, tkn string) (*accessToken, error) {
+func (s *Server) verifyAccessToken(ctx context.Context, tkn string) (_ *accessToken, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	var tokenID, subject string
 
 	if tokenIDSubject, err := s.Provider().Crypto().Decrypt(tkn); err == nil {

--- a/internal/auth/repository/eventsourcing/eventstore/token.go
+++ b/internal/auth/repository/eventsourcing/eventstore/token.go
@@ -21,7 +21,10 @@ type TokenRepo struct {
 	View       *view.View
 }
 
-func (repo *TokenRepo) TokenByIDs(ctx context.Context, userID, tokenID string) (*usr_model.TokenView, error) {
+func (repo *TokenRepo) TokenByIDs(ctx context.Context, userID, tokenID string) (_ *usr_model.TokenView, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	instanceID := authz.GetInstance(ctx).InstanceID()
 
 	// always load the latest sequence first, so in case the token was not found by id,
@@ -68,7 +71,10 @@ func (repo *TokenRepo) TokenByIDs(ctx context.Context, userID, tokenID string) (
 	return model.TokenViewToModel(token), nil
 }
 
-func (r *TokenRepo) getUserEvents(ctx context.Context, userID, instanceID string, changeDate time.Time, eventTypes []eventstore.EventType) ([]eventstore.Event, error) {
+func (r *TokenRepo) getUserEvents(ctx context.Context, userID, instanceID string, changeDate time.Time, eventTypes []eventstore.EventType) (_ []eventstore.Event, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	query, err := usr_view.UserByIDQuery(userID, instanceID, changeDate, eventTypes)
 	if err != nil {
 		return nil, err

--- a/internal/auth/repository/eventsourcing/view/token.go
+++ b/internal/auth/repository/eventsourcing/view/token.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/query"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	usr_view "github.com/zitadel/zitadel/internal/user/repository/view"
 	"github.com/zitadel/zitadel/internal/user/repository/view/model"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -87,6 +88,9 @@ func (v *View) DeleteOrgTokens(event eventstore.Event) error {
 }
 
 func (v *View) GetLatestTokenSequence(ctx context.Context, instanceID string) (_ *query.CurrentState, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	q := &query.CurrentStateSearchQueries{
 		Queries: make([]query.SearchQuery, 2),
 	}


### PR DESCRIPTION
During loadtesting we found some gaps in the userinfo metrics obtained from tracing. This PR adds some extra spans to fill the gaps.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
