### PR TITLE
fix: project existing check removed from project grant remove

### DIFF
--- a/internal/command/project_grant.go
+++ b/internal/command/project_grant.go
@@ -205,12 +205,6 @@ func (c *Commands) RemoveProjectGrant(ctx context.Context, projectID, grantID, r
 	if grantID == "" || projectID == "" {
 		return details, zerrors.ThrowInvalidArgument(nil, "PROJECT-1m9fJ", "Errors.IDMissing")
 	}
-
-	err = c.checkProjectExists(ctx, projectID, resourceOwner)
-	if err != nil {
-		return nil, err
-	}
-
 	existingGrant, err := c.projectGrantWriteModelByID(ctx, grantID, projectID, resourceOwner)
 	if err != nil {
 		return details, err

--- a/internal/command/project_grant_test.go
+++ b/internal/command/project_grant_test.go
@@ -1273,11 +1273,25 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 			},
 		},
 		{
-			name: "project not existing, precondition failed error",
+			name: "project already removed, precondition failed error",
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
-					expectFilter(),
+					expectFilter(
+						eventFromEventPusher(project.NewGrantAddedEvent(context.Background(),
+							&project.NewAggregate("project1", "org1").Aggregate,
+							"projectgrant1",
+							"grantedorg1",
+							[]string{"key1"},
+						)),
+						eventFromEventPusher(
+							project.NewProjectRemovedEvent(context.Background(),
+								&project.NewAggregate("project1", "org1").Aggregate,
+								"projectname1",
+								nil,
+							),
+						),
+					),
 				),
 			},
 			args: args{
@@ -1287,7 +1301,7 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 				resourceOwner: "org1",
 			},
 			res: res{
-				err: zerrors.IsPreconditionFailed,
+				err: zerrors.IsNotFound,
 			},
 		},
 		{
@@ -1295,15 +1309,6 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
-					expectFilter(
-						eventFromEventPusher(
-							project.NewProjectAddedEvent(context.Background(),
-								&project.NewAggregate("project1", "org1").Aggregate,
-								"projectname1", true, true, true,
-								domain.PrivateLabelingSettingUnspecified,
-							),
-						),
-					),
 					expectFilter(),
 				),
 			},
@@ -1322,15 +1327,6 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
-					expectFilter(
-						eventFromEventPusher(
-							project.NewProjectAddedEvent(context.Background(),
-								&project.NewAggregate("project1", "org1").Aggregate,
-								"projectname1", true, true, true,
-								domain.PrivateLabelingSettingUnspecified,
-							),
-						),
-					),
 					expectFilter(
 						eventFromEventPusher(project.NewGrantAddedEvent(context.Background(),
 							&project.NewAggregate("project1", "org1").Aggregate,
@@ -1365,15 +1361,6 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
-					expectFilter(
-						eventFromEventPusher(
-							project.NewProjectAddedEvent(context.Background(),
-								&project.NewAggregate("project1", "org1").Aggregate,
-								"projectname1", true, true, true,
-								domain.PrivateLabelingSettingUnspecified,
-							),
-						),
-					),
 					expectFilter(
 						eventFromEventPusher(project.NewGrantAddedEvent(context.Background(),
 							&project.NewAggregate("project1", "org1").Aggregate,
@@ -1410,15 +1397,6 @@ func TestCommandSide_RemoveProjectGrant(t *testing.T) {
 			fields: fields{
 				eventstore: eventstoreExpect(
 					t,
-					expectFilter(
-						eventFromEventPusher(
-							project.NewProjectAddedEvent(context.Background(),
-								&project.NewAggregate("project1", "org1").Aggregate,
-								"projectname1", true, true, true,
-								domain.PrivateLabelingSettingUnspecified,
-							),
-						),
-					),
 					expectFilter(
 						eventFromEventPusher(project.NewGrantAddedEvent(context.Background(),
 							&project.NewAggregate("project1", "org1").Aggregate,


### PR DESCRIPTION
# Which Problems Are Solved

Wrongly created project grants with a unexpected resourceowner can't be removed as there is a check if the project is existing, the project is never existing as the wrong resourceowner is used.

# How the Problems Are Solved

There is already a fix related to the resourceowner of the project grant, which should remove the possibility that this situation can happen anymore. This PR removes the check for the project existing, as when the projectgrant is existing and the project is not already removed, this check is not needed anymore.

# Additional Changes

None

# Additional Context

Closes #8900 
