### PR TITLE
chore: tag author in ready for review comment

### DIFF
--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const content = `### Thanks for your contribution! 🎉
+            const content = `### Thanks for your contribution ${{ github.event.pull_request.user.login }}! 🎉
 
             Please make sure you tick the following checkboxes before marking this Pull Request (PR) as ready for review:
             


### PR DESCRIPTION
# Which Problems Are Solved

It is not very clear if the author or the reviewer of a PR should tick the boxes.

# How the Problems Are Solved

The author of the PR is tagged in the comment, because the author should tick the boxes before marking it as ready for review. 