### PR TITLE
fix(webkeys): remove include private key from projection index

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -761,8 +761,8 @@ module.exports = {
               label: "Web key Lifecycle (Preview)",
               link: {
                 type: "generated-index",
-                title: "Action Service API (Preview)",
-                slug: "/apis/resources/action_service_v3",
+                title: "Web Key Service API (Preview)",
+                slug: "/apis/resources/webkey_service_v3",
                 description:
                   "This API is intended to manage web keys for a ZITADEL instance, used to sign and validate OIDC tokens.\n" +
                   "\n" +

--- a/internal/query/projection/web_key.go
+++ b/internal/query/projection/web_key.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	WebKeyTable = "projections.web_keys"
+	WebKeyTable = "projections.web_keys1"
 
 	WebKeyInstanceIDCol   = "instance_id"
 	WebKeyKeyIDCol        = "key_id"
@@ -58,9 +58,6 @@ func (*webKeyProjection) Init() *old_handler.Check {
 			handler.WithIndex(handler.NewIndex(
 				"web_key_state",
 				[]string{WebKeyInstanceIDCol, WebKeyStateCol},
-				handler.WithInclude(
-					WebKeyPrivateKeyCol,
-				),
 			)),
 		),
 	)

--- a/internal/query/web_key_by_state.sql
+++ b/internal/query/web_key_by_state.sql
@@ -1,5 +1,5 @@
 select private_key
-from projections.web_keys
+from projections.web_keys1
 where instance_id = $1
 and state = $2
 limit 1;

--- a/internal/query/web_key_list.sql
+++ b/internal/query/web_key_list.sql
@@ -1,4 +1,4 @@
 select key_id, creation_date, change_date, sequence, state, config, config_type
-from projections.web_keys
+from projections.web_keys1
 where instance_id = $1
 order by creation_date asc;

--- a/internal/query/web_key_public_keys.sql
+++ b/internal/query/web_key_public_keys.sql
@@ -1,3 +1,3 @@
 select public_key
-from projections.web_keys
+from projections.web_keys1
 where instance_id = $1;

--- a/proto/zitadel/resources/webkey/v3alpha/webkey_service.proto
+++ b/proto/zitadel/resources/webkey/v3alpha/webkey_service.proto
@@ -172,8 +172,8 @@ service ZITADELWebKeys {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Generate a web key pair for the instance";
-      description: "Delete a web key. Only inactive keys can be deleted. Once a key is deleted, any tokens signed by this key will be invalid."
+      summary: "Delete a web key pair for the instance";
+      description: "Delete a web key pair. Only inactive keys can be deleted. Once a key is deleted, any tokens signed by this key will be invalid."
       responses: {
         key: "200"
         value: {
@@ -198,7 +198,7 @@ service ZITADELWebKeys {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Generate a web key pair for the instance";
+      summary: "List web key details for the instance";
       description: "List web key details for the instance"
       responses: {
         key: "200"


### PR DESCRIPTION
# Which Problems Are Solved

When Web keys with a large RSA Bitsize were generated, the new web key did not get projected.
Zitadel logs printed the following errors:

```
time="2024-08-15T09:18:47Z" level=debug msg="execution of statements failed" caller="/home/tim/Repositories/zitadel/zitadel/internal/eventstore/handler/v2/handler.go:518" error="statement failed: ID=CRDB-pKtsr Message=exec failed Parent=(ERROR: index row size 3400 exceeds btree version 4 maximum 2704 for index \"web_keys_web_key_state_idx\" (SQLSTATE 54000))" lastProcessedIndex=-1 projection=projections.web_keys
```


# How the Problems Are Solved

Remove the the `WithInclude` option with the Private key from the `web_keys` projection index and bump the projection version.

# Additional Changes

- Correct RPC summaries for documentation
- Fix docs slug in sidebar.js

# Additional Context

- Found during release review.
