### PR TITLE
fix(oidc): make device auth audience and scope nullable

### DIFF
--- a/internal/query/device_auth_test.go
+++ b/internal/query/device_auth_test.go
@@ -169,15 +169,15 @@ func TestQueries_DeviceAuthByDeviceCode(t *testing.T) {
 
 const (
 	expectedDeviceAuthQueryC = `SELECT` +
-		` projections.device_auth_requests1.client_id,` +
-		` projections.device_auth_requests1.device_code,` +
-		` projections.device_auth_requests1.user_code,` +
-		` projections.device_auth_requests1.scopes,` +
-		` projections.device_auth_requests1.audience` +
-		` FROM projections.device_auth_requests1`
+		` projections.device_auth_requests2.client_id,` +
+		` projections.device_auth_requests2.device_code,` +
+		` projections.device_auth_requests2.user_code,` +
+		` projections.device_auth_requests2.scopes,` +
+		` projections.device_auth_requests2.audience` +
+		` FROM projections.device_auth_requests2`
 	expectedDeviceAuthWhereUserCodeQueryC = expectedDeviceAuthQueryC +
-		` WHERE projections.device_auth_requests1.instance_id = $1` +
-		` AND projections.device_auth_requests1.user_code = $2`
+		` WHERE projections.device_auth_requests2.instance_id = $1` +
+		` AND projections.device_auth_requests2.user_code = $2`
 )
 
 var (

--- a/internal/query/projection/device_auth.go
+++ b/internal/query/projection/device_auth.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	DeviceAuthRequestProjectionTable = "projections.device_auth_requests1"
+	DeviceAuthRequestProjectionTable = "projections.device_auth_requests2"
 
 	DeviceAuthRequestColumnClientID     = "client_id"
 	DeviceAuthRequestColumnDeviceCode   = "device_code"
@@ -44,8 +44,8 @@ func (*deviceAuthRequestProjection) Init() *old_handler.Check {
 			handler.NewColumn(DeviceAuthRequestColumnClientID, handler.ColumnTypeText),
 			handler.NewColumn(DeviceAuthRequestColumnDeviceCode, handler.ColumnTypeText),
 			handler.NewColumn(DeviceAuthRequestColumnUserCode, handler.ColumnTypeText),
-			handler.NewColumn(DeviceAuthRequestColumnScopes, handler.ColumnTypeTextArray),
-			handler.NewColumn(DeviceAuthRequestColumnAudience, handler.ColumnTypeTextArray),
+			handler.NewColumn(DeviceAuthRequestColumnScopes, handler.ColumnTypeTextArray, handler.Nullable()),
+			handler.NewColumn(DeviceAuthRequestColumnAudience, handler.ColumnTypeTextArray, handler.Nullable()),
 			handler.NewColumn(DeviceAuthRequestColumnCreationDate, handler.ColumnTypeTimestamp),
 			handler.NewColumn(DeviceAuthRequestColumnChangeDate, handler.ColumnTypeTimestamp),
 			handler.NewColumn(DeviceAuthRequestColumnSequence, handler.ColumnTypeInt64),


### PR DESCRIPTION
This fixes the projection of events that have a null audience or scope.
As audience was added in v2.50, legacy events do not have an audience, this made replay of the old events not possible after an upgrade.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
