### PR TITLE
fix: remove email validation for SearchUsers v2beta/users

### DIFF
--- a/proto/zitadel/member.proto
+++ b/proto/zitadel/member.proto
@@ -112,7 +112,7 @@ message EmailQuery {
     string email = 1 [
         (validate.rules).string = {max_len: 200},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "email address of the user. (spec: https://tools.ietf.org/html/rfc2822#section-3.4.1)"
+            description: "email address of the user"
             max_length: 200;
             example: "\"gigi@zitadel.com\"";
         }

--- a/proto/zitadel/user.proto
+++ b/proto/zitadel/user.proto
@@ -311,7 +311,7 @@ message EmailQuery {
     string email_address = 1 [
         (validate.rules).string = {max_len: 200},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "email address of the user. (spec: https://tools.ietf.org/html/rfc2822#section-3.4.1)"
+            description: "email address of the user"
             max_length: 200;
             example: "\"gigi@zitadel.com\"";
         }

--- a/proto/zitadel/user/v2beta/query.proto
+++ b/proto/zitadel/user/v2beta/query.proto
@@ -168,11 +168,10 @@ message DisplayNameQuery {
 // Query for users with a specific email.
 message EmailQuery {
     string email_address = 1 [
-        (validate.rules).string = {min_len: 1, max_len: 200, email: true},
+        (validate.rules).string = {max_len: 200},
         (google.api.field_behavior) = REQUIRED,
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "email address of the user. (spec: https://tools.ietf.org/html/rfc2822#section-3.4.1)"
-            min_length: 1;
+            description: "email address of the user"
             max_length: 200;
             example: "\"gigi@zitadel.com\"";
         }

--- a/proto/zitadel/user/v3alpha/query.proto
+++ b/proto/zitadel/user/v3alpha/query.proto
@@ -122,10 +122,10 @@ message UsernameQuery {
 message EmailQuery {
   // Defines the email of the user to query for.
   string address = 1 [
-    (validate.rules).string = {min_len: 1, max_len: 200},
+    (validate.rules).string = {max_len: 200},
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      min_length: 1;
+      description: "email address of the user"
       max_length: 200;
       example: "\"gigi@zitadel.com\"";
     }


### PR DESCRIPTION

In #7850 @cskeppstedt reported an issue when performing search user queries for email addresses. 

The error reported, when searching email address that didn't follow the 2822 format, was: `invalid EmailQuery.EmailAddress: value must be a valid email address `.

This error is due to an email validation rule present in the EmailQuery definition for v2beta/users. In this PR that validation is removed and, for an homogeneous behavior, I've modified other EmailQuery proto definitions so no min length is required and the RFC 2822 mention is removed from descriptions as we can indeed search for text like foobar and not foobar@example.com

Here are some screenshots of the tests I've performed:

![Captura desde 2024-04-26 14-27-46](https://github.com/zitadel/zitadel/assets/30386061/68b9677c-b740-40ae-a499-8b53e2547c52)

![Captura desde 2024-04-26 14-27-58](https://github.com/zitadel/zitadel/assets/30386061/4488b08e-6069-4736-b992-98728c6e0ad3)

![Captura desde 2024-04-26 14-28-56](https://github.com/zitadel/zitadel/assets/30386061/1d864c57-8508-418d-8983-22352e59f01c)

Should close #7850 

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [X] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [X] Functionality of the acceptance criteria is checked manually on the dev system.
