### PR TITLE
chore: add await for project to oidc integration tests

### DIFF
--- a/internal/api/grpc/oidc/v2/integration_test/oidc_test.go
+++ b/internal/api/grpc/oidc/v2/integration_test/oidc_test.go
@@ -19,14 +19,12 @@ import (
 	"github.com/zitadel/zitadel/pkg/grpc/object/v2"
 	oidc_pb "github.com/zitadel/zitadel/pkg/grpc/oidc/v2"
 	"github.com/zitadel/zitadel/pkg/grpc/session/v2"
-	"github.com/zitadel/zitadel/pkg/grpc/user/v2"
 )
 
 var (
 	CTX      context.Context
 	Instance *integration.Instance
 	Client   oidc_pb.OIDCServiceClient
-	User     *user.AddHumanUserResponse
 )
 
 const (
@@ -44,7 +42,6 @@ func TestMain(m *testing.M) {
 		Client = Instance.Client.OIDCv2
 
 		CTX = Instance.WithAuthorization(ctx, integration.UserTypeOrgOwner)
-		User = Instance.CreateHumanUser(CTX)
 		return m.Run()
 	}())
 }

--- a/internal/api/grpc/oidc/v2beta/integration_test/oidc_test.go
+++ b/internal/api/grpc/oidc/v2beta/integration_test/oidc_test.go
@@ -19,14 +19,12 @@ import (
 	object "github.com/zitadel/zitadel/pkg/grpc/object/v2beta"
 	oidc_pb "github.com/zitadel/zitadel/pkg/grpc/oidc/v2beta"
 	session "github.com/zitadel/zitadel/pkg/grpc/session/v2beta"
-	"github.com/zitadel/zitadel/pkg/grpc/user/v2"
 )
 
 var (
 	CTX      context.Context
 	Instance *integration.Instance
 	Client   oidc_pb.OIDCServiceClient
-	User     *user.AddHumanUserResponse
 )
 
 const (
@@ -44,7 +42,6 @@ func TestMain(m *testing.M) {
 		Client = Instance.Client.OIDCv2beta
 
 		CTX = Instance.WithAuthorization(ctx, integration.UserTypeOrgOwner)
-		User = Instance.CreateHumanUser(CTX)
 		return m.Run()
 	}())
 }

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
@@ -62,10 +62,10 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				changedRequest := &action.GetTargetRequest{Id: targetCreated.GetDetails().GetId()}
 				// replace original request with different targetID
 				urlRequest, closeRequest := testServerCall(wantRequest, 0, http.StatusOK, changedRequest)
-				targetRequest := instance.CreateTarget(ctx, t, "", urlRequest, domain.TargetTypeCall, false)
-				instance.SetExecution(ctx, t, conditionRequestFullMethod(fullMethod), executionTargetsSingleTarget(targetRequest.GetDetails().GetId()))
 
-				waitForExecutionOnCondition(ctx, t, instance, conditionRequestFullMethod(fullMethod))
+				targetRequest := waitForTarget(ctx, t, instance, urlRequest, domain.TargetTypeCall, false)
+
+				waitForExecutionOnCondition(ctx, t, instance, conditionRequestFullMethod(fullMethod), executionTargetsSingleTarget(targetRequest.GetDetails().GetId()))
 
 				// expected response from the GetTarget
 				expectedResponse := &action.GetTargetResponse{
@@ -119,10 +119,9 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				}
 				// after request with different targetID, return changed response
 				targetResponseURL, closeResponse := testServerCall(wantResponse, 0, http.StatusOK, changedResponse)
-				targetResponse := instance.CreateTarget(ctx, t, "", targetResponseURL, domain.TargetTypeCall, false)
-				instance.SetExecution(ctx, t, conditionResponseFullMethod(fullMethod), executionTargetsSingleTarget(targetResponse.GetDetails().GetId()))
 
-				waitForExecutionOnCondition(ctx, t, instance, conditionResponseFullMethod(fullMethod))
+				targetResponse := waitForTarget(ctx, t, instance, targetResponseURL, domain.TargetTypeCall, false)
+				waitForExecutionOnCondition(ctx, t, instance, conditionResponseFullMethod(fullMethod), executionTargetsSingleTarget(targetResponse.GetDetails().GetId()))
 				return func() {
 					closeRequest()
 					closeResponse()
@@ -161,12 +160,10 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				wantRequest := &middleware.ContextInfoRequest{FullMethod: fullMethod, InstanceID: instance.ID(), OrgID: orgID, ProjectID: projectID, UserID: userID, Request: request}
 				urlRequest, closeRequest := testServerCall(wantRequest, 0, http.StatusInternalServerError, &action.GetTargetRequest{Id: "notchanged"})
 
-				targetRequest := instance.CreateTarget(ctx, t, "", urlRequest, domain.TargetTypeCall, true)
-				instance.SetExecution(ctx, t, conditionRequestFullMethod(fullMethod), executionTargetsSingleTarget(targetRequest.GetDetails().GetId()))
+				targetRequest := waitForTarget(ctx, t, instance, urlRequest, domain.TargetTypeCall, true)
+				waitForExecutionOnCondition(ctx, t, instance, conditionRequestFullMethod(fullMethod), executionTargetsSingleTarget(targetRequest.GetDetails().GetId()))
 				// GetTarget with used target
 				request.Id = targetRequest.GetDetails().GetId()
-
-				waitForExecutionOnCondition(ctx, t, instance, conditionRequestFullMethod(fullMethod))
 				return func() {
 					closeRequest()
 				}, nil
@@ -233,10 +230,9 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				}
 				// after request with different targetID, return changed response
 				targetResponseURL, closeResponse := testServerCall(wantResponse, 0, http.StatusInternalServerError, changedResponse)
-				targetResponse := instance.CreateTarget(ctx, t, "", targetResponseURL, domain.TargetTypeCall, true)
-				instance.SetExecution(ctx, t, conditionResponseFullMethod(fullMethod), executionTargetsSingleTarget(targetResponse.GetDetails().GetId()))
 
-				waitForExecutionOnCondition(ctx, t, instance, conditionResponseFullMethod(fullMethod))
+				targetResponse := waitForTarget(ctx, t, instance, targetResponseURL, domain.TargetTypeCall, true)
+				waitForExecutionOnCondition(ctx, t, instance, conditionResponseFullMethod(fullMethod), executionTargetsSingleTarget(targetResponse.GetDetails().GetId()))
 				return func() {
 					closeResponse()
 				}, nil
@@ -277,7 +273,9 @@ func TestServer_ExecutionTarget(t *testing.T) {
 	}
 }
 
-func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *integration.Instance, condition *action.Condition) {
+func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *integration.Instance, condition *action.Condition, targets []*action.ExecutionTargetType) {
+	instance.SetExecution(ctx, t, condition, targets)
+
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 		got, err := instance.Client.ActionV3Alpha.SearchExecutions(ctx, &action.SearchExecutionsRequest{
@@ -291,8 +289,52 @@ func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *in
 			return
 		}
 		assert.Len(ttt, got.GetResult(), 1)
+		gotTargets := got.GetResult()[0].GetExecution().GetTargets()
+		// always first check length, otherwise its failed anyway
+		if assert.Len(ttt, gotTargets, len(targets)) {
+			for i := range targets {
+				assert.EqualExportedValues(ttt, targets[i].GetType(), gotTargets[i].GetType())
+			}
+		}
+
 	}, retryDuration, tick, "timeout waiting for expected execution result")
 	return
+}
+
+func waitForTarget(ctx context.Context, t *testing.T, instance *integration.Instance, endpoint string, ty domain.TargetType, interrupt bool) *action.CreateTargetResponse {
+	resp := instance.CreateTarget(ctx, t, "", endpoint, ty, interrupt)
+
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	require.EventuallyWithT(t, func(ttt *assert.CollectT) {
+		got, err := instance.Client.ActionV3Alpha.SearchTargets(ctx, &action.SearchTargetsRequest{
+			Filters: []*action.TargetSearchFilter{
+				{Filter: &action.TargetSearchFilter_InTargetIdsFilter{
+					InTargetIdsFilter: &action.InTargetIDsFilter{TargetIds: []string{resp.GetDetails().GetId()}},
+				}},
+			},
+		})
+		if !assert.NoError(ttt, err) {
+			return
+		}
+		assert.Len(ttt, got.GetResult(), 1)
+		config := got.GetResult()[0].GetConfig()
+		assert.Equal(ttt, config.GetEndpoint(), endpoint)
+		switch ty {
+		case domain.TargetTypeWebhook:
+			if !assert.NotNil(ttt, config.GetRestWebhook()) {
+				return
+			}
+			assert.Equal(ttt, interrupt, config.GetRestWebhook().GetInterruptOnError())
+		case domain.TargetTypeAsync:
+			assert.NotNil(ttt, config.GetRestAsync())
+		case domain.TargetTypeCall:
+			if !assert.NotNil(ttt, config.GetRestCall()) {
+				return
+			}
+			assert.Equal(ttt, interrupt, config.GetRestCall().GetInterruptOnError())
+		}
+	}, retryDuration, tick, "timeout waiting for expected execution result")
+	return resp
 }
 
 func conditionRequestFullMethod(fullMethod string) *action.Condition {

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
@@ -223,7 +223,9 @@ func TestServer_GetTarget(t *testing.T) {
 					assert.Error(ttt, err, "Error: "+err.Error())
 					return
 				}
-				assert.NoError(ttt, err)
+				if !assert.NoError(ttt, err) {
+					return
+				}
 
 				wantTarget := tt.want.GetTarget()
 				gotTarget := got.GetTarget()

--- a/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
+++ b/internal/api/grpc/resources/webkey/v3/integration_test/webkey_integration_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestServer_Feature_Disabled(t *testing.T) {
-	instance, iamCtx := createInstance(t, false)
+	instance, iamCtx, _ := createInstance(t, false)
 	client := instance.Client.WebKeyV3Alpha
 
 	t.Run("CreateWebKey", func(t *testing.T) {
@@ -62,18 +62,18 @@ func TestServer_Feature_Disabled(t *testing.T) {
 }
 
 func TestServer_ListWebKeys(t *testing.T) {
-	instance, iamCtx := createInstance(t, true)
+	instance, iamCtx, creationDate := createInstance(t, true)
 	// After the feature is first enabled, we can expect 2 generated keys with the default config.
 	checkWebKeyListState(iamCtx, t, instance, 2, "", &webkey.WebKey_Rsa{
 		Rsa: &webkey.WebKeyRSAConfig{
 			Bits:   webkey.WebKeyRSAConfig_RSA_BITS_2048,
 			Hasher: webkey.WebKeyRSAConfig_RSA_HASHER_SHA256,
 		},
-	})
+	}, creationDate)
 }
 
 func TestServer_CreateWebKey(t *testing.T) {
-	instance, iamCtx := createInstance(t, true)
+	instance, iamCtx, creationDate := createInstance(t, true)
 	client := instance.Client.WebKeyV3Alpha
 
 	_, err := client.CreateWebKey(iamCtx, &webkey.CreateWebKeyRequest{
@@ -93,11 +93,11 @@ func TestServer_CreateWebKey(t *testing.T) {
 			Bits:   webkey.WebKeyRSAConfig_RSA_BITS_2048,
 			Hasher: webkey.WebKeyRSAConfig_RSA_HASHER_SHA256,
 		},
-	})
+	}, creationDate)
 }
 
 func TestServer_ActivateWebKey(t *testing.T) {
-	instance, iamCtx := createInstance(t, true)
+	instance, iamCtx, creationDate := createInstance(t, true)
 	client := instance.Client.WebKeyV3Alpha
 
 	resp, err := client.CreateWebKey(iamCtx, &webkey.CreateWebKeyRequest{
@@ -122,11 +122,11 @@ func TestServer_ActivateWebKey(t *testing.T) {
 			Bits:   webkey.WebKeyRSAConfig_RSA_BITS_2048,
 			Hasher: webkey.WebKeyRSAConfig_RSA_HASHER_SHA256,
 		},
-	})
+	}, creationDate)
 }
 
 func TestServer_DeleteWebKey(t *testing.T) {
-	instance, iamCtx := createInstance(t, true)
+	instance, iamCtx, creationDate := createInstance(t, true)
 	client := instance.Client.WebKeyV3Alpha
 
 	keyIDs := make([]string, 2)
@@ -178,11 +178,12 @@ func TestServer_DeleteWebKey(t *testing.T) {
 			Bits:   webkey.WebKeyRSAConfig_RSA_BITS_2048,
 			Hasher: webkey.WebKeyRSAConfig_RSA_HASHER_SHA256,
 		},
-	})
+	}, creationDate)
 }
 
-func createInstance(t *testing.T, enableFeature bool) (*integration.Instance, context.Context) {
+func createInstance(t *testing.T, enableFeature bool) (*integration.Instance, context.Context, *timestamppb.Timestamp) {
 	instance := integration.NewInstance(CTX)
+	creationDate := timestamppb.Now()
 	iamCTX := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
 
 	if enableFeature {
@@ -203,7 +204,7 @@ func createInstance(t *testing.T, enableFeature bool) (*integration.Instance, co
 		}
 	}, retryDuration, tick)
 
-	return instance, iamCTX
+	return instance, iamCTX, creationDate
 }
 
 func assertFeatureDisabledError(t *testing.T, err error) {
@@ -214,7 +215,7 @@ func assertFeatureDisabledError(t *testing.T, err error) {
 	assert.Contains(t, s.Message(), "WEBKEY-Ohx6E")
 }
 
-func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integration.Instance, nKeys int, expectActiveKeyID string, config any) {
+func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integration.Instance, nKeys int, expectActiveKeyID string, config any, creationDate *timestamppb.Timestamp) {
 
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -227,8 +228,8 @@ func checkWebKeyListState(ctx context.Context, t *testing.T, instance *integrati
 		var gotActiveKeyID string
 		for _, key := range list {
 			integration.AssertResourceDetails(t, &resource_object.Details{
-				Created: timestamppb.Now(),
-				Changed: timestamppb.Now(),
+				Created: creationDate,
+				Changed: creationDate,
 				Owner: &object.Owner{
 					Type: object.OwnerType_OWNER_TYPE_INSTANCE,
 					Id:   instance.ID(),

--- a/internal/api/grpc/user/v2beta/integration_test/user_test.go
+++ b/internal/api/grpc/user/v2beta/integration_test/user_test.go
@@ -2454,7 +2454,7 @@ func TestServer_ListAuthenticationMethodTypes(t *testing.T) {
 		OwnerType: idp.IDPOwnerType_IDP_OWNER_TYPE_ORG,
 	})
 	require.NoError(t, err)
-	idpLink, err := Client.AddIDPLink(CTX, &user.AddIDPLinkRequest{UserId: userMultipleAuth, IdpLink: &user.IDPLink{
+	_, err = Client.AddIDPLink(CTX, &user.AddIDPLinkRequest{UserId: userMultipleAuth, IdpLink: &user.IDPLink{
 		IdpId:    provider.GetId(),
 		UserId:   "external-id",
 		UserName: "displayName",
@@ -2527,25 +2527,16 @@ func TestServer_ListAuthenticationMethodTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got *user.ListAuthenticationMethodTypesResponse
-			var err error
-
-			for {
-				got, err = Client.ListAuthenticationMethodTypes(tt.args.ctx, tt.args.req)
-				if err == nil && !got.GetDetails().GetTimestamp().AsTime().Before(idpLink.GetDetails().GetChangeDate().AsTime()) {
-					break
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.args.ctx, time.Minute)
+			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
+				got, err := Client.ListAuthenticationMethodTypes(tt.args.ctx, tt.args.req)
+				require.NoError(ttt, err)
+				if !assert.Equal(ttt, tt.want.GetDetails().GetTotalResult(), got.GetDetails().GetTotalResult()) {
+					return
 				}
-				select {
-				case <-CTX.Done():
-					t.Fatal(CTX.Err(), err)
-				case <-time.After(time.Second):
-					t.Log("retrying ListAuthenticationMethodTypes")
-					continue
-				}
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want.GetDetails().GetTotalResult(), got.GetDetails().GetTotalResult())
-			require.Equal(t, tt.want.GetAuthMethodTypes(), got.GetAuthMethodTypes())
+				assert.Equal(ttt, tt.want.GetAuthMethodTypes(), got.GetAuthMethodTypes())
+				integration.AssertListDetails(ttt, tt.want, got)
+			}, retryDuration, tick, "timeout waiting for expected auth methods result")
 		})
 	}
 }

--- a/internal/integration/assert.go
+++ b/internal/integration/assert.go
@@ -83,11 +83,12 @@ func AssertResourceDetails(t assert.TestingT, expected *resources_object.Details
 	if expected.GetOwner() != nil {
 		expectedOwner := expected.GetOwner()
 		actualOwner := actual.GetOwner()
-		assert.NotNil(t, actualOwner)
+		if !assert.NotNil(t, actualOwner) {
+			return
+		}
 		assert.Equal(t, expectedOwner.GetId(), actualOwner.GetId())
 		assert.Equal(t, expectedOwner.GetType(), actualOwner.GetType())
 	}
-	assert.Equal(t, expected.GetOwner(), actual.GetOwner())
 	assert.NotEmpty(t, actual.GetId())
 	if expected.GetId() != "" {
 		assert.Equal(t, expected.GetId(), actual.GetId())

--- a/internal/integration/assert.go
+++ b/internal/integration/assert.go
@@ -80,6 +80,13 @@ func AssertResourceDetails(t assert.TestingT, expected *resources_object.Details
 		gotCreatedDate := actual.GetCreated().AsTime()
 		assert.WithinRange(t, gotCreatedDate, wantCreatedDate.Add(-time.Minute), wantCreatedDate.Add(time.Minute))
 	}
+	if expected.GetOwner() != nil {
+		expectedOwner := expected.GetOwner()
+		actualOwner := actual.GetOwner()
+		assert.NotNil(t, actualOwner)
+		assert.Equal(t, expectedOwner.GetId(), actualOwner.GetId())
+		assert.Equal(t, expectedOwner.GetType(), actualOwner.GetType())
+	}
 	assert.Equal(t, expected.GetOwner(), actual.GetOwner())
 	assert.NotEmpty(t, actual.GetId())
 	if expected.GetId() != "" {

--- a/internal/integration/assert.go
+++ b/internal/integration/assert.go
@@ -106,7 +106,7 @@ func AssertListDetails[L ListDetails, D ListDetailsMsg[L]](t assert.TestingT, ex
 	if wantDetails.GetTimestamp() != nil {
 		gotCD := gotDetails.GetTimestamp().AsTime()
 		wantCD := time.Now()
-		assert.WithinRange(t, gotCD, wantCD.Add(-10*time.Minute), wantCD.Add(time.Minute))
+		assert.WithinRange(t, gotCD, wantCD.Add(-1*time.Minute), wantCD.Add(time.Minute))
 	}
 }
 

--- a/internal/integration/oidc.go
+++ b/internal/integration/oidc.go
@@ -52,7 +52,13 @@ func (i *Instance) CreateOIDCClient(ctx context.Context, redirectURI, logoutRedi
 		return nil, err
 	}
 	return resp, await(func() error {
-		_, err := i.Client.Mgmt.GetAppByID(ctx, &management.GetAppByIDRequest{
+		_, err := i.Client.Mgmt.GetProjectByID(ctx, &management.GetProjectByIDRequest{
+			Id: projectID,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = i.Client.Mgmt.GetAppByID(ctx, &management.GetAppByIDRequest{
 			ProjectId: projectID,
 			AppId:     resp.GetAppId(),
 		})
@@ -152,7 +158,13 @@ func (i *Instance) CreateOIDCImplicitFlowClient(ctx context.Context, redirectURI
 		return nil, err
 	}
 	return resp, await(func() error {
-		_, err := i.Client.Mgmt.GetAppByID(ctx, &management.GetAppByIDRequest{
+		_, err := i.Client.Mgmt.GetProjectByID(ctx, &management.GetProjectByIDRequest{
+			Id: project.GetId(),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = i.Client.Mgmt.GetAppByID(ctx, &management.GetAppByIDRequest{
 			ProjectId: project.GetId(),
 			AppId:     resp.GetAppId(),
 		})


### PR DESCRIPTION
# Which Problems Are Solved

In integration tests there is waiting for the application, but the project is also included if the token can be created.

# How the Problems Are Solved

Wait for project not only for the application in the integration tests.

# Additional Changes

Some more corrections in integration tests.

# Additional Context

None
