### PR TITLE
fix(api): grpc content type matcher all grpc types

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -180,7 +180,7 @@ func (a *API) RouteGRPC() {
 		Name("grpc")
 	http2Route.
 		Methods(http.MethodPost).
-		Headers("Content-Type", "application/grpc").
+		HeadersRegexp(http_util.ContentType, `application\/grpc(\+proto|\+json)?`).
 		Handler(a.grpcServer)
 
 	a.routeGRPCWeb()


### PR DESCRIPTION
# Which Problems Are Solved

ZITADEL returned a 404 Unimplemented error if the client sent 'application/grpc+proto' or 'application/grpc+json' which are both valid content types.

# How the Problems Are Solved

changed the header matcher to regexp

# Additional Context

Problem occured in https://github.com/zitadel/typescript/tree/grpc-transport