### PR TITLE
test(e2e): check for exactly one displayed event

### DIFF
--- a/e2e/cypress/e2e/events/events.cy.ts
+++ b/e2e/cypress/e2e/events/events.cy.ts
@@ -15,6 +15,6 @@ describe('events', () => {
     cy.contains('mat-select', 'Descending').click();
     cy.contains('mat-option', 'Descending').click();
     cy.get('[data-e2e="filter-finish-button"]').click();
-    cy.contains('[data-e2e="event-type-cell"]', eventTypeEnglish).should('have.length', 1);
+    cy.get('[data-e2e="event-type-cell"]').should('have.length', 1);
   });
 });


### PR DESCRIPTION
Ensures, that after applying the filter, only the filtered event is displayed.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
