### PR TITLE
fix(query): query event editors only once per call

### DIFF
--- a/internal/query/event.go
+++ b/internal/query/event.go
@@ -28,13 +28,14 @@ type EventEditor struct {
 }
 
 type eventsReducer struct {
-	ctx    context.Context
-	q      *Queries
-	events []*Event
+	ctx     context.Context
+	q       *Queries
+	events  []*Event
+	editors map[string]*EventEditor
 }
 
 func (r *eventsReducer) AppendEvents(events ...eventstore.Event) {
-	r.events = append(r.events, r.q.convertEvents(r.ctx, events)...)
+	r.events = append(r.events, r.convertEvents(r.ctx, events)...)
 }
 
 func (r *eventsReducer) Reduce() error { return nil }
@@ -49,7 +50,7 @@ func (q *Queries) SearchEvents(ctx context.Context, query *eventstore.SearchQuer
 	if auditLogRetention != 0 {
 		query = filterAuditLogRetention(ctx, auditLogRetention, query)
 	}
-	reducer := &eventsReducer{ctx: ctx, q: q}
+	reducer := &eventsReducer{ctx: ctx, q: q, editors: make(map[string]*EventEditor, query.GetLimit())}
 	if err = q.eventstore.FilterToReducer(ctx, query, reducer); err != nil {
 		return nil, err
 	}
@@ -78,24 +79,23 @@ func (q *Queries) SearchAggregateTypes(ctx context.Context) []string {
 	return q.eventstore.AggregateTypes()
 }
 
-func (q *Queries) convertEvents(ctx context.Context, events []eventstore.Event) []*Event {
+func (er *eventsReducer) convertEvents(ctx context.Context, events []eventstore.Event) []*Event {
 	result := make([]*Event, len(events))
-	users := make(map[string]*EventEditor)
 	for i, event := range events {
-		result[i] = q.convertEvent(ctx, event, users)
+		result[i] = er.convertEvent(ctx, event)
 	}
 	return result
 }
 
-func (q *Queries) convertEvent(ctx context.Context, event eventstore.Event, users map[string]*EventEditor) *Event {
+func (er *eventsReducer) convertEvent(ctx context.Context, event eventstore.Event) *Event {
 	ctx, span := tracing.NewSpan(ctx)
 	var err error
 	defer func() { span.EndWithError(err) }()
 
-	editor, ok := users[event.Creator()]
+	editor, ok := er.editors[event.Creator()]
 	if !ok {
-		editor = q.editorUserByID(ctx, event.Creator())
-		users[event.Creator()] = editor
+		editor = er.q.editorUserByID(ctx, event.Creator())
+		er.editors[event.Creator()] = editor
 	}
 
 	return &Event{


### PR DESCRIPTION
This fix improves performance if many events are queried because it does a single database call for each editor instead of a call per event

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
