### PR TITLE
fix: Typo in Init MFA OTP screen

### DIFF
--- a/internal/api/ui/login/static/i18n/de.yaml
+++ b/internal/api/ui/login/static/i18n/de.yaml
@@ -108,7 +108,7 @@ InitMFAPrompt:
 InitMFAOTP:
   Title: Zwei-Faktor-Authentifizierung
   Description: Erstelle deinen Zweitfaktor. Installiere eine Authentifizierungs-App, wenn du noch keine hast.
-  OTPDescription: Scanne den Code mit einer Authentifizierungs-App (z.B. Google/Mircorsoft Authenticator, Authy) oder kopiere das Secret und gib anschliessend den Code ein.
+  OTPDescription: Scanne den Code mit einer Authentifizierungs-App (z.B. Google/Microsoft Authenticator, Authy) oder kopiere das Secret und gib anschliessend den Code ein.
   SecretLabel: Secret
   CodeLabel: Code
   NextButtonText: Weiter


### PR DESCRIPTION
# Which Problems Are Solved

Type in the word Microsoft on the init mfa otp screen
# How the Problems Are Solved

Fix typo
