### PR TITLE
fix: typo in the fr translation file for login ui sms otp mfa

### DIFF
--- a/internal/api/ui/login/static/i18n/fr.yaml
+++ b/internal/api/ui/login/static/i18n/fr.yaml
@@ -103,7 +103,7 @@ InitMFAOTP:
   NextButtonText: Suivant
   CancelButtonText: Annuler
 
-InitMFASMS:
+InitMFAOTPSMS:
   Title: Vérification à deux facteurs
   DescriptionPhone: Créez votre 2-facteurs. Entrez votre numéro de téléphone pour le vérifier.
   DescriptionCode: Créez votre 2-facteurs. Entrez le code reçu pour vérifier votre numéro de téléphone.


### PR DESCRIPTION
# Which Problems Are Solved

SMS OTP MFA translations are not displayed in FR language on the login ui

# How the Problems Are Solved

By changing the typo in the FR translation file 

# Additional Changes


# Additional Context

- Closes #7945
- https://discordapp.com/channels/927474939156643850/1239843688633471006