### PR TITLE
fix(fields): use read commit isolation level in trigger

### DIFF
--- a/internal/eventstore/handler/v2/field_handler.go
+++ b/internal/eventstore/handler/v2/field_handler.go
@@ -97,7 +97,7 @@ func (h *FieldHandler) processEvents(ctx context.Context, config *triggerConfig)
 		defer cancel()
 	}
 
-	tx, err := h.client.BeginTx(txCtx, nil)
+	tx, err := h.client.BeginTx(txCtx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return false, err
 	}

--- a/internal/eventstore/v3/field.go
+++ b/internal/eventstore/v3/field.go
@@ -28,7 +28,7 @@ func (es *Eventstore) FillFields(ctx context.Context, events ...eventstore.FillF
 	ctx, span := tracing.NewSpan(ctx)
 	defer span.End()
 
-	tx, err := es.client.BeginTx(ctx, nil)
+	tx, err := es.client.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Which Problems Are Solved

If the processing time of serializable transactions in the fields handler take too long, the next iteration can fail.

# How the Problems Are Solved

Changed the isolation level of the current states query to Read Commited 
