### PR TITLE
refactor: deprecate pw age policy

### DIFF
--- a/internal/api/grpc/admin/password_age.go
+++ b/internal/api/grpc/admin/password_age.go
@@ -2,9 +2,9 @@ package admin
 
 import (
 	"context"
-	
-	"github.com/zitadel/logging"
 
+	"github.com/zitadel/logging"
+	
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	policy_grpc "github.com/zitadel/zitadel/internal/api/grpc/policy"
 	admin_pb "github.com/zitadel/zitadel/pkg/grpc/admin"

--- a/internal/api/grpc/admin/password_age.go
+++ b/internal/api/grpc/admin/password_age.go
@@ -2,6 +2,8 @@ package admin
 
 import (
 	"context"
+	
+	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	policy_grpc "github.com/zitadel/zitadel/internal/api/grpc/policy"
@@ -9,6 +11,7 @@ import (
 )
 
 func (s *Server) GetPasswordAgePolicy(ctx context.Context, req *admin_pb.GetPasswordAgePolicyRequest) (*admin_pb.GetPasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: GetPasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	policy, err := s.query.DefaultPasswordAgePolicy(ctx, true)
 	if err != nil {
 		return nil, err
@@ -19,6 +22,7 @@ func (s *Server) GetPasswordAgePolicy(ctx context.Context, req *admin_pb.GetPass
 }
 
 func (s *Server) UpdatePasswordAgePolicy(ctx context.Context, req *admin_pb.UpdatePasswordAgePolicyRequest) (*admin_pb.UpdatePasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: UpdatePasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	result, err := s.command.ChangeDefaultPasswordAgePolicy(ctx, UpdatePasswordAgePolicyToDomain(req))
 	if err != nil {
 		return nil, err

--- a/internal/api/grpc/management/policy_password_age.go
+++ b/internal/api/grpc/management/policy_password_age.go
@@ -3,6 +3,8 @@ package management
 import (
 	"context"
 
+	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/grpc/object"
 	policy_grpc "github.com/zitadel/zitadel/internal/api/grpc/policy"
@@ -10,6 +12,7 @@ import (
 )
 
 func (s *Server) GetPasswordAgePolicy(ctx context.Context, req *mgmt_pb.GetPasswordAgePolicyRequest) (*mgmt_pb.GetPasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: GetPasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	policy, err := s.query.PasswordAgePolicyByOrg(ctx, true, authz.GetCtxData(ctx).OrgID, false)
 	if err != nil {
 		return nil, err
@@ -21,6 +24,7 @@ func (s *Server) GetPasswordAgePolicy(ctx context.Context, req *mgmt_pb.GetPassw
 }
 
 func (s *Server) GetDefaultPasswordAgePolicy(ctx context.Context, req *mgmt_pb.GetDefaultPasswordAgePolicyRequest) (*mgmt_pb.GetDefaultPasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: GetDefaultPasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	policy, err := s.query.DefaultPasswordAgePolicy(ctx, true)
 	if err != nil {
 		return nil, err
@@ -31,6 +35,7 @@ func (s *Server) GetDefaultPasswordAgePolicy(ctx context.Context, req *mgmt_pb.G
 }
 
 func (s *Server) AddCustomPasswordAgePolicy(ctx context.Context, req *mgmt_pb.AddCustomPasswordAgePolicyRequest) (*mgmt_pb.AddCustomPasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: AddCustomPasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	result, err := s.command.AddPasswordAgePolicy(ctx, authz.GetCtxData(ctx).OrgID, AddPasswordAgePolicyToDomain(req))
 	if err != nil {
 		return nil, err
@@ -45,6 +50,7 @@ func (s *Server) AddCustomPasswordAgePolicy(ctx context.Context, req *mgmt_pb.Ad
 }
 
 func (s *Server) UpdateCustomPasswordAgePolicy(ctx context.Context, req *mgmt_pb.UpdateCustomPasswordAgePolicyRequest) (*mgmt_pb.UpdateCustomPasswordAgePolicyResponse, error) {
+	logging.Warn("Deprecated: UpdateCustomPasswordAgePolicy will be removed with ZITADEL v2.56.0")
 	result, err := s.command.ChangePasswordAgePolicy(ctx, authz.GetCtxData(ctx).OrgID, UpdatePasswordAgePolicyToDomain(req))
 	if err != nil {
 		return nil, err
@@ -59,6 +65,7 @@ func (s *Server) UpdateCustomPasswordAgePolicy(ctx context.Context, req *mgmt_pb
 }
 
 func (s *Server) ResetPasswordAgePolicyToDefault(ctx context.Context, req *mgmt_pb.ResetPasswordAgePolicyToDefaultRequest) (*mgmt_pb.ResetPasswordAgePolicyToDefaultResponse, error) {
+	logging.Warn("Deprecated: ResetPasswordAgePolicyToDefault will be removed with ZITADEL v2.56.0")
 	objectDetails, err := s.command.RemovePasswordAgePolicy(ctx, authz.GetCtxData(ctx).OrgID)
 	if err != nil {
 		return nil, err

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -2642,6 +2642,7 @@ service AdminService {
         };
     }
 
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc GetPasswordAgePolicy(GetPasswordAgePolicyRequest) returns (GetPasswordAgePolicyResponse) {
         option (google.api.http) = {
             get: "/policies/password/age";
@@ -2655,7 +2656,8 @@ service AdminService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Get Password Age Settings";
-            description: "Not implemented"
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             responses: {
                 key: "200";
                 value: {
@@ -2665,6 +2667,7 @@ service AdminService {
         };
     }
 
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc UpdatePasswordAgePolicy(UpdatePasswordAgePolicyRequest) returns (UpdatePasswordAgePolicyResponse) {
         option (google.api.http) = {
             put: "/policies/password/age";
@@ -2679,7 +2682,8 @@ service AdminService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Update Password Age Settings";
-            description: "Not implemented"
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             responses: {
                 key: "200";
                 value: {

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -4742,7 +4742,7 @@ service ManagementService {
         };
     }
 
-    // The password age policy is not used at the moment
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc GetPasswordAgePolicy(GetPasswordAgePolicyRequest) returns (GetPasswordAgePolicyResponse) {
         option (google.api.http) = {
             get: "/policies/password/age"
@@ -4756,7 +4756,8 @@ service ManagementService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Get Password Age Settings";
-            description: "Not implemented";
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -4768,7 +4769,7 @@ service ManagementService {
         };
     }
 
-    // The password age policy is not used at the moment
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc GetDefaultPasswordAgePolicy(GetDefaultPasswordAgePolicyRequest) returns (GetDefaultPasswordAgePolicyResponse) {
         option (google.api.http) = {
             get: "/policies/default/password/age"
@@ -4782,7 +4783,8 @@ service ManagementService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Get Default Password Age Settings";
-            description: "Not implemented";
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -4794,7 +4796,7 @@ service ManagementService {
         };
     }
 
-    // The password age policy is not used at the moment
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc AddCustomPasswordAgePolicy(AddCustomPasswordAgePolicyRequest) returns (AddCustomPasswordAgePolicyResponse) {
         option (google.api.http) = {
             post: "/policies/password/age"
@@ -4809,7 +4811,8 @@ service ManagementService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Add Password Age Settings";
-            description: "Not implemented";
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -4821,7 +4824,7 @@ service ManagementService {
         };
     }
 
-    // The password age policy is not used at the moment
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc UpdateCustomPasswordAgePolicy(UpdateCustomPasswordAgePolicyRequest) returns (UpdateCustomPasswordAgePolicyResponse) {
         option (google.api.http) = {
             put: "/policies/password/age"
@@ -4836,7 +4839,8 @@ service ManagementService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Update Password Age Settings";
-            description: "Not implemented";
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -4848,7 +4852,7 @@ service ManagementService {
         };
     }
 
-    // The password age policy is not used at the moment
+    // Deprecated: This method will be removed with ZITADEL v2.56.0
     rpc ResetPasswordAgePolicyToDefault(ResetPasswordAgePolicyToDefaultRequest) returns (ResetPasswordAgePolicyToDefaultResponse) {
         option (google.api.http) = {
             delete: "/policies/password/age"
@@ -4862,7 +4866,8 @@ service ManagementService {
             tags: "Settings";
             tags: "Password Settings";
             summary: "Reset Password Age Settings to Default";
-            description: "Not implemented";
+            description: "This method will be removed with ZITADEL v2.56.0";
+            deprecated: true;
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";


### PR DESCRIPTION
# Which Problems Are Solved

The password age policy methods are useless.

# How the Problems Are Solved

We deprecate the methods, so clients have time to migrate away until version v2.56.0.
Warning logs are printed when the methods are called.
The API docs show deprecation warnings.

![image](https://github.com/zitadel/zitadel/assets/12727842/18b850e4-6e71-4cf4-8333-eba58446b352)

# Additional Context

- Contributes to #8044 