### PR TITLE
fix(oidc): ignore algorithm for legacy signer

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -530,9 +530,6 @@ OIDC:
   GrantTypeRefreshToken: true # ZITADEL_OIDC_GRANTTYPEREFRESHTOKEN
   RequestObjectSupported: true # ZITADEL_OIDC_REQUESTOBJECTSUPPORTED
 
-  # Deprecated: The signing algorithm is determined by the generated keys.
-  # Use the web keys resource to generate keys with different algorithms.
-  SigningKeyAlgorithm: RS256 # ZITADEL_OIDC_SIGNINGKEYALGORITHM
   # Sets the default values for lifetime and expiration for OIDC
   # This default can be overwritten in the default instance configuration and for each instance during runtime
   # !!! Changing this after the initial setup will have no impact without a restart !!!

--- a/internal/api/oidc/key.go
+++ b/internal/api/oidc/key.go
@@ -354,15 +354,15 @@ func (o *OPStorage) getSigningKey(ctx context.Context) (op.SigningKey, error) {
 	if keys.State != nil {
 		position = keys.State.Position
 	}
-	return nil, o.refreshSigningKey(ctx, o.signingKeyAlgorithm, position)
+	return nil, o.refreshSigningKey(ctx, position)
 }
 
-func (o *OPStorage) refreshSigningKey(ctx context.Context, algorithm string, position float64) error {
+func (o *OPStorage) refreshSigningKey(ctx context.Context, position float64) error {
 	ok, err := o.ensureIsLatestKey(ctx, position)
 	if err != nil || !ok {
 		return zerrors.ThrowInternal(err, "OIDC-ASfh3", "cannot ensure that projection is up to date")
 	}
-	err = o.lockAndGenerateSigningKeyPair(ctx, algorithm)
+	err = o.lockAndGenerateSigningKeyPair(ctx)
 	if err != nil {
 		return zerrors.ThrowInternal(err, "OIDC-ADh31", "could not create signing key")
 	}
@@ -393,7 +393,7 @@ func PrivateKeyToSigningKey(key query.PrivateKey, algorithm crypto.EncryptionAlg
 	}, nil
 }
 
-func (o *OPStorage) lockAndGenerateSigningKeyPair(ctx context.Context, algorithm string) error {
+func (o *OPStorage) lockAndGenerateSigningKeyPair(ctx context.Context) error {
 	logging.Info("lock and generate signing key pair")
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -409,7 +409,7 @@ func (o *OPStorage) lockAndGenerateSigningKeyPair(ctx context.Context, algorithm
 		return err
 	}
 
-	return o.command.GenerateSigningKeyPair(setOIDCCtx(ctx), algorithm)
+	return o.command.GenerateSigningKeyPair(setOIDCCtx(ctx), "RS256")
 }
 
 func (o *OPStorage) getMaxKeySequence(ctx context.Context) (float64, error) {

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -31,7 +31,6 @@ type Config struct {
 	AuthMethodPrivateKeyJWT           bool
 	GrantTypeRefreshToken             bool
 	RequestObjectSupported            bool
-	SigningKeyAlgorithm               string
 	DefaultAccessTokenLifetime        time.Duration
 	DefaultIdTokenLifetime            time.Duration
 	DefaultRefreshTokenIdleExpiration time.Duration
@@ -71,7 +70,6 @@ type OPStorage struct {
 	defaultLogoutURLV2                string
 	defaultAccessTokenLifetime        time.Duration
 	defaultIdTokenLifetime            time.Duration
-	signingKeyAlgorithm               string
 	defaultRefreshTokenIdleExpiration time.Duration
 	defaultRefreshTokenExpiration     time.Duration
 	encAlg                            crypto.EncryptionAlgorithm
@@ -162,7 +160,6 @@ func NewServer(
 		jwksCacheControlMaxAge:     config.JWKSCacheControlMaxAge,
 		fallbackLogger:             fallbackLogger,
 		hasher:                     hasher,
-		signingKeyAlgorithm:        config.SigningKeyAlgorithm,
 		encAlg:                     encryptionAlg,
 		opCrypto:                   op.NewAESCrypto(opConfig.CryptoKey),
 		assetAPIPrefix:             assets.AssetAPI(),
@@ -232,7 +229,6 @@ func newStorage(config Config, command *command.Commands, query *query.Queries, 
 		defaultLoginURL:                   fmt.Sprintf("%s%s?%s=", login.HandlerPrefix, login.EndpointLogin, login.QueryAuthRequestID),
 		defaultLoginURLV2:                 config.DefaultLoginURLV2,
 		defaultLogoutURLV2:                config.DefaultLogoutURLV2,
-		signingKeyAlgorithm:               config.SigningKeyAlgorithm,
 		defaultAccessTokenLifetime:        config.DefaultAccessTokenLifetime,
 		defaultIdTokenLifetime:            config.DefaultIdTokenLifetime,
 		defaultRefreshTokenIdleExpiration: config.DefaultRefreshTokenIdleExpiration,


### PR DESCRIPTION
# Which Problems Are Solved

It was possible to set a diffent algorithm for the legacy signer. This is not supported howerver and breaks the token endpoint. 

# How the Problems Are Solved

Remove the OIDC.SigningKeyAlgorithm config option and hard-code RS256 for the legacy signer.

# Additional Changes

- none

# Additional Context

Only RS256 is supported by the legacy signer. It was mentioned in the comment of the config not to use it and use the webkeys resource instead.

- closes #9121
