### PR TITLE
fix(SAML): log underlying error if SAML response validation fails

### DIFF
--- a/internal/idp/providers/saml/session.go
+++ b/internal/idp/providers/saml/session.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
-
 	"github.com/zitadel/logging"
+
 	"github.com/zitadel/zitadel/internal/idp"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )

--- a/internal/idp/providers/saml/session.go
+++ b/internal/idp/providers/saml/session.go
@@ -3,6 +3,7 @@ package saml
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -68,8 +69,9 @@ func (s *Session) FetchUser(ctx context.Context) (user idp.User, err error) {
 
 	s.Assertion, err = s.ServiceProvider.ServiceProvider.ParseResponse(s.Request, []string{s.RequestID})
 	if err != nil {
-		if invalidRespErr, ok := err.(*saml.InvalidResponseError); ok {
-			logging.OnError(invalidRespErr.PrivateErr).Info("invalid SAML response details")
+		invalidRespErr := new(saml.InvalidResponseError)
+		if errors.As(err, &invalidRespErr) {
+			logging.WithError(invalidRespErr.PrivateErr).Info("invalid SAML response details")
 		}
 		return nil, zerrors.ThrowInvalidArgument(err, "SAML-nuo0vphhh9", "Errors.Intent.ResponseInvalid")
 	}

--- a/internal/idp/providers/saml/session.go
+++ b/internal/idp/providers/saml/session.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 
+	"github.com/zitadel/logging"
 	"github.com/zitadel/zitadel/internal/idp"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -67,6 +68,9 @@ func (s *Session) FetchUser(ctx context.Context) (user idp.User, err error) {
 
 	s.Assertion, err = s.ServiceProvider.ServiceProvider.ParseResponse(s.Request, []string{s.RequestID})
 	if err != nil {
+		if invalidRespErr, ok := err.(*saml.InvalidResponseError); ok {
+			logging.OnError(invalidRespErr.PrivateErr).Info("invalid SAML response details")
+		}
 		return nil, zerrors.ThrowInvalidArgument(err, "SAML-nuo0vphhh9", "Errors.Intent.ResponseInvalid")
 	}
 


### PR DESCRIPTION
# Which Problems Are Solved

If SAML response validation in crewjam/saml fails, a generic "Authentication failed" error is thrown. This makes it challenging to determine the actual cause, since there are a variety of reasons response validation may fail.

# How the Problems Are Solved

Add a log statement if we receive a response validation error from crewjam/saml that logs the internal `InvalidResponseError.PrivateErr` error from crewjam/saml to stdout. We continue to return a generic error message to the client to prevent leaking data.

Verified by running `go test -v ./internal/idp/providers/saml` in verbose mode, which output the following line for the "response_invalid" test case:
```
time="2024-10-03T14:53:10+01:00" level=info msg="invalid SAML response details" caller="/Users/sdouglas/Documents/thirdparty-repos/zitadel/internal/idp/providers/saml/session.go:72" error="cannot parse base64: illegal base64 data at input byte 2"
```

# Additional Changes

None

# Additional Context

- closes #8717