### PR TITLE
chore: ask for urgency proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -15,6 +15,7 @@ body:
     label: Severity
     description: How severe is the bug?
     options:
+    - I don't know
     - Low (it can wait)
     - Medium (it should be backlogged)
     - High (it should be prioritized)
@@ -110,3 +111,9 @@ body:
   attributes:
     label: Additional Context
     description: Please add any other infos that could be useful.
+- type: markdown
+  attributes:
+    value: |
+      ## Vote for this issue
+      If you come accross this issue and would like to see it taken care of, please vote with a thumbs up 👍.
+      If you have any additional thoughts or use cases, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -9,6 +9,18 @@ body:
     value: |
       Thanks for taking the time to fill out this bug report!  
       Learn more in our [contribution guide](https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#product-management) on how we will process your issue.
+- type: dropdown
+  id: severity
+  attributes:
+    label: Severity
+    description: How severe is the bug?
+    options:
+    - Low (it can wait)
+    - Medium (it should be backlogged)
+    - High (it should be prioritized)
+    - Critical (it should be worked on immediately)
+  validations:
+    required: true
 - type: checkboxes
   id: preflight
   attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -7,6 +7,16 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this proposal / feature reqeust
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How urgent is this proposal?
+      options:
+      - Low (it can wait)
+      - Medium (it should be backlogged)
+      - High (it should be prioritized)
+      - Critical (it should be worked on immediately)
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -13,10 +13,13 @@ body:
       label: Urgency
       description: How urgent is this proposal?
       options:
+      - I don't know
       - Low (it can wait)
       - Medium (it should be backlogged)
       - High (it should be prioritized)
       - Critical (it should be worked on immediately)
+    validations:
+      required: true
   - type: checkboxes
     id: preflight
     attributes:
@@ -63,3 +66,9 @@ body:
     attributes:
       label: Additional Context
       description: Please add any other infos that could be useful.
+  - type: markdown
+    attributes:
+        value: |
+            ## Vote for this issue
+            If you come accross this issue and would like to see it taken care of, please vote with a thumbs up 👍.
+            If you have any additional thoughts or use cases, please leave a comment.

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -21,6 +21,13 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: add "thumbs up reaction
+        if: ${{ github.event_name == 'issues' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { issue: { number: issueNumber }, repository: { owner: { login: owner }, name: repo } } = context.payload;
+            await github.reactions.createForIssue({ owner, repo, issue_number: issueNumber, content: "+1" });
       - uses: tspascoal/get-user-teams-membership@v3
         id: checkUserMember
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -13,6 +13,7 @@ jobs:
 
             How urgent is this PR review for you? Please select one of the following levels:
 
+            - [ ] I don't know
             - [ ] Low (shoud be reviewed on best effort)
             - [ ] Medium (should be reviewed within 14 days)
             - [ ] High (should be reviewed within 2 days)

--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -11,6 +11,13 @@ jobs:
           script: |
             const content = `### Thanks for your contribution @${{ github.event.pull_request.user.login }}! 🎉
 
+            How urgent is this PR review for you? Please select one of the following levels:
+
+            - [ ] Low (shoud be reviewed on best effort)
+            - [ ] Medium (should be reviewed within 14 days)
+            - [ ] High (should be reviewed within 2 days)
+            - [ ] Critical (should be reviewed now)
+
             Please make sure you tick the following checkboxes before marking this Pull Request (PR) as ready for review:
             
               - [ ] I am happy with the code


### PR DESCRIPTION
# Which Problems Are Solved

It is hard to prioritize new issues and PRs.

# How the Problems Are Solved

In issue and PR templates, an urgency can optionally be proposed. This also improves community involvement.

# Additional Changes

- [ ] Let's also encourage upvoting and automate an initial thumb up for each issue?