### PR TITLE
fix: vue logout url

### DIFF
--- a/console/src/app/utils/framework.ts
+++ b/console/src/app/utils/framework.ts
@@ -29,7 +29,7 @@ export const OIDC_CONFIGURATIONS: OidcAppConfigurations = {
     .setResponseTypesList([OIDCResponseType.OIDC_RESPONSE_TYPE_CODE])
     .setGrantTypesList([OIDCGrantType.OIDC_GRANT_TYPE_AUTHORIZATION_CODE])
     .setRedirectUrisList(['http://localhost:5173/auth/signinwin/zitadel'])
-    .setPostLogoutRedirectUrisList(['http://localhost:5173']),
+    .setPostLogoutRedirectUrisList(['http://localhost:5173/']),
   // web applications
   ['next']: new AddOIDCAppRequest()
     .setAppType(OIDCAppType.OIDC_APP_TYPE_WEB)


### PR DESCRIPTION
# Which Problems Are Solved

The default vue logout URL doesn't work with the @zitadel/vue defaults

# How the Problems Are Solved

A trailing slash is added to the default logout URL.

# Additional Context

Found while testing https://github.com/zitadel/zitadel-vue/pull/53