### PR TITLE
fix(login): org register script references

### DIFF
--- a/internal/api/ui/login/static/templates/register_org.html
+++ b/internal/api/ui/login/static/templates/register_org.html
@@ -112,10 +112,10 @@
     </div>
 </form>
 
-<script src="{{ resourceUrl " scripts/input_suffix_offset.js" }}"></script>
-<script src="{{ resourceUrl " scripts/form_submit.js" }}"></script>
-<script src="{{ resourceUrl " scripts/password_policy_check.js" }}"></script>
-<script src="{{ resourceUrl " scripts/register_check.js" }}"></script>
-<script src="{{ resourceUrl " scripts/loginname_suffix.js" }}"></script>
+<script src="{{ resourceUrl "scripts/input_suffix_offset.js" }}"></script>
+<script src="{{ resourceUrl "scripts/form_submit.js" }}"></script>
+<script src="{{ resourceUrl "scripts/password_policy_check.js" }}"></script>
+<script src="{{ resourceUrl "scripts/register_check.js" }}"></script>
+<script src="{{ resourceUrl "scripts/loginname_suffix.js" }}"></script>
 
 {{template "main-bottom" .}}


### PR DESCRIPTION
Closes #8838 

This fixes a bug of the `/register/org` page where scripts where not referenced correctly