### PR TITLE
refactor(eventstore): use trigger in notify instead of event channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/h2non/gock v1.2.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/improbable-eng/grpc-web v0.15.0
+	github.com/jackc/pgx-shopspring-decimal v0.0.0-20220624020537-1d36b5a1853e
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jarcoal/jpath v0.0.0-20140328210829-f76b8b2dbf52
 	github.com/jinzhu/gorm v1.9.16
@@ -52,6 +53,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/cors v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/shopspring/decimal v1.4.0
 	github.com/sony/sonyflake v1.2.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx-shopspring-decimal v0.0.0-20220624020537-1d36b5a1853e h1:i3gQ/Zo7sk4LUVbsAjTNeC4gIjoPNIZVzs4EXstssV4=
+github.com/jackc/pgx-shopspring-decimal v0.0.0-20220624020537-1d36b5a1853e/go.mod h1:zUHglCZ4mpDUPgIwqEKoba6+tcUQzRdb1+DPTuYe9pI=
 github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
 github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
@@ -648,6 +650,8 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/api/grpc/server/gateway.go
+++ b/internal/api/grpc/server/gateway.go
@@ -121,6 +121,7 @@ func CreateGatewayWithPrefix(
 			client_middleware.DefaultTracingClient(),
 			client_middleware.UnaryActivityClientInterceptor(),
 		),
+		// grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	}
 	connection, err := dial(ctx, port, opts)
 	if err != nil {
@@ -148,6 +149,7 @@ func CreateGateway(
 				client_middleware.DefaultTracingClient(),
 				client_middleware.UnaryActivityClientInterceptor(),
 			),
+			// grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		})
 	if err != nil {
 		return nil, err

--- a/internal/command/org.go
+++ b/internal/command/org.go
@@ -323,7 +323,7 @@ func (c *Commands) addOrgWithIDAndMember(ctx context.Context, name, userID, reso
 		return nil, err
 	}
 	events = append(events, orgMemberEvent)
-	pushedEvents, err := c.eventstore.Push(ctx, events...)
+	pushedEvents, err := c.eventstore.PushWithAwaitTriggers(ctx, events...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/cockroach/crdb.go
+++ b/internal/database/cockroach/crdb.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/mitchellh/mapstructure"
@@ -80,6 +82,11 @@ func (c *Config) Connect(useAdmin bool, pusherRatio, spoolerRatio float64, purpo
 	config, err := pgxpool.ParseConfig(c.String(useAdmin, purpose.AppName()))
 	if err != nil {
 		return nil, err
+	}
+
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		pgxdecimal.Register(conn.TypeMap())
+		return nil
 	}
 
 	if connConfig.MaxOpenConns != 0 {

--- a/internal/database/postgres/pg.go
+++ b/internal/database/postgres/pg.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	pgxdecimal "github.com/jackc/pgx-shopspring-decimal"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/mitchellh/mapstructure"
@@ -81,6 +83,10 @@ func (c *Config) Connect(useAdmin bool, pusherRatio, spoolerRatio float64, purpo
 	config, err := pgxpool.ParseConfig(c.String(useAdmin, purpose.AppName()))
 	if err != nil {
 		return nil, err
+	}
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		pgxdecimal.Register(conn.TypeMap())
+		return nil
 	}
 
 	if connConfig.MaxOpenConns != 0 {

--- a/internal/eventstore/context.go
+++ b/internal/eventstore/context.go
@@ -1,0 +1,1 @@
+package eventstore

--- a/internal/eventstore/event.go
+++ b/internal/eventstore/event.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -44,7 +46,7 @@ type Event interface {
 	// CreatedAt is the time the event was created at
 	CreatedAt() time.Time
 	// Position is the global position of the event
-	Position() float64
+	Position() decimal.Decimal
 
 	// Unmarshal parses the payload and stores the result
 	// in the value pointed to by ptr. If ptr is nil or not a pointer,

--- a/internal/eventstore/event_base.go
+++ b/internal/eventstore/event_base.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/service"
 )
@@ -21,7 +23,7 @@ type BaseEvent struct {
 	Agg *Aggregate
 
 	Seq                           uint64
-	Pos                           float64
+	Pos                           decimal.Decimal
 	Creation                      time.Time
 	previousAggregateSequence     uint64
 	previousAggregateTypeSequence uint64
@@ -34,7 +36,7 @@ type BaseEvent struct {
 }
 
 // Position implements Event.
-func (e *BaseEvent) Position() float64 {
+func (e *BaseEvent) Position() decimal.Decimal {
 	return e.Pos
 }
 

--- a/internal/eventstore/handler/statement.go
+++ b/internal/eventstore/handler/statement.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 )
 
 type Executer interface {
 	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }

--- a/internal/eventstore/handler/v2/field_handler.go
+++ b/internal/eventstore/handler/v2/field_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
@@ -123,7 +124,7 @@ func (h *FieldHandler) processEvents(ctx context.Context, config *triggerConfig)
 		return additionalIteration, err
 	}
 	// stop execution if currentState.eventTimestamp >= config.maxCreatedAt
-	if config.maxPosition != 0 && currentState.position >= config.maxPosition {
+	if !config.maxPosition.IsZero() && currentState.position.GreaterThanOrEqual(config.maxPosition) {
 		return false, nil
 	}
 
@@ -186,9 +187,9 @@ func (h *FieldHandler) fetchEvents(ctx context.Context, tx *sql.Tx, currentState
 }
 
 func skipPreviouslyReducedEvents(events []eventstore.Event, currentState *state) (index int, offset uint32) {
-	var position float64
+	var position decimal.Decimal
 	for i, event := range events {
-		if event.Position() != position {
+		if !event.Position().Equal(position) {
 			offset = 0
 			position = event.Position()
 		}

--- a/internal/eventstore/handler/v2/state.go
+++ b/internal/eventstore/handler/v2/state.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -14,7 +15,7 @@ import (
 
 type state struct {
 	instanceID     string
-	position       float64
+	position       decimal.Decimal
 	eventTimestamp time.Time
 	aggregateType  eventstore.AggregateType
 	aggregateID    string
@@ -45,7 +46,7 @@ func (h *Handler) currentState(ctx context.Context, tx *sql.Tx, config *triggerC
 		aggregateType = new(sql.NullString)
 		sequence      = new(sql.NullInt64)
 		timestamp     = new(sql.NullTime)
-		position      = new(sql.NullFloat64)
+		position      = new(decimal.NullDecimal)
 		offset        = new(sql.NullInt64)
 	)
 
@@ -75,7 +76,7 @@ func (h *Handler) currentState(ctx context.Context, tx *sql.Tx, config *triggerC
 	currentState.aggregateType = eventstore.AggregateType(aggregateType.String)
 	currentState.sequence = uint64(sequence.Int64)
 	currentState.eventTimestamp = timestamp.Time
-	currentState.position = position.Float64
+	currentState.position = position.Decimal
 	// psql does not provide unsigned numbers so we work around it
 	currentState.offset = uint32(offset.Int64)
 	return currentState, nil

--- a/internal/eventstore/handler/v2/statement.go
+++ b/internal/eventstore/handler/v2/statement.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/logging"
 	"golang.org/x/exp/constraints"
 
@@ -83,7 +84,7 @@ type Statement struct {
 	AggregateType eventstore.AggregateType
 	AggregateID   string
 	Sequence      uint64
-	Position      float64
+	Position      decimal.Decimal
 	CreationDate  time.Time
 	InstanceID    string
 

--- a/internal/eventstore/read_model.go
+++ b/internal/eventstore/read_model.go
@@ -1,19 +1,23 @@
 package eventstore
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
 
 // ReadModel is the minimum representation of a read model.
 // It implements a basic reducer
 // it might be saved in a database or in memory
 type ReadModel struct {
-	AggregateID       string    `json:"-"`
-	ProcessedSequence uint64    `json:"-"`
-	CreationDate      time.Time `json:"-"`
-	ChangeDate        time.Time `json:"-"`
-	Events            []Event   `json:"-"`
-	ResourceOwner     string    `json:"-"`
-	InstanceID        string    `json:"-"`
-	Position          float64   `json:"-"`
+	AggregateID       string          `json:"-"`
+	ProcessedSequence uint64          `json:"-"`
+	CreationDate      time.Time       `json:"-"`
+	ChangeDate        time.Time       `json:"-"`
+	Events            []Event         `json:"-"`
+	ResourceOwner     string          `json:"-"`
+	InstanceID        string          `json:"-"`
+	Position          decimal.Decimal `json:"-"`
 }
 
 // AppendEvents adds all the events to the read model.

--- a/internal/eventstore/repository/event.go
+++ b/internal/eventstore/repository/event.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
 
@@ -18,7 +20,7 @@ type Event struct {
 	// Seq is the sequence of the event
 	Seq uint64
 	// Pos is the global sequence of the event multiple events can have the same sequence
-	Pos float64
+	Pos decimal.Decimal
 
 	//CreationDate is the time the event is created
 	// it's used for human readability.
@@ -91,7 +93,7 @@ func (e *Event) Sequence() uint64 {
 }
 
 // Position implements [eventstore.Event]
-func (e *Event) Position() float64 {
+func (e *Event) Position() decimal.Decimal {
 	return e.Pos
 }
 

--- a/internal/eventstore/repository/search_query.go
+++ b/internal/eventstore/repository/search_query.go
@@ -55,6 +55,8 @@ const (
 	//OperationNotIn checks if a stored value does not match one of the passed value list
 	OperationNotIn
 
+	OperationGreaterEqual
+
 	operationCount
 )
 
@@ -232,10 +234,10 @@ func instanceIDsFilter(builder *eventstore.SearchQueryBuilder, query *SearchQuer
 }
 
 func positionAfterFilter(builder *eventstore.SearchQueryBuilder, query *SearchQuery) *Filter {
-	if builder.GetPositionAfter() == 0 {
+	if builder.GetPositionAfter().IsZero() {
 		return nil
 	}
-	query.Position = NewFilter(FieldPosition, builder.GetPositionAfter(), OperationGreater)
+	query.Position = NewFilter(FieldPosition, builder.GetPositionAfter(), OperationGreaterEqual)
 	return query.Position
 }
 

--- a/internal/eventstore/repository/sql/crdb.go
+++ b/internal/eventstore/repository/sql/crdb.go
@@ -414,6 +414,8 @@ func (db *CRDB) operation(operation repository.Operation) string {
 		return "="
 	case repository.OperationGreater:
 		return ">"
+	case repository.OperationGreaterEqual:
+		return ">="
 	case repository.OperationLess:
 		return "<"
 	case repository.OperationJSONContains:

--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/api/call"
@@ -189,7 +190,7 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 			return zerrors.ThrowInvalidArgumentf(nil, "SQL-4GP6F", "events scanner: invalid type %T", dest)
 		}
 		event := new(repository.Event)
-		position := new(sql.NullFloat64)
+		position := new(decimal.NullDecimal)
 
 		if useV1 {
 			err = scanner(
@@ -226,7 +227,7 @@ func eventsScanner(useV1 bool) func(scanner scan, dest interface{}) (err error) 
 			logging.New().WithError(err).Warn("unable to scan row")
 			return zerrors.ThrowInternal(err, "SQL-M0dsf", "unable to scan row")
 		}
-		event.Pos = position.Float64
+		event.Pos = position.Decimal
 		return reduce(event)
 	}
 }

--- a/internal/eventstore/search_query.go
+++ b/internal/eventstore/search_query.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -23,7 +25,7 @@ type SearchQueryBuilder struct {
 	queries               []*SearchQuery
 	tx                    *sql.Tx
 	allowTimeTravel       bool
-	positionAfter         float64
+	positionGreaterEqual  decimal.Decimal
 	awaitOpenTransactions bool
 	creationDateAfter     time.Time
 	creationDateBefore    time.Time
@@ -74,8 +76,8 @@ func (b *SearchQueryBuilder) GetAllowTimeTravel() bool {
 	return b.allowTimeTravel
 }
 
-func (b SearchQueryBuilder) GetPositionAfter() float64 {
-	return b.positionAfter
+func (b SearchQueryBuilder) GetPositionAfter() decimal.Decimal {
+	return b.positionGreaterEqual
 }
 
 func (b SearchQueryBuilder) GetAwaitOpenTransactions() bool {
@@ -267,8 +269,8 @@ func (builder *SearchQueryBuilder) AllowTimeTravel() *SearchQueryBuilder {
 }
 
 // PositionAfter filters for events which happened after the specified time
-func (builder *SearchQueryBuilder) PositionAfter(position float64) *SearchQueryBuilder {
-	builder.positionAfter = position
+func (builder *SearchQueryBuilder) PositionGreaterEqual(position decimal.Decimal) *SearchQueryBuilder {
+	builder.positionGreaterEqual = position
 	return builder
 }
 

--- a/internal/eventstore/subscription.go
+++ b/internal/eventstore/subscription.go
@@ -1,8 +1,11 @@
 package eventstore
 
 import (
+	"context"
+	"slices"
 	"sync"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/logging"
 )
 
@@ -12,37 +15,18 @@ var (
 )
 
 type Subscription struct {
-	Events chan Event
-	types  map[AggregateType][]EventType
+	Trigger SubscriptionTrigger
+	types   map[AggregateType][]EventType
 }
 
-// SubscribeAggregates subscribes for all events on the given aggregates
-func SubscribeAggregates(eventQueue chan Event, aggregates ...AggregateType) *Subscription {
-	types := make(map[AggregateType][]EventType, len(aggregates))
-	for _, aggregate := range aggregates {
-		types[aggregate] = nil
-	}
-	sub := &Subscription{
-		Events: eventQueue,
-		types:  types,
-	}
-
-	subsMutext.Lock()
-	defer subsMutext.Unlock()
-
-	for _, aggregate := range aggregates {
-		subscriptions[aggregate] = append(subscriptions[aggregate], sub)
-	}
-
-	return sub
-}
+type SubscriptionTrigger func(ctx context.Context, position decimal.Decimal) error
 
 // SubscribeEventTypes subscribes for the given event types
 // if no event types are provided the subscription is for all events of the aggregate
-func SubscribeEventTypes(eventQueue chan Event, types map[AggregateType][]EventType) *Subscription {
+func SubscribeEventTypes(trigger SubscriptionTrigger, types map[AggregateType][]EventType) *Subscription {
 	sub := &Subscription{
-		Events: eventQueue,
-		types:  types,
+		Trigger: trigger,
+		types:   types,
 	}
 
 	subsMutext.Lock()
@@ -55,9 +39,10 @@ func SubscribeEventTypes(eventQueue chan Event, types map[AggregateType][]EventT
 	return sub
 }
 
-func (es *Eventstore) notify(events []Event) {
+func (es *Eventstore) notify(ctx context.Context, events []Event) <-chan bool {
 	subsMutext.Lock()
 	defer subsMutext.Unlock()
+	var toNotify []*Subscription
 	for _, event := range events {
 		subs, ok := subscriptions[event.Aggregate().Type]
 		if !ok {
@@ -67,22 +52,37 @@ func (es *Eventstore) notify(events []Event) {
 			eventTypes := sub.types[event.Aggregate().Type]
 			//subscription for all events
 			if len(eventTypes) == 0 {
-				sub.Events <- event
+				toNotify = append(toNotify, sub)
 				continue
 			}
 			//subscription for certain events
 			for _, eventType := range eventTypes {
 				if event.Type() == eventType {
-					select {
-					case sub.Events <- event:
-					default:
-						logging.Debug("unable to push event")
-					}
+					toNotify = append(toNotify, sub)
 					break
 				}
 			}
 		}
 	}
+	var wg sync.WaitGroup
+	for _, sub := range slices.Compact(toNotify) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := sub.Trigger(ctx, events[len(events)-1].Position())
+			if err != nil {
+				logging.WithError(err).Error("failed to trigger subscription")
+			}
+		}()
+	}
+	lock := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		lock <- true
+		close(lock)
+	}()
+
+	return lock
 }
 
 func (s *Subscription) Unsubscribe() {
@@ -100,9 +100,5 @@ func (s *Subscription) Unsubscribe() {
 				subs = subs[:len(subs)-1]
 			}
 		}
-	}
-	_, ok := <-s.Events
-	if ok {
-		close(s.Events)
 	}
 }

--- a/internal/eventstore/v1/models/event.go
+++ b/internal/eventstore/v1/models/event.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -20,7 +22,7 @@ var _ eventstore.Event = (*Event)(nil)
 type Event struct {
 	ID               string
 	Seq              uint64
-	Pos              float64
+	Pos              decimal.Decimal
 	CreationDate     time.Time
 	Typ              eventstore.EventType
 	PreviousSequence uint64
@@ -80,7 +82,7 @@ func (e *Event) Sequence() uint64 {
 }
 
 // Position implements [eventstore.Event]
-func (e *Event) Position() float64 {
+func (e *Event) Position() decimal.Decimal {
 	return e.Pos
 }
 

--- a/internal/eventstore/v3/event.go
+++ b/internal/eventstore/v3/event.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
@@ -21,7 +22,7 @@ type event struct {
 	typ       eventstore.EventType
 	createdAt time.Time
 	sequence  uint64
-	position  float64
+	position  decimal.Decimal
 	payload   Payload
 }
 
@@ -84,8 +85,8 @@ func (e *event) Sequence() uint64 {
 	return e.sequence
 }
 
-// Sequence implements [eventstore.Event]
-func (e *event) Position() float64 {
+// Position implements [eventstore.Event]
+func (e *event) Position() decimal.Decimal {
 	return e.position
 }
 

--- a/internal/query/access_token.go
+++ b/internal/query/access_token.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/text/language"
 
+	"github.com/shopspring/decimal"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/oidcsession"
@@ -140,7 +141,7 @@ func (q *Queries) accessTokenByOIDCSessionAndTokenID(ctx context.Context, oidcSe
 
 // checkSessionNotTerminatedAfter checks if a [session.TerminateType] event (or user events leading to a session termination)
 // occurred after a certain time and will return an error if so.
-func (q *Queries) checkSessionNotTerminatedAfter(ctx context.Context, sessionID, userID string, position float64, fingerprintID string) (err error) {
+func (q *Queries) checkSessionNotTerminatedAfter(ctx context.Context, sessionID, userID string, position decimal.Decimal, fingerprintID string) (err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
@@ -162,7 +163,7 @@ func (q *Queries) checkSessionNotTerminatedAfter(ctx context.Context, sessionID,
 }
 
 type sessionTerminatedModel struct {
-	position      float64
+	position      decimal.Decimal
 	sessionID     string
 	userID        string
 	fingerPrintID string
@@ -182,7 +183,7 @@ func (s *sessionTerminatedModel) AppendEvents(events ...eventstore.Event) {
 
 func (s *sessionTerminatedModel) Query() *eventstore.SearchQueryBuilder {
 	query := eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
-		PositionAfter(s.position).
+		PositionGreaterEqual(s.position).
 		AddQuery().
 		AggregateTypes(session.AggregateType).
 		AggregateIDs(s.sessionID).

--- a/load-test/Makefile
+++ b/load-test/Makefile
@@ -4,42 +4,43 @@ ZITADEL_HOST ?=
 ADMIN_LOGIN_NAME ?=
 ADMIN_PASSWORD ?=
 
+K6 := ./../../xk6-modules/k6
+
 .PHONY: human_password_login
 human_password_login: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/human_password_login.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/human_password_login.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: machine_pat_login
 machine_pat_login: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_pat_login.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_pat_login.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: machine_client_credentials_login
 machine_client_credentials_login: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_client_credentials_login.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_client_credentials_login.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: user_info
 user_info: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/user_info.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/user_info.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: manipulate_user
 manipulate_user: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/manipulate_user.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/manipulate_user.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: introspect
 introspect: ensure_modules bundle
 	go install go.k6.io/xk6/cmd/xk6@latest
 	cd ../../xk6-modules && xk6 build --with xk6-zitadel=.
-	./../../xk6-modules/k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/introspection.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/introspection.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: add_session
 add_session: bundle
-	k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/session.js --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/session.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: machine_jwt_profile_grant
 machine_jwt_profile_grant: ensure_modules ensure_key_pair bundle
 	go install go.k6.io/xk6/cmd/xk6@latest
 	cd ../../xk6-modules && xk6 build --with xk6-zitadel=.
-	./../../xk6-modules/k6 run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_jwt_profile_grant.js --iterations 1
-	# --vus ${VUS} --duration ${DURATION}
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/machine_jwt_profile_grant.js --vus ${VUS} --duration ${DURATION}
 
 .PHONY: lint
 lint:
@@ -58,6 +59,8 @@ endif
 bundle:
 	npm i
 	npm run bundle
+	go install go.k6.io/xk6/cmd/xk6@latest
+	cd ../../xk6-modules && xk6 build --with xk6-zitadel=.
 
 .PHONY: ensure_key_pair
 ensure_key_pair:

--- a/load-test/src/use_cases/manipulate_user.ts
+++ b/load-test/src/use_cases/manipulate_user.ts
@@ -45,3 +45,4 @@ export function teardown(data: any) {
   removeOrg(data.org, data.tokens.accessToken);
   console.info('teardown: org removed');
 }
+

--- a/load-test/src/user.ts
+++ b/load-test/src/user.ts
@@ -51,7 +51,7 @@ export function createHuman(username: string, org: Org, accessToken: string): Pr
       .then((res) => {
         check(res, {
           'create user is status ok': (r) => r.status === 201,
-        }) || reject(`unable to create user(username: ${username}) status: ${res.status} body: ${res.body}`);
+        }) || reject(`unable to create user(username: ${username}) status: ${res.status} body: ${res.body} duration: ${res.timings.duration}`);
         createHumanTrend.add(res.timings.duration);
 
         const user = http.get(url(`/v2beta/users/${res.json('userId')!}`), {


### PR DESCRIPTION
# Which Problems Are Solved

Instead of making the logic to update the projections more complex the notify function of the eventstore now uses the handler.Trigger function. This allows to remove the "pubsub"-logic of the handler.

# How the Problems Are Solved

The eventstore.notify function now uses the handler.Trigger function instead of the event channels

# Additional Info

awaiting https://github.com/zitadel/zitadel/pull/8527
