### PR TITLE
feat(init): configurable existing postgres db

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -147,6 +147,10 @@ Database:
         Cert: # ZITADEL_DATABASE_POSTGRES_USER_SSL_CERT
         Key: # ZITADEL_DATABASE_POSTGRES_USER_SSL_KEY
     Admin:
+      # The default ExistingDatabase is postgres
+      # If your db system doesn't have a database named postgres, configure an existing database here
+      # It is used in zitadel init to connect to postgres and create a dedicated database for ZITADEL.
+      ExistingDatabase: # ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE
       Username: # ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME
       Password: # ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD
       SSL:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -120,6 +120,9 @@ Database:
         Cert: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_CERT
         Key: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_KEY
     Admin:
+      # If your db system doesn't have a database named defaultdb, configure an existing database here
+      # It is used in zitadel init to connect to postgres and create a dedicated database for ZITADEL.
+      ExistingDatabase: defaultdb # ZITADEL_DATABASE_COCKROACH_ADMIN_EXISTINGDATABASE
       Username: root # ZITADEL_DATABASE_COCKROACH_ADMIN_USERNAME
       Password: "" # ZITADEL_DATABASE_COCKROACH_ADMIN_PASSWORD
       SSL:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -120,9 +120,10 @@ Database:
         Cert: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_CERT
         Key: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_KEY
     Admin:
-      # If your db system doesn't have a database named defaultdb, configure an existing database here
-      # It is used in zitadel init to connect to postgres and create a dedicated database for ZITADEL.
-      ExistingDatabase: defaultdb # ZITADEL_DATABASE_COCKROACH_ADMIN_EXISTINGDATABASE
+      # By default, ExistingDatabase not specified in the connection string
+      # If the connection resolves to a database that is not existing in your system, configure an existing one here
+      # It is used in zitadel init to connect to cockroach and create a dedicated database for ZITADEL.
+      ExistingDatabase: # ZITADEL_DATABASE_COCKROACH_ADMIN_EXISTINGDATABASE
       Username: root # ZITADEL_DATABASE_COCKROACH_ADMIN_USERNAME
       Password: "" # ZITADEL_DATABASE_COCKROACH_ADMIN_PASSWORD
       SSL:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -120,7 +120,7 @@ Database:
         Cert: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_CERT
         Key: "" # ZITADEL_DATABASE_COCKROACH_USER_SSL_KEY
     Admin:
-      # By default, ExistingDatabase not specified in the connection string
+      # By default, ExistingDatabase is not specified in the connection string
       # If the connection resolves to a database that is not existing in your system, configure an existing one here
       # It is used in zitadel init to connect to cockroach and create a dedicated database for ZITADEL.
       ExistingDatabase: # ZITADEL_DATABASE_COCKROACH_ADMIN_EXISTINGDATABASE

--- a/internal/database/cockroach/crdb.go
+++ b/internal/database/cockroach/crdb.go
@@ -34,7 +34,7 @@ type Config struct {
 	MaxConnLifetime time.Duration
 	MaxConnIdleTime time.Duration
 	User            User
-	Admin           User
+	Admin           AdminUser
 	// Additional options to be appended as options=<Options>
 	// The value will be taken as is. Multiple options are space separated.
 	Options string
@@ -114,6 +114,12 @@ type User struct {
 	SSL      SSL
 }
 
+type AdminUser struct {
+	// ExistingDatabase is the database to connect to before the ZITADEL database exists
+	ExistingDatabase string
+	User             `mapstructure:",squash"`
+}
+
 type SSL struct {
 	// type of connection security
 	Mode string
@@ -147,7 +153,7 @@ func (c *Config) checkSSL(user User) {
 func (c Config) String(useAdmin bool, appName string) string {
 	user := c.User
 	if useAdmin {
-		user = c.Admin
+		user = c.Admin.User
 	}
 	c.checkSSL(user)
 	fields := []string{
@@ -163,6 +169,8 @@ func (c Config) String(useAdmin bool, appName string) string {
 	}
 	if !useAdmin {
 		fields = append(fields, "dbname="+c.Database)
+	} else {
+		fields = append(fields, "dbname="+c.Admin.ExistingDatabase)
 	}
 	if user.Password != "" {
 		fields = append(fields, "password="+user.Password)

--- a/internal/database/cockroach/crdb.go
+++ b/internal/database/cockroach/crdb.go
@@ -169,7 +169,7 @@ func (c Config) String(useAdmin bool, appName string) string {
 	}
 	if !useAdmin {
 		fields = append(fields, "dbname="+c.Database)
-	} else {
+	} else if c.Admin.ExistingDatabase != "" {
 		fields = append(fields, "dbname="+c.Admin.ExistingDatabase)
 	}
 	if user.Password != "" {

--- a/internal/database/postgres/pg.go
+++ b/internal/database/postgres/pg.go
@@ -116,8 +116,9 @@ type User struct {
 }
 
 type AdminUser struct {
-	DefaultDatabase string
-	User            `mapstructure:",squash"`
+	// ExistingDatabase is the database to connect to before the ZITADEL database exists
+	ExistingDatabase string
+	User             `mapstructure:",squash"`
 }
 
 type SSL struct {
@@ -172,7 +173,7 @@ func (c Config) String(useAdmin bool, appName string) string {
 	if !useAdmin {
 		fields = append(fields, "dbname="+c.Database)
 	} else {
-		defaultDB := c.Admin.DefaultDatabase
+		defaultDB := c.Admin.ExistingDatabase
 		if defaultDB == "" {
 			defaultDB = "postgres"
 		}

--- a/internal/database/postgres/pg.go
+++ b/internal/database/postgres/pg.go
@@ -35,7 +35,7 @@ type Config struct {
 	MaxConnLifetime    time.Duration
 	MaxConnIdleTime    time.Duration
 	User               User
-	Admin              User
+	Admin              AdminUser
 	// Additional options to be appended as options=<Options>
 	// The value will be taken as is. Multiple options are space separated.
 	Options string
@@ -115,6 +115,11 @@ type User struct {
 	SSL      SSL
 }
 
+type AdminUser struct {
+	DefaultDatabase string
+	User            `mapstructure:",squash"`
+}
+
 type SSL struct {
 	// type of connection security
 	Mode string
@@ -148,7 +153,7 @@ func (s *Config) checkSSL(user User) {
 func (c Config) String(useAdmin bool, appName string) string {
 	user := c.User
 	if useAdmin {
-		user = c.Admin
+		user = c.Admin.User
 	}
 	c.checkSSL(user)
 	fields := []string{
@@ -167,7 +172,11 @@ func (c Config) String(useAdmin bool, appName string) string {
 	if !useAdmin {
 		fields = append(fields, "dbname="+c.Database)
 	} else {
-		fields = append(fields, "dbname=postgres")
+		defaultDB := c.Admin.DefaultDatabase
+		if defaultDB == "" {
+			defaultDB = "postgres"
+		}
+		fields = append(fields, "dbname="+defaultDB)
 	}
 	if user.SSL.Mode != sslDisabledMode {
 		if user.SSL.RootCert != "" {


### PR DESCRIPTION
# Which Problems Are Solved

The init job fails if no database called *postgres* or *defaultdb* for cockroach respectively exists.

# How the Problems Are Solved

The value is now configurable, for example by env variable *ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE*

# Additional Context

- Closes #5810