### PR TITLE
fix: add missing totp remove endpoint in user v2 API

### DIFF
--- a/internal/api/grpc/user/v2/totp.go
+++ b/internal/api/grpc/user/v2/totp.go
@@ -35,3 +35,11 @@ func (s *Server) VerifyTOTPRegistration(ctx context.Context, req *user.VerifyTOT
 		Details: object.DomainToDetailsPb(objectDetails),
 	}, nil
 }
+
+func (s *Server) RemoveTOTP(ctx context.Context, req *user.RemoveTOTPRequest) (*user.RemoveTOTPResponse, error) {
+	objectDetails, err := s.command.HumanRemoveTOTP(ctx, req.GetUserId(), "")
+	if err != nil {
+		return nil, err
+	}
+	return &user.RemoveTOTPResponse{Details: object.DomainToDetailsPb(objectDetails)}, nil
+}

--- a/internal/api/grpc/user/v2/totp_integration_test.go
+++ b/internal/api/grpc/user/v2/totp_integration_test.go
@@ -205,3 +205,80 @@ func TestServer_VerifyTOTPRegistration(t *testing.T) {
 		})
 	}
 }
+
+func TestServer_RemoveTOTP(t *testing.T) {
+	userID := Tester.CreateHumanUser(CTX).GetUserId()
+	Tester.RegisterUserPasskey(CTX, userID)
+	_, sessionToken, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userID)
+
+	userVerified := Tester.CreateHumanUser(CTX)
+	Tester.RegisterUserPasskey(CTX, userVerified.GetUserId())
+	_, sessionTokenVerified, _, _ := Tester.CreateVerifiedWebAuthNSession(t, CTX, userVerified.GetUserId())
+	userVerifiedCtx := Tester.WithAuthorizationToken(context.Background(), sessionTokenVerified)
+	_, err := Tester.Client.UserV2.VerifyPhone(userVerifiedCtx, &user.VerifyPhoneRequest{
+		UserId:           userVerified.GetUserId(),
+		VerificationCode: userVerified.GetPhoneCode(),
+	})
+	require.NoError(t, err)
+
+	regOtherUser, err := Client.RegisterTOTP(CTX, &user.RegisterTOTPRequest{
+		UserId: userVerified.GetUserId(),
+	})
+	require.NoError(t, err)
+	codeOtherUser, err := totp.GenerateCode(regOtherUser.Secret, time.Now())
+	require.NoError(t, err)
+	_, err = Client.VerifyTOTPRegistration(userVerifiedCtx, &user.VerifyTOTPRegistrationRequest{
+		UserId: userVerified.GetUserId(),
+		Code:   codeOtherUser,
+	},
+	)
+	require.NoError(t, err)
+
+	type args struct {
+		ctx context.Context
+		req *user.RemoveTOTPRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *user.RemoveTOTPResponse
+		wantErr bool
+	}{
+		{
+			name: "not added",
+			args: args{
+				ctx: Tester.WithAuthorizationToken(context.Background(), sessionToken),
+				req: &user.RemoveTOTPRequest{
+					UserId: userID,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success",
+			args: args{
+				ctx: userVerifiedCtx,
+				req: &user.RemoveTOTPRequest{
+					UserId: userVerified.GetUserId(),
+				},
+			},
+			want: &user.RemoveTOTPResponse{
+				Details: &object.Details{
+					ResourceOwner: Tester.Organisation.ResourceOwner,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Client.RemoveTOTP(tt.args.ctx, tt.args.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			integration.AssertDetails(t, tt.want, got)
+		})
+	}
+}

--- a/proto/zitadel/user/v2beta/user_service.proto
+++ b/proto/zitadel/user/v2beta/user_service.proto
@@ -655,6 +655,28 @@ service UserService {
     };
   }
 
+  rpc RemoveTOTP (RemoveTOTPRequest) returns (RemoveTOTPResponse) {
+    option (google.api.http) = {
+      delete: "/v2beta/users/{user_id}/totp"
+    };
+
+    option (zitadel.protoc_gen_zitadel.v2.options) = {
+      auth_option: {
+        permission: "authenticated"
+      }
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Remove TOTP generator from a user";
+      description: "Remove the configured TOTP generator of the authenticated user. As only one TOTP generator per user is allowed, the user will not have TOTP as a second-factor afterward."
+      responses: {
+        key: "200"
+        value: {
+          description: "OK";
+        }
+      };
+    };
+  }
+
   rpc AddOTPSMS (AddOTPSMSRequest) returns (AddOTPSMSResponse) {
     option (google.api.http) = {
       post: "/v2beta/users/{user_id}/otp_sms"
@@ -1468,6 +1490,22 @@ message VerifyTOTPRegistrationRequest {
 }
 
 message VerifyTOTPRegistrationResponse {
+  zitadel.object.v2beta.Details details = 1;
+}
+
+message RemoveTOTPRequest {
+  string user_id = 1 [
+    (validate.rules).string = {min_len: 1, max_len: 200},
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      min_length: 1;
+      max_length: 200;
+      example: "\"163840776835432705\"";
+    }
+  ];
+}
+
+message RemoveTOTPResponse {
   zitadel.object.v2beta.Details details = 1;
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

TOTP remove endpoint available in management API, not in user v2 API.

# How the Problems Are Solved

Add endpoint RemoveTOTP to user v2 API.

# Additional Changes

None

# Additional Context

close #6605 
