### PR TITLE
perf(eventstore): try different statement for push

### DIFF
--- a/internal/eventstore/repository/event.go
+++ b/internal/eventstore/repository/event.go
@@ -3,9 +3,13 @@ package repository
 import (
 	"database/sql"
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
@@ -84,7 +88,9 @@ func (e *Event) Type() eventstore.EventType {
 
 // Revision implements [eventstore.Event]
 func (e *Event) Revision() uint16 {
-	return 0
+	revision, err := strconv.Atoi(strings.TrimPrefix(string(e.Version), "v"))
+	logging.OnError(err).Debug("failed to parse revision")
+	return uint16(revision)
 }
 
 // Sequence implements [eventstore.Event]

--- a/internal/eventstore/v1/models/event.go
+++ b/internal/eventstore/v1/models/event.go
@@ -3,9 +3,13 @@ package models
 import (
 	"encoding/json"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -93,7 +97,9 @@ func (e *Event) Type() eventstore.EventType {
 
 // Type implements [eventstore.action]
 func (e *Event) Revision() uint16 {
-	return 0
+	revision, err := strconv.Atoi(strings.TrimPrefix(string(e.Aggregate().Version), "v"))
+	logging.OnError(err).Debug("failed to parse revision")
+	return uint16(revision)
 }
 
 func eventData(i interface{}) ([]byte, error) {

--- a/internal/eventstore/v3/event_test.go
+++ b/internal/eventstore/v3/event_test.go
@@ -119,7 +119,7 @@ func Test_commandToEvent(t *testing.T) {
 			}
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := commandToEvent(tt.args.sequence, tt.args.command)
+			got, err := commandToEventWithSequence(tt.args.sequence, tt.args.command)
 
 			tt.want.err(t, err)
 			assert.Equal(t, tt.want.event, got)

--- a/internal/eventstore/v3/push2.sql
+++ b/internal/eventstore/v3/push2.sql
@@ -1,0 +1,78 @@
+WITH events AS (
+  select 
+    *
+    , TRANSACTION_TIMESTAMP() AS created_at
+    , EXTRACT(EPOCH FROM TRANSACTION_TIMESTAMP()) as position
+    , ROW_NUMBER() OVER(PARTITION BY owner, aggregate_type, aggregate_id) AS increment
+    , ROW_NUMBER() OVER() AS position_order
+  FROM (VALUES
+    %s
+  ) AS events (
+    instance_id
+    , "owner"
+    , aggregate_type
+    , aggregate_id
+    , revision
+
+    , creator
+    , event_type
+    , payload
+  )
+), aggregates AS (
+  SELECT
+    instance_id
+    , aggregate_type
+    , aggregate_id
+    , MAX("sequence") AS "sequence"
+  FROM
+    eventstore.events2
+  WHERE
+    (instance_id, aggregate_type, aggregate_id) IN (SELECT instance_id, aggregate_type, aggregate_id FROM events)
+  GROUP BY
+    instance_id
+    , aggregate_type
+    , aggregate_id
+) INSERT INTO eventstore.events2 (
+    instance_id
+    , "owner"
+    , aggregate_type
+    , aggregate_id
+    , revision
+
+    , creator
+    , event_type
+    , payload
+    , "sequence"
+    , created_at
+
+    , "position"
+    , in_tx_order
+) SELECT 
+  e.instance_id
+  , e."owner"
+  , e.aggregate_type
+  , e.aggregate_id
+  , e.revision
+  
+  , e.creator
+  , e.event_type
+  , e.payload
+  , COALESCE(a.sequence, 0) + e.increment AS "sequence"
+  , e.created_at
+
+  , e.position
+  , e.position_order
+FROM 
+  aggregates a
+RIGHT JOIN
+  events e
+ON
+  a.instance_id = e.instance_id
+  AND a.aggregate_type = e.aggregate_type
+  AND a.aggregate_id = e.aggregate_id
+RETURNING
+  "sequence"
+  , created_at
+  , "position"
+  , in_tx_order
+;


### PR DESCRIPTION
# Which Problems Are Solved

There are potentially many statements executed during a push to the eventstore.

# How the Problems Are Solved

Reduces the amount of statements executed.

# Additional Context

- part of https://github.com/zitadel/zitadel/issues/8352