### PR TITLE
fix: update IDP Success and Failure URLs to accept up to 2048 characters again

### DIFF
--- a/proto/zitadel/resources/user/v3alpha/authenticator.proto
+++ b/proto/zitadel/resources/user/v3alpha/authenticator.proto
@@ -383,21 +383,21 @@ message ReturnWebAuthNRegistrationCode {}
 message RedirectURLs {
   // URL to which the user will be redirected after a successful login.
   string success_url = 1 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/success\"";
     }
   ];
   // URL to which the user will be redirected after a failed login.
   string failure_url = 2 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/fail\"";
     }
   ];

--- a/proto/zitadel/user/v2/idp.proto
+++ b/proto/zitadel/user/v2/idp.proto
@@ -32,20 +32,20 @@ message LDAPCredentials {
 
 message RedirectURLs {
   string success_url = 1 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "URL on which the user will be redirected after a successful login"
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/success\"";
     }
   ];
   string failure_url = 2 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "URL on which the user will be redirected after a failed login"
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/fail\"";
     }
   ];

--- a/proto/zitadel/user/v2beta/idp.proto
+++ b/proto/zitadel/user/v2beta/idp.proto
@@ -32,20 +32,20 @@ message LDAPCredentials {
 
 message RedirectURLs {
   string success_url = 1 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "URL on which the user will be redirected after a successful login"
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/success\"";
     }
   ];
   string failure_url = 2 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 2048, uri_ref: true},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "URL on which the user will be redirected after a failed login"
       min_length: 1;
-      max_length: 200;
+      max_length: 2048;
       example: "\"https://custom.com/login/idp/fail\"";
     }
   ];


### PR DESCRIPTION
# Which Problems Are Solved

Durning the review of #8540, I noticed that the max length of the success and failure url was set back to 200 instead of 2048 as changed in #8327.
Looks like this was accidentally changed during the v2 GA release and migration to v3 resources 

# How the Problems Are Solved

Reapplied the change to 2048 max length

# Additional Changes

None

# Additional Context

- relates to #8327
- relates to #8343
  - requires backport until 2.58.x
- relates to #8494
  - requires backport to 2.60.x
