### PR TITLE
fix(eventstore): set owner of previous events if present

### DIFF
--- a/internal/eventstore/v3/sequence.go
+++ b/internal/eventstore/v3/sequence.go
@@ -124,7 +124,18 @@ func scanToSequence(rows *sql.Rows, sequences []*latestSequence) error {
 		return nil
 	}
 	sequence.sequence = currentSequence
-	if sequence.aggregate.ResourceOwner == "" {
+	if resourceOwner != "" && sequence.aggregate.ResourceOwner != "" && sequence.aggregate.ResourceOwner != resourceOwner {
+		logging.WithFields(
+			"current_sequence", sequence.sequence,
+			"instance_id", sequence.aggregate.InstanceID,
+			"agg_type", sequence.aggregate.Type,
+			"agg_id", sequence.aggregate.ID,
+			"current_owner", resourceOwner,
+			"provided_owner", sequence.aggregate.ResourceOwner,
+		).Info("would have set wrong resource owner")
+	}
+	// set resource owner from previous events
+	if resourceOwner != "" {
 		sequence.aggregate.ResourceOwner = resourceOwner
 	}
 


### PR DESCRIPTION
# Which Problems Are Solved

It is currently possible to change the resource owner on an event stream

# How the Problems Are Solved

The eventstore framework sets the resource owner of the latest event of the aggregate id.

# Additional Context

part of https://github.com/zitadel/zitadel/issues/9072
