### PR TITLE
fix(crdb): obtain latest sequences when the tx is retried

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -296,7 +296,7 @@ func (c *Commands) asyncPush(ctx context.Context, cmds ...eventstore.Command) {
 		_, err := c.eventstore.Push(localCtx, cmds...)
 		if err != nil {
 			for _, cmd := range cmds {
-				logging.WithError(err).Errorf("could not push event %q", cmd.Type())
+				logging.WithError(err).Warnf("could not push event %q", cmd.Type())
 			}
 		}
 

--- a/internal/eventstore/eventstore_pusher_test.go
+++ b/internal/eventstore/eventstore_pusher_test.go
@@ -390,10 +390,10 @@ func TestCRDB_Push_Parallel(t *testing.T) {
 				},
 			},
 			res: res{
-				minErrCount: 1,
+				minErrCount: 0,
 				eventsRes: eventsRes{
 					aggIDs:            []string{"204"},
-					pushedEventsCount: 6,
+					pushedEventsCount: 8,
 					aggTypes:          database.TextArray[eventstore.AggregateType]{eventstore.AggregateType(t.Name())},
 				},
 			},

--- a/internal/eventstore/v3/push.go
+++ b/internal/eventstore/v3/push.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -29,13 +28,10 @@ func (es *Eventstore) Push(ctx context.Context, commands ...eventstore.Command) 
 	// tx is not closed because [crdb.ExecuteInTx] takes care of that
 	var (
 		sequences []*latestSequence
-		once      sync.Once
 	)
 
 	err = crdb.ExecuteInTx(ctx, &transaction{tx}, func() error {
-		once.Do(func() {
-			sequences, err = latestSequences(ctx, tx, commands)
-		})
+		sequences, err = latestSequences(ctx, tx, commands)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
During concurrent push of the same event type, cockroachDB could fail and retry the transaction. We only obtained the latest sequences once, so the transaction would keep failing.

An example event that would cause the original bug was the "Secret check succeeded" pushed async after every introspection call. On many concurrent requests the zitadel logs would print:

```
time="2024-04-18T09:17:33Z" level=error msg="could not push event \"project.application.api.secret.check.succeeded\"" caller="/home/tim/Repositories/zitadel/zitadel/internal/command/command.go:299" error="retrying txn failed after 50 attempts. original error: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: WriteTooOldError: write for key /Table/110/1/\"263288598801940483\"/\"project\"/\"263290668288311299\"/15971/0 at timestamp 1713431853.075040897,0 too old; must write at or above 1713431853.075808133,1: \"sql txn\" meta={id=b569d913 key=/Table/110/1/\"263288598801940483\"/\"project\"/\"263290668288311299\"/15970/0 iso=Serializable pri=0.03735800 epo=0 ts=1713431853.075808133,1 min=1713431853.075040897,0 seq=5} lock=true stat=PENDING rts=1713431853.075040897,0 wto=false gul=1713431853.575040897,0 (SQLSTATE 40001)."
```

This PR fixes it be reobtaining the latest sequences on every transaction retry.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
