### PR TITLE
chore: fix crdb version on v24.2.1

### DIFF
--- a/e2e/config/localhost/docker-compose.yaml
+++ b/e2e/config/localhost/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
 
   db:
     restart: 'always'
-    image: 'cockroachdb/cockroach:latest'
+    image: 'cockroachdb/cockroach:v24.2.1'
     command: 'start-single-node --insecure --http-addr :9090'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9090/health?ready=1']


### PR DESCRIPTION
Fix crdb to version v24.2.1 for e2e tests