### PR TITLE
fix: add PGUSER env var in docker-compose files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
+      PGUSER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres

--- a/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose-sa.yaml
@@ -34,6 +34,7 @@ services:
     restart: 'always'
     image: postgres:16-alpine
     environment:
+      - PGUSER=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     networks:

--- a/docs/docs/self-hosting/deploy/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
     restart: 'always'
     image: postgres:16-alpine
     environment:
+      - PGUSER=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=zitadel


### PR DESCRIPTION
# Which Problems Are Solved

Postgres spams `FATAL:  role "root" does not exist` as mentioned in #7832 (even with `-U`)

# How the Problems Are Solved

By setting `PGUSER` in env with db username accordingly (`postgres` in this case)

Explanation: When making connections to pg, if connection param for user is not set, it defaults to system username (`root` in this case, which is default username inside docker)

`PGUSER` is already being used in [one of the docker-compose files](https://github.com/zitadel/zitadel/blob/54f1c0bc50d9b547670871f9b44fb3d5ab1af186/internal/integration/config/docker-compose.yaml#L14) but missing in some, which this PR fills

`PGUSER` env var as mentioned in [postgres docs](https://www.postgresql.org/docs/current/libpq-envars.html)

# Additional Changes

None

# Additional Context

Related discussion made at #7832 
