### PR TITLE
fix: user registration through IdP

### DIFF
--- a/internal/api/ui/login/init_user_handler.go
+++ b/internal/api/ui/login/init_user_handler.go
@@ -104,16 +104,17 @@ func (l *Login) checkUserInitCode(w http.ResponseWriter, r *http.Request, authRe
 }
 
 func (l *Login) resendUserInit(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, userID string, loginName string, showPassword bool) {
-	userOrgID := ""
+	var userOrgID, authRequestID string
 	if authReq != nil {
 		userOrgID = authReq.UserOrgID
+		authRequestID = authReq.ID
 	}
 	initCodeGenerator, err := l.query.InitEncryptionGenerator(r.Context(), domain.SecretGeneratorTypeInitCode, l.userCodeAlg)
 	if err != nil {
 		l.renderInitUser(w, r, authReq, userID, loginName, "", showPassword, err)
 		return
 	}
-	_, err = l.command.ResendInitialMail(setContext(r.Context(), userOrgID), userID, "", userOrgID, initCodeGenerator, authReq.ID)
+	_, err = l.command.ResendInitialMail(setContext(r.Context(), userOrgID), userID, "", userOrgID, initCodeGenerator, authRequestID)
 	l.renderInitUser(w, r, authReq, userID, loginName, "", showPassword, err)
 }
 

--- a/internal/api/ui/login/mfa_verify_otp_handler.go
+++ b/internal/api/ui/login/mfa_verify_otp_handler.go
@@ -76,7 +76,7 @@ func (l *Login) renderOTPVerification(w http.ResponseWriter, r *http.Request, au
 func (l *Login) handleOTPVerificationCheck(w http.ResponseWriter, r *http.Request) {
 	formData := new(mfaOTPFormData)
 	authReq, err := l.getAuthRequestAndParseData(r, formData)
-	if err != nil {
+	if authReq == nil || err != nil {
 		l.renderError(w, r, authReq, err)
 		return
 	}

--- a/internal/command/user_human.go
+++ b/internal/command/user_human.go
@@ -689,16 +689,17 @@ func AddHumanFromDomain(user *domain.Human, metadataList []*domain.Metadata, aut
 		human.DisplayName = user.DisplayName
 		human.PreferredLanguage = user.PreferredLanguage
 		human.Gender = user.Gender
-		human.Password = user.Password.SecretString
 		human.Register = true
 		human.Metadata = addMetadata
+	}
+	if authRequest != nil {
 		human.UserAgentID = authRequest.AgentID
 		human.AuthRequestID = authRequest.ID
 	}
 	if user.Email != nil {
 		human.Email = Email{
-			Address:  user.EmailAddress,
-			Verified: user.IsEmailVerified,
+			Address:  user.Email.EmailAddress,
+			Verified: user.Email.IsEmailVerified,
 		}
 	}
 	if user.Phone != nil {
@@ -706,6 +707,9 @@ func AddHumanFromDomain(user *domain.Human, metadataList []*domain.Metadata, aut
 			Number:   user.Phone.PhoneNumber,
 			Verified: user.Phone.IsPhoneVerified,
 		}
+	}
+	if user.Password != nil {
+		human.Password = user.Password.SecretString
 	}
 	if idp != nil {
 		human.Links = []*AddLink{


### PR DESCRIPTION
fixes a nil pointer panic (introduced with https://github.com/zitadel/zitadel/pull/7815), which occurred after a user was registered through an IdP.
While checking the logs, further panics were discovered and fixed in this PR.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
