### PR TITLE
fix(eventstore): set application name during push to instance id

### DIFF
--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -272,7 +272,19 @@ func prepareConditions(criteria querier, query *repository.SearchQuery, useV1 bo
 	}
 
 	if query.AwaitOpenTransactions {
+		instanceIDs := make(database.TextArray[string], 0, 3)
+		if query.InstanceID != nil {
+			instanceIDs = append(instanceIDs, query.InstanceID.Value.(string))
+		} else if query.InstanceIDs != nil {
+			instanceIDs = append(instanceIDs, query.InstanceIDs.Value.(database.TextArray[string])...)
+		}
+
+		for i := range instanceIDs {
+			instanceIDs[i] = dialect.DBPurposeEventPusher.AppName() + "_" + instanceIDs[i]
+		}
+
 		clauses += awaitOpenTransactions(useV1)
+		args = append(args, instanceIDs)
 	}
 
 	if clauses == "" {

--- a/internal/eventstore/v3/push.go
+++ b/internal/eventstore/v3/push.go
@@ -13,9 +13,13 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/zitadel/logging"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/database/dialect"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
+
+var appNamePrefix = dialect.DBPurposeEventPusher.AppName() + "_"
 
 func (es *Eventstore) Push(ctx context.Context, commands ...eventstore.Command) (events []eventstore.Event, err error) {
 	tx, err := es.client.BeginTx(ctx, nil)
@@ -26,6 +30,13 @@ func (es *Eventstore) Push(ctx context.Context, commands ...eventstore.Command) 
 	var (
 		sequences []*latestSequence
 	)
+
+	// needs to be set like this because psql complains about parameters in the SET statement
+	_, err = tx.ExecContext(ctx, "SET application_name = '"+appNamePrefix+authz.GetInstance(ctx).InstanceID()+"'")
+	if err != nil {
+		logging.WithError(err).Warn("failed to set application name")
+		return nil, err
+	}
 
 	err = crdb.ExecuteInTx(ctx, &transaction{tx}, func() error {
 		sequences, err = latestSequences(ctx, tx, commands)


### PR DESCRIPTION
# Which Problems Are Solved

Noisy neighbours can introduce projection latencies because the projections only query events older than the start timestamp of the oldest push transaction.

# How the Problems Are Solved

During push we set the application name to `zitadel_es_pusher_<instance_id>` instead of `zitadel_es_pusher` which is used to query events by projections.
