### PR TITLE
test(e2e): wait before select org

### DIFF
--- a/e2e/cypress/e2e/organization/organizations.cy.ts
+++ b/e2e/cypress/e2e/organization/organizations.cy.ts
@@ -25,8 +25,9 @@ describe('organizations', () => {
 
     it('should delete an org', () => {
       cy.visit(orgsPath);
+      cy.wait(2000);
       cy.contains('tr', newOrg).click();
-      cy.wait(3000);
+      cy.wait(1000);
       cy.get('[data-e2e="actions"]').click();
       cy.get('[data-e2e="delete"]', { timeout: 1000 }).should('be.visible').click();
       cy.get('[data-e2e="confirm-dialog-input"]').focus().clear().type(newOrg);


### PR DESCRIPTION
# Which Problems Are Solved

The e2e tests fail because the organization selection is too fast.

# How the Problems Are Solved

Wait until console has loaded properly.

# Additional Context

- The tests still use the wrong browser, #8404 describes the problem
- closes https://github.com/zitadel/zitadel/issues/8378