### PR TITLE
docs: please help

### DIFF
--- a/docs/docs/apis/known_docs_issues.mdx
+++ b/docs/docs/apis/known_docs_issues.mdx
@@ -2,14 +2,14 @@
 title: Please Help
 ---
 
-This page describes important known issues.
-If you have an idea that helps us fixing them,
+This page describes important known issues with our API documentation.
+If you have an idea that helps us fixing them efficiently,
 please file [an issue](https://github.com/zitadel/zitadel/issues/new/choose) or [start a discussion](https://github.com/zitadel/zitadel/discussions/new/choose) on GitHub.
 If you like, a ZITADEL shirt is headed your way once the issue is fixed based on your input :pray:
 
 ## Generated Examples for oneOf Fields
 
-The generated examples for mutually exclusive oneof fields are not correct.
+The generated examples for mutually exclusive oneOf fields are not correct.
 
 Let's take the [ListUserGrants docs](/docs/apis/resources/mgmt/management-service-list-user-grants) as an example.
 The example suggests that the `queries` field is an array a single object that takes all the queries in its object properties:

--- a/docs/docs/apis/known_docs_issues.mdx
+++ b/docs/docs/apis/known_docs_issues.mdx
@@ -12,7 +12,7 @@ If you like, a ZITADEL shirt is headed your way once the issue is fixed based on
 The generated examples for mutually exclusive oneOf fields are not correct.
 
 Let's take the [ListUserGrants docs](/docs/apis/resources/mgmt/management-service-list-user-grants) as an example.
-The example suggests that the `queries` field is an array a single object that takes all the queries in its object properties:
+The example suggests that the `queries` field is an array that takes only one single object which in turn takes all the possible queries in its object properties:
 
 ```json
 {

--- a/docs/docs/apis/known_issues.mdx
+++ b/docs/docs/apis/known_issues.mdx
@@ -1,0 +1,69 @@
+---
+title: Please Help
+---
+
+This page describes important known issues.
+If you have an idea that helps us fixing them,
+please file [an issue](https://github.com/zitadel/zitadel/issues/new/choose) or [start a discussion](https://github.com/zitadel/zitadel/discussions/new/choose) on GitHub.
+If you like, a ZITADEL shirt is headed your way once the issue is fixed based on your input :pray:
+
+## Generated Examples for oneOf Fields
+
+The generated examples for mutually exclusive oneof fields are not correct.
+
+Let's take the [ListUserGrants docs](/docs/apis/resources/mgmt/management-service-list-user-grants) as an example.
+The example suggests that the `queries` field is an array a single object that takes all the queries in its object properties:
+
+```json
+{
+  "query": {
+    "offset": "0",
+    "limit": 100,
+    "asc": true
+  },
+  "queries": [
+    {
+      "projectIdQuery": {
+        "projectId": "69629023906488334"
+      },
+      "userIdQuery": {
+        "userId": "69629023906488334"
+      },
+      "withGrantedQuery": {
+        "withGranted": true
+      }
+    }
+  ]
+}
+```
+
+However, the correct way to represent this is to have the queries as separate items in the queries array:
+
+```json
+{
+  "query": {
+    "offset": "0",
+    "limit": 100,
+    "asc": true
+  },
+  "queries": [
+    {
+      "projectIdQuery": {
+        "projectId": "69629023906488334"
+      }
+    }, {
+      "userIdQuery": {
+        "userId": "69629023906488334"
+      }
+    }, {
+      "withGrantedQuery": {
+        "withGranted": true
+      }
+    }
+  ]
+}
+```
+
+The [protoc grpc-gateway plugin generates OpenAPI v2 files](https://github.com/grpc-ecosystem/grpc-gateway/issues/441) that are used to generate the examples.
+[OpenAPI v3 supports the *oneOf* keyword](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) but OpenAPI v2 doesn't.
+The grpc-gateway plugin therefore just flattens the proto *oneof* fields into the messages properties where they are defined.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -764,6 +764,7 @@ module.exports = {
           collapsed: true,
           items: ["apis/assets/assets"],
         },
+          "apis/known_issues",
       ],
     },
     {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -763,8 +763,7 @@ module.exports = {
           label: "Assets",
           collapsed: true,
           items: ["apis/assets/assets"],
-        },
-          "apis/known_issues",
+        }
       ],
     },
     {
@@ -833,6 +832,7 @@ module.exports = {
       label: "Rate Limits (Cloud)", // The link label
       href: "/legal/policies/rate-limit-policy", // The internal path
     },
+    "apis/known_docs_issues",
   ],
   selfHosting: [
     {


### PR DESCRIPTION
# Which Problems Are Solved

We have limited control over API docs generation.
This can cause misleading or even wrong API documentation that is hard to fix.
The problem at hand is the wrong representation of proto oneof fields in the request examples described in this PRs commit.

# How the Problems Are Solved

As long as we don't have an easy fix for these problems or a better solution for generating the APIs in the first place, we describe the docs issues in a linkable page and ask the community for ideas. 

# Additional Context

- Closes #5352