### PR TITLE
fix(login): avoid disallowed languages with custom texts

### DIFF
--- a/internal/i18n/translator.go
+++ b/internal/i18n/translator.go
@@ -68,6 +68,16 @@ func (t *Translator) AddMessages(tag language.Tag, messages ...Message) error {
 	if len(messages) == 0 {
 		return nil
 	}
+	var isAllowed bool
+	for _, allowed := range t.allowedLanguages {
+		if allowed == tag {
+			isAllowed = true
+			break
+		}
+	}
+	if !isAllowed {
+		return nil
+	}
 	i18nMessages := make([]*i18n.Message, len(messages))
 	for i, message := range messages {
 		i18nMessages[i] = &i18n.Message{

--- a/internal/i18n/translator.go
+++ b/internal/i18n/translator.go
@@ -64,6 +64,8 @@ func (t *Translator) SupportedLanguages() []language.Tag {
 	return t.allowedLanguages
 }
 
+// AddMessages adds messages to the translator for the given language tag.
+// If the tag is not in the allowed languages, the messages are not added.
 func (t *Translator) AddMessages(tag language.Tag, messages ...Message) error {
 	if len(messages) == 0 {
 		return nil


### PR DESCRIPTION
# Which Problems Are Solved

If a browsers default language is not allowed by instance restrictions, the login still renders it if it finds any custom texts for this language. In that case, the login tries to render all texts on all screens in this language using custom texts, even for texts that are not customized.

![image](https://github.com/user-attachments/assets/1038ecac-90c9-4352-b75d-e7466a639711)
![image](https://github.com/user-attachments/assets/e4cbd0fb-a60e-41c5-a404-23e6d144de6c)
![image](https://github.com/user-attachments/assets/98d8b0b9-e082-48ae-9540-66792341fe1c)

# How the Problems Are Solved

If a custom messages language is not allowed, it is not added to the i18n library's translations bundle. The library correctly falls back to the instances default language.

![image](https://github.com/user-attachments/assets/fadac92e-bdea-4f8c-b6c2-2aa6476b89b3)

This library method only receives messages for allowed languages
![image](https://github.com/user-attachments/assets/33081929-d3a5-4b0f-b838-7b69f88c13bc)

# Additional Context

Reported via support request