### PR TITLE
fix(eventstore): set app_name in acquire

### DIFF
--- a/internal/database/postgres/pg.go
+++ b/internal/database/postgres/pg.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/zitadel/logging"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/database/dialect"
 )
 
@@ -91,6 +93,18 @@ func (c *Config) Connect(useAdmin bool, pusherRatio, spoolerRatio float64, purpo
 			}
 		}
 		return nil
+	}
+
+	// For the pusher we set the app name with the instance ID
+	if purpose == dialect.DBPurposeEventPusher {
+		config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
+			return setAppNameWithID(ctx, conn, purpose, authz.GetInstance(ctx).InstanceID())
+		}
+		config.AfterRelease = func(conn *pgx.Conn) bool {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			return setAppNameWithID(ctx, conn, purpose, "IDLE")
+		}
 	}
 
 	if connConfig.MaxOpenConns != 0 {
@@ -218,4 +232,12 @@ func (c Config) String(useAdmin bool, appName string) string {
 	}
 
 	return strings.Join(fields, " ")
+}
+
+func setAppNameWithID(ctx context.Context, conn *pgx.Conn, purpose dialect.DBPurpose, id string) bool {
+	// needs to be set like this because psql complains about parameters in the SET statement
+	query := fmt.Sprintf("SET application_name = '%s_%s'", purpose.AppName(), id)
+	_, err := conn.Exec(ctx, query)
+	logging.OnError(err).Warn("failed to set application name")
+	return err == nil
 }

--- a/internal/eventstore/v3/push.go
+++ b/internal/eventstore/v3/push.go
@@ -8,12 +8,9 @@ import (
 	"github.com/zitadel/logging"
 
 	"github.com/zitadel/zitadel/internal/database"
-	"github.com/zitadel/zitadel/internal/database/dialect"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 )
-
-var appNamePrefix = dialect.DBPurposeEventPusher.AppName() + "_"
 
 var pushTxOpts = &sql.TxOptions{
 	Isolation: sql.LevelReadCommitted,

--- a/internal/eventstore/v3/push_without_func.go
+++ b/internal/eventstore/v3/push_without_func.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/zitadel/logging"
 
-	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -69,14 +68,6 @@ func (es *Eventstore) pushWithoutFunc(ctx context.Context, client database.Conte
 	var (
 		sequences []*latestSequence
 	)
-
-	// needs to be set like this because psql complains about parameters in the SET statement
-	_, err = tx.ExecContext(ctx, "SET application_name = '"+appNamePrefix+authz.GetInstance(ctx).InstanceID()+"'")
-	if err != nil {
-		logging.WithError(err).Warn("failed to set application name")
-		return nil, err
-	}
-
 	sequences, err = latestSequences(ctx, tx, commands)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Which Problems Are Solved

Sometimes the projection spooler misses events, resulting in gaps in the projection. Normally the spooler should wait on active push transaction for a given appname that includes the instance ID.

1. In the new push the appname was never set. Thus the spooler would never wait
2. Previously this behaviour was seen infrequently and might have resulted from a race condition between the moment the transaction started and the app_name was set.

# How the Problems Are Solved

Set the application_name in the Before Acquire hook of the PGX connection pool.

# Additional Changes

Reset the application_name in the After Release hook.

# Additional Context

- https://discord.com/channels/927474939156643850/1308717775362986004
- Possibly introduced or amplified by https://github.com/zitadel/zitadel/pull/8918
