### PR TITLE
fix(middleware): init translation messages

### DIFF
--- a/internal/api/grpc/server/middleware/translation_interceptor.go
+++ b/internal/api/grpc/server/middleware/translation_interceptor.go
@@ -41,5 +41,5 @@ func getTranslator(ctx context.Context) (*i18n.Translator, error) {
 	if err != nil {
 		logging.New().WithError(err).Error("could not load translator")
 	}
-	return translator, nil
+	return translator, err
 }

--- a/internal/api/grpc/server/middleware/translation_interceptor.go
+++ b/internal/api/grpc/server/middleware/translation_interceptor.go
@@ -41,5 +41,5 @@ func getTranslator(ctx context.Context) (*i18n.Translator, error) {
 	if err != nil {
 		logging.New().WithError(err).Error("could not load translator")
 	}
-	return translator, err
+	return translator, nil
 }

--- a/internal/i18n/bundle.go
+++ b/internal/i18n/bundle.go
@@ -3,58 +3,67 @@ package i18n
 import (
 	"encoding/json"
 	"io"
-	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/zitadel/logging"
 	"golang.org/x/text/language"
 	"sigs.k8s.io/yaml"
 
 	"github.com/zitadel/zitadel/internal/domain"
-	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 const i18nPath = "/i18n"
 
-func newBundle(dir http.FileSystem, defaultLanguage language.Tag, allowedLanguages []language.Tag) (*i18n.Bundle, error) {
-	bundle := i18n.NewBundle(defaultLanguage)
-	bundle.RegisterUnmarshalFunc("yaml", func(data []byte, v interface{}) error { return yaml.Unmarshal(data, v) })
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
-	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
-	i18nDir, err := dir.Open(i18nPath)
-	if err != nil {
-		return nil, zerrors.ThrowNotFound(err, "I18N-MnXRie", "path not found")
-	}
-	defer i18nDir.Close()
-	files, err := i18nDir.Readdir(0)
-	if err != nil {
-		return nil, zerrors.ThrowNotFound(err, "I18N-Gew23", "cannot read dir")
-	}
-	for _, file := range files {
-		fileLang, _ := strings.CutSuffix(file.Name(), filepath.Ext(file.Name()))
-		if err = domain.LanguageIsAllowed(false, allowedLanguages, language.Make(fileLang)); err != nil {
-			continue
-		}
-		if err := addFileFromFileSystemToBundle(dir, bundle, file); err != nil {
-			return nil, zerrors.ThrowNotFoundf(err, "I18N-ZS2AW", "cannot append file %s to Bundle", file.Name())
-		}
-	}
-	return bundle, nil
+var translationMessages = map[Namespace]map[language.Tag]*i18n.MessageFile{
+	ZITADEL:      make(map[language.Tag]*i18n.MessageFile),
+	LOGIN:        make(map[language.Tag]*i18n.MessageFile),
+	NOTIFICATION: make(map[language.Tag]*i18n.MessageFile),
 }
 
-func addFileFromFileSystemToBundle(dir http.FileSystem, bundle *i18n.Bundle, file os.FileInfo) error {
-	f, err := dir.Open("/i18n/" + file.Name())
-	if err != nil {
-		return err
+func init() {
+	unmarshaler := map[string]i18n.UnmarshalFunc{
+		"yaml": func(data []byte, v interface{}) error { return yaml.Unmarshal(data, v) },
+		"json": json.Unmarshal,
+		"toml": toml.Unmarshal,
 	}
-	defer f.Close()
-	content, err := io.ReadAll(f)
-	if err != nil {
-		return err
+	for ns := range translationMessages {
+		dir := LoadFilesystem(ns)
+		i18nDir, err := dir.Open(i18nPath)
+		logging.WithFields("namespace", ns).OnError(err).Panic("unable to open translation files")
+		defer i18nDir.Close()
+		files, err := i18nDir.Readdir(0)
+		logging.WithFields("namespace", ns).OnError(err).Panic("unable to read translation files")
+		for _, file := range files {
+			f, err := dir.Open("/i18n/" + file.Name())
+			logging.WithFields("namespace", ns, "file", file.Name()).OnError(err).Panic("unable to open translation file")
+			defer f.Close()
+
+			content, err := io.ReadAll(f)
+			logging.WithFields("namespace", ns, "file", file.Name()).OnError(err).Panic("unable to read translation file")
+
+			messageFile, err := i18n.ParseMessageFileBytes(content, file.Name(), unmarshaler)
+			logging.WithFields("namespace", ns, "file", file.Name()).OnError(err).Panic("unable to parse translation file")
+
+			fileLang, _ := strings.CutSuffix(file.Name(), filepath.Ext(file.Name()))
+			lang := language.Make(fileLang)
+
+			translationMessages[ns][lang] = messageFile
+		}
 	}
-	_, err = bundle.ParseMessageFileBytes(content, file.Name())
-	return err
+}
+
+func newBundle(ns Namespace, defaultLanguage language.Tag, allowedLanguages []language.Tag) (*i18n.Bundle, error) {
+	bundle := i18n.NewBundle(defaultLanguage)
+
+	for lang, file := range translationMessages[ns] {
+		if err := domain.LanguageIsAllowed(false, allowedLanguages, lang); err != nil {
+			continue
+		}
+		bundle.MustAddMessages(lang, file.Messages...)
+	}
+
+	return bundle, nil
 }

--- a/internal/i18n/fs.go
+++ b/internal/i18n/fs.go
@@ -5,6 +5,11 @@ import (
 
 	"github.com/rakyll/statik/fs"
 	"github.com/zitadel/logging"
+
+	// ensure fs is setup
+	_ "github.com/zitadel/zitadel/internal/api/ui/login/statik"
+	_ "github.com/zitadel/zitadel/internal/notification/statik"
+	_ "github.com/zitadel/zitadel/internal/statik"
 )
 
 var zitadelFS, loginFS, notificationFS http.FileSystem

--- a/internal/i18n/translator.go
+++ b/internal/i18n/translator.go
@@ -51,7 +51,7 @@ func newTranslator(ns Namespace, defaultLanguage language.Tag, allowedLanguages 
 	if len(t.allowedLanguages) == 0 {
 		t.allowedLanguages = SupportedLanguages()
 	}
-	t.bundle, err = newBundle(LoadFilesystem(ns), defaultLanguage, t.allowedLanguages)
+	t.bundle, err = newBundle(ns, defaultLanguage, t.allowedLanguages)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instead of loading the translation files for each request the files are cached on startup.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
