### PR TITLE
docs: fix example for self hosting load balancing

### DIFF
--- a/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-config.yaml
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-config.yaml
@@ -2,7 +2,7 @@
 Log:
   Level: 'info'
 
-# Make ZITADEL accessible over HTTP, not HTTPS
+# Make ZITADEL accessible over HTTPs, not HTTP
 ExternalSecure: true
 ExternalDomain: my.domain
 ExternalPort: 443


### PR DESCRIPTION
Fix a wrong stated comment in the loadbalancing example.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
