### PR TITLE
docs: fix typo where Enpoints should be Endpoints

### DIFF
--- a/docs/docs/apis/observability/health.md
+++ b/docs/docs/apis/observability/health.md
@@ -1,6 +1,6 @@
 ---
-title: ZITADEL Ready and Health Enpoints
-sidebar_label: Ready and Health Enpoints
+title: ZITADEL Ready and Health Endpoints
+sidebar_label: Ready and Health Endpoints
 ---
 
 ZITADEL exposes a `Ready`- and `Healthy` endpoint to allow external systems like load balancers, orchestration systems, uptime probes and others to check the status.


### PR DESCRIPTION
# Which Problems Are Solved

- Fixed a typo in docs/docs/apis/observability/health.md where `Enpoints` should be `Endpoints`

<!--
# How the Problems Are Solved

# Additional Changes

# Additional Context
-->