### PR TITLE
fix: correctly differ between grpc and grpc-web

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -180,7 +180,7 @@ func (a *API) RouteGRPC() {
 		Name("grpc")
 	http2Route.
 		Methods(http.MethodPost).
-		HeadersRegexp(http_util.ContentType, `application\/grpc(\+proto|\+json)?`).
+		HeadersRegexp(http_util.ContentType, `^application\/grpc(\+proto|\+json)?$`).
 		Handler(a.grpcServer)
 
 	a.routeGRPCWeb()


### PR DESCRIPTION
# Which Problems Are Solved

While #8285 also checked for `+proto` and `+json` grpc content types, it accidentally matched all grpc-web requests to grpc. 

# How the Problems Are Solved

- fixed the regex by checking for an exact match (added start `^` and end `$` anchors)

# Additional Changes

None

# Additional Context

- relates to #8285