### PR TITLE
chore: correct require usage to assert for eventual consistency

### DIFF
--- a/internal/api/grpc/admin/integration_test/iam_member_test.go
+++ b/internal/api/grpc/admin/integration_test/iam_member_test.go
@@ -92,7 +92,7 @@ func TestServer_ListIAMMembers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.args.ctx, 20*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.args.ctx, time.Minute)
 			assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 				got, err := Client.ListIAMMembers(tt.args.ctx, tt.args.req)
 				if tt.wantErr {

--- a/internal/api/grpc/admin/integration_test/iam_member_test.go
+++ b/internal/api/grpc/admin/integration_test/iam_member_test.go
@@ -103,10 +103,11 @@ func TestServer_ListIAMMembers(t *testing.T) {
 				wantResult := tt.want.GetResult()
 				gotResult := got.GetResult()
 
-				require.Len(ct, gotResult, len(wantResult))
-				for i, want := range wantResult {
-					assert.Equal(ct, want.GetUserId(), gotResult[i].GetUserId())
-					assert.ElementsMatch(ct, want.GetRoles(), gotResult[i].GetRoles())
+				if assert.Len(ct, gotResult, len(wantResult)) {
+					for i, want := range wantResult {
+						assert.Equal(ct, want.GetUserId(), gotResult[i].GetUserId())
+						assert.ElementsMatch(ct, want.GetRoles(), gotResult[i].GetRoles())
+					}
 				}
 			}, retryDuration, tick)
 		})

--- a/internal/api/grpc/admin/integration_test/iam_settings_test.go
+++ b/internal/api/grpc/admin/integration_test/iam_settings_test.go
@@ -54,7 +54,7 @@ func TestServer_GetSecurityPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.ctx, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.ctx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				resp, err := instance.Client.Admin.GetSecurityPolicy(tt.ctx, &admin_pb.GetSecurityPolicyRequest{})
 				if tt.wantErr {

--- a/internal/api/grpc/org/v2/integration_test/query_test.go
+++ b/internal/api/grpc/org/v2/integration_test/query_test.go
@@ -411,17 +411,17 @@ func TestServer_ListOrganizations(t *testing.T) {
 				// totalResult is unrelated to the tests here so gets carried over, can vary from the count of results due to permissions
 				tt.want.Details.TotalResult = got.Details.TotalResult
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						// domain from result, as it is generated though the create
+						tt.want.Result[i].PrimaryDomain = got.Result[i].PrimaryDomain
+						// sequence from result, as it can be with different sequence from create
+						tt.want.Result[i].Details.Sequence = got.Result[i].Details.Sequence
+					}
 
-				for i := range tt.want.Result {
-					// domain from result, as it is generated though the create
-					tt.want.Result[i].PrimaryDomain = got.Result[i].PrimaryDomain
-					// sequence from result, as it can be with different sequence from create
-					tt.want.Result[i].Details.Sequence = got.Result[i].Details.Sequence
-				}
-
-				for i := range tt.want.Result {
-					assert.Contains(ttt, got.Result, tt.want.Result[i])
+					for i := range tt.want.Result {
+						assert.Contains(ttt, got.Result, tt.want.Result[i])
+					}
 				}
 				integration.AssertListDetails(t, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected user result")

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
@@ -255,7 +255,7 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				require.NoError(t, err)
 				defer close()
 			}
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.ActionV3Alpha.GetTarget(tt.ctx, tt.req)
 				if tt.wantErr {
@@ -278,7 +278,7 @@ func TestServer_ExecutionTarget(t *testing.T) {
 }
 
 func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *integration.Instance, condition *action.Condition) {
-	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, 5*time.Second)
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 		got, err := instance.Client.ActionV3Alpha.SearchExecutions(ctx, &action.SearchExecutionsRequest{
 			Filters: []*action.ExecutionSearchFilter{

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
@@ -290,9 +290,7 @@ func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *in
 		if !assert.NoError(ttt, err) {
 			return
 		}
-		if assert.Len(ttt, got.GetResult(), 1) {
-			return
-		}
+		assert.Len(ttt, got.GetResult(), 1)
 	}, retryDuration, tick, "timeout waiting for expected execution result")
 	return
 }

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
@@ -220,10 +220,10 @@ func TestServer_GetTarget(t *testing.T) {
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.ActionV3Alpha.GetTarget(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
-					require.Error(ttt, err, "Error: "+err.Error())
+					assert.Error(ttt, err, "Error: "+err.Error())
 					return
 				}
-				require.NoError(ttt, err)
+				assert.NoError(ttt, err)
 
 				wantTarget := tt.want.GetTarget()
 				gotTarget := got.GetTarget()
@@ -488,11 +488,11 @@ func TestServer_ListTargets(t *testing.T) {
 				require.NoError(ttt, listErr)
 
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
-
-				for i := range tt.want.Result {
-					integration.AssertResourceDetails(ttt, tt.want.Result[i].GetDetails(), got.Result[i].GetDetails())
-					assert.EqualExportedValues(ttt, tt.want.Result[i].GetConfig(), got.Result[i].GetConfig())
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						integration.AssertResourceDetails(ttt, tt.want.Result[i].GetDetails(), got.Result[i].GetDetails())
+						assert.EqualExportedValues(ttt, tt.want.Result[i].GetConfig(), got.Result[i].GetConfig())
+					}
 				}
 				integration.AssertResourceListDetails(ttt, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected execution result")
@@ -872,14 +872,15 @@ func TestServer_SearchExecutions(t *testing.T) {
 				}
 				require.NoError(ttt, listErr)
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
-				for i := range tt.want.Result {
-					// as not sorted, all elements have to be checked
-					// workaround as oneof elements can only be checked with assert.EqualExportedValues()
-					if j, found := containExecution(got.Result, tt.want.Result[i]); found {
-						integration.AssertResourceDetails(ttt, tt.want.Result[i].GetDetails(), got.Result[j].GetDetails())
-						got.Result[j].Details = tt.want.Result[i].GetDetails()
-						assert.EqualExportedValues(ttt, tt.want.Result[i], got.Result[j])
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						// as not sorted, all elements have to be checked
+						// workaround as oneof elements can only be checked with assert.EqualExportedValues()
+						if j, found := containExecution(got.Result, tt.want.Result[i]); found {
+							integration.AssertResourceDetails(ttt, tt.want.Result[i].GetDetails(), got.Result[j].GetDetails())
+							got.Result[j].Details = tt.want.Result[i].GetDetails()
+							assert.EqualExportedValues(ttt, tt.want.Result[i], got.Result[j])
+						}
 					}
 				}
 				integration.AssertResourceListDetails(ttt, tt.want, got)

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
@@ -216,7 +216,7 @@ func TestServer_GetTarget(t *testing.T) {
 				err := tt.args.dep(tt.args.ctx, tt.args.req, tt.want)
 				require.NoError(t, err)
 			}
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.ActionV3Alpha.GetTarget(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
@@ -478,7 +478,7 @@ func TestServer_ListTargets(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, listErr := instance.Client.ActionV3Alpha.SearchTargets(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
@@ -863,7 +863,7 @@ func TestServer_SearchExecutions(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, listErr := instance.Client.ActionV3Alpha.SearchExecutions(tt.args.ctx, tt.args.req)
 				if tt.wantErr {

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/server_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/server_test.go
@@ -44,7 +44,7 @@ func ensureFeatureEnabled(t *testing.T, instance *integration.Instance) {
 	})
 	require.NoError(t, err)
 
-	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, 5*time.Minute)
 	require.EventuallyWithT(t,
 		func(ttt *assert.CollectT) {
 			f, err := instance.Client.FeatureV2.GetInstanceFeatures(ctx, &feature.GetInstanceFeaturesRequest{
@@ -54,10 +54,10 @@ func ensureFeatureEnabled(t *testing.T, instance *integration.Instance) {
 			assert.True(ttt, f.Actions.GetEnabled())
 		},
 		retryDuration,
-		time.Second,
+		tick,
 		"timed out waiting for ensuring instance feature")
 
-	retryDuration, tick = integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	retryDuration, tick = integration.WaitForAndTickWithMaxDuration(ctx, 5*time.Minute)
 	require.EventuallyWithT(t,
 		func(ttt *assert.CollectT) {
 			_, err := instance.Client.ActionV3Alpha.ListExecutionMethods(ctx, &action.ListExecutionMethodsRequest{})

--- a/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
@@ -188,7 +188,7 @@ func TestServer_ListUserSchemas(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 20*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.UserSchemaV3.SearchUserSchemas(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
@@ -296,7 +296,7 @@ func TestServer_GetUserSchema(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.UserSchemaV3.GetUserSchema(tt.args.ctx, tt.args.req)
 				if tt.wantErr {

--- a/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
@@ -197,14 +197,15 @@ func TestServer_ListUserSchemas(t *testing.T) {
 				}
 				require.NoError(ttt, err)
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
-				for i := range tt.want.Result {
-					wantSchema := tt.want.Result[i]
-					gotSchema := got.Result[i]
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						wantSchema := tt.want.Result[i]
+						gotSchema := got.Result[i]
 
-					integration.AssertResourceDetails(ttt, wantSchema.GetDetails(), gotSchema.GetDetails())
-					wantSchema.Details = gotSchema.GetDetails()
-					grpc.AllFieldsEqual(ttt, wantSchema.ProtoReflect(), gotSchema.ProtoReflect(), grpc.CustomMappers)
+						integration.AssertResourceDetails(ttt, wantSchema.GetDetails(), gotSchema.GetDetails())
+						wantSchema.Details = gotSchema.GetDetails()
+						grpc.AllFieldsEqual(ttt, wantSchema.ProtoReflect(), gotSchema.ProtoReflect(), grpc.CustomMappers)
+					}
 				}
 				integration.AssertListDetails(ttt, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected user schema result")
@@ -299,10 +300,10 @@ func TestServer_GetUserSchema(t *testing.T) {
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.UserSchemaV3.GetUserSchema(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
-					require.Error(ttt, err, "Error: "+err.Error())
+					assert.Error(ttt, err, "Error: "+err.Error())
 					return
 				}
-				require.NoError(ttt, err)
+				assert.NoError(ttt, err)
 
 				wantSchema := tt.want.GetUserSchema()
 				gotSchema := got.GetUserSchema()

--- a/internal/api/grpc/settings/v2/integration_test/settings_test.go
+++ b/internal/api/grpc/settings/v2/integration_test/settings_test.go
@@ -53,7 +53,7 @@ func TestServer_GetSecuritySettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.ctx, 20*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.ctx, time.Minute)
 			assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 				resp, err := Client.GetSecuritySettings(tt.ctx, &settings.GetSecuritySettingsRequest{})
 				if tt.wantErr {

--- a/internal/api/grpc/settings/v2/integration_test/settings_test.go
+++ b/internal/api/grpc/settings/v2/integration_test/settings_test.go
@@ -57,10 +57,12 @@ func TestServer_GetSecuritySettings(t *testing.T) {
 			assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 				resp, err := Client.GetSecuritySettings(tt.ctx, &settings.GetSecuritySettingsRequest{})
 				if tt.wantErr {
-					require.Error(ct, err)
+					assert.Error(ct, err)
 					return
 				}
-				require.NoError(ct, err)
+				if !assert.NoError(ct, err) {
+					return
+				}
 				got, want := resp.GetSettings(), tt.want.GetSettings()
 				assert.Equal(ct, want.GetEmbeddedIframe().GetEnabled(), got.GetEmbeddedIframe().GetEnabled(), "enable iframe embedding")
 				assert.Equal(ct, want.GetEmbeddedIframe().GetAllowedOrigins(), got.GetEmbeddedIframe().GetAllowedOrigins(), "allowed origins")

--- a/internal/api/grpc/settings/v2beta/integration_test/settings_test.go
+++ b/internal/api/grpc/settings/v2beta/integration_test/settings_test.go
@@ -57,10 +57,12 @@ func TestServer_GetSecuritySettings(t *testing.T) {
 			assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 				resp, err := Client.GetSecuritySettings(tt.ctx, &settings.GetSecuritySettingsRequest{})
 				if tt.wantErr {
-					require.Error(ct, err)
+					assert.Error(ct, err)
 					return
 				}
-				require.NoError(ct, err)
+				if !assert.NoError(ct, err) {
+					return
+				}
 				got, want := resp.GetSettings(), tt.want.GetSettings()
 				assert.Equal(ct, want.GetEmbeddedIframe().GetEnabled(), got.GetEmbeddedIframe().GetEnabled(), "enable iframe embedding")
 				assert.Equal(ct, want.GetEmbeddedIframe().GetAllowedOrigins(), got.GetEmbeddedIframe().GetAllowedOrigins(), "allowed origins")

--- a/internal/api/grpc/user/v2/integration_test/idp_link_test.go
+++ b/internal/api/grpc/user/v2/integration_test/idp_link_test.go
@@ -245,9 +245,10 @@ func TestServer_ListIDPLinks(t *testing.T) {
 				}
 				require.NoError(ttt, err)
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
-				for i := range tt.want.Result {
-					assert.Contains(ttt, got.Result, tt.want.Result[i])
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						assert.Contains(ttt, got.Result, tt.want.Result[i])
+					}
 				}
 				integration.AssertListDetails(t, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected idplinks result")

--- a/internal/api/grpc/user/v2/integration_test/passkey_test.go
+++ b/internal/api/grpc/user/v2/integration_test/passkey_test.go
@@ -593,9 +593,10 @@ func TestServer_ListPasskeys(t *testing.T) {
 				}
 				require.NoError(ttt, err)
 				// always first check length, otherwise its failed anyway
-				assert.Len(ttt, got.Result, len(tt.want.Result))
-				for i := range tt.want.Result {
-					assert.Contains(ttt, got.Result, tt.want.Result[i])
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					for i := range tt.want.Result {
+						assert.Contains(ttt, got.Result, tt.want.Result[i])
+					}
 				}
 				integration.AssertListDetails(ttt, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected idplinks result")

--- a/internal/api/grpc/user/v2/integration_test/query_test.go
+++ b/internal/api/grpc/user/v2/integration_test/query_test.go
@@ -162,10 +162,12 @@ func TestServer_GetUserByID(t *testing.T) {
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := Client.GetUserByID(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
-					require.Error(ttt, err)
+					assert.Error(ttt, err)
 					return
 				}
-				require.NoError(ttt, err)
+				if !assert.NoError(ttt, err) {
+					return
+				}
 
 				tt.want.User.Details = userAttr.Details
 				tt.want.User.UserId = userAttr.UserID
@@ -912,27 +914,27 @@ func TestServer_ListUsers(t *testing.T) {
 				// always only give back dependency infos which are required for the response
 				require.Len(ttt, tt.want.Result, len(infos))
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					// totalResult is unrelated to the tests here so gets carried over, can vary from the count of results due to permissions
+					tt.want.Details.TotalResult = got.Details.TotalResult
 
-				// totalResult is unrelated to the tests here so gets carried over, can vary from the count of results due to permissions
-				tt.want.Details.TotalResult = got.Details.TotalResult
-
-				// fill in userid and username as it is generated
-				for i := range infos {
-					tt.want.Result[i].UserId = infos[i].UserID
-					tt.want.Result[i].Username = infos[i].Username
-					tt.want.Result[i].PreferredLoginName = infos[i].Username
-					tt.want.Result[i].LoginNames = []string{infos[i].Username}
-					if human := tt.want.Result[i].GetHuman(); human != nil {
-						human.Email.Email = infos[i].Username
-						if tt.want.Result[i].GetHuman().GetPasswordChanged() != nil {
-							human.PasswordChanged = infos[i].Changed
+					// fill in userid and username as it is generated
+					for i := range infos {
+						tt.want.Result[i].UserId = infos[i].UserID
+						tt.want.Result[i].Username = infos[i].Username
+						tt.want.Result[i].PreferredLoginName = infos[i].Username
+						tt.want.Result[i].LoginNames = []string{infos[i].Username}
+						if human := tt.want.Result[i].GetHuman(); human != nil {
+							human.Email.Email = infos[i].Username
+							if tt.want.Result[i].GetHuman().GetPasswordChanged() != nil {
+								human.PasswordChanged = infos[i].Changed
+							}
 						}
+						tt.want.Result[i].Details = infos[i].Details
 					}
-					tt.want.Result[i].Details = infos[i].Details
-				}
-				for i := range tt.want.Result {
-					assert.Contains(ttt, got.Result, tt.want.Result[i])
+					for i := range tt.want.Result {
+						assert.Contains(ttt, got.Result, tt.want.Result[i])
+					}
 				}
 				integration.AssertListDetails(ttt, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected user result")

--- a/internal/api/grpc/user/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/user/v2beta/integration_test/query_test.go
@@ -171,10 +171,12 @@ func TestServer_GetUserByID(t *testing.T) {
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := Client.GetUserByID(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
-					require.Error(t, err)
+					assert.Error(ttt, err)
 					return
 				}
-				require.NoError(t, err)
+				if !assert.NoError(ttt, err) {
+					return
+				}
 
 				tt.want.User.Details = detailsV2ToV2beta(userAttr.Details)
 				tt.want.User.UserId = userAttr.UserID
@@ -188,7 +190,7 @@ func TestServer_GetUserByID(t *testing.T) {
 					}
 				}
 				assert.Equal(ttt, tt.want.User, got.User)
-				integration.AssertDetails(t, tt.want, got)
+				integration.AssertDetails(ttt, tt.want, got)
 			}, retryDuration, tick)
 		})
 	}
@@ -314,10 +316,13 @@ func TestServer_GetUserByID_Permission(t *testing.T) {
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := Client.GetUserByID(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
-					require.Error(ttt, err)
+					assert.Error(ttt, err)
 					return
 				}
-				require.NoError(ttt, err)
+				if !assert.NoError(ttt, err) {
+					return
+				}
+
 				tt.want.User.UserId = tt.args.req.GetUserId()
 				tt.want.User.Username = newOrgOwnerEmail
 				tt.want.User.PreferredLoginName = newOrgOwnerEmail
@@ -923,27 +928,27 @@ func TestServer_ListUsers(t *testing.T) {
 				// always only give back dependency infos which are required for the response
 				require.Len(ttt, tt.want.Result, len(infos))
 				// always first check length, otherwise its failed anyway
-				require.Len(ttt, got.Result, len(tt.want.Result))
-				// fill in userid and username as it is generated
+				if assert.Len(ttt, got.Result, len(tt.want.Result)) {
+					// totalResult is unrelated to the tests here so gets carried over, can vary from the count of results due to permissions
+					tt.want.Details.TotalResult = got.Details.TotalResult
 
-				// totalResult is unrelated to the tests here so gets carried over, can vary from the count of results due to permissions
-				tt.want.Details.TotalResult = got.Details.TotalResult
-
-				for i := range infos {
-					tt.want.Result[i].UserId = infos[i].UserID
-					tt.want.Result[i].Username = infos[i].Username
-					tt.want.Result[i].PreferredLoginName = infos[i].Username
-					tt.want.Result[i].LoginNames = []string{infos[i].Username}
-					if human := tt.want.Result[i].GetHuman(); human != nil {
-						human.Email.Email = infos[i].Username
-						if tt.want.Result[i].GetHuman().GetPasswordChanged() != nil {
-							human.PasswordChanged = infos[i].Changed
+					// fill in userid and username as it is generated
+					for i := range infos {
+						tt.want.Result[i].UserId = infos[i].UserID
+						tt.want.Result[i].Username = infos[i].Username
+						tt.want.Result[i].PreferredLoginName = infos[i].Username
+						tt.want.Result[i].LoginNames = []string{infos[i].Username}
+						if human := tt.want.Result[i].GetHuman(); human != nil {
+							human.Email.Email = infos[i].Username
+							if tt.want.Result[i].GetHuman().GetPasswordChanged() != nil {
+								human.PasswordChanged = infos[i].Changed
+							}
 						}
+						tt.want.Result[i].Details = detailsV2ToV2beta(infos[i].Details)
 					}
-					tt.want.Result[i].Details = detailsV2ToV2beta(infos[i].Details)
-				}
-				for i := range tt.want.Result {
-					assert.Contains(ttt, got.Result, tt.want.Result[i])
+					for i := range tt.want.Result {
+						assert.Contains(ttt, got.Result, tt.want.Result[i])
+					}
 				}
 				integration.AssertListDetails(ttt, tt.want, got)
 			}, retryDuration, tick, "timeout waiting for expected user result")


### PR DESCRIPTION
# Which Problems Are Solved

Eventual consistency is handled wrongly in the newly improved integration tests.

# How the Problems Are Solved

Correct the usage of the require package with the assert package where necessary, to remove the panics where the EventuallyWithT functions can rerun.

# Additional Changes

Modify the timeout values for some EventuallyWithT which can vary when a instance is freshly setup.

# Additional Context

None
