### PR TITLE
fix(setup): make step 41 repeatable

### DIFF
--- a/cmd/setup/41.go
+++ b/cmd/setup/41.go
@@ -11,6 +11,8 @@ import (
 
 type FillFieldsForInstanceDomains struct {
 	eventstore *eventstore.Eventstore
+
+	Version string `json:"version"`
 }
 
 func (mig *FillFieldsForInstanceDomains) Execute(ctx context.Context, _ eventstore.Event) error {
@@ -37,4 +39,9 @@ func (mig *FillFieldsForInstanceDomains) Execute(ctx context.Context, _ eventsto
 
 func (mig *FillFieldsForInstanceDomains) String() string {
 	return "41_fill_fields_for_instance_domains"
+}
+
+func (f *FillFieldsForInstanceDomains) Check(lastRun map[string]interface{}) bool {
+	currentVersion, _ := lastRun["version"].(string)
+	return currentVersion != f.Version
 }

--- a/cmd/setup/41.go
+++ b/cmd/setup/41.go
@@ -38,7 +38,7 @@ func (mig *FillFieldsForInstanceDomains) Execute(ctx context.Context, _ eventsto
 }
 
 func (mig *FillFieldsForInstanceDomains) String() string {
-	return "41_fill_fields_for_instance_domains"
+	return "repeatable_fill_fields_for_instance_domains"
 }
 
 func (f *FillFieldsForInstanceDomains) Check(lastRun map[string]interface{}) bool {

--- a/cmd/setup/41.go
+++ b/cmd/setup/41.go
@@ -11,8 +11,6 @@ import (
 
 type FillFieldsForInstanceDomains struct {
 	eventstore *eventstore.Eventstore
-
-	Version string `json:"version"`
 }
 
 func (mig *FillFieldsForInstanceDomains) Execute(ctx context.Context, _ eventstore.Event) error {

--- a/cmd/setup/41.go
+++ b/cmd/setup/41.go
@@ -42,6 +42,5 @@ func (mig *FillFieldsForInstanceDomains) String() string {
 }
 
 func (f *FillFieldsForInstanceDomains) Check(lastRun map[string]interface{}) bool {
-	currentVersion, _ := lastRun["version"].(string)
-	return currentVersion != f.Version
+	return true
 }

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -128,7 +128,6 @@ type Steps struct {
 	s38BackChannelLogoutNotificationStart   *BackChannelLogoutNotificationStart
 	s40InitPushFunc                         *InitPushFunc
 	s39DeleteStaleOrgFields                 *DeleteStaleOrgFields
-	s41FillFieldsForInstanceDomains         *FillFieldsForInstanceDomains
 }
 
 func MustNewSteps(v *viper.Viper) *Steps {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -171,7 +171,6 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s38BackChannelLogoutNotificationStart = &BackChannelLogoutNotificationStart{dbClient: esPusherDBClient, esClient: eventstoreClient}
 	steps.s39DeleteStaleOrgFields = &DeleteStaleOrgFields{dbClient: esPusherDBClient}
 	steps.s40InitPushFunc = &InitPushFunc{dbClient: esPusherDBClient}
-	steps.s41FillFieldsForInstanceDomains = &FillFieldsForInstanceDomains{eventstore: eventstoreClient}
 
 	err = projection.Create(ctx, projectionDBClient, eventstoreClient, config.Projections, nil, nil, nil)
 	logging.OnError(err).Fatal("unable to start projections")
@@ -187,6 +186,10 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		&projectionTables{
 			es:      eventstoreClient,
 			Version: build.Version(),
+		},
+		&FillFieldsForInstanceDomains{
+			eventstore: eventstoreClient,
+			Version:    build.Version(),
 		},
 	}
 
@@ -219,7 +222,6 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s35AddPositionToIndexEsWm,
 		steps.s36FillV2Milestones,
 		steps.s38BackChannelLogoutNotificationStart,
-		steps.s41FillFieldsForInstanceDomains,
 	} {
 		mustExecuteMigration(ctx, eventstoreClient, step, "migration failed")
 	}

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -189,7 +189,6 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		},
 		&FillFieldsForInstanceDomains{
 			eventstore: eventstoreClient,
-			Version:    build.Version(),
 		},
 	}
 


### PR DESCRIPTION
# Which Problems Are Solved

setup step 41 cannot handle downgrades at the moment. This step writes the instance domain to the fields table. If there are new instances created during the downgraded version is running there would be domain missing in the fields afterwards.

# How the Problems Are Solved

Make step 41 repeatable