### PR TITLE
chore(test): set connection lifetimes for postgresql

### DIFF
--- a/internal/integration/config/postgres.yaml
+++ b/internal/integration/config/postgres.yaml
@@ -7,6 +7,8 @@ Database:
     Database: zitadel
     MaxOpenConns: 20
     MaxIdleConns: 20
+    MaxConnLifetime: 1h
+    MaxConnIdleTime: 5m
     User:
       Username: zitadel
       SSL:


### PR DESCRIPTION
# Which Problems Are Solved

defaults.yaml only specifies defaults for cockroach. Therefore, options omitted for postgresql are actually set to `0`.
This means that the connections timeouts are set to `0` and connections were not reused, resulting in a performance penalty while running the integration tests.

# How the Problems Are Solved

Set MaxConnLifeTime and MaxConnIdleTime options in postgres


# Additional Changes

- none

# Additional Context

- none

