### PR TITLE
perf(eventstore): optimize indexes

### DIFF
--- a/cmd/setup/33.go
+++ b/cmd/setup/33.go
@@ -1,0 +1,32 @@
+package setup
+
+import (
+	"context"
+	"embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 33/cockroach/33.sql
+	//go:embed 33/postgres/33.sql
+	eventstoreIndexes embed.FS
+)
+
+type EventstoreIndexes struct {
+	dbClient *database.DB
+}
+
+func (mig *EventstoreIndexes) Execute(ctx context.Context, _ eventstore.Event) error {
+	stmt, err := readStmt(eventstoreIndexes, "33", mig.dbClient.Type(), "33.sql")
+	if err != nil {
+		return err
+	}
+	_, err = mig.dbClient.ExecContext(ctx, stmt)
+	return err
+}
+
+func (mig *EventstoreIndexes) String() string {
+	return "33_eventstore_indexes"
+}

--- a/cmd/setup/33/cockroach/33.sql
+++ b/cmd/setup/33/cockroach/33.sql
@@ -1,0 +1,7 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_active_instances_events  ON eventstore.events2 (aggregate_type, event_type) WHERE aggregate_type = 'instance' AND event_type IN ('instance.added', 'instance.removed'); 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_current_sequence ON eventstore.events2 ("sequence" DESC, aggregate_id, aggregate_type, instance_id);
+
+CREATE INDEX es_inst_agg_typ_event_typ_pos_idx ON eventstore.events2 (instance_id, aggregate_type, event_type, "position") STORING (revision, created_at, payload, creator, owner, in_tx_order);
+CREATE INDEX es_inst_agg_typ_pos_idx ON eventstore.events2 (instance_id, aggregate_type, "position") STORING (event_type, revision, created_at, payload, creator, owner, in_tx_order);
+
+-- TODO: remove old indexes

--- a/cmd/setup/33/postgres/33.sql
+++ b/cmd/setup/33/postgres/33.sql
@@ -1,0 +1,6 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_active_instances_idx  ON eventstore.events2 (aggregate_type, event_type) WHERE aggregate_type = 'instance' AND event_type IN ('instance.added', 'instance.removed');
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_current_sequence_idx ON eventstore.events2 ("sequence" DESC, aggregate_id, aggregate_type, instance_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_inst_agg_typ_id_idx ON eventstore.events2 (instance_id, aggregate_id, aggregate_type, "position");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_inst_agg_typ_event_typ_idx ON eventstore.events2 (instance_id, aggregate_type, event_type, "position");
+
+-- TODO: remove old indexes

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -117,6 +117,7 @@ type Steps struct {
 	s30FillFieldsForOrgDomainVerified      *FillFieldsForOrgDomainVerified
 	s31AddAggregateIndexToFields           *AddAggregateIndexToFields
 	s32AddAuthSessionID                    *AddAuthSessionID
+	S33EventstoreIndexes                   *EventstoreIndexes
 }
 
 func MustNewSteps(v *viper.Viper) *Steps {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -161,6 +161,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s30FillFieldsForOrgDomainVerified = &FillFieldsForOrgDomainVerified{eventstore: eventstoreClient}
 	steps.s31AddAggregateIndexToFields = &AddAggregateIndexToFields{dbClient: esPusherDBClient}
 	steps.s32AddAuthSessionID = &AddAuthSessionID{dbClient: esPusherDBClient}
+	steps.S33EventstoreIndexes = &EventstoreIndexes{dbClient: esPusherDBClient}
 
 	err = projection.Create(ctx, projectionDBClient, eventstoreClient, config.Projections, nil, nil, nil)
 	logging.OnError(err).Fatal("unable to start projections")
@@ -203,6 +204,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s26AuthUsers3,
 		steps.s29FillFieldsForProjectGrant,
 		steps.s30FillFieldsForOrgDomainVerified,
+		steps.S33EventstoreIndexes,
 	} {
 		mustExecuteMigration(ctx, eventstoreClient, step, "migration failed")
 	}


### PR DESCRIPTION
# Which Problems Are Solved

P99 of the eventstore library was higher than 10ms based on load tests.

# How the Problems Are Solved

The newly created indexes solve the problem and replace the old ones.

# Additional Context

- part of https://github.com/zitadel/zitadel/issues/8556
