### PR TITLE
docs: remove duplicate from API path prefixes

### DIFF
--- a/docs/docs/apis/introduction.mdx
+++ b/docs/docs/apis/introduction.mdx
@@ -303,7 +303,6 @@ For easy copying to your reverse proxy configuration, here is the list of URL pa
 /saml/v2/
 /oauth/v2/
 /device
-/oidc/v1/
 /.well-known/openid-configuration
 /openapi/
 /idps/callback


### PR DESCRIPTION


# Which Problems Are Solved

The `/oauth/v1` path prefix is duplicated, which is an error in most proxies.


# How the Problems Are Solved

Remove the duplicate path prefix from the docs.

