### PR TITLE
fix(API): select org context by domain

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -124,7 +124,7 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		orgID = resourceOwner
 	}
 	// System API calls don't have a resource owner
-	if orgID != "" {
+	if orgID != "" || orgDomain != "" {
 		orgID, err = t.ExistsOrg(ctx, orgID, orgDomain)
 		if err != nil {
 			return CtxData{}, zerrors.ThrowPermissionDenied(nil, "AUTH-Bs7Ds", "Organisation doesn't exist")

--- a/internal/api/grpc/user/v2/integration_test/user_test.go
+++ b/internal/api/grpc/user/v2/integration_test/user_test.go
@@ -103,6 +103,47 @@ func TestServer_AddHumanUser(t *testing.T) {
 			},
 		},
 		{
+			name: "default verification (org domain ctx)",
+			args: args{
+				CTX,
+				&user.AddHumanUserRequest{
+					Organization: &object.Organization{
+						Org: &object.Organization_OrgDomain{
+							OrgDomain: Instance.DefaultOrg.PrimaryDomain,
+						},
+					},
+					Profile: &user.SetHumanProfile{
+						GivenName:         "Donald",
+						FamilyName:        "Duck",
+						NickName:          gu.Ptr("Dukkie"),
+						DisplayName:       gu.Ptr("Donald Duck"),
+						PreferredLanguage: gu.Ptr("en"),
+						Gender:            user.Gender_GENDER_DIVERSE.Enum(),
+					},
+					Email: &user.SetHumanEmail{},
+					Phone: &user.SetHumanPhone{},
+					Metadata: []*user.SetMetadataEntry{
+						{
+							Key:   "somekey",
+							Value: []byte("somevalue"),
+						},
+					},
+					PasswordType: &user.AddHumanUserRequest_Password{
+						Password: &user.Password{
+							Password:       "DifficultPW666!",
+							ChangeRequired: true,
+						},
+					},
+				},
+			},
+			want: &user.AddHumanUserResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+		},
+		{
 			name: "return email verification code",
 			args: args{
 				CTX,


### PR DESCRIPTION
# Which Problems Are Solved

V2 and V3 APIs allow setting the organization context by providing the organization domain in the request. Users currently experience the following error: "rpc error: code = Unauthenticated desc = context missing (AUTH-rKLWEH)"

# How the Problems Are Solved

Correctly check the org domain when set.

# Additional Changes

None

# Additional Context

- support request
