### PR TITLE
feat: Allow using IAM assumable role as AWS credentials for data import from S3 (#8127)

### DIFF
--- a/internal/api/grpc/admin/import.go
+++ b/internal/api/grpc/admin/import.go
@@ -247,8 +247,15 @@ func (s *Server) transportDataFromFile(ctx context.Context, v1Transformation boo
 }
 
 func getFileFromS3(ctx context.Context, input *admin_pb.ImportDataRequest_S3Input) ([]byte, error) {
+	var creds *credentials.Credentials
+	if input.AccessKeyId != "" && input.SecretAccessKey != "" {
+		creds = credentials.NewStaticV4(input.AccessKeyId, input.SecretAccessKey, "")
+	} else {
+		creds = credentials.NewIAM(input.Endpoint)
+	}
+
 	minioClient, err := minio.New(input.Endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(input.AccessKeyId, input.SecretAccessKey, ""),
+		Creds:  creds,
 		Secure: input.Ssl,
 	})
 	if err != nil {


### PR DESCRIPTION
# Which Problems Are Solved

Solves issue #8127 - adds ability to use AWS IAM credentials for import from S3 buckets

# How the Problems Are Solved

Use minio IAM credentials:
```
creds = credentials.NewIAM(input.Endpoint)
```

# Additional Context
- Closes #8127