### PR TITLE
fix: only allow domain discovery if no organization was preselected

### DIFF
--- a/internal/auth/repository/eventsourcing/eventstore/auth_request.go
+++ b/internal/auth/repository/eventsourcing/eventstore/auth_request.go
@@ -785,9 +785,12 @@ func (repo *AuthRequestRepo) checkLoginName(ctx context.Context, request *domain
 	}
 	// the user was either not found or not active
 	// so check if the loginname suffix matches a verified org domain
-	ok, errDomainDiscovery := repo.checkDomainDiscovery(ctx, request, loginNameInput)
-	if errDomainDiscovery != nil || ok {
-		return errDomainDiscovery
+	// but only if no org was requested (by id or domain)
+	if request.RequestedOrgID == "" {
+		ok, errDomainDiscovery := repo.checkDomainDiscovery(ctx, request, loginNameInput)
+		if errDomainDiscovery != nil || ok {
+			return errDomainDiscovery
+		}
 	}
 	// let's once again check if the user was just inactive
 	if user != nil && user.State == int32(domain.UserStateInactive) {


### PR DESCRIPTION
# Which Problems Are Solved

If an organization was preselected using an orgID or primaryDomain scope, users could still switch to another organization, if the latter allowed domain discovery and the entered username / or login_hint included the corresponding domain suffix.

# How the Problems Are Solved

Domain discovery will only be done in case no org was preselected.

# Additional Changes

None

# Additional Context

- closes https://github.com/zitadel/zitadel/issues/8464
- closes https://github.com/zitadel/zitadel/issues/8588