### PR TITLE
fix(mirror): read config correctly

### DIFF
--- a/cmd/mirror/mirror.go
+++ b/cmd/mirror/mirror.go
@@ -18,7 +18,7 @@ var (
 	shouldReplace bool
 )
 
-func New() *cobra.Command {
+func New(configFiles *[]string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mirror",
 		Short: "mirrors all data of ZITADEL from one database to another",
@@ -37,6 +37,12 @@ Order of execution:
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			err := viper.MergeConfig(bytes.NewBuffer(defaultConfig))
 			logging.OnError(err).Fatal("unable to read default config")
+
+			for _, file := range *configFiles {
+				viper.SetConfigFile(file)
+				err := viper.MergeInConfig()
+				logging.WithFields("file", file).OnError(err).Warn("unable to read config file")
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			config := mustNewMigrationConfig(viper.GetViper())

--- a/cmd/zitadel.go
+++ b/cmd/zitadel.go
@@ -56,7 +56,7 @@ func New(out io.Writer, in io.Reader, args []string, server chan<- *start.Server
 		start.New(server),
 		start.NewStartFromInit(server),
 		start.NewStartFromSetup(server),
-		mirror.New(),
+		mirror.New(&configFiles),
 		key.New(),
 		ready.New(),
 	)


### PR DESCRIPTION
# Which Problems Are Solved

The mirror command read the configurations in the wrong order

# How the Problems Are Solved

The Pre execution run of `mirror` reads the default config first and then applies the custom configs

# Additional Context
- requires backports to 2.54.x, 2.55.x and 2.56.x