### PR TITLE
fix: change saml sp to saml idp

### DIFF
--- a/console/src/app/modules/idp-table/idp-table.component.html
+++ b/console/src/app/modules/idp-table/idp-table.component.html
@@ -87,7 +87,7 @@
             </div>
             <div class="idp-table-provider-type" *ngSwitchCase="ProviderType.PROVIDER_TYPE_SAML">
               <img class="idp-logo" src="./assets/images/idp/saml-icon.svg" alt="saml" />
-              SAML SP
+              SAML
             </div>
             <div class="idp-table-provider-type" *ngSwitchDefault>coming soon</div>
           </div>

--- a/console/src/app/modules/policies/idp-settings/idp-settings.component.html
+++ b/console/src/app/modules/policies/idp-settings/idp-settings.component.html
@@ -214,7 +214,7 @@
   >
     <img class="idp-logo" src="./assets/images/idp/saml-icon.svg" alt="oauth" />
     <div class="text-container">
-      <span class="title">SAML SP</span>
+      <span class="title">SAML</span>
     </div>
   </a>
 </div>

--- a/console/src/assets/i18n/en.json
+++ b/console/src/assets/i18n/en.json
@@ -2047,7 +2047,7 @@
         "DESCRIPTION": "Enter the credentials for your Apple Provider"
       },
       "SAML": {
-        "TITLE": "Sign in with SAML IdP",
+        "TITLE": "Sign in with SAML",
         "DESCRIPTION": "Enter the credentials for your SAML Provider"
       }
     },

--- a/console/src/assets/i18n/en.json
+++ b/console/src/assets/i18n/en.json
@@ -2047,7 +2047,7 @@
         "DESCRIPTION": "Enter the credentials for your Apple Provider"
       },
       "SAML": {
-        "TITLE": "Sign in with SAML SP",
+        "TITLE": "Sign in with SAML IdP",
         "DESCRIPTION": "Enter the credentials for your SAML Provider"
       }
     },

--- a/docs/docs/guides/integrate/identity-providers/azure-ad-saml.mdx
+++ b/docs/docs/guides/integrate/identity-providers/azure-ad-saml.mdx
@@ -51,7 +51,7 @@ Configure the sign-on method of the app.
 
 ### Go to the IdP Providers Overview
 
-<IDPsOverview templates="SAML SP"/>
+<IDPsOverview templates="SAML"/>
 
 ### Create a new SAML Service Provider (SP)
 
@@ -70,7 +70,7 @@ Now we configure the identity provider on ZITADEL.
 
 ## Configure Basic SAML Configuration
 
-After you created the SAML SP in ZITADEL, you can copy the URLs you need to configure in your Entra ID application.
+After you created the SAML provider in ZITADEL, you can copy the URLs you need to configure in your Entra ID application.
 
 ![Azure SAML App URLs](/img/guides/zitadel_azure_saml_provider_urls.png)
 

--- a/docs/docs/guides/integrate/identity-providers/mocksaml.mdx
+++ b/docs/docs/guides/integrate/identity-providers/mocksaml.mdx
@@ -23,23 +23,23 @@ MockSAML is not intended for any production environment, only for test purposes
 ### Download metadata
 
 You can either download the metadata under [https://mocksaml.com/api/saml/metadata?download=true](https://mocksaml.com/api/saml/metadata?download=true) or skip this step and
-fill in the URL when creating the SAML SP in ZITADEL.
+fill in the URL when creating the SAML Provider in ZITADEL.
 
 ## ZITADEL configuration
 
 ### Go to the IdP providers overview
 
-<IDPsOverview templates="SAML SP"/>
+<IDPsOverview templates="SAML"/>
 
 ### Create a new SAML ServiceProvider
 
-The SAML SP provider template has everything you need preconfigured.
+The SAML provider template has everything you need preconfigured.
 Add the metadata.xml or the URL to the metadata which are accessible by you ZITADEL instance.
 All the necessary configuration is contained in the metadata which has to be exchanged by the ServiceProvider and the IdentityProvider.
 
 <GeneralConfigDescription provider_account="SAML account" />
 
-![SAML SP Provider](/img/guides/zitadel_saml_create_provider.png)
+![SAML Provider](/img/guides/zitadel_saml_create_provider.png)
 
 ### Download metadata
 
@@ -50,7 +50,7 @@ They are available under `https://${CUSTOMDOMAIN}/idps/\{ID of the provider in Z
 
 <Activate/>
 
-![Activate the SAML SP Provider](/img/guides/zitadel_activate_saml.png)
+![Activate the SAML Provider](/img/guides/zitadel_activate_saml.png)
 
 ### Ensure your Login Policy allows External IDPs
 
@@ -58,11 +58,11 @@ They are available under `https://${CUSTOMDOMAIN}/idps/\{ID of the provider in Z
 
 ## Test the setup
 
-<TestSetup loginscreen="your SAML SP login"/>
+<TestSetup loginscreen="your SAML login"/>
 
-![SAML SP Button](/img/guides/zitadel_login_saml.png)
+![SAML Button](/img/guides/zitadel_login_saml.png)
 
-![SAML SP Login](/img/guides/mocksaml_login.png)
+![SAML Login](/img/guides/mocksaml_login.png)
 
 ## Optional: Add ZITADEL action to autofill userdata
 

--- a/docs/docs/guides/integrate/identity-providers/okta_saml.mdx
+++ b/docs/docs/guides/integrate/identity-providers/okta_saml.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure OKTA as a SAML Identity Provider in ZITADEL
-sidebar_label: OKTA SAML SP
+sidebar_label: OKTA SAML
 id: okta-saml
 ---
 
@@ -18,12 +18,12 @@ import TestSetup from './_test_setup.mdx';
 
 ### Go to the IdP Providers Overview
 
-<IDPsOverview templates="SAML SP"/>
+<IDPsOverview templates="SAML"/>
 
-### Create a new SAML Service Provider (SP)
+### Create a new SAML Provider
 
 To be able to create the application in OKTA we need the provider id from ZITADEL.
-1. Create a new SAML SP with a name and a random text in the Metadata Xml field.
+1. Create a new SAML Provider with a name and a random text in the Metadata Xml field.
 We will fill that as soon as we have done the configuration in OKTA.
 2. Save Configuration
 
@@ -33,7 +33,7 @@ As an alternative you can add the SAML identity provider through the API, either
 
 ![OKTA Provider Empty](/img/guides/zitadel_okta_saml_provider_empty.png)
 
-After you created the SAML SP in ZITADEL, you can copy the URLs you need to configure in your OKTA application.
+After you created the SAML Provider in ZITADEL, you can copy the URLs you need to configure in your OKTA application.
 
 ![OKTA SAML App URLs](/img/guides/zitadel_okta_saml_provider_urls.png)
 


### PR DESCRIPTION
# Which Problems Are Solved

In the configuration of external idps we show SAML SP as provider which is confusing, as it is a SAML IdP which is configured

# How the Problems Are Solved

Rename SAML SP to SAML IdP
