### PR TITLE
fix: potential panics in login and return proper http 405

### DIFF
--- a/internal/api/ui/login/init_password_handler.go
+++ b/internal/api/ui/login/init_password_handler.go
@@ -91,16 +91,18 @@ func (l *Login) checkPWCode(w http.ResponseWriter, r *http.Request, authReq *dom
 func (l *Login) resendPasswordSet(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, data *initPasswordFormData) {
 	userOrg := data.OrgID
 	userID := data.UserID
+	var authReqID string
 	if authReq != nil {
 		userOrg = authReq.UserOrgID
 		userID = authReq.UserID
+		authReqID = authReq.ID
 	}
 	passwordCodeGenerator, err := l.query.InitEncryptionGenerator(r.Context(), domain.SecretGeneratorTypePasswordResetCode, l.userCodeAlg)
 	if err != nil {
 		l.renderInitPassword(w, r, authReq, userID, "", err)
 		return
 	}
-	_, err = l.command.RequestSetPassword(setContext(r.Context(), userOrg), userID, userOrg, domain.NotificationTypeEmail, passwordCodeGenerator, authReq.ID)
+	_, err = l.command.RequestSetPassword(setContext(r.Context(), userOrg), userID, userOrg, domain.NotificationTypeEmail, passwordCodeGenerator, authReqID)
 	l.renderInitPassword(w, r, authReq, userID, "", err)
 }
 

--- a/internal/api/ui/login/login_handler.go
+++ b/internal/api/ui/login/login_handler.go
@@ -69,7 +69,7 @@ func (l *Login) handleLoginNameCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if data.Register {
-		if authReq.LoginPolicy != nil && authReq.LoginPolicy.AllowExternalIDP && authReq.AllowedExternalIDPs != nil && len(authReq.AllowedExternalIDPs) > 0 {
+		if authReq != nil && authReq.LoginPolicy != nil && authReq.LoginPolicy.AllowExternalIDP && authReq.AllowedExternalIDPs != nil && len(authReq.AllowedExternalIDPs) > 0 {
 			l.handleRegisterOption(w, r)
 			return
 		}

--- a/internal/api/ui/login/mail_verify_handler.go
+++ b/internal/api/ui/login/mail_verify_handler.go
@@ -58,16 +58,17 @@ func (l *Login) handleMailVerificationCheck(w http.ResponseWriter, r *http.Reque
 		l.checkMailCode(w, r, authReq, data.UserID, data.Code)
 		return
 	}
-	userOrg := ""
+	var userOrg, authReqID string
 	if authReq != nil {
 		userOrg = authReq.UserOrgID
+		authReqID = authReq.ID
 	}
 	emailCodeGenerator, err := l.query.InitEncryptionGenerator(r.Context(), domain.SecretGeneratorTypeVerifyEmailCode, l.userCodeAlg)
 	if err != nil {
 		l.checkMailCode(w, r, authReq, data.UserID, data.Code)
 		return
 	}
-	_, err = l.command.CreateHumanEmailVerificationCode(setContext(r.Context(), userOrg), data.UserID, userOrg, emailCodeGenerator, authReq.ID)
+	_, err = l.command.CreateHumanEmailVerificationCode(setContext(r.Context(), userOrg), data.UserID, userOrg, emailCodeGenerator, authReqID)
 	l.renderMailVerification(w, r, authReq, data.UserID, err)
 }
 

--- a/internal/api/ui/login/passwordless_registration_handler.go
+++ b/internal/api/ui/login/passwordless_registration_handler.go
@@ -114,11 +114,11 @@ func (l *Login) renderPasswordlessRegistration(w http.ResponseWriter, r *http.Re
 	}
 	if authReq == nil {
 		policy, err := l.query.ActiveLabelPolicyByOrg(r.Context(), orgID, false)
-		logging.Log("HANDL-XjWKE").OnError(err).Error("unable to get active label policy")
+		logging.OnError(err).Error("unable to get active label policy")
 		data.LabelPolicy = labelPolicyToDomain(policy)
 		if err == nil {
 			texts, err := l.authRepo.GetLoginText(r.Context(), orgID)
-			logging.Log("LOGIN-HJK4t").OnError(err).Warn("could not get custom texts")
+			logging.OnError(err).Warn("could not get custom texts")
 			l.addLoginTranslations(translator, texts)
 		}
 	}


### PR DESCRIPTION
# Which Problems Are Solved

We identified some parts in the code, which could panic with a nil pointer when accessed without auth request.
Additionally, if a GRPC method was called with an unmapped HTTP method, e.g. POST instead of GET a 501 instead of a 405 was returned.

# How the Problems Are Solved

- Additional checks for existing authRequest
- custom http status code mapper for gateway

# Additional Changes

None.

# Additional Context

- noted internally in OPS