### PR TITLE
fix: callback url suggestion for provider

### DIFF
--- a/console/src/app/modules/providers/provider-next/provider-next.service.ts
+++ b/console/src/app/modules/providers/provider-next/provider-next.service.ts
@@ -85,7 +85,7 @@ export class ProviderNextService {
       map((env) => [
         {
           label: 'ZITADEL Callback URL',
-          url: `${env.issuer}/ui/login/login/externalidp/callback`,
+          url: `${env.issuer}/idps/callback`,
         },
       ]),
     );


### PR DESCRIPTION
# Which Problems Are Solved

Working on the `typescript` project, I followed the docs in terms of how to set up GitHub redirect URI:

![Screenshot 2024-06-12 at 6 13 42 PM](https://github.com/zitadel/zitadel/assets/4237280/7184bccc-5f91-4101-9aa3-e15bd60893b0)

In this case, `https://development-<...>.zitadel.cloud/ui/login/login/externalidp/callback`

But the redirect URI passed to GitHub is `https://development-<...>.zitadel.cloud/IDPs/callback`, causing a Mismatching error.

```
https://development-<...>.zitadel.cloud/ui/login/login/externalidp/callback?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=271335938330761930
```

# How the Problems Are Solved

Fix the suggestion in the GUI
