### PR TITLE
chore(doc): do not expose database to public networks in examples

### DIFF
--- a/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
@@ -44,8 +44,6 @@ services:
       timeout: '30s'
       retries: 5
       start_period: '20s'
-    ports:
-      - '5432:5432'
 
 networks:
   zitadel:

--- a/docs/docs/self-hosting/deploy/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose.yaml
@@ -39,8 +39,6 @@ services:
       timeout: '30s'
       retries: 5
       start_period: '20s'
-    ports:
-      - '5432:5432'
 
 networks:
   zitadel:

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
@@ -31,8 +31,6 @@ services:
     environment:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=postgres
-    ports:
-      - '5432:5432'
     networks:
       - 'zitadel'
     healthcheck:

--- a/docs/docs/self-hosting/manage/configure/docker-compose.yaml
+++ b/docs/docs/self-hosting/manage/configure/docker-compose.yaml
@@ -20,8 +20,6 @@ services:
     environment:
       - POSTGRES_USER=root
       - POSTGRES_PASSWORD=postgres
-    ports:
-      - '5432:5432'
     networks:
       - 'zitadel'
     healthcheck:

--- a/docs/docs/self-hosting/manage/reverseproxy/docker-compose.yaml
+++ b/docs/docs/self-hosting/manage/reverseproxy/docker-compose.yaml
@@ -133,8 +133,6 @@ services:
       timeout: 60s
       retries: 10
       start_period: 5s
-    ports:
-      - '5432:5432'
     networks:
       - 'zitadel'
     volumes:


### PR DESCRIPTION
# Which Problems Are Solved

The docker-compose examples expose the database to the world.

# How the Problems Are Solved

Remove the `ports` config from the `db` service.
