### PR TITLE
fix(import): add tracing spans to all import related functions

### DIFF
--- a/internal/api/grpc/admin/import.go
+++ b/internal/api/grpc/admin/import.go
@@ -246,7 +246,10 @@ func (s *Server) transportDataFromFile(ctx context.Context, v1Transformation boo
 	return dataOrgs, nil
 }
 
-func getFileFromS3(ctx context.Context, input *admin_pb.ImportDataRequest_S3Input) ([]byte, error) {
+func getFileFromS3(ctx context.Context, input *admin_pb.ImportDataRequest_S3Input) (_ []byte, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	minioClient, err := minio.New(input.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(input.AccessKeyId, input.SecretAccessKey, ""),
 		Secure: input.Ssl,
@@ -272,7 +275,10 @@ func getFileFromS3(ctx context.Context, input *admin_pb.ImportDataRequest_S3Inpu
 	return ioutil.ReadAll(object)
 }
 
-func getFileFromGCS(ctx context.Context, input *admin_pb.ImportDataRequest_GCSInput) ([]byte, error) {
+func getFileFromGCS(ctx context.Context, input *admin_pb.ImportDataRequest_GCSInput) (_ []byte, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	saJson, err := base64.StdEncoding.DecodeString(input.ServiceaccountJson)
 	if err != nil {
 		return nil, err
@@ -292,8 +298,11 @@ func getFileFromGCS(ctx context.Context, input *admin_pb.ImportDataRequest_GCSIn
 	return ioutil.ReadAll(reader)
 }
 
-func importOrg1(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, ctxData authz.CtxData, org *admin_pb.DataOrg, success *admin_pb.ImportDataSuccess, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) error {
-	_, err := s.command.AddOrgWithID(ctx, org.GetOrg().GetName(), ctxData.UserID, ctxData.ResourceOwner, org.GetOrgId(), []string{})
+func importOrg1(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, ctxData authz.CtxData, org *admin_pb.DataOrg, success *admin_pb.ImportDataSuccess, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
+	_, err = s.command.AddOrgWithID(ctx, org.GetOrg().GetName(), ctxData.UserID, ctxData.ResourceOwner, org.GetOrgId(), []string{})
 	if err != nil {
 		*errors = append(*errors, &admin_pb.ImportDataError{Type: "org", Id: org.GetOrgId(), Message: err.Error()})
 		if _, err := s.query.OrgByID(ctx, true, org.OrgId); err != nil {
@@ -328,11 +337,14 @@ func importOrg1(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataEr
 	return importResources(ctx, s, errors, successOrg, org, count, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode)
 }
 
-func importLabelPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) error {
+func importLabelPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.LabelPolicy == nil {
 		return nil
 	}
-	_, err := s.command.AddLabelPolicy(ctx, org.GetOrgId(), management.AddLabelPolicyToDomain(org.GetLabelPolicy()))
+	_, err = s.command.AddLabelPolicy(ctx, org.GetOrgId(), management.AddLabelPolicyToDomain(org.GetLabelPolicy()))
 	if err != nil {
 		*errors = append(*errors, &admin_pb.ImportDataError{Type: "label_policy", Id: org.GetOrgId(), Message: err.Error()})
 		if isCtxTimeout(ctx) {
@@ -351,6 +363,9 @@ func importLabelPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.Impor
 }
 
 func importLockoutPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.LockoutPolicy == nil {
 		return
 	}
@@ -360,7 +375,10 @@ func importLockoutPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.Imp
 	}
 }
 
-func importOidcIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) error {
+func importOidcIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.OidcIdps == nil {
 		return nil
 	}
@@ -380,7 +398,10 @@ func importOidcIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDa
 	return nil
 }
 
-func importJwtIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) error {
+func importJwtIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.JwtIdps == nil {
 		return nil
 	}
@@ -401,6 +422,9 @@ func importJwtIdps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDat
 }
 
 func importLoginPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.LoginPolicy == nil {
 		return
 	}
@@ -411,6 +435,9 @@ func importLoginPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.Impor
 }
 
 func importPwComlexityPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.PasswordComplexityPolicy == nil {
 		return
 	}
@@ -421,6 +448,9 @@ func importPwComlexityPolicy(ctx context.Context, s *Server, errors *[]*admin_pb
 }
 
 func importPrivacyPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.PrivacyPolicy == nil {
 		return
 	}
@@ -430,7 +460,10 @@ func importPrivacyPolicy(ctx context.Context, s *Server, errors *[]*admin_pb.Imp
 	}
 }
 
-func importHumanUsers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) error {
+func importHumanUsers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.HumanUsers == nil {
 		return nil
 	}
@@ -465,7 +498,10 @@ func importHumanUsers(ctx context.Context, s *Server, errors *[]*admin_pb.Import
 	return nil
 }
 
-func importMachineUsers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importMachineUsers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.MachineUsers == nil {
 		return nil
 	}
@@ -486,7 +522,10 @@ func importMachineUsers(ctx context.Context, s *Server, errors *[]*admin_pb.Impo
 	return nil
 }
 
-func importUserMetadata(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importUserMetadata(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.UserMetadata == nil {
 		return nil
 	}
@@ -507,7 +546,10 @@ func importUserMetadata(ctx context.Context, s *Server, errors *[]*admin_pb.Impo
 	return nil
 }
 
-func importMachineKeys(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importMachineKeys(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.MachineKeys == nil {
 		return nil
 	}
@@ -537,7 +579,10 @@ func importMachineKeys(ctx context.Context, s *Server, errors *[]*admin_pb.Impor
 	return nil
 }
 
-func importUserLinks(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importUserLinks(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.UserLinks == nil {
 		return nil
 	}
@@ -548,6 +593,7 @@ func importUserLinks(ctx context.Context, s *Server, errors *[]*admin_pb.ImportD
 			IDPExternalID: userLinks.ProvidedUserId,
 			DisplayName:   userLinks.ProvidedUserName,
 		}
+		// TBD: why not command.BulkAddedUserIDPLinks?
 		if _, err := s.command.AddUserIDPLink(ctx, userLinks.UserId, org.GetOrgId(), externalIDP); err != nil {
 			*errors = append(*errors, &admin_pb.ImportDataError{Type: "user_link", Id: userLinks.UserId + "_" + userLinks.IdpId, Message: err.Error()})
 			if isCtxTimeout(ctx) {
@@ -563,7 +609,10 @@ func importUserLinks(ctx context.Context, s *Server, errors *[]*admin_pb.ImportD
 
 }
 
-func importProjects(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importProjects(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.Projects == nil {
 		return nil
 	}
@@ -584,7 +633,10 @@ func importProjects(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDa
 	return nil
 }
 
-func importOIDCApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importOIDCApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.OidcApps == nil {
 		return nil
 	}
@@ -605,7 +657,10 @@ func importOIDCApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDa
 	return nil
 }
 
-func importAPIApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importAPIApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.ApiApps == nil {
 		return nil
 	}
@@ -626,7 +681,10 @@ func importAPIApps(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDat
 	return nil
 }
 
-func importAppKeys(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importAppKeys(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.AppKeys == nil {
 		return nil
 	}
@@ -658,7 +716,10 @@ func importAppKeys(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDat
 	return nil
 }
 
-func importActions(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importActions(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.Actions == nil {
 		return nil
 	}
@@ -678,12 +739,17 @@ func importActions(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDat
 	}
 	return nil
 }
-func importProjectRoles(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) error {
+func importProjectRoles(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.ProjectRoles == nil {
 		return nil
 	}
 	for _, role := range org.GetProjectRoles() {
 		logging.Debugf("import projectroles: %s", role.ProjectId+"_"+role.RoleKey)
+
+		// TBD: why not command.BulkAddProjectRole?
 		_, err := s.command.AddProjectRole(ctx, management.AddProjectRoleRequestToDomain(role), org.GetOrgId())
 		if err != nil {
 			*errors = append(*errors, &admin_pb.ImportDataError{Type: "project_role", Id: role.ProjectId + "_" + role.RoleKey, Message: err.Error()})
@@ -700,7 +766,10 @@ func importProjectRoles(ctx context.Context, s *Server, errors *[]*admin_pb.Impo
 	return nil
 }
 
-func importResources(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) error {
+func importResources(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if err := importOrgDomains(ctx, s, errors, successOrg, org); err != nil {
 		return err
 	}
@@ -760,7 +829,10 @@ func importResources(ctx context.Context, s *Server, errors *[]*admin_pb.ImportD
 	return nil
 }
 
-func importOrgDomains(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) error {
+func importOrgDomains(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.Domains == nil {
 		return nil
 	}
@@ -799,6 +871,9 @@ func importOrgDomains(ctx context.Context, s *Server, errors *[]*admin_pb.Import
 }
 
 func importLoginTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.LoginTexts == nil {
 		return
 	}
@@ -811,6 +886,9 @@ func importLoginTexts(ctx context.Context, s *Server, errors *[]*admin_pb.Import
 }
 
 func importInitMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.InitMessages == nil {
 		return
 	}
@@ -823,6 +901,9 @@ func importInitMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.
 }
 
 func importPWResetMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.PasswordResetMessages == nil {
 		return
 	}
@@ -835,6 +916,9 @@ func importPWResetMessageTexts(ctx context.Context, s *Server, errors *[]*admin_
 }
 
 func importVerifyEmailMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.VerifyEmailMessages == nil {
 		return
 	}
@@ -847,6 +931,9 @@ func importVerifyEmailMessageTexts(ctx context.Context, s *Server, errors *[]*ad
 }
 
 func importVerifyPhoneMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.VerifyPhoneMessages != nil {
 		return
 	}
@@ -859,6 +946,9 @@ func importVerifyPhoneMessageTexts(ctx context.Context, s *Server, errors *[]*ad
 }
 
 func importDomainClaimedMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.DomainClaimedMessages == nil {
 		return
 	}
@@ -871,6 +961,9 @@ func importDomainClaimedMessageTexts(ctx context.Context, s *Server, errors *[]*
 }
 
 func importPasswordlessRegistrationMessageTexts(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, org *admin_pb.DataOrg) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.End() }()
+
 	if org.PasswordlessRegistrationMessages == nil {
 		return
 	}
@@ -882,7 +975,10 @@ func importPasswordlessRegistrationMessageTexts(ctx context.Context, s *Server, 
 	}
 }
 
-func importOrg2(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, success *admin_pb.ImportDataSuccess, count *counts, org *admin_pb.DataOrg) error {
+func importOrg2(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, success *admin_pb.ImportDataSuccess, count *counts, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	successOrg := findOldOrg(success, org.OrgId)
 	if successOrg == nil {
 		return nil
@@ -932,7 +1028,10 @@ func importOrg2(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataEr
 	return nil
 }
 
-func importOrg3(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, success *admin_pb.ImportDataSuccess, count *counts, org *admin_pb.DataOrg) error {
+func importOrg3(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, success *admin_pb.ImportDataSuccess, count *counts, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	successOrg := findOldOrg(success, org.OrgId)
 	if successOrg == nil {
 		return nil
@@ -946,7 +1045,10 @@ func importOrg3(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataEr
 	return importProjectMembers(ctx, s, errors, successOrg, count, org)
 }
 
-func importOrgMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) error {
+func importOrgMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.OrgMembers == nil {
 		return nil
 	}
@@ -967,7 +1069,10 @@ func importOrgMembers(ctx context.Context, s *Server, errors *[]*admin_pb.Import
 	return nil
 }
 
-func importProjectGrantMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) error {
+func importProjectGrantMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.ProjectGrantMembers == nil {
 		return nil
 	}
@@ -988,7 +1093,10 @@ func importProjectGrantMembers(ctx context.Context, s *Server, errors *[]*admin_
 	return nil
 }
 
-func importProjectMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) error {
+func importProjectMembers(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, successOrg *admin_pb.ImportDataSuccessOrg, count *counts, org *admin_pb.DataOrg) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if org.ProjectMembers == nil {
 		return nil
 	}
@@ -1018,7 +1126,10 @@ func findOldOrg(success *admin_pb.ImportDataSuccess, orgId string) *admin_pb.Imp
 	return nil
 }
 
-func (s *Server) importData(ctx context.Context, orgs []*admin_pb.DataOrg) (*admin_pb.ImportDataResponse, *counts, error) {
+func (s *Server) importData(ctx context.Context, orgs []*admin_pb.DataOrg) (_ *admin_pb.ImportDataResponse, _ *counts, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	errors := make([]*admin_pb.ImportDataError, 0)
 	success := &admin_pb.ImportDataSuccess{}
 	count := &counts{}

--- a/internal/command/idp.go
+++ b/internal/command/idp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zitadel/zitadel/internal/command/preparation"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/repository/idp"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -133,6 +134,9 @@ type AppleProvider struct {
 
 // ExistsIDPOnOrgOrInstance query first org level IDPs and then instance level IDPs, no check if the IDP is active
 func ExistsIDPOnOrgOrInstance(ctx context.Context, filter preparation.FilterToQueryReducer, instanceID, orgID, id string) (exists bool, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	writeModel := NewOrgIDPRemoveWriteModel(orgID, id)
 	events, err := filter(ctx, writeModel.Query())
 	if err != nil {

--- a/internal/command/org_custom_login_text.go
+++ b/internal/command/org_custom_login_text.go
@@ -9,12 +9,16 @@ import (
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/i18n"
 	"github.com/zitadel/zitadel/internal/repository/org"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 // SetOrgLoginText only validates if the language is supported, not if it is allowed.
 // This enables setting texts before allowing a language
-func (c *Commands) SetOrgLoginText(ctx context.Context, resourceOwner string, loginText *domain.CustomLoginText) (*domain.ObjectDetails, error) {
+func (c *Commands) SetOrgLoginText(ctx context.Context, resourceOwner string, loginText *domain.CustomLoginText) (_ *domain.ObjectDetails, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if resourceOwner == "" {
 		return nil, zerrors.ThrowInvalidArgument(nil, "ORG-m29rF", "Errors.ResourceOwnerMissing")
 	}

--- a/internal/command/org_custom_message_text.go
+++ b/internal/command/org_custom_message_text.go
@@ -9,12 +9,16 @@ import (
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/i18n"
 	"github.com/zitadel/zitadel/internal/repository/org"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 // SetOrgMessageText only validates if the language is supported, not if it is allowed.
 // This enables setting texts before allowing a language
-func (c *Commands) SetOrgMessageText(ctx context.Context, resourceOwner string, messageText *domain.CustomMessageText) (*domain.ObjectDetails, error) {
+func (c *Commands) SetOrgMessageText(ctx context.Context, resourceOwner string, messageText *domain.CustomMessageText) (_ *domain.ObjectDetails, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if resourceOwner == "" {
 		return nil, zerrors.ThrowInvalidArgument(nil, "ORG-2biiR", "Errors.ResourceOwnerMissing")
 	}

--- a/internal/command/org_flow.go
+++ b/internal/command/org_flow.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/repository/org"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -32,7 +33,10 @@ func (c *Commands) ClearFlow(ctx context.Context, flowType domain.FlowType, reso
 	return writeModelToObjectDetails(&existingFlow.WriteModel), nil
 }
 
-func (c *Commands) SetTriggerActions(ctx context.Context, flowType domain.FlowType, triggerType domain.TriggerType, actionIDs []string, resourceOwner string) (*domain.ObjectDetails, error) {
+func (c *Commands) SetTriggerActions(ctx context.Context, flowType domain.FlowType, triggerType domain.TriggerType, actionIDs []string, resourceOwner string) (_ *domain.ObjectDetails, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if !flowType.Valid() || !triggerType.Valid() || resourceOwner == "" {
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-Dfhj5", "Errors.Flow.FlowTypeMissing")
 	}
@@ -67,9 +71,12 @@ func (c *Commands) SetTriggerActions(ctx context.Context, flowType domain.FlowTy
 	return writeModelToObjectDetails(&existingFlow.WriteModel), nil
 }
 
-func (c *Commands) getOrgFlowWriteModelByType(ctx context.Context, flowType domain.FlowType, resourceOwner string) (*OrgFlowWriteModel, error) {
+func (c *Commands) getOrgFlowWriteModelByType(ctx context.Context, flowType domain.FlowType, resourceOwner string) (_ *OrgFlowWriteModel, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	flowWriteModel := NewOrgFlowWriteModel(flowType, resourceOwner)
-	err := c.eventstore.FilterToQueryReducer(ctx, flowWriteModel)
+	err = c.eventstore.FilterToQueryReducer(ctx, flowWriteModel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/org_idp_config.go
+++ b/internal/command/org_idp_config.go
@@ -11,7 +11,10 @@ import (
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
-func (c *Commands) ImportIDPConfig(ctx context.Context, config *domain.IDPConfig, idpConfigID, resourceOwner string) (*domain.IDPConfig, error) {
+func (c *Commands) ImportIDPConfig(ctx context.Context, config *domain.IDPConfig, idpConfigID, resourceOwner string) (_ *domain.IDPConfig, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	existingIDP, err := c.orgIDPConfigWriteModelByID(ctx, idpConfigID, resourceOwner)
 	if err != nil {
 		return nil, err

--- a/internal/command/org_policy_domain.go
+++ b/internal/command/org_policy_domain.go
@@ -11,7 +11,10 @@ import (
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
-func (c *Commands) AddOrgDomainPolicy(ctx context.Context, resourceOwner string, userLoginMustBeDomain, validateOrgDomains, smtpSenderAddressMatchesInstanceDomain bool) (*domain.ObjectDetails, error) {
+func (c *Commands) AddOrgDomainPolicy(ctx context.Context, resourceOwner string, userLoginMustBeDomain, validateOrgDomains, smtpSenderAddressMatchesInstanceDomain bool) (_ *domain.ObjectDetails, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if resourceOwner == "" {
 		return nil, zerrors.ThrowInvalidArgument(nil, "Org-4Jfsf", "Errors.ResourceOwnerMissing")
 	}
@@ -60,7 +63,10 @@ func (c *Commands) RemoveOrgDomainPolicy(ctx context.Context, orgID string) (*do
 }
 
 // Deprecated: Use commands.domainPolicyWriteModel directly, to remove the domain.DomainPolicy struct
-func (c *Commands) getOrgDomainPolicy(ctx context.Context, orgID string) (*domain.DomainPolicy, error) {
+func (c *Commands) getOrgDomainPolicy(ctx context.Context, orgID string) (_ *domain.DomainPolicy, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	policy, err := c.orgDomainPolicyWriteModel(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -90,7 +96,10 @@ func prepareAddOrgDomainPolicy(
 	smtpSenderAddressMatchesInstanceDomain bool,
 ) preparation.Validation {
 	return func() (preparation.CreateCommands, error) {
-		return func(ctx context.Context, filter preparation.FilterToQueryReducer) ([]eventstore.Command, error) {
+		return func(ctx context.Context, filter preparation.FilterToQueryReducer) (_ []eventstore.Command, err error) {
+			ctx, span := tracing.NewSpan(ctx)
+			defer func() { span.EndWithError(err) }()
+
 			writeModel, err := orgDomainPolicy(ctx, filter, a.ID)
 			if err != nil {
 				return nil, err

--- a/internal/command/project_application_api.go
+++ b/internal/command/project_application_api.go
@@ -68,6 +68,9 @@ func (c *Commands) AddAPIAppCommand(app *addAPIApp) preparation.Validation {
 }
 
 func (c *Commands) AddAPIApplicationWithID(ctx context.Context, apiApp *domain.APIApp, resourceOwner, appID string) (_ *domain.APIApp, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	existingAPI, err := c.getAPIAppWriteModel(ctx, apiApp.AggregateID, appID, resourceOwner)
 	if err != nil {
 		return nil, err
@@ -105,6 +108,9 @@ func (c *Commands) AddAPIApplication(ctx context.Context, apiApp *domain.APIApp,
 }
 
 func (c *Commands) addAPIApplicationWithID(ctx context.Context, apiApp *domain.APIApp, resourceOwner string, project *domain.Project, appID string) (_ *domain.APIApp, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	apiApp.AppID = appID
 
 	addedApplication := NewAPIApplicationWriteModel(apiApp.AggregateID, resourceOwner)
@@ -262,9 +268,12 @@ func (c *Commands) APISecretCheckFailed(ctx context.Context, appID, projectID, r
 	c.apiSecretCheckFailed(ctx, &agg.Aggregate, appID)
 }
 
-func (c *Commands) getAPIAppWriteModel(ctx context.Context, projectID, appID, resourceOwner string) (*APIApplicationWriteModel, error) {
+func (c *Commands) getAPIAppWriteModel(ctx context.Context, projectID, appID, resourceOwner string) (_ *APIApplicationWriteModel, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	appWriteModel := NewAPIApplicationWriteModelWithAppID(projectID, appID, resourceOwner)
-	err := c.eventstore.FilterToQueryReducer(ctx, appWriteModel)
+	err = c.eventstore.FilterToQueryReducer(ctx, appWriteModel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/project_application_key.go
+++ b/internal/command/project_application_key.go
@@ -10,6 +10,9 @@ import (
 )
 
 func (c *Commands) AddApplicationKeyWithID(ctx context.Context, key *domain.ApplicationKey, resourceOwner string) (_ *domain.ApplicationKey, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	writeModel, err := c.applicationKeyWriteModelByID(ctx, key.AggregateID, key.ApplicationID, key.KeyID, resourceOwner)
 	if err != nil {
 		return nil, err
@@ -47,6 +50,8 @@ func (c *Commands) AddApplicationKey(ctx context.Context, key *domain.Applicatio
 }
 
 func (c *Commands) addApplicationKey(ctx context.Context, key *domain.ApplicationKey, resourceOwner string) (_ *domain.ApplicationKey, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
 
 	keyWriteModel := NewApplicationKeyWriteModel(key.AggregateID, key.ApplicationID, key.KeyID, resourceOwner)
 	err = c.eventstore.FilterToQueryReducer(ctx, keyWriteModel)

--- a/internal/command/project_grant.go
+++ b/internal/command/project_grant.go
@@ -14,6 +14,9 @@ import (
 )
 
 func (c *Commands) AddProjectGrantWithID(ctx context.Context, grant *domain.ProjectGrant, grantID string, resourceOwner string) (_ *domain.ProjectGrant, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	existingMember, err := c.projectGrantWriteModelByID(ctx, grantID, grant.AggregateID, resourceOwner)
 	if err != nil && !zerrors.IsNotFound(err) {
 		return nil, err

--- a/internal/command/project_grant_member.go
+++ b/internal/command/project_grant_member.go
@@ -11,14 +11,17 @@ import (
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
-func (c *Commands) AddProjectGrantMember(ctx context.Context, member *domain.ProjectGrantMember) (*domain.ProjectGrantMember, error) {
+func (c *Commands) AddProjectGrantMember(ctx context.Context, member *domain.ProjectGrantMember) (_ *domain.ProjectGrantMember, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if !member.IsValid() {
 		return nil, zerrors.ThrowInvalidArgument(nil, "PROJECT-8fi7G", "Errors.Project.Grant.Member.Invalid")
 	}
 	if len(domain.CheckForInvalidRoles(member.Roles, domain.ProjectGrantRolePrefix, c.zitadelRoles)) > 0 {
 		return nil, zerrors.ThrowInvalidArgument(nil, "PROJECT-m9gKK", "Errors.Project.Grant.Member.Invalid")
 	}
-	err := c.checkUserExists(ctx, member.UserID, "")
+	err = c.checkUserExists(ctx, member.UserID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/project_role.go
+++ b/internal/command/project_role.go
@@ -8,10 +8,14 @@ import (
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/project"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 func (c *Commands) AddProjectRole(ctx context.Context, projectRole *domain.ProjectRole, resourceOwner string) (_ *domain.ProjectRole, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	err = c.checkProjectExists(ctx, projectRole.AggregateID, resourceOwner)
 	if err != nil {
 		return nil, err

--- a/internal/command/user.go
+++ b/internal/command/user.go
@@ -336,7 +336,10 @@ func (c *Commands) UserDomainClaimedSent(ctx context.Context, orgID, userID stri
 	return err
 }
 
-func (c *Commands) checkUserExists(ctx context.Context, userID, resourceOwner string) error {
+func (c *Commands) checkUserExists(ctx context.Context, userID, resourceOwner string) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	existingUser, err := c.userWriteModelByID(ctx, userID, resourceOwner)
 	if err != nil {
 		return err

--- a/internal/command/user_domain_policy.go
+++ b/internal/command/user_domain_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/zitadel/zitadel/internal/command/preparation"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -60,7 +61,10 @@ func orgDomainPolicy(ctx context.Context, filter preparation.FilterToQueryReduce
 }
 
 // Deprecated: Use commands.instanceDomainPolicyWriteModel directly, to remove use of eventstore.Filter function
-func instanceDomainPolicy(ctx context.Context, filter preparation.FilterToQueryReducer) (*InstanceDomainPolicyWriteModel, error) {
+func instanceDomainPolicy(ctx context.Context, filter preparation.FilterToQueryReducer) (_ *InstanceDomainPolicyWriteModel, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	policy := NewInstanceDomainPolicyWriteModel(ctx)
 	events, err := filter(ctx, policy.Query())
 	if err != nil {
@@ -74,7 +78,10 @@ func instanceDomainPolicy(ctx context.Context, filter preparation.FilterToQueryR
 	return policy, err
 }
 
-func domainPolicyUsernames(ctx context.Context, filter preparation.FilterToQueryReducer, orgID string) (*DomainPolicyUsernamesWriteModel, error) {
+func domainPolicyUsernames(ctx context.Context, filter preparation.FilterToQueryReducer, orgID string) (_ *DomainPolicyUsernamesWriteModel, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	policy := NewDomainPolicyUsernamesWriteModel(orgID)
 	events, err := filter(ctx, policy.Query())
 	if err != nil {

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -16,7 +16,10 @@ import (
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
-func (c *Commands) ImportHumanTOTP(ctx context.Context, userID, userAgentID, resourceOwner string, key string) error {
+func (c *Commands) ImportHumanTOTP(ctx context.Context, userID, userAgentID, resourceOwner string, key string) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	encryptedSecret, err := crypto.Encrypt([]byte(key), c.multifactors.OTP.CryptoMFA)
 	if err != nil {
 		return err

--- a/internal/command/user_idp_link.go
+++ b/internal/command/user_idp_link.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (c *Commands) AddUserIDPLink(ctx context.Context, userID, resourceOwner string, link *AddLink) (_ *domain.ObjectDetails, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if userID == "" {
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-03j8f", "Errors.IDMissing")
 	}

--- a/internal/command/user_metadata.go
+++ b/internal/command/user_metadata.go
@@ -6,10 +6,14 @@ import (
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/user"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
 func (c *Commands) SetUserMetadata(ctx context.Context, metadata *domain.Metadata, userID, resourceOwner string) (_ *domain.Metadata, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	err = c.checkUserExists(ctx, userID, resourceOwner)
 	if err != nil {
 		return nil, err

--- a/internal/domain/human.go
+++ b/internal/domain/human.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/crypto"
 	es_models "github.com/zitadel/zitadel/internal/eventstore/v1/models"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -104,7 +105,10 @@ func (u *Human) EnsureDisplayName() {
 	u.DisplayName = u.Username
 }
 
-func (u *Human) HashPasswordIfExisting(ctx context.Context, policy *PasswordComplexityPolicy, hasher *crypto.Hasher, onetime bool) error {
+func (u *Human) HashPasswordIfExisting(ctx context.Context, policy *PasswordComplexityPolicy, hasher *crypto.Hasher, onetime bool) (err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	if u.Password != nil {
 		u.Password.ChangeRequired = onetime
 		return u.Password.HashPasswordIfExisting(ctx, policy, hasher)

--- a/internal/query/secret_generators.go
+++ b/internal/query/secret_generators.go
@@ -102,7 +102,10 @@ type SecretGeneratorSearchQueries struct {
 	Queries []SearchQuery
 }
 
-func (q *Queries) InitEncryptionGenerator(ctx context.Context, generatorType domain.SecretGeneratorType, algorithm crypto.EncryptionAlgorithm) (crypto.Generator, error) {
+func (q *Queries) InitEncryptionGenerator(ctx context.Context, generatorType domain.SecretGeneratorType, algorithm crypto.EncryptionAlgorithm) (_ crypto.Generator, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
 	generatorConfig, err := q.SecretGeneratorByType(ctx, generatorType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Which Problems Are Solved

This fix adds tracing spans to all V1 API import related functions. This is to troubleshoot import related performance issues reported to us.

# How the Problems Are Solved

Add a tracing span to `api/grpc/admin/import.go` and all related functions that are called in the `command` package.

# Additional Changes

- none

# Additional Context

- Reported by internal communication