### PR TITLE
fix: correctly search for verified domain

### DIFF
--- a/internal/api/grpc/org/converter.go
+++ b/internal/api/grpc/org/converter.go
@@ -22,7 +22,7 @@ func OrgQueriesToModel(queries []*org_pb.OrgQuery) (_ []query.SearchQuery, err e
 func OrgQueryToModel(apiQuery *org_pb.OrgQuery) (query.SearchQuery, error) {
 	switch q := apiQuery.Query.(type) {
 	case *org_pb.OrgQuery_DomainQuery:
-		return query.NewOrgDomainSearchQuery(object.TextMethodToQuery(q.DomainQuery.Method), q.DomainQuery.Domain)
+		return query.NewOrgVerifiedDomainSearchQuery(object.TextMethodToQuery(q.DomainQuery.Method), q.DomainQuery.Domain)
 	case *org_pb.OrgQuery_NameQuery:
 		return query.NewOrgNameSearchQuery(object.TextMethodToQuery(q.NameQuery.Method), q.NameQuery.Name)
 	case *org_pb.OrgQuery_StateQuery:

--- a/internal/api/grpc/org/v2/integration_test/query_test.go
+++ b/internal/api/grpc/org/v2/integration_test/query_test.go
@@ -230,7 +230,7 @@ func TestServer_ListOrganizations(t *testing.T) {
 						Details: orgResp.GetDetails(),
 					}
 					domain := gofakeit.DomainName()
-					_, err := Instance.Client.Mgmt.AddOrgDomain(ctx, &management.AddOrgDomainRequest{
+					_, err := Instance.Client.Mgmt.AddOrgDomain(integration.SetOrgID(ctx, orgResp.GetOrganizationId()), &management.AddOrgDomainRequest{
 						Domain: domain,
 					})
 					if err != nil {

--- a/internal/api/grpc/org/v2/query.go
+++ b/internal/api/grpc/org/v2/query.go
@@ -57,7 +57,7 @@ func orgQueriesToQuery(ctx context.Context, queries []*org.SearchQuery) (_ []que
 func orgQueryToQuery(ctx context.Context, orgQuery *org.SearchQuery) (query.SearchQuery, error) {
 	switch q := orgQuery.Query.(type) {
 	case *org.SearchQuery_DomainQuery:
-		return query.NewOrgDomainSearchQuery(object.TextMethodToQuery(q.DomainQuery.Method), q.DomainQuery.Domain)
+		return query.NewOrgVerifiedDomainSearchQuery(object.TextMethodToQuery(q.DomainQuery.Method), q.DomainQuery.Domain)
 	case *org.SearchQuery_NameQuery:
 		return query.NewOrgNameSearchQuery(object.TextMethodToQuery(q.NameQuery.Method), q.NameQuery.Name)
 	case *org.SearchQuery_StateQuery:

--- a/internal/query/org.go
+++ b/internal/query/org.go
@@ -308,8 +308,24 @@ func NewOrgIDSearchQuery(value string) (SearchQuery, error) {
 	return NewTextQuery(OrgColumnID, value, TextEquals)
 }
 
-func NewOrgDomainSearchQuery(method TextComparison, value string) (SearchQuery, error) {
-	return NewTextQuery(OrgColumnDomain, value, method)
+func NewOrgVerifiedDomainSearchQuery(method TextComparison, value string) (SearchQuery, error) {
+	domainQuery, err := NewTextQuery(OrgDomainDomainCol, value, method)
+	if err != nil {
+		return nil, err
+	}
+	verifiedQuery, err := NewBoolQuery(OrgDomainIsVerifiedCol, true)
+	if err != nil {
+		return nil, err
+	}
+	subSelect, err := NewSubSelect(OrgDomainOrgIDCol, []SearchQuery{domainQuery, verifiedQuery})
+	if err != nil {
+		return nil, err
+	}
+	return NewListQuery(
+		OrgColumnID,
+		subSelect,
+		ListIn,
+	)
 }
 
 func NewOrgNameSearchQuery(method TextComparison, value string) (SearchQuery, error) {


### PR DESCRIPTION
# Which Problems Are Solved

Searching orgs by domain currently only looked for the primary domain, but should be possible with all verified domains (as documented)

# How the Problems Are Solved

- fixed the search query

# Additional Changes

None

# Additional Context

- closes https://github.com/zitadel/zitadel/issues/8749
