### PR TITLE
tests: tune projections to prevent secret generator not found

### DIFF
--- a/e2e/config/host.docker.internal/zitadel.yaml
+++ b/e2e/config/host.docker.internal/zitadel.yaml
@@ -42,6 +42,9 @@ Console:
   InstanceManagementURL: "https://example.com/instances/{{.InstanceID}}"
 
 Projections:
+  HandleActiveInstances: 30m
+  RequeueEvery: 5s
+  TransactionDuration: 5s
   Customizations:
     NotificationsQuotas:
       RequeueEvery: 1s

--- a/e2e/config/localhost/zitadel.yaml
+++ b/e2e/config/localhost/zitadel.yaml
@@ -24,6 +24,9 @@ Console:
   InstanceManagementURL: "https://example.com/instances/{{.InstanceID}}"
 
 Projections:
+  HandleActiveInstances: 30m
+  RequeueEvery: 5s
+  TransactionDuration: 5s
   Customizations:
     NotificationsQuotas:
       RequeueEvery: 1s


### PR DESCRIPTION
# Which Problems Are Solved

Try to fix the "secret generator not found" error in e2e tests.

# How the Problems Are Solved

Extend the HandleActiveInstances time and decrease the RequeueEvery time for projections. In addition, allow longer context timeouts for TransactionDuration.

Settings are found to work well in integration tests.

# Additional Changes

- none

# Additional Context

- (hopefully) fixes https://github.com/zitadel/zitadel/issues/8471
- Found also during https://github.com/zitadel/zitadel/pull/8407