### PR TITLE
fix: general function to determine id for smtp config in projection

### DIFF
--- a/internal/query/projection/smtp.go
+++ b/internal/query/projection/smtp.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	SMTPConfigProjectionTable = "projections.smtp_configs4"
+	SMTPConfigProjectionTable = "projections.smtp_configs5"
 	SMTPConfigTable           = SMTPConfigProjectionTable + "_" + smtpConfigSMTPTableSuffix
 	SMTPConfigHTTPTable       = SMTPConfigProjectionTable + "_" + smtpConfigHTTPTableSuffix
 
@@ -146,12 +146,9 @@ func (p *smtpConfigProjection) reduceSMTPConfigAdded(event eventstore.Event) (*h
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
 	description := e.Description
 	state := domain.SMTPConfigStateInactive
 	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
 		description = "generic"
 		state = domain.SMTPConfigStateActive
 	}
@@ -165,7 +162,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigAdded(event eventstore.Event) (*h
 				handler.NewCol(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 				handler.NewCol(SMTPConfigColumnResourceOwner, e.Aggregate().ResourceOwner),
 				handler.NewCol(SMTPConfigColumnAggregateID, e.Aggregate().ID),
-				handler.NewCol(SMTPConfigColumnID, id),
+				handler.NewCol(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCol(SMTPConfigColumnSequence, e.Sequence()),
 				handler.NewCol(SMTPConfigColumnState, state),
 				handler.NewCol(SMTPConfigColumnDescription, description),
@@ -174,7 +171,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigAdded(event eventstore.Event) (*h
 		handler.AddCreateStatement(
 			[]handler.Column{
 				handler.NewCol(SMTPConfigSMTPColumnInstanceID, e.Aggregate().InstanceID),
-				handler.NewCol(SMTPConfigSMTPColumnID, id),
+				handler.NewCol(SMTPConfigSMTPColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCol(SMTPConfigSMTPColumnTLS, e.TLS),
 				handler.NewCol(SMTPConfigSMTPColumnSenderAddress, e.SenderAddress),
 				handler.NewCol(SMTPConfigSMTPColumnSenderName, e.SenderName),
@@ -203,7 +200,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigHTTPAdded(event eventstore.Event)
 				handler.NewCol(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 				handler.NewCol(SMTPConfigColumnResourceOwner, e.Aggregate().ResourceOwner),
 				handler.NewCol(SMTPConfigColumnAggregateID, e.Aggregate().ID),
-				handler.NewCol(SMTPConfigColumnID, e.ID),
+				handler.NewCol(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCol(SMTPConfigColumnSequence, e.Sequence()),
 				handler.NewCol(SMTPConfigColumnState, domain.SMTPConfigStateInactive),
 				handler.NewCol(SMTPConfigColumnDescription, e.Description),
@@ -212,7 +209,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigHTTPAdded(event eventstore.Event)
 		handler.AddCreateStatement(
 			[]handler.Column{
 				handler.NewCol(SMTPConfigSMTPColumnInstanceID, e.Aggregate().InstanceID),
-				handler.NewCol(SMTPConfigSMTPColumnID, e.ID),
+				handler.NewCol(SMTPConfigSMTPColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCol(SMTPConfigHTTPColumnEndpoint, e.Endpoint),
 			},
 			handler.WithTableSuffix(smtpConfigHTTPTableSuffix),
@@ -238,7 +235,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigHTTPChanged(event eventstore.Even
 		stmts = append(stmts, handler.AddUpdateStatement(
 			columns,
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigColumnID, e.ID),
+				handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 			},
 		))
@@ -252,7 +249,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigHTTPChanged(event eventstore.Even
 		stmts = append(stmts, handler.AddUpdateStatement(
 			smtpColumns,
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigHTTPColumnID, e.ID),
+				handler.NewCond(SMTPConfigHTTPColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigHTTPColumnInstanceID, e.Aggregate().InstanceID),
 			},
 			handler.WithTableSuffix(smtpConfigHTTPTableSuffix),
@@ -268,12 +265,6 @@ func (p *smtpConfigProjection) reduceSMTPConfigChanged(event eventstore.Event) (
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
-	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
-	}
-
 	stmts := make([]func(eventstore.Event) handler.Exec, 0, 3)
 	columns := []handler.Column{
 		handler.NewCol(SMTPConfigColumnChangeDate, e.CreationDate()),
@@ -286,39 +277,39 @@ func (p *smtpConfigProjection) reduceSMTPConfigChanged(event eventstore.Event) (
 		stmts = append(stmts, handler.AddUpdateStatement(
 			columns,
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigColumnID, id),
+				handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 			},
 		))
 	}
 
-	httpColumns := make([]handler.Column, 0, 7)
+	smtpColumns := make([]handler.Column, 0, 7)
 	if e.TLS != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnTLS, *e.TLS))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnTLS, *e.TLS))
 	}
 	if e.FromAddress != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnSenderAddress, *e.FromAddress))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnSenderAddress, *e.FromAddress))
 	}
 	if e.FromName != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnSenderName, *e.FromName))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnSenderName, *e.FromName))
 	}
 	if e.ReplyToAddress != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnReplyToAddress, *e.ReplyToAddress))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnReplyToAddress, *e.ReplyToAddress))
 	}
 	if e.Host != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnHost, *e.Host))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnHost, *e.Host))
 	}
 	if e.User != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnUser, *e.User))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnUser, *e.User))
 	}
 	if e.Password != nil {
-		httpColumns = append(httpColumns, handler.NewCol(SMTPConfigSMTPColumnPassword, *e.Password))
+		smtpColumns = append(smtpColumns, handler.NewCol(SMTPConfigSMTPColumnPassword, *e.Password))
 	}
-	if len(httpColumns) > 0 {
+	if len(smtpColumns) > 0 {
 		stmts = append(stmts, handler.AddUpdateStatement(
-			httpColumns,
+			smtpColumns,
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigSMTPColumnID, e.ID),
+				handler.NewCond(SMTPConfigSMTPColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigSMTPColumnInstanceID, e.Aggregate().InstanceID),
 			},
 			handler.WithTableSuffix(smtpConfigSMTPTableSuffix),
@@ -334,12 +325,6 @@ func (p *smtpConfigProjection) reduceSMTPConfigPasswordChanged(event eventstore.
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
-	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
-	}
-
 	return handler.NewMultiStatement(
 		e,
 		handler.AddUpdateStatement(
@@ -347,8 +332,8 @@ func (p *smtpConfigProjection) reduceSMTPConfigPasswordChanged(event eventstore.
 				handler.NewCol(SMTPConfigSMTPColumnPassword, e.Password),
 			},
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigColumnID, id),
-				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
+				handler.NewCond(SMTPConfigSMTPColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
+				handler.NewCond(SMTPConfigSMTPColumnInstanceID, e.Aggregate().InstanceID),
 			},
 			handler.WithTableSuffix(smtpConfigSMTPTableSuffix),
 		),
@@ -358,7 +343,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigPasswordChanged(event eventstore.
 				handler.NewCol(SMTPConfigColumnSequence, e.Sequence()),
 			},
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigColumnID, id),
+				handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 			},
 		),
@@ -371,12 +356,6 @@ func (p *smtpConfigProjection) reduceSMTPConfigActivated(event eventstore.Event)
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
-	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
-	}
-
 	return handler.NewMultiStatement(
 		e,
 		handler.AddUpdateStatement(
@@ -386,7 +365,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigActivated(event eventstore.Event)
 				handler.NewCol(SMTPConfigColumnState, domain.SMTPConfigStateInactive),
 			},
 			[]handler.Condition{
-				handler.Not(handler.NewCond(SMTPConfigColumnID, e.ID)),
+				handler.Not(handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate()))),
 				handler.NewCond(SMTPConfigColumnState, domain.SMTPConfigStateActive),
 				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 			},
@@ -398,7 +377,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigActivated(event eventstore.Event)
 				handler.NewCol(SMTPConfigColumnState, domain.SMTPConfigStateActive),
 			},
 			[]handler.Condition{
-				handler.NewCond(SMTPConfigColumnID, id),
+				handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 				handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 			},
 		),
@@ -411,12 +390,6 @@ func (p *smtpConfigProjection) reduceSMTPConfigDeactivated(event eventstore.Even
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
-	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
-	}
-
 	return handler.NewUpdateStatement(
 		e,
 		[]handler.Column{
@@ -425,7 +398,7 @@ func (p *smtpConfigProjection) reduceSMTPConfigDeactivated(event eventstore.Even
 			handler.NewCol(SMTPConfigColumnState, domain.SMTPConfigStateInactive),
 		},
 		[]handler.Condition{
-			handler.NewCond(SMTPConfigColumnID, id),
+			handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 			handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 		},
 	), nil
@@ -437,17 +410,20 @@ func (p *smtpConfigProjection) reduceSMTPConfigRemoved(event eventstore.Event) (
 		return nil, err
 	}
 
-	// Deal with old and unique SMTP settings (empty ID)
-	id := e.ID
-	if e.ID == "" {
-		id = e.Aggregate().ResourceOwner
-	}
-
 	return handler.NewDeleteStatement(
 		e,
 		[]handler.Condition{
-			handler.NewCond(SMTPConfigColumnID, id),
+			handler.NewCond(SMTPConfigColumnID, getSMTPConfigID(e.ID, e.Aggregate())),
 			handler.NewCond(SMTPConfigColumnInstanceID, e.Aggregate().InstanceID),
 		},
 	), nil
+}
+
+func getSMTPConfigID(id string, aggregate *eventstore.Aggregate) string {
+	// Deal with old and unique SMTP settings (empty ID)
+	returnedID := id
+	if returnedID == "" {
+		returnedID = aggregate.ResourceOwner
+	}
+	return returnedID
 }

--- a/internal/query/projection/smtp_test.go
+++ b/internal/query/projection/smtp_test.go
@@ -21,6 +21,61 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 		want   wantReduce
 	}{
 		{
+			name: "reduceSMTPConfigChanged (no id)",
+			args: args{
+				event: getEvent(
+					testEvent(
+						instance.SMTPConfigChangedEventType,
+						instance.AggregateType,
+						[]byte(`{
+						"instance_id": "instance-id",	
+						"resource_owner": "ro-id",	
+						"aggregate_id": "agg-id",	
+						"description": "test",
+						"tls": true,
+						"senderAddress": "sender",
+						"senderName": "name",
+						"replyToAddress": "reply-to",
+						"host": "host",
+						"user": "user"		
+					}`,
+						),
+					), eventstore.GenericEventMapper[instance.SMTPConfigChangedEvent]),
+			},
+			reduce: (&smtpConfigProjection{}).reduceSMTPConfigChanged,
+			want: wantReduce{
+				aggregateType: eventstore.AggregateType("instance"),
+				sequence:      15,
+				executer: &testExecuter{
+					executions: []execution{
+						{
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedArgs: []interface{}{
+								anyArg{},
+								uint64(15),
+								"test",
+								"ro-id",
+								"instance-id",
+							},
+						},
+						{
+							expectedStmt: "UPDATE projections.smtp_configs5_smtp SET (tls, sender_address, sender_name, reply_to_address, host, username) = ($1, $2, $3, $4, $5, $6) WHERE (id = $7) AND (instance_id = $8)",
+							expectedArgs: []interface{}{
+								true,
+								"sender",
+								"name",
+								"reply-to",
+								"host",
+								"user",
+								"ro-id",
+								"instance-id",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "reduceSMTPConfigChanged",
 			args: args{
 				event: getEvent(
@@ -50,7 +105,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -60,7 +115,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4_smtp SET (tls, sender_address, sender_name, reply_to_address, host, username) = ($1, $2, $3, $4, $5, $6) WHERE (id = $7) AND (instance_id = $8)",
+							expectedStmt: "UPDATE projections.smtp_configs5_smtp SET (tls, sender_address, sender_name, reply_to_address, host, username) = ($1, $2, $3, $4, $5, $6) WHERE (id = $7) AND (instance_id = $8)",
 							expectedArgs: []interface{}{
 								true,
 								"sender",
@@ -100,7 +155,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -137,7 +192,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -146,7 +201,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4_smtp SET sender_address = $1 WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.smtp_configs5_smtp SET sender_address = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"sender",
 								"config-id",
@@ -182,7 +237,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -192,7 +247,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4_http SET endpoint = $1 WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.smtp_configs5_http SET endpoint = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"endpoint",
 								"config-id",
@@ -227,7 +282,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, description) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -264,7 +319,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -273,7 +328,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4_http SET endpoint = $1 WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.smtp_configs5_http SET endpoint = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								"endpoint",
 								"config-id",
@@ -316,7 +371,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -330,7 +385,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4_smtp (instance_id, id, tls, sender_address, sender_name, reply_to_address, host, username, password) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5_smtp (instance_id, id, tls, sender_address, sender_name, reply_to_address, host, username, password) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"ro-id",
@@ -381,7 +436,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -395,7 +450,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4_smtp (instance_id, id, tls, sender_address, sender_name, reply_to_address, host, username, password) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5_smtp (instance_id, id, tls, sender_address, sender_name, reply_to_address, host, username, password) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"config-id",
@@ -437,7 +492,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5 (creation_date, change_date, instance_id, resource_owner, aggregate_id, id, sequence, state, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								anyArg{},
@@ -451,7 +506,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "INSERT INTO projections.smtp_configs4_http (instance_id, id, endpoint) VALUES ($1, $2, $3)",
+							expectedStmt: "INSERT INTO projections.smtp_configs5_http (instance_id, id, endpoint) VALUES ($1, $2, $3)",
 							expectedArgs: []interface{}{
 								"instance-id",
 								"config-id",
@@ -483,7 +538,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (NOT (id = $4)) AND (state = $5) AND (instance_id = $6)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (NOT (id = $4)) AND (state = $5) AND (instance_id = $6)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -494,7 +549,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -528,7 +583,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence, state) = ($1, $2, $3) WHERE (id = $4) AND (instance_id = $5)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -568,7 +623,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4_smtp SET password = $1 WHERE (id = $2) AND (instance_id = $3)",
+							expectedStmt: "UPDATE projections.smtp_configs5_smtp SET password = $1 WHERE (id = $2) AND (instance_id = $3)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								"config-id",
@@ -576,7 +631,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 							},
 						},
 						{
-							expectedStmt: "UPDATE projections.smtp_configs4 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
+							expectedStmt: "UPDATE projections.smtp_configs5 SET (change_date, sequence) = ($1, $2) WHERE (id = $3) AND (instance_id = $4)",
 							expectedArgs: []interface{}{
 								anyArg{},
 								uint64(15),
@@ -609,7 +664,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.smtp_configs4 WHERE (id = $1) AND (instance_id = $2)",
+							expectedStmt: "DELETE FROM projections.smtp_configs5 WHERE (id = $1) AND (instance_id = $2)",
 							expectedArgs: []interface{}{
 								"config-id",
 								"instance-id",
@@ -636,7 +691,7 @@ func TestSMTPConfigProjection_reduces(t *testing.T) {
 				executer: &testExecuter{
 					executions: []execution{
 						{
-							expectedStmt: "DELETE FROM projections.smtp_configs4 WHERE (instance_id = $1)",
+							expectedStmt: "DELETE FROM projections.smtp_configs5 WHERE (instance_id = $1)",
 							expectedArgs: []interface{}{
 								"agg-id",
 							},

--- a/internal/query/smtp_test.go
+++ b/internal/query/smtp_test.go
@@ -14,26 +14,26 @@ import (
 )
 
 var (
-	prepareSMTPConfigStmt = `SELECT projections.smtp_configs4.creation_date,` +
-		` projections.smtp_configs4.change_date,` +
-		` projections.smtp_configs4.resource_owner,` +
-		` projections.smtp_configs4.sequence,` +
-		` projections.smtp_configs4.id,` +
-		` projections.smtp_configs4.state,` +
-		` projections.smtp_configs4.description,` +
-		` projections.smtp_configs4_smtp.id,` +
-		` projections.smtp_configs4_smtp.tls,` +
-		` projections.smtp_configs4_smtp.sender_address,` +
-		` projections.smtp_configs4_smtp.sender_name,` +
-		` projections.smtp_configs4_smtp.reply_to_address,` +
-		` projections.smtp_configs4_smtp.host,` +
-		` projections.smtp_configs4_smtp.username,` +
-		` projections.smtp_configs4_smtp.password,` +
-		` projections.smtp_configs4_http.id,` +
-		` projections.smtp_configs4_http.endpoint` +
-		` FROM projections.smtp_configs4` +
-		` LEFT JOIN projections.smtp_configs4_smtp ON projections.smtp_configs4.id = projections.smtp_configs4_smtp.id AND projections.smtp_configs4.instance_id = projections.smtp_configs4_smtp.instance_id` +
-		` LEFT JOIN projections.smtp_configs4_http ON projections.smtp_configs4.id = projections.smtp_configs4_http.id AND projections.smtp_configs4.instance_id = projections.smtp_configs4_http.instance_id` +
+	prepareSMTPConfigStmt = `SELECT projections.smtp_configs5.creation_date,` +
+		` projections.smtp_configs5.change_date,` +
+		` projections.smtp_configs5.resource_owner,` +
+		` projections.smtp_configs5.sequence,` +
+		` projections.smtp_configs5.id,` +
+		` projections.smtp_configs5.state,` +
+		` projections.smtp_configs5.description,` +
+		` projections.smtp_configs5_smtp.id,` +
+		` projections.smtp_configs5_smtp.tls,` +
+		` projections.smtp_configs5_smtp.sender_address,` +
+		` projections.smtp_configs5_smtp.sender_name,` +
+		` projections.smtp_configs5_smtp.reply_to_address,` +
+		` projections.smtp_configs5_smtp.host,` +
+		` projections.smtp_configs5_smtp.username,` +
+		` projections.smtp_configs5_smtp.password,` +
+		` projections.smtp_configs5_http.id,` +
+		` projections.smtp_configs5_http.endpoint` +
+		` FROM projections.smtp_configs5` +
+		` LEFT JOIN projections.smtp_configs5_smtp ON projections.smtp_configs5.id = projections.smtp_configs5_smtp.id AND projections.smtp_configs5.instance_id = projections.smtp_configs5_smtp.instance_id` +
+		` LEFT JOIN projections.smtp_configs5_http ON projections.smtp_configs5.id = projections.smtp_configs5_http.id AND projections.smtp_configs5.instance_id = projections.smtp_configs5_http.instance_id` +
 		` AS OF SYSTEM TIME '-1 ms'`
 	prepareSMTPConfigCols = []string{
 		"creation_date",


### PR DESCRIPTION
Fix the handling of smtp config events without ID.
