### PR TITLE
fix(tests): check eventual web key state

### DIFF
--- a/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
+++ b/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
@@ -215,9 +215,9 @@ func assertFeatureDisabledError(t *testing.T, err error) {
 func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integration.Instance, nKeys int, expectActiveKeyID string, config any) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := instance.Client.WebKeyV3Alpha.ListWebKeys(ctx, &webkey.ListWebKeysRequest{})
-		require.NoError(t, err)
+		require.NoError(collect, err)
 		list := resp.GetWebKeys()
-		assert.Len(t, list, nKeys)
+		assert.Len(collect, list, nKeys)
 
 		now := time.Now()
 		var gotActiveKeyID string
@@ -230,10 +230,10 @@ func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integrati
 					Id:   instance.ID(),
 				},
 			}, key.GetDetails())
-			assert.WithinRange(t, key.GetDetails().GetChanged().AsTime(), now.Add(-time.Minute), now.Add(time.Minute))
-			assert.NotEqual(t, webkey.WebKeyState_STATE_UNSPECIFIED, key.GetState())
-			assert.NotEqual(t, webkey.WebKeyState_STATE_REMOVED, key.GetState())
-			assert.Equal(t, config, key.GetConfig().GetConfig())
+			assert.WithinRange(collect, key.GetDetails().GetChanged().AsTime(), now.Add(-time.Minute), now.Add(time.Minute))
+			assert.NotEqual(collect, webkey.WebKeyState_STATE_UNSPECIFIED, key.GetState())
+			assert.NotEqual(collect, webkey.WebKeyState_STATE_REMOVED, key.GetState())
+			assert.Equal(collect, config, key.GetConfig().GetConfig())
 
 			if key.GetState() == webkey.WebKeyState_STATE_ACTIVE {
 				gotActiveKeyID = key.GetDetails().GetId()

--- a/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
+++ b/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
@@ -239,9 +239,9 @@ func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integrati
 				gotActiveKeyID = key.GetDetails().GetId()
 			}
 		}
-		assert.NotEmpty(t, gotActiveKeyID)
+		assert.NotEmpty(collect, gotActiveKeyID)
 		if expectActiveKeyID != "" {
-			assert.Equal(t, expectActiveKeyID, gotActiveKeyID)
+			assert.Equal(collect, expectActiveKeyID, gotActiveKeyID)
 		}
 	}, time.Minute, time.Second)
 }

--- a/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
+++ b/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
@@ -191,13 +191,13 @@ func createInstance(t *testing.T, enableFeature bool) (*integration.Instance, co
 		})
 		require.NoError(t, err)
 	}
-	assert.EventuallyWithT(t, func(ttt *assert.CollectT) {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp, err := instance.Client.WebKeyV3Alpha.ListWebKeys(iamCTX, &webkey.ListWebKeysRequest{})
 		if enableFeature {
-			assert.NoError(ttt, err)
-			assert.Len(t, resp.GetWebKeys(), 2)
+			assert.NoError(collect, err)
+			assert.Len(collect, resp.GetWebKeys(), 2)
 		} else {
-			assert.Error(t, err)
+			assert.Error(collect, err)
 		}
 	}, time.Minute, time.Second)
 


### PR DESCRIPTION
# Which Problems Are Solved

Deal with eventual consistency in the webkey integration tests.

# How the Problems Are Solved

Use an eventual with T for the list state check.

# Additional Changes

- none

# Additional Context

- none
