### PR TITLE
fix: empty custom text changes push no events

### DIFF
--- a/internal/command/instance_custom_login_text.go
+++ b/internal/command/instance_custom_login_text.go
@@ -21,6 +21,9 @@ func (c *Commands) SetCustomInstanceLoginText(ctx context.Context, loginText *do
 	if err != nil {
 		return nil, err
 	}
+	if len(events) == 0 {
+		return writeModelToObjectDetails(&existingMailText.WriteModel), nil
+	}
 	pushedEvents, err := c.eventstore.Push(ctx, events...)
 	if err != nil {
 		return nil, err

--- a/internal/command/instance_custom_login_text_test.go
+++ b/internal/command/instance_custom_login_text_test.go
@@ -38,7 +38,6 @@ func TestCommandSide_SetCustomIAMLoginText(t *testing.T) {
 				eventstore: eventstoreExpect(
 					t,
 					expectFilter(),
-					expectPush(),
 				),
 			},
 			args: args{

--- a/internal/command/instance_custom_message_text.go
+++ b/internal/command/instance_custom_message_text.go
@@ -21,6 +21,9 @@ func (c *Commands) SetDefaultMessageText(ctx context.Context, instanceID string,
 	if err != nil {
 		return nil, err
 	}
+	if len(events) == 0 {
+		return writeModelToObjectDetails(&existingMessageText.WriteModel), nil
+	}
 	pushedEvents, err := c.eventstore.Push(ctx, events...)
 	if err != nil {
 		return nil, err

--- a/internal/command/instance_custom_message_text_test.go
+++ b/internal/command/instance_custom_message_text_test.go
@@ -54,7 +54,6 @@ func TestCommandSide_SetDefaultMessageText(t *testing.T) {
 				eventstore: eventstoreExpect(
 					t,
 					expectFilter(),
-					expectPush(),
 				),
 			},
 			args: args{

--- a/internal/command/org_custom_login_text.go
+++ b/internal/command/org_custom_login_text.go
@@ -23,6 +23,9 @@ func (c *Commands) SetOrgLoginText(ctx context.Context, resourceOwner string, lo
 	if err != nil {
 		return nil, err
 	}
+	if len(events) == 0 {
+		return writeModelToObjectDetails(&existingLoginText.WriteModel), nil
+	}
 	pushedEvents, err := c.eventstore.Push(ctx, events...)
 	if err != nil {
 		return nil, err

--- a/internal/command/org_custom_login_text_test.go
+++ b/internal/command/org_custom_login_text_test.go
@@ -56,7 +56,6 @@ func TestCommandSide_SetCustomOrgLoginText(t *testing.T) {
 				eventstore: eventstoreExpect(
 					t,
 					expectFilter(),
-					expectPush(),
 				),
 			},
 			args: args{

--- a/internal/command/org_custom_message_text.go
+++ b/internal/command/org_custom_message_text.go
@@ -23,6 +23,9 @@ func (c *Commands) SetOrgMessageText(ctx context.Context, resourceOwner string, 
 	if err != nil {
 		return nil, err
 	}
+	if len(events) == 0 {
+		return writeModelToObjectDetails(&existingMessageText.WriteModel), nil
+	}
 	pushedEvents, err := c.eventstore.Push(ctx, events...)
 	if err != nil {
 		return nil, err

--- a/internal/command/org_custom_message_text_test.go
+++ b/internal/command/org_custom_message_text_test.go
@@ -67,7 +67,6 @@ func TestCommandSide_SetCustomMessageText(t *testing.T) {
 				eventstore: eventstoreExpect(
 					t,
 					expectFilter(),
-					expectPush(),
 				),
 			},
 			args: args{


### PR DESCRIPTION
# Which Problems Are Solved

If there is no custom text given, the call ends in an internal error as no events have to be pushed.

# How the Problems Are Solved

If no events have to be pushed, no trying to push an empty list of events.

# Additional Changes

No additional changes.

# Additional Context

Closes #6954