### PR TITLE
fix(login): correctly reload policies on auth request

### DIFF
--- a/internal/auth_request/repository/cache/cache.go
+++ b/internal/auth_request/repository/cache/cache.go
@@ -24,16 +24,20 @@ type AuthRequestCache struct {
 }
 
 func Start(dbClient *database.DB, amountOfCachedAuthRequests uint16) *AuthRequestCache {
+	cache := &AuthRequestCache{
+		client: dbClient,
+	}
 	idCache, err := lru.New[string, *domain.AuthRequest](int(amountOfCachedAuthRequests))
 	logging.OnError(err).Info("auth request cache disabled")
+	if err == nil {
+		cache.idCache = idCache
+	}
 	codeCache, err := lru.New[string, *domain.AuthRequest](int(amountOfCachedAuthRequests))
 	logging.OnError(err).Info("auth request cache disabled")
-
-	return &AuthRequestCache{
-		client:    dbClient,
-		idCache:   idCache,
-		codeCache: codeCache,
+	if err == nil {
+		cache.codeCache = codeCache
 	}
+	return cache
 }
 
 func (c *AuthRequestCache) Health(ctx context.Context) error {

--- a/internal/domain/auth_request.go
+++ b/internal/domain/auth_request.go
@@ -56,6 +56,16 @@ type AuthRequest struct {
 	DefaultTranslations      []*CustomText
 	OrgTranslations          []*CustomText
 	SAMLRequestID            string
+	// orgID the policies were last loaded with
+	policyOrgID string
+}
+
+func (a *AuthRequest) SetPolicyOrgID(id string) {
+	a.policyOrgID = id
+}
+
+func (a *AuthRequest) PolicyOrgID() string {
+	return a.policyOrgID
 }
 
 type ExternalUser struct {


### PR DESCRIPTION
A bug was introduced with #7824, which would not correctly reload policies and idps in case the organization was change during the authentication.

fixes https://github.com/zitadel/zitadel/issues/7837

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
