### PR TITLE
fix: improve secret generation for apple idp

### DIFF
--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/config/hook"
 	"github.com/zitadel/zitadel/internal/config/systemdefaults"
-	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/id"
@@ -70,7 +69,6 @@ func MustNewConfig(v *viper.Viper) *Config {
 			hook.EnumHookFunc(authz.MemberTypeString),
 			actions.HTTPConfigDecodeHook,
 			hooks.MapTypeStringDecode[string, *authz.SystemAPIUser],
-			hooks.MapTypeStringDecode[string, crypto.HasherConfig],
 			hooks.SliceTypeStringDecode[authz.RoleMapping],
 		)),
 	)

--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -336,6 +336,10 @@ func (l *Login) handleExternalLoginCallback(w http.ResponseWriter, r *http.Reque
 
 	user, err := session.FetchUser(r.Context())
 	if err != nil {
+		logging.WithFields(
+			"instance", authz.GetInstance(r.Context()).InstanceID(),
+			"providerID", identityProvider.ID,
+		).WithError(err).Info("external authentication failed")
 		l.externalAuthFailed(w, r, authReq, tokens(session), user, err)
 		return
 	}

--- a/internal/idp/providers/apple/apple.go
+++ b/internal/idp/providers/apple/apple.go
@@ -57,7 +57,7 @@ func clientSecretFromPrivateKey(key []byte, teamID, clientID, keyID string) (str
 		return "", err
 	}
 	iat := time.Now().Add(-2 * time.Second)
-	exp := iat.Add(10 * time.Minute)
+	exp := iat.Add(time.Hour)
 	return crypto.Sign(&openid.JWTTokenRequest{
 		Issuer:    teamID,
 		Subject:   clientID,

--- a/internal/idp/providers/apple/apple.go
+++ b/internal/idp/providers/apple/apple.go
@@ -57,7 +57,7 @@ func clientSecretFromPrivateKey(key []byte, teamID, clientID, keyID string) (str
 		return "", err
 	}
 	iat := time.Now().Add(-2 * time.Second)
-	exp := iat.Add(5 * time.Minute)
+	exp := iat.Add(10 * time.Minute)
 	return crypto.Sign(&openid.JWTTokenRequest{
 		Issuer:    teamID,
 		Subject:   clientID,

--- a/internal/idp/providers/apple/apple.go
+++ b/internal/idp/providers/apple/apple.go
@@ -57,7 +57,7 @@ func clientSecretFromPrivateKey(key []byte, teamID, clientID, keyID string) (str
 		return "", err
 	}
 	iat := time.Now().Add(-2 * time.Second)
-	exp := iat.Add(time.Hour)
+	exp := iat.Add(24 * time.Hour)
 	return crypto.Sign(&openid.JWTTokenRequest{
 		Issuer:    teamID,
 		Subject:   clientID,

--- a/internal/idp/providers/apple/apple.go
+++ b/internal/idp/providers/apple/apple.go
@@ -57,7 +57,7 @@ func clientSecretFromPrivateKey(key []byte, teamID, clientID, keyID string) (str
 		return "", err
 	}
 	iat := time.Now().Add(-2 * time.Second)
-	exp := iat.Add(24 * time.Hour)
+	exp := iat.Add(time.Hour)
 	return crypto.Sign(&openid.JWTTokenRequest{
 		Issuer:    teamID,
 		Subject:   clientID,

--- a/internal/idp/providers/apple/apple.go
+++ b/internal/idp/providers/apple/apple.go
@@ -56,8 +56,8 @@ func clientSecretFromPrivateKey(key []byte, teamID, clientID, keyID string) (str
 	if err != nil {
 		return "", err
 	}
-	iat := time.Now()
-	exp := iat.Add(time.Hour)
+	iat := time.Now().Add(-2 * time.Second)
+	exp := iat.Add(5 * time.Minute)
 	return crypto.Sign(&openid.JWTTokenRequest{
 		Issuer:    teamID,
 		Subject:   clientID,


### PR DESCRIPTION
A customer reported that the login with Apple not always works, but often an invalid_client is returned.
We saw duplicate invocation of the callback in the logs, but are missing detailed information.
This PR adds additional logs. Since the authentication is relying on JWT, we also change the `iat` by 2 seconds into the past to mitigate potential clock skew problems.

Additionally a previous unintended change in the config parsing is removed.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
