### PR TITLE
fix: translate missing event types

### DIFF
--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -1031,6 +1031,9 @@ EventTypes:
           check:
             succeeded: Проверката на OIDC Client Secret е успешна
             failed: Проверката на OIDC Client Secret е неуспешна
+        key:
+          added: Добавен е ключ за приложение OIDC
+          removed: Отстранен ключ за приложение OIDC
       api:
         secret:
           check:

--- a/internal/static/i18n/cs.yaml
+++ b/internal/static/i18n/cs.yaml
@@ -1010,9 +1010,9 @@ EventTypes:
           check:
             succeeded: Kontrola tajného klíče OIDC klienta byla úspěšná
             failed: Kontrola tajného klíče OIDC klienta selhala
-          key:
-            added: Přidán klíč k aplikaci OIDC
-            removed: Odstranění klíče aplikace OIDC
+        key:
+          added: Přidán klíč k aplikaci OIDC
+          removed: Odstranění klíče aplikace OIDC
       api:
         secret:
           check:

--- a/internal/static/i18n/cs.yaml
+++ b/internal/static/i18n/cs.yaml
@@ -1010,6 +1010,9 @@ EventTypes:
           check:
             succeeded: Kontrola tajného klíče OIDC klienta byla úspěšná
             failed: Kontrola tajného klíče OIDC klienta selhala
+          key:
+            added: Přidán klíč k aplikaci OIDC
+            removed: Odstranění klíče aplikace OIDC
       api:
         secret:
           check:

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -1012,6 +1012,9 @@ EventTypes:
           check:
             succeeded: OIDC Client Secret Validierung erfolgreich
             failed: OIDC Client Secret Validierung fehlgeschlagen
+        key:
+          added: OIDC App Key wurde hinzugefügt
+          removed: OIDC App Key wurde gelöscht
       api:
         secret:
           check:

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -1012,6 +1012,9 @@ EventTypes:
           check:
             succeeded: OIDC Client Secret check succeeded
             failed: OIDC Client Secret check failed
+        key:
+          added: OIDC App Key added
+          removed: OIDC App Key removed
       api:
         secret:
           check:

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -1012,6 +1012,9 @@ EventTypes:
           check:
             succeeded: Comprobación con éxito del secreto del cliente OIDC
             failed: Comprobación fallida del secreto del cliente OIDC
+        key:
+          added: OIDC App Key añadida
+          removed: OIDC App Key eliminada
       api:
         secret:
           check:

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -1007,6 +1007,9 @@ EventTypes:
           verified:
             check: Vérification du secret du client OIDC réussie
             failed: La vérification du secret du client OIDC a échoué
+        key:
+          added: Clé d'application de l'OIDC ajoutée
+          removed: Clé d'application de l'OIDC supprimée
       api:
         secret:
           check:

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -1011,6 +1011,9 @@ EventTypes:
           check:
             succeeded: Проверката на OIDC клиентска тајна е успешна
             failed: Проверката на OIDC клиентска тајна е неуспешна
+        key:
+          added: Додаден е OIDC клуч за апликација
+          removed: OIDC клучот за апликација е отстранет
       api:
         secret:
           check:

--- a/internal/static/i18n/nl.yaml
+++ b/internal/static/i18n/nl.yaml
@@ -1011,6 +1011,9 @@ EventTypes:
           check:
             succeeded: OIDC Client Secret controle geslaagd
             failed: OIDC Client Secret controle mislukt
+        key:
+          added: OIDC app-sleutel toegevoegd
+          removed: OIDC app-sleutel verwijderd
       api:
         secret:
           check:

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -1012,6 +1012,9 @@ EventTypes:
           check:
             succeeded: Sprawdzenie sekretu OIDC Klienta powiodło się
             failed: Sprawdzenie sekretu OIDC Klienta nie powiodło się
+        key:
+          added: Dodano klucz aplikacji OIDC
+          removed: Klucz aplikacji OIDC usunięty
       api:
         secret:
           check:

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -1011,6 +1011,9 @@ EventTypes:
           check:
             succeeded: 检查 OIDC Client Secret 成功
             failed: 检查 OIDC Client Secret 失败
+        key:
+          added: 添加了 OIDC 应用密钥
+          removed: OIDC 应用密钥已删除
       api:
         secret:
           check:

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -7857,7 +7857,7 @@ message ImportHumanUserRequest {
             (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
                 min_length: 1;
                 max_length: 200;
-                example: "\"idp-config-id\"";
+                example: "\"external-user-id\"";
                 description: "The id of the user in the external identity provider"
             }
         ];


### PR DESCRIPTION
Add missing translations on event types and correct wrong example in api

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
