### PR TITLE
docs: note audience scope for service user

### DIFF
--- a/docs/docs/guides/integrate/service-users/client-credentials.md
+++ b/docs/docs/guides/integrate/service-users/client-credentials.md
@@ -49,6 +49,9 @@ curl --request POST \
 If you want to access ZITADEL APIs, make sure to include the required scopes `urn:zitadel:iam:org:project:id:zitadel:aud`.
 Read our guide [how to access ZITADEL APIs](../zitadel-apis/access-zitadel-apis) to learn more.
 
+**Important Note:** If the service user token needs to be validated using token introspection, ensure you include the `urn:zitadel:iam:org:project:id:{projectid}:aud` scope in your token request. 
+Without this, token introspection will fail.
+
 You should receive a successful response with `access_token`,  `token_type` and time to expiry in seconds as `expires_in`.
 
 ```bash

--- a/docs/docs/guides/integrate/service-users/private-key-jwt.md
+++ b/docs/docs/guides/integrate/service-users/private-key-jwt.md
@@ -163,7 +163,7 @@ curl --request POST \
 If you want to access ZITADEL APIs, make sure to include the required scopes `urn:zitadel:iam:org:project:id:zitadel:aud`.
 Read our guide [how to access ZITADEL APIs](../zitadel-apis/access-zitadel-apis) to learn more.
 
-**Important Note:** If service user token needs to be validated using token introspection, ensure you include the `urn:zitadel:iam:org:project:id:{projectid}:aud` scope in your token request. 
+**Important Note:** If the service user token needs to be validated using token introspection, ensure you include the `urn:zitadel:iam:org:project:id:{projectid}:aud` scope in your token request. 
 Without this, token introspection will fail.
 
 You should receive a successful response with `access_token`,  `token_type` and time to expiry in seconds as `expires_in`.

--- a/docs/docs/guides/integrate/service-users/private-key-jwt.md
+++ b/docs/docs/guides/integrate/service-users/private-key-jwt.md
@@ -163,7 +163,7 @@ curl --request POST \
 If you want to access ZITADEL APIs, make sure to include the required scopes `urn:zitadel:iam:org:project:id:zitadel:aud`.
 Read our guide [how to access ZITADEL APIs](../zitadel-apis/access-zitadel-apis) to learn more.
 
-**Important Note:** If service user token needs to be validated using token introspection, ensure you include the 'urn:zitadel:iam:org:project:id:{projectid}:aud' scope in your token request. 
+**Important Note:** If service user token needs to be validated using token introspection, ensure you include the `urn:zitadel:iam:org:project:id:{projectid}:aud` scope in your token request. 
 Without this, token introspection will fail.
 
 You should receive a successful response with `access_token`,  `token_type` and time to expiry in seconds as `expires_in`.

--- a/docs/docs/guides/integrate/service-users/private-key-jwt.md
+++ b/docs/docs/guides/integrate/service-users/private-key-jwt.md
@@ -163,6 +163,9 @@ curl --request POST \
 If you want to access ZITADEL APIs, make sure to include the required scopes `urn:zitadel:iam:org:project:id:zitadel:aud`.
 Read our guide [how to access ZITADEL APIs](../zitadel-apis/access-zitadel-apis) to learn more.
 
+**Important Note:** If service user token needs to be validated using token introspection, ensure you include the 'urn:zitadel:iam:org:project:id:{projectid}:aud' scope in your token request. 
+Without this, token introspection will fail.
+
 You should receive a successful response with `access_token`,  `token_type` and time to expiry in seconds as `expires_in`.
 
 ```bash


### PR DESCRIPTION
# Which Problems Are Solved
- It is not possible to introspect service user token if `urn:zitadel:iam:org:project:id:{projectid}:aud` scope is not added in token request.
- Adding this note to the document could reduce confusion and debugging time
- https://discord.com/channels/927474939156643850/1168857403945660436/1168930850029707386