### PR TITLE
fix(saml): parse xsd:duration format correctly

### DIFF
--- a/internal/idp/providers/saml/saml_test.go
+++ b/internal/idp/providers/saml/saml_test.go
@@ -3,6 +3,7 @@ package saml
 import (
 	"encoding/xml"
 	"testing"
+	"time"
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
@@ -254,6 +255,31 @@ func TestParseMetadata(t *testing.T) {
 			},
 			&saml.EntityDescriptor{
 				EntityID: "http://localhost:8000/metadata",
+				IDPSSODescriptors: []saml.IDPSSODescriptor{
+					{
+						XMLName: xml.Name{
+							Space: "urn:oasis:names:tc:SAML:2.0:metadata",
+							Local: "IDPSSODescriptor",
+						},
+						SingleSignOnServices: []saml.Endpoint{
+							{
+								Binding:  saml.HTTPRedirectBinding,
+								Location: "http://localhost:8000/sso",
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"valid entities using xsd duration descriptor",
+			args{
+				metadata: []byte(`<?xml version="1.0" encoding="UTF-8"?><EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" cacheDuration="PT5H"><EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8000/metadata" cacheDuration="PT5H"><IDPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"><SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:8000/sso"></SingleSignOnService></IDPSSODescriptor></EntityDescriptor></EntitiesDescriptor>`),
+			},
+			&saml.EntityDescriptor{
+				EntityID:      "http://localhost:8000/metadata",
+				CacheDuration: 5 * time.Hour,
 				IDPSSODescriptors: []saml.IDPSSODescriptor{
 					{
 						XMLName: xml.Name{


### PR DESCRIPTION
# Which Problems Are Solved

SAML IdPs exposing an `EntitiesDescriptor` using an `xsd:duration` time format for the `cacheDuration` property (e.g. `PT5H`) failed parsing.

# How the Problems Are Solved

Handle the unmarshalling for `EntitiesDescriptor` specifically. [crewjam/saml](https://github.com/crewjam/saml/blob/bbccb7933d5f60512ebc6caec7120c604581983d/metadata.go#L88-L103) already did this for `EntitiyDescriptor` the same way.

# Additional Changes

None

# Additional Context

- reported by a customer
- needs to be backported to current cloud version (2.66.x)
