### PR TITLE
fix(login): correctly set preferred login name in the login ui

### DIFF
--- a/internal/user/repository/view/user_by_id.sql
+++ b/internal/user/repository/view/user_by_id.sql
@@ -33,7 +33,7 @@ SELECT
     , (SELECT array_agg(ll.login_name) login_names FROM projections.login_names3 ll
                                                    WHERE u.instance_id = ll.instance_id AND u.id = ll.user_id
                                                    GROUP BY ll.user_id, ll.instance_id) AS login_names
-    , l.login_name
+    , l.login_name as preferred_login_name
     , h.first_name
     , h.last_name
     , h.nick_name


### PR DESCRIPTION
# Which Problems Are Solved

A customer noted that after upgrade to 2.53.0, users were no longer able to reset their passwords through the login UI.
This was due to a accidental change in https://github.com/zitadel/zitadel/pull/7969

# How the Problems Are Solved

The `preferred_login_name` is now correctly read from the database.

# Additional Changes

None.

# Additional Context

relates to #7969