### PR TITLE
fix(cnsl): Email Verified checkbox value was not updated

### DIFF
--- a/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.html
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/edit-dialog/edit-dialog.component.html
@@ -43,7 +43,7 @@
     </div>
 
     <ng-container *ngIf="data.type === EditDialogType.EMAIL && data.isVerifiedTextKey">
-      <mat-checkbox class="verified-checkbox" [(ngModel)]="isVerified">
+      <mat-checkbox class="verified-checkbox" [(ngModel)]="isVerified" [ngModelOptions]="{ standalone: true }">
         {{ data.isVerifiedTextKey | translate }}
       </mat-checkbox>
       <cnsl-info-section class="full-width desc">


### PR DESCRIPTION
In #7762 @sschoeb reported that an email was always sent when the email address was changed in the console no matter if the Email Verified checkbox was set.

There was an issue with the checkbox ngModel that no matter the value of the checkbox isVerified was always false therefore the state was initialized and the email was sent. 

Adding [ngModelOptions]="{standalone: true}" to the checkbox fixes the issue and the email is only sent if the Email Verified checkbox is not checked as intended.

Thanks @sschoeb for reporting the issue

Should close #7762

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
