### PR TITLE
fix: race condition in system jwt signature check

### DIFF
--- a/internal/api/authz/system_token.go
+++ b/internal/api/authz/system_token.go
@@ -76,7 +76,7 @@ func (s *SystemTokenVerifierFromConfig) VerifySystemToken(ctx context.Context, t
 
 type systemJWTStorage struct {
 	keys       map[string]*SystemAPIUser
-	mutex      sync.Mutex
+	mutex      sync.RWMutex
 	cachedKeys map[string]*rsa.PublicKey
 }
 
@@ -98,7 +98,9 @@ func (s *SystemAPIUser) readKey() (*rsa.PublicKey, error) {
 }
 
 func (s *systemJWTStorage) GetKeyByIDAndClientID(_ context.Context, _, userID string) (*jose.JSONWebKey, error) {
+	s.mutex.RLock()
 	cachedKey, ok := s.cachedKeys[userID]
+	s.mutex.RUnlock()
 	if ok {
 		return &jose.JSONWebKey{KeyID: userID, Key: cachedKey}, nil
 	}


### PR DESCRIPTION
# Which Problems Are Solved

The integration tests noted a race condition when loading the key used to verify the signature of a System API JWT.

# How the Problems Are Solved

- Changed the mutex to a `RWMutex` and `RLock` before accessing the `cachedKeys` map

# Additional Changes

None

# Additional Context

noticed in https://github.com/zitadel/zitadel/actions/runs/10850005593/job/30111110726?pr=8602#step:8:403