### PR TITLE
docs(v2): fix duplicate section of user, session,  oidc and settings services

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -289,7 +289,7 @@ module.exports = {
             outputDir: "docs/apis/resources/user_service_v2",
             sidebarOptions: {
               groupPathsBy: "tag",
-              categoryLinkSource: "tag",
+              categoryLinkSource: "auto",
             },
           },
           session_v2: {
@@ -297,7 +297,7 @@ module.exports = {
             outputDir: "docs/apis/resources/session_service_v2",
             sidebarOptions: {
               groupPathsBy: "tag",
-              categoryLinkSource: "tag",
+              categoryLinkSource: "auto",
             },
           },
           oidc_v2: {
@@ -305,7 +305,7 @@ module.exports = {
             outputDir: "docs/apis/resources/oidc_service_v2",
             sidebarOptions: {
               groupPathsBy: "tag",
-              categoryLinkSource: "tag",
+              categoryLinkSource: "auto",
             },
           },
           settings_v2: {
@@ -313,7 +313,7 @@ module.exports = {
             outputDir: "docs/apis/resources/settings_service_v2",
             sidebarOptions: {
               groupPathsBy: "tag",
-              categoryLinkSource: "tag",
+              categoryLinkSource: "auto",
             },
           },
           user_schema_v3: {


### PR DESCRIPTION
# Which Problems Are Solved

Duplicate section in the doc
![image](https://github.com/user-attachments/assets/b9d31f87-9158-443f-8f76-1bae31fb7ee8)


# How the Problems Are Solved

Change the category link source to add a introduction section
![image](https://github.com/user-attachments/assets/562843e6-e8b9-4125-a3f7-8e4d2a24522d)


