### PR TITLE
fix(eventstore): set created filters to exclusion sub-query

### DIFF
--- a/internal/eventstore/repository/sql/query.go
+++ b/internal/eventstore/repository/sql/query.go
@@ -285,7 +285,7 @@ func prepareConditions(criteria querier, query *repository.SearchQuery, useV1 bo
 
 	excludeAggregateIDs := query.ExcludeAggregateIDs
 	if len(excludeAggregateIDs) > 0 {
-		excludeAggregateIDs = append(excludeAggregateIDs, query.InstanceID, query.InstanceIDs, query.Position)
+		excludeAggregateIDs = append(excludeAggregateIDs, query.InstanceID, query.InstanceIDs, query.Position, query.CreatedAfter, query.CreatedBefore)
 	}
 	excludeAggregateIDsClauses, excludeAggregateIDsArgs := prepareQuery(criteria, useV1, excludeAggregateIDs...)
 	if excludeAggregateIDsClauses != "" {


### PR DESCRIPTION
# Which Problems Are Solved

In eventstore queries with aggregate ID exclusion filters, filters on events creation date where not passed to the sub-query. This results in a high amount of returned rows from the sub-query and high overall query cost.

# How the Problems Are Solved

When CreatedAfter and CreatedBefore are used on the global search query, copy those filters to the sub-query. We already did this for the position column filter.

# Additional Changes

- none

# Additional Context

- Introduced in https://github.com/zitadel/zitadel/pull/8940
