### PR TITLE
fix(cache): convert expiry to number

### DIFF
--- a/internal/cache/connector/redis/get.lua
+++ b/internal/cache/connector/redis/get.lua
@@ -13,8 +13,8 @@ end
 
 -- max-age must be checked manually
 local expiry = getCall("HGET", object_id, "expiry")
-if not (expiry == nil) and expiry > 0 then
-    if getTime() > expiry then
+if not (expiry == nil) and tonumber(expiry) > 0 then
+    if getTime() > tonumber(expiry) then
         remove(object_id)
         return nil
     end


### PR DESCRIPTION
# Which Problems Are Solved

When `LastUseAge` was configured properly, the Redis LUA script uses manual cleanup for `MaxAge` based expiry. The expiry obtained from Redis apears to be a string and was compared to an int, resulting in a script error.

# How the Problems Are Solved

Convert expiry to number.

# Additional Changes

- none

# Additional Context

- Introduced in #8822
- LastUseAge was fixed in #9097
- closes https://github.com/zitadel/zitadel/issues/9140