### PR TITLE
docs: change recommendation from cockroachDB to postgreSQL

### DIFF
--- a/docs/docs/concepts/architecture/software.md
+++ b/docs/docs/concepts/architecture/software.md
@@ -144,4 +144,4 @@ The storage layer of ZITADEL is responsible for multiple tasks. For example:
 - Backup and restore operation for disaster recovery purpose
 
 ZITADEL currently supports PostgreSQL and CockroachDB..
-Make sure to read our [Production Guide](/docs/self-hosting/manage/production#prefer-cockroachdb) before you decide on using one of them.
+Make sure to read our [Production Guide](/docs/self-hosting/manage/production#prefer-postgresql) before you decide on using one of them.

--- a/docs/docs/concepts/architecture/solution.md
+++ b/docs/docs/concepts/architecture/solution.md
@@ -11,7 +11,7 @@ Since the storage layer takes the heavy lifting of making sure that data in sync
 Depending on your projects needs our general recommendation is to run ZITADEL and ZITADELs storage layer across multiple availability zones in the same region or if you need higher guarantees run the storage layer across multiple regions.
 Consult the [CockroachDB documentation](https://www.cockroachlabs.com/docs/) for more details or use the [CockroachCloud Service](https://www.cockroachlabs.com/docs/cockroachcloud/create-an-account.html)
 Alternatively you can run ZITADEL also with Postgres which is [Enterprise Supported](/docs/support/software-release-cycles-support#partially-supported).
-Make sure to read our [Production Guide](/self-hosting/manage/production#prefer-cockroachdb) before you decide to use it.
+Make sure to read our [Production Guide](/self-hosting/manage/production#prefer-postgresql) before you decide to use it.
 
 ## Scalability
 

--- a/docs/docs/self-hosting/deploy/overview.mdx
+++ b/docs/docs/self-hosting/deploy/overview.mdx
@@ -14,7 +14,7 @@ Choose your platform and run ZITADEL with the most minimal configuration possibl
 ## Prerequisites
 
 - For test environments, ZITADEL does not need many resources, 1 CPU and 512MB memory are more than enough. (With more CPU, the password hashing might be faster)
-- A PostgreSQL or CockroachDB as only needed storage. Make sure to read our [Production Guide](/docs/self-hosting/manage/production#prefer-cockroachdb) before you decide to use Postgresql.
+- A PostgreSQL or CockroachDB as only needed storage. Make sure to read our [Production Guide](/docs/self-hosting/manage/production#prefer-postgresql) before you decide to use Postgresql.
 
 ## Releases
 

--- a/docs/docs/self-hosting/manage/database/_postgres.mdx
+++ b/docs/docs/self-hosting/manage/database/_postgres.mdx
@@ -1,7 +1,6 @@
 ## ZITADEL with Postgres
 
 If you want to use a PostgreSQL database you can [overwrite the default configuration](../configure/configure.mdx).
-Make sure to read our [Production Guide](/docs/self-hosting/manage/production#prefer-cockroachdb) before you decide to use it.
 
 Currently versions >= 14 are supported.
 

--- a/docs/docs/self-hosting/manage/production.md
+++ b/docs/docs/self-hosting/manage/production.md
@@ -109,17 +109,16 @@ but in the Projections.Customizations.Telemetry section
 
 ## Database
 
-### Prefer CockroachDB
+### Prefer PostgreSQL
 
 ZITADEL supports [CockroachDB](https://www.cockroachlabs.com/) and [PostgreSQL](https://www.postgresql.org/).
-We recommend using CockroachDB,
-as horizontal scaling is much easier than with PostgreSQL.
-Also, if you are concerned about multi-regional data locality,
-[the way to go is with CockroachDB](https://www.cockroachlabs.com/docs/stable/multiregion-overview.html).
+We recommend using PostgreSQL, as it is the better choice when you want to prioritize performance and latency.
+
+However, if [multi-regional data locality](https://www.cockroachlabs.com/docs/stable/multiregion-overview.html) is a critical requirement, CockroachDB might be a suitable option.
 
 The indexes for the database are optimized using load tests from [ZITADEL Cloud](https://zitadel.com), 
-which runs with CockroachDB.
-If you identify problems with your Postgresql during load tests that indicate that the indexes are not optimized,
+which runs with PostgreSQL.
+If you identify problems with your CockroachDB during load tests that indicate that the indexes are not optimized,
 please create an issue in our [github repository](https://github.com/zitadel/zitadel).
 
 ### Configure ZITADEL
@@ -128,7 +127,7 @@ Depending on your environment, you maybe would want to tweak some settings about
 
 ```yaml
 Database:
-  cockroach:
+  postgres:
     Host: localhost
     Port: 26257
     Database: zitadel
@@ -139,6 +138,7 @@ Database:
     //highlight-end
     Options: ""
 ```
+
 
 You also might want to configure how [projections](/concepts/eventstore/implementation#projections) are computed. These are the default values:
 


### PR DESCRIPTION
# Which Problems Are Solved

As we switched to PostgreSQL with our cloud zitadel, we now want to recommend it instead of CockroachDB.

# How the Problems Are Solved

Replaced the recommend section with postgresql
