### PR TITLE
docs(nginx): pass host as received from client

### DIFF
--- a/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-disabled-tls.conf
+++ b/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-disabled-tls.conf
@@ -7,7 +7,7 @@ http {
         http2 on;
         location / {
             grpc_pass grpc://zitadel-disabled-tls:8080;
-            grpc_set_header Host $host:$server_port;
+            grpc_set_header Host $host;
         }
     }
 }

--- a/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-enabled-tls.conf
+++ b/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-enabled-tls.conf
@@ -9,7 +9,7 @@ http {
         ssl_certificate_key /etc/certs/selfsigned.key;
         location / {
             grpc_pass grpcs://zitadel-enabled-tls:8080;
-            grpc_set_header Host $host:$server_port;
+            grpc_set_header Host $host;
         }
     }
 }

--- a/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-external-tls.conf
+++ b/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx-external-tls.conf
@@ -9,7 +9,7 @@ http {
         ssl_certificate_key /etc/certs/selfsigned.key;
         location / {
             grpc_pass grpc://zitadel-external-tls:8080;
-            grpc_set_header Host $host:$server_port;
+            grpc_set_header Host $host;
         }
     }
 }


### PR DESCRIPTION
# Which Problems Are Solved

The Host header reaching ZITADEL must be the same like it is requested by the browser, or all sorts of issues arise. However, in the NginX docs, it is appended by the port.

# How the Problems Are Solved

Port is removed from examples

# Additional Context

- Closes https://github.com/zitadel/zitadel/issues/7804
- Relates to https://github.com/netbirdio/netbird/issues/1395
