### PR TITLE
docs(advisory): add technical advisory for token type change

### DIFF
--- a/docs/docs/support/advisory/a10009.md
+++ b/docs/docs/support/advisory/a10009.md
@@ -6,7 +6,7 @@ title: Technical Advisory 10009
 
 Version: 2.53.0
 
-Date: Calendar week 23/24 2024
+Date: 2024-05-28
 
 ## Description
 

--- a/docs/docs/support/advisory/a10010.md
+++ b/docs/docs/support/advisory/a10010.md
@@ -1,0 +1,30 @@
+---
+title: Technical Advisory 10010
+---
+
+## Date and Version
+
+Version: 2.53.0
+
+Date: 2024-05-28
+
+## Description
+
+Version 2.53.0 optimizes the way tokens are created and migrates them to the v2 implementation already used by OAuth / OIDC tokens created through the session API.
+
+Because of this tokens events are no longer created on the user itself. To be as backwards compatible as possible a separate event is created on the user for the audit log.
+
+## Statement
+
+This change was tracked in the following PR:
+[perf(oidc): optimize token creation](https://github.com/zitadel/zitadel/pull/7822), which was released in Version [2.53.0](https://github.com/zitadel/zitadel/releases/tag/v2.53.0)
+
+## Mitigation
+
+If you use the ListEvents API to check the audit trail of a user or being able to compute Daily or Monthly Active Users, be sure to also include the `user.token.v2.added` event type in your search
+if you already query for the `user.token.added` event type.
+
+## Impact
+
+Once this update has been released and deployed, the `user.token.added` event will no longer be created when a user access token is created, but instead a `user.token.v2.added`.
+Existing `user.token.added` events will be untouched.

--- a/docs/docs/support/technical_advisory.mdx
+++ b/docs/docs/support/technical_advisory.mdx
@@ -164,7 +164,19 @@ We understand that these advisories may include breaking changes, and we aim to 
       Fixes rare cases where updating projections was blocked by a `WRITE_TOO_OLD`-error when using cockroachdb.
     </td>
     <td>2.53.0</td>
-    <td>2024-05-27</td>
+    <td>2024-05-28</td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./advisory/a10010">A-10010</a>
+    </td>
+    <td>Event type of token added event changed</td>
+    <td>Breaking Behavior Change</td>
+    <td>
+      Version 2.53.0 improves the token issuance. Due to this there are changes to the event types created on token creation.
+    </td>
+    <td>2.53.0</td>
+    <td>2024-05-28</td>
   </tr>
 </table>
 


### PR DESCRIPTION
# Which Problems Are Solved

Among others #7822 changed the event type of the `user.token.added` to `user.token.v2.added`. To make customers aware of this in case they use it for calculating DAU / MAU, resp. for an audit trail, we want to raise awareness.

# How the Problems Are Solved

Technical advisory to state the change.

# Additional Changes

None.

# Additional Context

Relates to #7822 