### PR TITLE
chore: add to timeouts for query operations in integration tests

### DIFF
--- a/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/execution_target_test.go
@@ -251,7 +251,7 @@ func TestServer_ExecutionTarget(t *testing.T) {
 				require.NoError(t, err)
 				defer close()
 			}
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 2*time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.ActionV3Alpha.GetTarget(tt.ctx, tt.req)
 				if tt.wantErr {
@@ -276,7 +276,7 @@ func TestServer_ExecutionTarget(t *testing.T) {
 func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *integration.Instance, condition *action.Condition, targets []*action.ExecutionTargetType) {
 	instance.SetExecution(ctx, t, condition, targets)
 
-	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, 2*time.Minute)
 	require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 		got, err := instance.Client.ActionV3Alpha.SearchExecutions(ctx, &action.SearchExecutionsRequest{
 			Filters: []*action.ExecutionSearchFilter{
@@ -305,7 +305,7 @@ func waitForExecutionOnCondition(ctx context.Context, t *testing.T, instance *in
 func waitForTarget(ctx context.Context, t *testing.T, instance *integration.Instance, endpoint string, ty domain.TargetType, interrupt bool) *action.CreateTargetResponse {
 	resp := instance.CreateTarget(ctx, t, "", endpoint, ty, interrupt)
 
-	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, 2*time.Minute)
 	require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 		got, err := instance.Client.ActionV3Alpha.SearchTargets(ctx, &action.SearchTargetsRequest{
 			Filters: []*action.TargetSearchFilter{

--- a/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/action/v3alpha/integration_test/query_test.go
@@ -480,7 +480,7 @@ func TestServer_ListTargets(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 2*time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, listErr := instance.Client.ActionV3Alpha.SearchTargets(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
@@ -865,7 +865,7 @@ func TestServer_SearchExecutions(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 2*time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, listErr := instance.Client.ActionV3Alpha.SearchExecutions(tt.args.ctx, tt.args.req)
 				if tt.wantErr {

--- a/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
+++ b/internal/api/grpc/resources/userschema/v3alpha/integration_test/query_test.go
@@ -188,7 +188,7 @@ func TestServer_ListUserSchemas(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 2*time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.UserSchemaV3.SearchUserSchemas(tt.args.ctx, tt.args.req)
 				if tt.wantErr {
@@ -296,7 +296,7 @@ func TestServer_GetUserSchema(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, time.Minute)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(isolatedIAMOwnerCTX, 2*time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				got, err := instance.Client.UserSchemaV3.GetUserSchema(tt.args.ctx, tt.args.req)
 				if tt.wantErr {

--- a/internal/integration/assert.go
+++ b/internal/integration/assert.go
@@ -63,7 +63,7 @@ func AssertDetails[D Details, M DetailsMsg[D]](t assert.TestingT, expected, actu
 	if wantDetails.GetChangeDate() != nil {
 		wantChangeDate := time.Now()
 		gotChangeDate := gotDetails.GetChangeDate().AsTime()
-		assert.WithinRange(t, gotChangeDate, wantChangeDate.Add(-time.Minute), wantChangeDate.Add(time.Minute))
+		assert.WithinRange(t, gotChangeDate, wantChangeDate.Add(-10*time.Minute), wantChangeDate.Add(time.Minute))
 	}
 
 	assert.Equal(t, wantDetails.GetResourceOwner(), gotDetails.GetResourceOwner())
@@ -73,12 +73,12 @@ func AssertResourceDetails(t assert.TestingT, expected *resources_object.Details
 	if expected.GetChanged() != nil {
 		wantChangeDate := time.Now()
 		gotChangeDate := actual.GetChanged().AsTime()
-		assert.WithinRange(t, gotChangeDate, wantChangeDate.Add(-time.Minute), wantChangeDate.Add(time.Minute))
+		assert.WithinRange(t, gotChangeDate, wantChangeDate.Add(-10*time.Minute), wantChangeDate.Add(time.Minute))
 	}
 	if expected.GetCreated() != nil {
 		wantCreatedDate := time.Now()
 		gotCreatedDate := actual.GetCreated().AsTime()
-		assert.WithinRange(t, gotCreatedDate, wantCreatedDate.Add(-time.Minute), wantCreatedDate.Add(time.Minute))
+		assert.WithinRange(t, gotCreatedDate, wantCreatedDate.Add(-10*time.Minute), wantCreatedDate.Add(time.Minute))
 	}
 	if expected.GetOwner() != nil {
 		expectedOwner := expected.GetOwner()


### PR DESCRIPTION
Draft to test hypothesis that the timeout is to short for the pipeline performance in the integration tests.