### PR TITLE
fix(migrations): clean stale org fields using events

### DIFF
--- a/cmd/setup/39.sql
+++ b/cmd/setup/39.sql
@@ -1,6 +1,8 @@
 DELETE FROM eventstore.fields
 WHERE aggregate_type = 'org'
-AND aggregate_id NOT IN (
-	SELECT id
-	FROM projections.orgs1
+AND aggregate_id IN (
+	SELECT aggregate_id
+	FROM eventstore.events2
+	WHERE aggregate_type = 'org'
+	AND event_type = 'org.removed'
 );


### PR DESCRIPTION
# Which Problems Are Solved

Migration step 39 is supposed to cleanup stale organization entries in the eventstore.fields table. In order to do this it used the projection to check which orgs still exist.

During initial setup of ZITADEL the first instance with the organization is created. Howevet, the projections are filled after all migrations are done. With the organization projection empty, the fields of the first org would be deleted.

This was discovered during development of a new field type. The accosiated events did not yet have any projection based filled assigned. It seems fields with a pre-fill projection are somehow restored. Therefore a restoration migration isn't required IMO.

# How the Problems Are Solved

Query the event store for `org.removed` events instead. This has the drawback of using a sequential scan on the eventstore, making the migration more expensive.

# Additional Changes

- none

# Additional Context

- Introduced in https://github.com/zitadel/zitadel/pull/8946
