### PR TITLE
fix: change pr template to not link to existing issues and prs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ For example:
 
 Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
 Use the Closing #issue syntax for issues that are resolved with this PR.
-- Closes #123
-- Discussion #456
-- Follow-up for PR #789
-- https://discord.com/channels/123/456
+- Closes #xxx
+- Discussion #xxx
+- Follow-up for PR #xxx
+- https://discord.com/channels/xxx/xxx


### PR DESCRIPTION
# Which Problems Are Solved

In the PR template we have added some ideas about additional context, but we link to existing prs and issues as an example.
So everytime someone doesn't change the description when creating the issue, its a mention to that issue or pr.


# How the Problems Are Solved
replace with non existing values


![Uploading image.png…]()
