### PR TITLE
fix: ignore projectID and origin check for service accounts

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -116,19 +116,9 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 			return CtxData{}, zerrors.ThrowUnauthenticated(errors.Join(err, sysTokenErr), "AUTH-7fs1e", "Errors.Token.Invalid")
 		}
 	}
-	var projectID string
-	var origins []string
-	if clientID != "" {
-		projectID, origins, err = t.ProjectIDAndOriginsByClientID(ctx, clientID)
-		if err != nil {
-			return CtxData{}, zerrors.ThrowPermissionDenied(err, "AUTH-GHpw2", "could not read projectid by clientid")
-		}
-		// We used to check origins for every token, but service users shouldn't be used publicly (native app / SPA).
-		// Therefore, mostly won't send an origin and aren't able to configure them anyway.
-		// For the current time we will only check origins for tokens issued to users through apps (code / implicit flow).
-		if err := checkOrigin(ctx, origins); err != nil {
-			return CtxData{}, err
-		}
+	projectID, err := projectIDAndCheckOriginForClientID(ctx, clientID, t)
+	if err != nil {
+		return CtxData{}, err
 	}
 	if orgID == "" && orgDomain == "" {
 		orgID = resourceOwner
@@ -149,6 +139,22 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		ResourceOwner:     resourceOwner,
 		SystemMemberships: sysMemberships,
 	}, nil
+}
+
+func projectIDAndCheckOriginForClientID(ctx context.Context, clientID string, t APITokenVerifier) (string, error) {
+	if clientID == "" {
+		return "", nil
+	}
+	projectID, origins, err := t.ProjectIDAndOriginsByClientID(ctx, clientID)
+	logging.WithFields("clientID", clientID).OnError(err).Debug("could not check projectID and origin of clientID (might be service account)")
+
+	// We used to check origins for every token, but service users shouldn't be used publicly (native app / SPA).
+	// Therefore, mostly won't send an origin and aren't able to configure them anyway.
+	// For the current time we will only check origins for tokens issued to users through apps (code / implicit flow).
+	if projectID == "" {
+		return "", nil
+	}
+	return projectID, checkOrigin(ctx, origins)
 }
 
 func SetCtxData(ctx context.Context, ctxData CtxData) context.Context {

--- a/internal/api/oidc/integration_test/token_client_credentials_test.go
+++ b/internal/api/oidc/integration_test/token_client_credentials_test.go
@@ -109,7 +109,7 @@ func TestServer_ClientCredentialsExchange(t *testing.T) {
 			},
 		},
 		{
-			name:         "openid, profile, email",
+			name:         "openid, profile, email, zitadel",
 			clientID:     clientID,
 			clientSecret: clientSecret,
 			scope:        []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, domain.ProjectScopeZITADEL},

--- a/internal/api/oidc/integration_test/token_client_credentials_test.go
+++ b/internal/api/oidc/integration_test/token_client_credentials_test.go
@@ -3,6 +3,7 @@
 package oidc_test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 
 	oidc_api "github.com/zitadel/zitadel/internal/api/oidc"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/integration"
+	"github.com/zitadel/zitadel/pkg/grpc/auth"
 	"github.com/zitadel/zitadel/pkg/grpc/management"
 	"github.com/zitadel/zitadel/pkg/grpc/user"
 )
@@ -106,6 +109,17 @@ func TestServer_ClientCredentialsExchange(t *testing.T) {
 			},
 		},
 		{
+			name:         "openid, profile, email",
+			clientID:     clientID,
+			clientSecret: clientSecret,
+			scope:        []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeEmail, domain.ProjectScopeZITADEL},
+			wantClaims: claims{
+				name:     name,
+				username: name,
+				updated:  machine.GetDetails().GetChangeDate().AsTime(),
+			},
+		},
+		{
 			name:         "org id and domain scope",
 			clientID:     clientID,
 			clientSecret: clientSecret,
@@ -173,6 +187,13 @@ func TestServer_ClientCredentialsExchange(t *testing.T) {
 			assert.Empty(t, userinfo.UserInfoEmail)
 			assert.Empty(t, userinfo.UserInfoPhone)
 			assert.Empty(t, userinfo.Address)
+
+			_, err = Instance.Client.Auth.GetMyUser(integration.WithAuthorizationToken(CTX, tokens.AccessToken), &auth.GetMyUserRequest{})
+			if slices.Contains(tt.scope, domain.ProjectScopeZITADEL) {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }

--- a/internal/domain/request.go
+++ b/internal/domain/request.go
@@ -9,6 +9,7 @@ const (
 	ProjectIDScope        = "urn:zitadel:iam:org:project:id:"
 	ProjectIDScopeZITADEL = "zitadel"
 	AudSuffix             = ":aud"
+	ProjectScopeZITADEL   = ProjectIDScope + ProjectIDScopeZITADEL + AudSuffix
 	SelectIDPScope        = "urn:zitadel:iam:org:idp:id:"
 )
 


### PR DESCRIPTION
# Which Problems Are Solved

Calls with tokens issued through JWT Profile or Client Credentials Grants were no longer possible and threw a "could not read projectid by clientid (AUTH-GHpw2)" error.
ZITADEL checks the allowed origins of an application and load its projectID into the context on any API call.
Tokens from service accounts did not contain any clientID and therefore never did that check.
But due to a change in https://github.com/zitadel/zitadel/pull/8580, were the service user id was set as client_id in the OIDC session to fix the introspection response (https://github.com/zitadel/zitadel/issues/8590).

# How the Problems Are Solved

- Check if the project and origin were retrieved and only then check the origins

# Additional Changes

None.

# Additional Context

- closes https://github.com/zitadel/zitadel/issues/8676
- relates to https://github.com/zitadel/zitadel/pull/8580 (released on 2.62.0)
- relates to https://github.com/zitadel/zitadel/issues/8590