### PR TITLE
fix(setup): improve search query to use index

### DIFF
--- a/internal/migration/step.go
+++ b/internal/migration/step.go
@@ -18,6 +18,7 @@ type StepStates struct {
 // Query implements eventstore.QueryReducer.
 func (*StepStates) Query() *eventstore.SearchQueryBuilder {
 	return eventstore.NewSearchQueryBuilder(eventstore.ColumnsEvent).
+		InstanceID(""). // to make sure we can use an appropriate index
 		AddQuery().
 		AggregateTypes(SystemAggregate).
 		AggregateIDs(SystemAggregateID).


### PR DESCRIPTION
# Which Problems Are Solved

The setup filter for previous steps and kept getting slower. This is due to the filter, which did not provide any instanceID and thus resulting in a full table scan.

# How the Problems Are Solved

- Added an empty instanceID filter (since it's on system level)

# Additional Changes

None

# Additional Context

Noticed internally and during migrations on some regions
