### PR TITLE
fix: use correct check for user existing on import

### DIFF
--- a/internal/command/user_human.go
+++ b/internal/command/user_human.go
@@ -448,7 +448,7 @@ func (c *Commands) ImportHuman(ctx context.Context, orgID string, human *domain.
 			return nil, nil, err
 		}
 
-		if existing.UserState != domain.UserStateUnspecified {
+		if existing.UserState.Exists() {
 			return nil, nil, zerrors.ThrowPreconditionFailed(nil, "COMMAND-ziuna", "Errors.User.AlreadyExisting")
 		}
 	}


### PR DESCRIPTION
# Which Problems Are Solved

- ImportHuman was not checking for a `UserStateDeleted` state on import, resulting in "already existing" errors when attempting to delete and re-import a user with the same id 

# How the Problems Are Solved

Use the `Exists` helper method to check for both `UserStateUnspecified` and `UserStateDeleted` states on import 

# Additional Changes

N/A

# Additional Context

N/A