### PR TITLE
fix(eventstore): early return if no events in field handler

### DIFF
--- a/internal/eventstore/handler/v2/field_handler.go
+++ b/internal/eventstore/handler/v2/field_handler.go
@@ -149,16 +149,13 @@ func (h *FieldHandler) processEvents(ctx context.Context, config *triggerConfig)
 
 func (h *FieldHandler) fetchEvents(ctx context.Context, tx *sql.Tx, currentState *state) (_ []eventstore.FillFieldsEvent, additionalIteration bool, err error) {
 	events, err := h.es.Filter(ctx, h.eventQuery(currentState).SetTx(tx))
-	if err != nil {
-		h.log().WithError(err).Debug("filter eventstore failed")
+	if err != nil || len(events) == 0 {
+		h.log().OnError(err).Debug("filter eventstore failed")
 		return nil, false, err
 	}
 	eventAmount := len(events)
 
 	idx, offset := skipPreviouslyReducedEvents(events, currentState)
-	if idx == -1 && len(events) == 0 {
-		return nil, false, nil
-	}
 
 	if currentState.position == events[len(events)-1].Position() {
 		offset += currentState.offset

--- a/internal/eventstore/handler/v2/field_handler.go
+++ b/internal/eventstore/handler/v2/field_handler.go
@@ -156,6 +156,9 @@ func (h *FieldHandler) fetchEvents(ctx context.Context, tx *sql.Tx, currentState
 	eventAmount := len(events)
 
 	idx, offset := skipPreviouslyReducedEvents(events, currentState)
+	if idx == -1 && len(events) == 0 {
+		return nil, false, nil
+	}
 
 	if currentState.position == events[len(events)-1].Position() {
 		offset += currentState.offset


### PR DESCRIPTION
# Which Problems Are Solved

Fixes a panic which can occur if there are no events to reduce in the fields handler

# How the Problems Are Solved

Check if there are any events to reduce

# Additional Changes

none

# Additional Context

- Panic was added in https://github.com/zitadel/zitadel/pull/8191