### PR TITLE
fix(actions): correct statements to query targets

### DIFF
--- a/internal/query/targets_by_execution_ids.sql
+++ b/internal/query/targets_by_execution_ids.sql
@@ -1,22 +1,4 @@
 WITH RECURSIVE
-    dissolved_execution_targets(execution_id, instance_id, position, "include", "target_id")
-        AS (SELECT execution_id
-                 , instance_id
-                 , ARRAY [position]
-                 , "include"
-                 , "target_id"
-            FROM matched_targets_and_includes
-            UNION ALL
-            SELECT e.execution_id
-                 , p.instance_id
-                 , e.position || p.position
-                 , p."include"
-                 , p."target_id"
-            FROM dissolved_execution_targets e
-                     JOIN projections.executions1_targets p
-                          ON e.instance_id = p.instance_id
-                              AND e.include IS NOT NULL
-                              AND e.include = p.execution_id),
     matched AS ((SELECT *
                  FROM projections.executions1
                  WHERE instance_id = $1
@@ -37,7 +19,25 @@ WITH RECURSIVE
                                           ON m.id = pos.execution_id
                                               AND m.instance_id = pos.instance_id
                                      ORDER BY execution_id,
-                                              position)
+                                              position),
+    dissolved_execution_targets(execution_id, instance_id, position, "include", "target_id")
+        AS (SELECT execution_id
+                 , instance_id
+                 , ARRAY [position]
+                 , "include"
+                 , "target_id"
+            FROM matched_targets_and_includes
+            UNION ALL
+            SELECT e.execution_id
+                 , p.instance_id
+                 , e.position || p.position
+                 , p."include"
+                 , p."target_id"
+            FROM dissolved_execution_targets e
+                     JOIN projections.executions1_targets p
+                          ON e.instance_id = p.instance_id
+                              AND e.include IS NOT NULL
+                              AND e.include = p.execution_id)
 select e.execution_id, e.instance_id, e.target_id, t.target_type, t.endpoint, t.timeout, t.interrupt_on_error
 FROM dissolved_execution_targets e
          JOIN projections.targets1 t


### PR DESCRIPTION
# Which Problems Are Solved

Curretly loading targets fails on cockraochdb because the order of `with`-statements is wrong.

# How the Problems Are Solved

Changed the order of queries in the statements.