### PR TITLE
docs: fix wrong examples and links

### DIFF
--- a/docs/docs/concepts/features/actions_v2.md
+++ b/docs/docs/concepts/features/actions_v2.md
@@ -36,5 +36,5 @@ Possible conditions for the Execution:
 
 ## Further reading
 
-- [Actions v2 example execution locally](/apis/actionsv2/execution-local)
-- [Actions v2 reference](/apis/actionsv2/introduction#action)
+- [Actions v2 reference](/apis/actions/v3/usage)
+- [Actions v2 example execution locally](/apis/actions/v3/testing-locally)

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -9208,7 +9208,7 @@ message AddOrgMemberRequest {
     string user_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
     repeated string roles = 2  [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            example: "[\"IAM_OWNER\"]";
+            example: "[\"ORG_OWNER\"]";
             description: "If no roles are provided the user won't have any rights"
         }
     ];


### PR DESCRIPTION
# Which Problems Are Solved

- The addorgmember request shows a wrong example in the api documentation
- Broken Links on actions feature description

# How the Problems Are Solved

- Change example of AddOrgMember API Docs
- Point towards correct links