### PR TITLE
fix(api): map REST request body in user invite requests

### DIFF
--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -1091,6 +1091,7 @@ service UserService {
   rpc CreateInviteCode (CreateInviteCodeRequest) returns (CreateInviteCodeResponse) {
     option (google.api.http) = {
       post: "/v2/users/{user_id}/invite_code"
+      body: "*"
     };
 
     option (zitadel.protoc_gen_zitadel.v2.options) = {
@@ -1140,6 +1141,7 @@ service UserService {
   rpc VerifyInviteCode (VerifyInviteCodeRequest) returns (VerifyInviteCodeResponse) {
     option (google.api.http) = {
       post: "/v2/users/{user_id}/invite_code/verify"
+      body: "*"
     };
 
     option (zitadel.protoc_gen_zitadel.v2.options) = {


### PR DESCRIPTION
# Which Problems Are Solved

The `CreateInviteCode` and `VerifyInviteCode` methods missed the body mapping.

# How the Problems Are Solved

Added the mapping.

# Additional Changes

None

# Additional Context

Noticed during internal login UI tests using REST