### PR TITLE
fix: correctly compute user state

### DIFF
--- a/internal/command/user_model.go
+++ b/internal/command/user_model.go
@@ -97,6 +97,7 @@ func (wm *UserWriteModel) Query() *eventstore.SearchQueryBuilder {
 		EventTypes(
 			user.HumanAddedType,
 			user.HumanRegisteredType,
+			user.HumanInitialCodeAddedType,
 			user.HumanInitializedCheckSucceededType,
 			user.UserIDPLinkAddedType,
 			user.UserIDPLinkRemovedType,


### PR DESCRIPTION
# Which Problems Are Solved

A customer reported, that after a created user (in initial state) got (manually) locked and a new initial code would be created, the user could not be locked again.

# How the Problems Are Solved

Query for the initial code added event

# Additional Changes

None

# Additional Context

- reported by a customer
