### PR TITLE
fix(logging): reduce log level of errors in introspection and login UI

### DIFF
--- a/internal/api/oidc/introspect.go
+++ b/internal/api/oidc/introspect.go
@@ -80,7 +80,7 @@ func (s *Server) Introspect(ctx context.Context, r *op.Request[op.IntrospectionR
 	// with active: false
 	defer func() {
 		if err != nil {
-			s.getLogger(ctx).ErrorContext(ctx, "oidc introspection", "err", err)
+			s.getLogger(ctx).InfoContext(ctx, "oidc introspection", "err", err)
 			resp, err = op.NewResponse(new(oidc.IntrospectionResponse)), nil
 		}
 	}()

--- a/internal/api/oidc/introspect.go
+++ b/internal/api/oidc/introspect.go
@@ -80,7 +80,11 @@ func (s *Server) Introspect(ctx context.Context, r *op.Request[op.IntrospectionR
 	// with active: false
 	defer func() {
 		if err != nil {
-			s.getLogger(ctx).InfoContext(ctx, "oidc introspection", "err", err)
+			if zerrors.IsInternal(err) {
+				s.getLogger(ctx).ErrorContext(ctx, "oidc introspection", "err", err)
+			} else {
+				s.getLogger(ctx).InfoContext(ctx, "oidc introspection", "err", err)
+			}
 			resp, err = op.NewResponse(new(oidc.IntrospectionResponse)), nil
 		}
 	}()

--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -342,7 +342,11 @@ func (l *Login) renderInternalError(w http.ResponseWriter, r *http.Request, auth
 		if authReq != nil {
 			log = log.WithField("auth_req_id", authReq.ID)
 		}
-		log.Info()
+		if zerrors.IsInternal(err) {
+			log.Error()
+		} else {
+			log.Info()
+		}
 
 		_, msg = l.getErrorMessage(r, err)
 	}

--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -342,7 +342,7 @@ func (l *Login) renderInternalError(w http.ResponseWriter, r *http.Request, auth
 		if authReq != nil {
 			log = log.WithField("auth_req_id", authReq.ID)
 		}
-		log.Error()
+		log.Info()
 
 		_, msg = l.getErrorMessage(r, err)
 	}


### PR DESCRIPTION
# Which Problems Are Solved

Introspection errors such as invalid audience and errors in the login UI such as invalid user agents where all logged as severity error.

# How the Problems Are Solved

- errors that are not internal errors are logged as `info`

# Additional Changes

None

# Additional Context

- internal discussion