### PR TITLE
feat: ready without configuration

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,14 +11,17 @@ RUN useradd -s "" --home / zitadel && \
     chown zitadel /app/zitadel && \
     chmod +x /app/zitadel && \
     chown zitadel /app/entrypoint.sh && \
-    chmod +x /app/entrypoint.sh
+    chmod +x /app/entrypoint.sh && \
+    mkdir /emptytmp
 
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
-HEALTHCHECK CMD /app/zitadel ready
-
 USER zitadel
+
+HEALTHCHECK --interval=5s --timeout=120s --retries=6 \
+    CMD ["/app/zitadel", "ready"]
+
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 FROM --platform=$TARGETPLATFORM scratch as final
@@ -26,9 +29,13 @@ ARG TARGETPLATFORM
 
 COPY --from=artifact /etc/passwd /etc/passwd
 COPY --from=artifact /etc/ssl/certs /etc/ssl/certs
-COPY --from=artifact /app/zitadel /app/zitadel
-
-HEALTHCHECK CMD /app/zitadel ready
+COPY --from=artifact --chown=zitadel:zitadel /app/zitadel /app/zitadel
+COPY --from=artifact --chown=zitadel:zitadel /emptytmp /tmp
 
 USER zitadel
+
+# /app/zitadel ready is a healthcheck endpoint that immediately
+HEALTHCHECK --interval=5s --timeout=600s --retries=3 \
+    CMD ["/app/zitadel", "ready"]
+
 ENTRYPOINT ["/app/zitadel"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,6 +16,8 @@ RUN useradd -s "" --home / zitadel && \
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
+HEALTHCHECK CMD /app/zitadel ready
+
 USER zitadel
 ENTRYPOINT ["/app/entrypoint.sh"]
 
@@ -26,7 +28,7 @@ COPY --from=artifact /etc/passwd /etc/passwd
 COPY --from=artifact /etc/ssl/certs /etc/ssl/certs
 COPY --from=artifact /app/zitadel /app/zitadel
 
-HEALTHCHECK NONE
+HEALTHCHECK CMD /app/zitadel ready
 
 USER zitadel
 ENTRYPOINT ["/app/zitadel"]

--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -26,8 +26,8 @@ func New() *cobra.Command {
 	adminCMD.AddCommand(
 		initialise.New(),
 		setup.New(),
-		start.New(nil),
-		start.NewStartFromInit(nil),
+		start.New(),
+		start.NewStartFromInit(),
 		key.New(),
 	)
 

--- a/cmd/initialise/init.go
+++ b/cmd/initialise/init.go
@@ -3,10 +3,10 @@ package initialise
 import (
 	"context"
 	"embed"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/zitadel/logging"
+	"github.com/zitadel/zitadel/internal/socket"
 
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/database/dialect"
@@ -72,9 +72,13 @@ func InitAll(ctx context.Context, config *Config) {
 }
 
 func initialise(config database.Config, steps ...func(*database.DB) error) error {
+	closeSocket, err := socket.ListenAndIgnore()
+	logging.OnError(err).Fatal("unable to listen on socket")
+	defer closeSocket()
+
 	logging.Info("initialization started")
 
-	err := ReadStmts(config.Type())
+	err = ReadStmts(config.Type())
 	if err != nil {
 		return err
 	}

--- a/cmd/initialise/init.go
+++ b/cmd/initialise/init.go
@@ -6,10 +6,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/zitadel/logging"
-	"github.com/zitadel/zitadel/internal/socket"
-
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/database/dialect"
+	"github.com/zitadel/zitadel/internal/unixsocket"
 )
 
 var (
@@ -72,7 +71,7 @@ func InitAll(ctx context.Context, config *Config) {
 }
 
 func initialise(config database.Config, steps ...func(*database.DB) error) error {
-	closeSocket, err := socket.ListenAndIgnore()
+	closeSocket, err := unixsocket.ListenAndIgnore()
 	logging.OnError(err).Fatal("unable to listen on socket")
 	defer closeSocket()
 

--- a/cmd/mirror/mirror.go
+++ b/cmd/mirror/mirror.go
@@ -3,12 +3,13 @@ package mirror
 import (
 	"bytes"
 	_ "embed"
+	"errors"
+	"fmt"
+	"github.com/zitadel/zitadel/internal/unixsocket"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/zitadel/logging"
-
 	"github.com/zitadel/zitadel/cmd/key"
 )
 
@@ -19,6 +20,7 @@ var (
 )
 
 func New(configFiles *[]string) *cobra.Command {
+	closeSocket := func() error { return nil }
 	cmd := &cobra.Command{
 		Use:   "mirror",
 		Short: "mirrors all data of ZITADEL from one database to another",
@@ -34,29 +36,49 @@ Order of execution:
 3. mirror event store tables
 4. recompute projections
 5. verify`,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			err := viper.MergeConfig(bytes.NewBuffer(defaultConfig))
-			logging.OnError(err).Fatal("unable to read default config")
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			closeSocket, err = unixsocket.ListenAndIgnore()
+			if err != nil {
+				return fmt.Errorf("unable to listen on socket: %w", err)
+			}
+			if err = viper.MergeConfig(bytes.NewBuffer(defaultConfig)); err != nil {
+				return errors.New("unable to read default config")
+			}
 
 			for _, file := range *configFiles {
 				viper.SetConfigFile(file)
-				err := viper.MergeInConfig()
-				logging.WithFields("file", file).OnError(err).Warn("unable to read config file")
+				if err = viper.MergeInConfig(); err != nil {
+					return fmt.Errorf("unable to read config file: %w", err)
+				}
 			}
+			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			defer closeSocket()
 			config := mustNewMigrationConfig(viper.GetViper())
 			projectionConfig := mustNewProjectionsConfig(viper.GetViper())
 
 			masterKey, err := key.MasterKey(cmd)
-			logging.OnError(err).Fatal("unable to read master key")
+			if err != nil {
+				return fmt.Errorf("unable to read master key: %w", err)
+			}
+			if err = copySystem(cmd.Context(), config); err != nil {
+				return fmt.Errorf("unable to copy system tables: %w", err)
+			}
+			if err = copyAuth(cmd.Context(), config); err != nil {
+				return fmt.Errorf("unable to copy auth tables: %w", err)
+			}
+			if err = copyEventstore(cmd.Context(), config); err != nil {
+				return fmt.Errorf("unable to copy eventstore tables: %w", err)
+			}
 
-			copySystem(cmd.Context(), config)
-			copyAuth(cmd.Context(), config)
-			copyEventstore(cmd.Context(), config)
-
-			projections(cmd.Context(), projectionConfig, masterKey)
-			verifyMigration(cmd.Context(), config)
+			if err = projections(cmd.Context(), projectionConfig, masterKey); err != nil {
+				return fmt.Errorf("unable to recompute projections: %w", err)
+			}
+			if err = verifyMigration(cmd.Context(), config); err != nil {
+				return fmt.Errorf("unable to verify migration: %w", err)
+			}
+			return nil
 		},
 	}
 
@@ -70,11 +92,11 @@ The flag should be provided if you want to execute the mirror command multiple t
 	migrateProjectionsFlags(cmd)
 
 	cmd.AddCommand(
-		eventstoreCmd(),
-		systemCmd(),
-		projectionsCmd(),
-		authCmd(),
-		verifyCmd(),
+		eventstoreCmd(closeSocket),
+		systemCmd(closeSocket),
+		projectionsCmd(closeSocket),
+		authCmd(closeSocket),
+		verifyCmd(closeSocket),
 	)
 
 	return cmd

--- a/cmd/ready/ready.go
+++ b/cmd/ready/ready.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/zitadel/logging"
-	"github.com/zitadel/zitadel/internal/socket"
+	"github.com/zitadel/zitadel/internal/unixsocket"
 	"net"
 	"net/http"
 	"os"
@@ -33,7 +33,7 @@ func ready(config *Config) bool {
 		logging.Info("ready check passed")
 		return true
 	}
-	socketErr := expectTrueFromSocket(socket.ReadinessQuery)
+	socketErr := expectTrueFromSocket(unixsocket.ReadinessQuery)
 	if socketErr == nil {
 		logging.Info("ready check passed")
 		return true
@@ -43,12 +43,12 @@ func ready(config *Config) bool {
 	return false
 }
 
-func expectTrueFromSocket(query socket.SocketRequest) error {
+func expectTrueFromSocket(query unixsocket.SocketRequest) error {
 	resp, err := query.Request()
 	if err != nil {
 		return fmt.Errorf("socket request error: %w", err)
 	}
-	if resp != socket.True {
+	if resp != unixsocket.True {
 		return fmt.Errorf("zitadel process did not respond true to a readiness query")
 	}
 	return nil

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	_ "embed"
+	"github.com/zitadel/zitadel/internal/socket"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -53,7 +54,11 @@ func New() *cobra.Command {
 Requirements:
 - cockroachdb`,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := tls.ModeFromFlag(cmd)
+			closeSocket, err := socket.ListenAndIgnore()
+			logging.OnError(err).Fatal("unable to listen on socket")
+			defer closeSocket()
+
+			err = tls.ModeFromFlag(cmd)
 			logging.OnError(err).Fatal("invalid tlsMode")
 
 			err = BindInitProjections(cmd)

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"embed"
 	_ "embed"
-	"github.com/zitadel/zitadel/internal/socket"
+	"github.com/zitadel/zitadel/internal/unixsocket"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ func New() *cobra.Command {
 Requirements:
 - cockroachdb`,
 		Run: func(cmd *cobra.Command, args []string) {
-			closeSocket, err := socket.ListenAndIgnore()
+			closeSocket, err := unixsocket.ListenAndIgnore()
 			logging.OnError(err).Fatal("unable to listen on socket")
 			defer closeSocket()
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	_ "embed"
 	"fmt"
-	"github.com/zitadel/zitadel/internal/socket"
+	"github.com/zitadel/zitadel/internal/unixsocket"
 	"math"
 	"net/http"
 	"os"
@@ -621,16 +621,16 @@ func checkExisting(values []string) func(string) bool {
 }
 
 func listenSocket(ctx context.Context) (chan<- *Server, func() error, error) {
-	return socket.Listen(func(server *Server, request socket.SocketRequest) (socket.SocketResponse, error) {
+	return unixsocket.Listen(func(server *Server, request unixsocket.SocketRequest) (unixsocket.SocketResponse, error) {
 		switch request {
-		case socket.ReadinessQuery:
+		case unixsocket.ReadinessQuery:
 			if readyErr := server.Queries.Health(ctx); readyErr != nil {
 				logging.Warnf("readiness check failed: %v", readyErr)
-				return socket.False, nil
+				return unixsocket.False, nil
 			}
-			return socket.True, nil
+			return unixsocket.True, nil
 		default:
-			return socket.UnknownRequest, fmt.Errorf("unknown request: %d", request)
+			return unixsocket.UnknownRequest, fmt.Errorf("unknown request: %d", request)
 		}
 	})
 }

--- a/cmd/zitadel.go
+++ b/cmd/zitadel.go
@@ -28,7 +28,7 @@ var (
 	defaultConfig []byte
 )
 
-func New(out io.Writer, in io.Reader, args []string, server chan<- *start.Server) *cobra.Command {
+func New(out io.Writer, in io.Reader, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zitadel",
 		Short: "The ZITADEL CLI lets you interact with ZITADEL",
@@ -53,9 +53,9 @@ func New(out io.Writer, in io.Reader, args []string, server chan<- *start.Server
 		admin.New(), //is now deprecated, remove later on
 		initialise.New(),
 		setup.New(),
-		start.New(server),
-		start.NewStartFromInit(server),
-		start.NewStartFromSetup(server),
+		start.New(),
+		start.NewStartFromInit(),
+		start.NewStartFromSetup(),
 		mirror.New(&configFiles),
 		key.New(),
 		ready.New(),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  zitadel:
+    restart: 'always'
+    networks:
+      - 'zitadel'
+    image: zitadel:local
+    command: 'start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled'
+    environment:
+      - 'ZITADEL_DATABASE_POSTGRES_HOST=db'
+      - 'ZITADEL_DATABASE_POSTGRES_PORT=5432'
+      - 'ZITADEL_DATABASE_POSTGRES_DATABASE=zitadel'
+      - 'ZITADEL_DATABASE_POSTGRES_USER_USERNAME=zitadel'
+      - 'ZITADEL_DATABASE_POSTGRES_USER_PASSWORD=zitadel'
+      - 'ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE=disable'
+      - 'ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=postgres'
+      - 'ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD=postgres'
+      - 'ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable'
+      - 'ZITADEL_EXTERNALSECURE=false'
+    depends_on:
+      db:
+        condition: 'service_healthy'
+    ports:
+      - '8080:8080'
+
+  db:
+    restart: 'always'
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=zitadel
+    networks:
+      - 'zitadel'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-d", "zitadel", "-U", "postgres"]
+      interval: '10s'
+      timeout: '30s'
+      retries: 5
+      start_period: '20s'
+
+networks:
+  zitadel:

--- a/internal/socket/listen.go
+++ b/internal/socket/listen.go
@@ -1,0 +1,60 @@
+package socket
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/zitadel/logging"
+)
+
+func Listen[T any](handleFunc HandleFunc[T]) (chan<- T, func() error, error) {
+	listener, err := listen()
+	if err != nil {
+		return nil, func() error { return nil }, fmt.Errorf("cannot start socket listener: %w", err)
+	}
+	serverStartedUp := make(chan T)
+	go acceptSocketConnections[T](listener, serverStartedUp, handleFunc)
+	return serverStartedUp, listener.Close, nil
+}
+
+func ListenAndIgnore() (func() error, error) {
+	listener, err := listen()
+	if err != nil {
+		return func() error { return nil }, fmt.Errorf("cannot start socket listener: %w", err)
+	}
+	go acceptSocketConnections[any](listener, make(chan any), nil)
+	return listener.Close, nil
+}
+
+func listen() (net.Listener, error) {
+	if err := os.Remove(Path); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot remove socket file: %w", err)
+	}
+	return net.Listen("unix", Path)
+}
+
+type Handler func(request SocketRequest) (SocketResponse, error)
+
+func acceptSocketConnections[T any](listener net.Listener, startupDone <-chan T, handle HandleFunc[T]) {
+	var server T
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			logging.Errorf("accept socket error: %v", err)
+			continue
+		}
+		if server == nil {
+			server = <-startupDone
+		}
+		if handle == nil {
+			conn.Close()
+			return
+		}
+		go func() {
+			if handleErr := respond(conn, handle, server); handleErr != nil {
+				logging.Errorf("socket handle error: %v", handleErr)
+			}
+		}()
+	}
+}

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -1,0 +1,69 @@
+package socket
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+const Path = "/tmp/zitadel.sock"
+
+type SocketRequest byte
+
+const (
+	unknown SocketRequest = iota
+	ReadinessQuery
+)
+
+type SocketResponse byte
+
+const (
+	unknownResponse SocketResponse = iota
+	UnknownRequest
+	True
+	False
+)
+
+func (s SocketRequest) Request() (resp SocketResponse, err error) {
+	conn, err := net.Dial("unix", Path)
+	if err != nil {
+		return resp, fmt.Errorf("dial error: %w", err)
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte{byte(s)})
+	if err != nil {
+		return resp, fmt.Errorf("write error: %w", err)
+	}
+	response, err := io.ReadAll(conn)
+	if err != nil {
+		return resp, fmt.Errorf("read error: %w", err)
+	}
+	if len(response) != 1 {
+		return resp, fmt.Errorf("invalid response length")
+	}
+	return SocketResponse(response[0]), nil
+}
+
+type HandleFunc[T any] func(T, SocketRequest) (SocketResponse, error)
+
+func respond[T any](conn net.Conn, handler HandleFunc[T], server T) error {
+	defer conn.Close()
+	buf := make([]byte, 1)
+	_, err := conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("could not read from socket: %v", err)
+	}
+	if len(buf) != 1 {
+		return fmt.Errorf("invalid request length: %d", len(buf))
+	}
+	req := SocketRequest(buf[0])
+	resp, err := handler(server, req)
+	if err != nil {
+		return fmt.Errorf("handler error: %w", err)
+	}
+	_, err = conn.Write([]byte{byte(resp)})
+	if err != nil {
+		return fmt.Errorf("could not write response: %v", err)
+	}
+	return nil
+}

--- a/internal/unixsocket/listen.go
+++ b/internal/unixsocket/listen.go
@@ -1,4 +1,4 @@
-package socket
+package unixsocket
 
 import (
 	"fmt"

--- a/internal/unixsocket/socket.go
+++ b/internal/unixsocket/socket.go
@@ -1,4 +1,4 @@
-package socket
+package unixsocket
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,6 @@ import (
 
 func main() {
 	args := os.Args[1:]
-	rootCmd := cmd.New(os.Stdout, os.Stdin, args, nil)
+	rootCmd := cmd.New(os.Stdout, os.Stdin, args)
 	cobra.CheckErr(rootCmd.Execute())
 }


### PR DESCRIPTION
# Which Problems Are Solved

The `zitadel ready` command checks ZITADELs readiness via HTTP call. For this, it needs to have the same port and TLS config passed via the --config flag like the main ZITADEL process. This makes it impossible to configure reliable default status checks, for example using the Dockerfile HEALTHCHECK directive.

# How the Problems Are Solved

`zitadel ready` also queries ZITADELs readiness via a UNIX socket, which is responded by the main ZITADEL process. This is done if the explicitly configured health check fails to ensure backwards compatibility.

The ZITADEL `init`, `setup`, `start-from-init`, `start-from-setup`, `start` and `mirror` commands immediately start listening on the socket. They only return their first response once they are ready to accept traffic. The `init`, `setup` and `mirror` subcommands never serve traffic, so they only respond when their jobs are done. This allows to configure the HEALTHCHECK directive in the Dockerfile with a long `--timeout` flag.

# Additional Context

Replaces #8606 
Closes #8684