### PR TITLE
fix: read correct defaults

### DIFF
--- a/cmd/mirror/mirror.go
+++ b/cmd/mirror/mirror.go
@@ -34,6 +34,10 @@ Order of execution:
 3. mirror event store tables
 4. recompute projections
 5. verify`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			err := viper.MergeConfig(bytes.NewBuffer(defaultConfig))
+			logging.OnError(err).Fatal("unable to read default config")
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			config := mustNewMigrationConfig(viper.GetViper())
 			projectionConfig := mustNewProjectionsConfig(viper.GetViper())
@@ -58,9 +62,6 @@ Order of execution:
 * eventstore.unique_constraints
 The flag should be provided if you want to execute the mirror command multiple times so that the static data are also mirrored to prevent inconsistent states.`)
 	migrateProjectionsFlags(cmd)
-
-	err := viper.MergeConfig(bytes.NewBuffer(defaultConfig))
-	logging.OnError(err).Fatal("unable to read default config")
 
 	cmd.AddCommand(
 		eventstoreCmd(),


### PR DESCRIPTION
# Which Problems Are Solved

Corrects reading of default configuration, despite reading all default configs only required defaults are read.

# How the Problems Are Solved

Reading the defualt config of the `mirror`-command was moved to a pre-run step of the command instead of doing it during initialization of the executable.

# Additional Context

- Closes https://github.com/zitadel/zitadel/issues/8059
- https://discord.com/channels/927474939156643850/1248594307267559535