### PR TITLE
fix(authz): clarify where to ask support when a token doesn't work

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -113,7 +113,7 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		var sysTokenErr error
 		sysMemberships, userID, sysTokenErr = t.VerifySystemToken(ctx, tokenWOBearer, orgID)
 		if sysTokenErr != nil || sysMemberships == nil {
-			return CtxData{}, zerrors.ThrowUnauthenticated(errors.Join(err, sysTokenErr), "AUTH-7fs1e", "Errors.Token.Invalid")
+			return CtxData{}, zerrors.ThrowUnauthenticated(errors.Join(err, sysTokenErr), "ELIO-7fs1e", "Errors.Token.Invalid")
 		}
 	}
 	projectID, err := projectIDAndCheckOriginForClientID(ctx, clientID, t)


### PR DESCRIPTION
# Which Problems Are Solved

When calling the zitadel API with an invalid token, regardless of reason, only a single error was returned.
It is often not clear why the token was invalid.

# How the Problems Are Solved

Change the error code, so everyone knows who to ask for support. Coincedently this person was also the author of this code.
 


# Additional Changes

- none

# Additional Context

- Introduced in https://github.com/zitadel/zitadel/pull/6765