### PR TITLE
fix: show settings button for users w/o iam perms

### DIFF
--- a/console/src/app/modules/nav/nav.component.html
+++ b/console/src/app/modules/nav/nav.component.html
@@ -96,7 +96,12 @@
                     [routerLinkActive]="['active']"
                     [routerLinkActiveOptions]="{ exact: false }"
                     [routerLink]="['/org-settings']"
-                    *ngIf="(['policy.read'] | hasRole | async) && ((authService.cachedOrgs | async)?.length ?? 1) > 1"
+                    *ngIf="
+                      (['policy.read'] | hasRole | async) &&
+                      ((['iam.read$', 'iam.write$'] | hasRole | async) === false ||
+                        (((authService.cachedOrgs | async)?.length ?? 1) > 1 &&
+                          (['iam.read$', 'iam.write$'] | hasRole | async)))
+                    "
                   >
                     <span class="label">{{ 'MENU.SETTINGS' | translate }}</span>
                   </a>


### PR DESCRIPTION
In this PR https://github.com/zitadel/zitadel/pull/7274 it is documented that:

> On a newly created instance when having a single organization, settings are hidden from the organizations menu

In issue #7819 a possible edge case is reported. Assuming that the instance has only one organization a user without iam permissions would not see the Default Settings button and as the Settings button is currently only shown if user has policy.read permissions and there are more than one organization, a user without iam permissions sould have to click on the Modify buttons. 

I propose this PR where the Settings button will be kept hidden for users with iam permissions and for orgs < 2 but it will be shown for users that has no iam permissions in any case.

Here's a screenshot for the IAM Owner user, no Settings button but Default Settings is shown:

![image](https://github.com/zitadel/zitadel/assets/30386061/8a4b53c6-d406-443b-9358-6d8783f0b6c7)

Here's a screenshot for an ORG Owner user and only one org, Settings button is shown but Default Settings is kept hidden:

![image](https://github.com/zitadel/zitadel/assets/30386061/48fe0cb6-2f8f-4b76-80b8-c476ea0554c9)

Should close #7819 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
