### PR TITLE
fix(cache): ignore NOSCRIPT errors in redis circuit breaker

### DIFF
--- a/internal/cache/connector/redis/circuit_breaker.go
+++ b/internal/cache/connector/redis/circuit_breaker.go
@@ -86,5 +86,6 @@ func (l *limiter) ReportResult(err error) {
 	done := <-l.inflight
 	done(err == nil ||
 		errors.Is(err, redis.Nil) ||
-		errors.Is(err, context.Canceled))
+		errors.Is(err, context.Canceled) ||
+		redis.HasErrorPrefix(err, "NOSCRIPT"))
 }


### PR DESCRIPTION
# Which Problems Are Solved

When Zitadel starts the first time with a configured Redis cache, the circuit break would open on the first requests, with no explanatory error and only log-lines explaining the state of the Circuit breaker.

Using a debugger, `NOSCRIPT No matching script. Please use EVAL.` was found the be passed to `Limiter.ReportResult`. This error is actually retried by go-redis after a [`Script.Run`](https://pkg.go.dev/github.com/redis/go-redis/v9@v9.7.0#Script.Run):

> Run optimistically uses EVALSHA to run the script. If script does not exist it is retried using EVAL.

# How the Problems Are Solved

Add the `NOSCRIPT` error prefix to the whitelist.

# Additional Changes

- none

# Additional Context

- Introduced in: https://github.com/zitadel/zitadel/pull/8890
- Workaround for: https://github.com/redis/go-redis/issues/3203
