### PR TITLE
fix(eventstore): set application name during push to instance id

### DIFF
--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -272,7 +272,19 @@ func prepareConditions(criteria querier, query *repository.SearchQuery, useV1 bo
 	}
 
 	if query.AwaitOpenTransactions {
+		instanceIDs := make(database.TextArray[string], 0, 3)
+		if query.InstanceID != nil {
+			instanceIDs = append(instanceIDs, query.InstanceID.Value.(string))
+		} else if query.InstanceIDs != nil {
+			instanceIDs = append(instanceIDs, query.InstanceIDs.Value.(database.TextArray[string])...)
+		}
+
+		for i := range instanceIDs {
+			instanceIDs[i] = dialect.DBPurposeEventPusher.AppName() + "_" + instanceIDs[i]
+		}
+
 		clauses += awaitOpenTransactions(useV1)
+		args = append(args, instanceIDs)
 	}
 
 	if clauses == "" {


### PR DESCRIPTION
# Which Problems Are Solved

Noisy neighbours can introduce projection latencies because the projections only query events older than the start timestamp of the oldest push transaction.

# How the Problems Are Solved

During push we set the application name to `zitadel_es_pusher_<instance_id>` instead of `zitadel_es_pusher` which is used to query events by projections.
