### PR TITLE
fix: Back Button on Register Pages Redirect

### DIFF
--- a/internal/api/ui/login/static/templates/register.html
+++ b/internal/api/ui/login/static/templates/register.html
@@ -106,7 +106,7 @@
     {{template "error-message" .}}
 
     <div class="lgn-actions">
-        <a class="lgn-icon-button lgn-left-action" id="back" href="{{ loginNameChangeUrl .AuthReqID }}" formnovalidate>
+        <a class="lgn-icon-button lgn-left-action" id="back" href="{{ if .AuthReqID }}{{ loginNameChangeUrl .AuthReqID }}{{ else }}{{ loginUrl }}{{ end }}" formnovalidate>
             <i class="lgn-icon-arrow-left-solid"></i>
         </a>
         <span class="fill-space"></span>

--- a/internal/api/ui/login/static/templates/register_option.html
+++ b/internal/api/ui/login/static/templates/register_option.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="authRequestID" value="{{ .AuthReqID }}" />
 
     <div class="lgn-actions">
-        <a class="lgn-icon-button lgn-left-action" href="{{ loginNameChangeUrl .AuthReqID }}">
+        <a class="lgn-icon-button lgn-left-action" href="{{ if .AuthReqID }}{{ loginNameChangeUrl .AuthReqID }}{{ else }}{{ loginUrl }}{{ end }}">
             <i class="lgn-icon-arrow-left-solid"></i>
         </a>
     </div>

--- a/internal/api/ui/login/static/templates/register_org.html
+++ b/internal/api/ui/login/static/templates/register_org.html
@@ -11,6 +11,11 @@
 
     <input type="hidden" name="authRequestID" value="{{ .AuthReqID }}"/>
 
+    <div class="lgn-actions">
+        <a class="lgn-icon-button lgn-left-action" href="{{ if .AuthReqID }}{{ loginNameChangeUrl .AuthReqID }}{{ else }}{{ loginUrl }}{{ end }}">
+            <i class="lgn-icon-arrow-left-solid"></i>
+        </a>
+    </div>
     <div class="lgn-register">
         <div class="lgn-field">
             <label class="lgn-label" for="orgname">{{t "RegistrationOrg.OrgNameLabel"}}</label>


### PR DESCRIPTION
# Which Problems Are Solved

- If a user visits a register page without first visiting a login page, the authReqID is null. If a user clicks the back button on one of the register pages, it would not render the loginName page without an authReqID.
- No back button on register org page.
- Register button on the login page only goes to the register user page. Added ability to go to the register org page.

# How the Problems Are Solved

- Updated the register page back button links to point to the `{ loginUrl } ` if no authReqID is present. If there is an authReqID, it's passed to the loginName page.
- Added back button to the register org page.
- In the Default/Org Settings, there are 2 checkboxes. One for User Registration allowed and one for Organization Registration allowed. The current functionality ties the visibility of the register button on the login page to the User Registration allowed checkbox. I've updated the visibility and link of the button to the following:
    - If both boxes are checked, the register button is displayed and links to the user register page. (Matches existing functionality)
    - If user registration is checked and the organization register is not checked, the register button is displayed and links to the user register page. (Matches existing functionality)
    - If the organization register is checked and the user register is not checked, the register button is displayed and links to the register org page. (New functionality. Previously register button was not displayed.)
    - If neither boxes are checked, the register button is not displayed. (Matches existing functionality)

# Additional Changes

None

# Additional Context

Closes #8554 and #8620.
