### PR TITLE
feat: enable docker healthchecks

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,6 +16,8 @@ RUN useradd -s "" --home / zitadel && \
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
+HEALTHCHECK CMD /app/zitadel ready
+
 USER zitadel
 ENTRYPOINT ["/app/entrypoint.sh"]
 
@@ -26,7 +28,7 @@ COPY --from=artifact /etc/passwd /etc/passwd
 COPY --from=artifact /etc/ssl/certs /etc/ssl/certs
 COPY --from=artifact /app/zitadel /app/zitadel
 
-HEALTHCHECK NONE
+HEALTHCHECK CMD /app/zitadel ready
 
 USER zitadel
 ENTRYPOINT ["/app/zitadel"]


### PR DESCRIPTION
# Which Problems Are Solved
- Zitadel containers had no out of the box healthcheck.


# How the Problems Are Solved
- `HEALTHCHECK` directive has been added to both artifact and final images in the Dockerfile.

# Additional Context
- Closes ##6055.
