### PR TITLE
fix(console): missing styles for ProfilePictureComponent dialog

### DIFF
--- a/console/src/app/pages/users/user-detail/detail-form/detail-form.module.ts
+++ b/console/src/app/pages/users/user-detail/detail-form/detail-form.module.ts
@@ -12,6 +12,7 @@ import { InputModule } from 'src/app/modules/input/input.module';
 
 import { DetailFormComponent } from './detail-form.component';
 import { ProfilePictureComponent } from './profile-picture/profile-picture.component';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   declarations: [DetailFormComponent, ProfilePictureComponent],
@@ -26,6 +27,7 @@ import { ProfilePictureComponent } from './profile-picture/profile-picture.compo
     MatButtonModule,
     MatTooltipModule,
     MatIconModule,
+    MatDialogModule,
     TranslateModule,
     InputModule,
   ],


### PR DESCRIPTION
# Which Problems Are Solved

- The UI layout is broken in Upload your Profile Picture

# How the Problems Are Solved

- MatDialog module was missing

# Additional Context

Here's a screenshot showing the fix

![Captura desde 2024-07-12 12-18-43](https://github.com/user-attachments/assets/7a01fa0e-3e89-4679-9606-085610f5adfe)

- Closes #8284 
