### PR TITLE
fix(in-memory): safe access to subscriptions

### DIFF
--- a/internal/eventstore/v3/subscription.go
+++ b/internal/eventstore/v3/subscription.go
@@ -1,0 +1,74 @@
+package eventstore
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+type subscriptions struct {
+	mutex      sync.RWMutex
+	eventTypes map[eventstore.EventType][]chan<- decimal.Decimal
+}
+
+func newSubscriptions() *subscriptions {
+	return &subscriptions{
+		eventTypes: make(map[eventstore.EventType][]chan<- decimal.Decimal),
+	}
+}
+
+func (s *subscriptions) Add(ch chan<- decimal.Decimal, eventTypes ...eventstore.EventType) {
+	s.mutex.Lock()
+	for _, typ := range eventTypes {
+		s.eventTypes[typ] = append(s.eventTypes[typ], ch)
+	}
+	s.mutex.Unlock()
+}
+
+func (s *subscriptions) Has(typ eventstore.EventType) bool {
+	s.mutex.RLock()
+	_, has := s.eventTypes[typ]
+	s.mutex.RUnlock()
+	return has
+}
+
+func (s *subscriptions) GetSubscribedEvents(events []eventstore.Event) []eventstore.Event {
+	out := make([]eventstore.Event, 0, len(events))
+
+	s.mutex.RLock()
+	for _, event := range events {
+		if _, has := s.eventTypes[event.Type()]; has {
+			out = append(out, event)
+		}
+	}
+	s.mutex.RUnlock()
+
+	return out
+}
+
+func (s *subscriptions) GetSubscribers(typ eventstore.EventType) []chan<- decimal.Decimal {
+	s.mutex.RLock()
+	subsribers := s.eventTypes[typ]
+	s.mutex.RUnlock()
+	return subsribers
+}
+
+func buildPgNotifyQuery(events []eventstore.Event) (query string, args []any, ok bool) {
+	if len(events) == 0 {
+		return "", nil, false
+	}
+
+	notifies := make([]string, len(events))
+	args = make([]any, 0, len(events)*2)
+
+	for i, event := range events {
+		notifies[i] = fmt.Sprintf("pg_notify($%d, $%d)", i*2+1, i*2+2)
+		args = append(args, event.Type(), event.Position())
+	}
+
+	return fmt.Sprintf("SELECT %s;", strings.Join(notifies, ", ")), args, true
+}

--- a/internal/eventstore/v3/subscription.go
+++ b/internal/eventstore/v3/subscription.go
@@ -29,13 +29,6 @@ func (s *subscriptions) Add(ch chan<- decimal.Decimal, eventTypes ...eventstore.
 	s.mutex.Unlock()
 }
 
-func (s *subscriptions) Has(typ eventstore.EventType) bool {
-	s.mutex.RLock()
-	_, has := s.eventTypes[typ]
-	s.mutex.RUnlock()
-	return has
-}
-
 func (s *subscriptions) GetSubscribedEvents(events []eventstore.Event) []eventstore.Event {
 	out := make([]eventstore.Event, 0, len(events))
 
@@ -48,13 +41,6 @@ func (s *subscriptions) GetSubscribedEvents(events []eventstore.Event) []eventst
 	s.mutex.RUnlock()
 
 	return out
-}
-
-func (s *subscriptions) GetSubscribers(typ eventstore.EventType) []chan<- decimal.Decimal {
-	s.mutex.RLock()
-	subsribers := s.eventTypes[typ]
-	s.mutex.RUnlock()
-	return subsribers
 }
 
 func buildPgNotifyQuery(events []eventstore.Event) (query string, args []any, ok bool) {

--- a/internal/eventstore/v3/subscription_test.go
+++ b/internal/eventstore/v3/subscription_test.go
@@ -1,0 +1,81 @@
+package eventstore
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+func Test_buildPgNotifyQuery(t *testing.T) {
+	type args struct {
+		events []eventstore.Event
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantQuery string
+		wantArgs  []any
+		wantOk    bool
+	}{
+		{
+			name:      "nil events",
+			args:      args{nil},
+			wantQuery: "",
+			wantArgs:  nil,
+			wantOk:    false,
+		},
+		{
+			name: "1 event",
+			args: args{[]eventstore.Event{
+				&event{
+					typ:      "foo",
+					position: decimal.NewFromInt(1),
+				},
+			}},
+			wantQuery: "SELECT pg_notify($1, $2);",
+			wantArgs: []any{
+				eventstore.EventType("foo"),
+				decimal.NewFromInt(1),
+			},
+			wantOk: true,
+		},
+		{
+			name: "multiple events",
+			args: args{[]eventstore.Event{
+				&event{
+					typ:      "foo",
+					position: decimal.NewFromInt(1),
+				},
+				&event{
+					typ:      "bar",
+					position: decimal.NewFromInt(2),
+				},
+				&event{
+					typ:      "spanac",
+					position: decimal.NewFromInt(3),
+				},
+			}},
+			wantQuery: "SELECT pg_notify($1, $2), pg_notify($3, $4), pg_notify($5, $6);",
+			wantArgs: []any{
+				eventstore.EventType("foo"),
+				decimal.NewFromInt(1),
+				eventstore.EventType("bar"),
+				decimal.NewFromInt(2),
+				eventstore.EventType("spanac"),
+				decimal.NewFromInt(3),
+			},
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQuery, gotArgs, gotOk := buildPgNotifyQuery(tt.args.events)
+			assert.Equal(t, tt.wantQuery, gotQuery)
+			assert.Equal(t, tt.wantArgs, gotArgs)
+			assert.Equal(t, tt.wantOk, gotOk)
+		})
+	}
+}


### PR DESCRIPTION
# Which Problems Are Solved

Memory safe access to subscriptions and reduced notification roundtrips.

# How the Problems Are Solved

- subscriptions type with RWMutex 
- Use multiple `pg_notify()` in a single query

# Additional Changes

- none

# Additional Context

POC
