### PR TITLE
fix: correct email headers (mime version and content-type)

### DIFF
--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -51,9 +51,9 @@ func (msg *Email) GetContent() (string, error) {
 	}
 
 	//default mime-type is html
-	mime := "MIME-version: 1.0;" + lineBreak + "Content-Type: text/html; charset=\"UTF-8\";" + lineBreak + lineBreak
+	mime := "MIME-Version: 1.0;" + lineBreak + "Content-Type: text/html; charset=\"UTF-8\";" + lineBreak + lineBreak
 	if !isHTML(msg.Content) {
-		mime = "MIME-version: 1.0;" + lineBreak + "Content-Type: text/plain; charset=\"UTF-8\";" + lineBreak + lineBreak
+		mime = "MIME-Version: 1.0;" + lineBreak + "Content-Type: text/plain; charset=\"UTF-8\";" + lineBreak + lineBreak
 	}
 	subject := "Subject: " + bEncodeSubject(msg.Subject) + lineBreak
 	message += subject + mime + lineBreak + msg.Content

--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -51,9 +51,9 @@ func (msg *Email) GetContent() (string, error) {
 	}
 
 	//default mime-type is html
-	mime := "MIME-Version: 1.0;" + lineBreak + "Content-Type: text/html; charset=\"UTF-8\";" + lineBreak + lineBreak
+	mime := "MIME-Version: 1.0" + lineBreak + "Content-Type: text/html; charset=\"UTF-8\"" + lineBreak + lineBreak
 	if !isHTML(msg.Content) {
-		mime = "MIME-Version: 1.0;" + lineBreak + "Content-Type: text/plain; charset=\"UTF-8\";" + lineBreak + lineBreak
+		mime = "MIME-Version: 1.0" + lineBreak + "Content-Type: text/plain; charset=\"UTF-8\"" + lineBreak + lineBreak
 	}
 	subject := "Subject: " + bEncodeSubject(msg.Subject) + lineBreak
 	message += subject + mime + lineBreak + msg.Content


### PR DESCRIPTION
As noticed by a customer (relates to #7880), the `Mime-Version` and `Content-Type` were not properly formatted, which depending on the smtp relay led to bad spam scoring.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
