### PR TITLE
fix(setup): decode role mappings

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -906,7 +906,7 @@ AuditLogRetention: 0s # ZITADEL_AUDITLOGRETENTION
 
 InternalAuthZ:
   # Configure the RolePermissionMappings by environment variable using JSON notation:
-  # ZITADEL_INTERNALAUTHZ_ROLEPERMISSIONMAPPINGS='[{"role": "IAM_OWNER", "permissions": ["iam.read", "iam.write"]}]'
+  # ZITADEL_INTERNALAUTHZ_ROLEPERMISSIONMAPPINGS='[{"role": "IAM_OWNER", "permissions": ["iam.write"]}, {"role": "ORG_OWNER", "permissions": ["org.write"]}]'
   # Beware that if you configure the RolePermissionMappings by environment variable, all the default RolePermissionMappings are lost.
   RolePermissionMappings:
     - Role: "SYSTEM_OWNER"

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -69,6 +69,7 @@ func MustNewConfig(v *viper.Viper) *Config {
 			hook.EnumHookFunc(authz.MemberTypeString),
 			actions.HTTPConfigDecodeHook,
 			hooks.MapTypeStringDecode[string, *authz.SystemAPIUser],
+			hooks.SliceTypeStringDecode[authz.RoleMapping],
 		)),
 	)
 	logging.OnError(err).Fatal("unable to read default config")

--- a/cmd/start/config_test.go
+++ b/cmd/start/config_test.go
@@ -223,6 +223,52 @@ Actions:
 				Greeting:        "bar",
 			}})
 		},
+	}, {
+		name: "roles ok",
+		args: args{yaml: `
+InternalAuthZ:
+  RolePermissionMappings:
+  - Role: IAM_OWNER
+    Permissions:
+    - iam.write
+  - Role: ORG_OWNER
+    Permissions:
+    - org.write
+    - org.read
+Log:
+  Level: info
+Actions:
+  HTTP:
+    DenyList: []
+`},
+		want: func(t *testing.T, config *Config) {
+			assert.Equal(t, config.InternalAuthZ, authz.Config{
+				RolePermissionMappings: []authz.RoleMapping{
+					{Role: "IAM_OWNER", Permissions: []string{"iam.write"}},
+					{Role: "ORG_OWNER", Permissions: []string{"org.write", "org.read"}},
+				},
+			})
+		},
+	}, {
+		name: "roles string ok",
+		args: args{yaml: `
+InternalAuthZ:
+  RolePermissionMappings: >
+    [{"role": "IAM_OWNER", "permissions": ["iam.write"]}, {"role": "ORG_OWNER", "permissions": ["org.write", "org.read"]}]
+Log:
+  Level: info
+Actions:
+  HTTP:
+    DenyList: []
+`},
+		want: func(t *testing.T, config *Config) {
+			assert.Equal(t, config.InternalAuthZ, authz.Config{
+				RolePermissionMappings: []authz.RoleMapping{
+					{Role: "IAM_OWNER", Permissions: []string{"iam.write"}},
+					{Role: "ORG_OWNER", Permissions: []string{"org.write", "org.read"}},
+				},
+			})
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The setup job fails if role <--> permission mappings are provided by an env var in JSON format, as described in the defaults.yaml.

This PR makes sure, role mappings provided as JSON string in the YAML or by env var is decoded into the target type authz.RoleMapping. Also, it updates the example value, to the minimal configuration necessary for the setup job to succeed.

Unit test that ensure correct decoding are added in the start package and by intention not duplicated to the setup package.

The bug [was reported on Discord](https://discord.com/channels/927474939156643850/1209156907487469598).

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
