### PR TITLE
fix: include tzdata to validate timezones in scim

### DIFF
--- a/internal/api/scim/resources/user_metadata.go
+++ b/internal/api/scim/resources/user_metadata.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+	// import timezone database to ensure it is available at runtime
+	// data is required to validate time zones.
+	_ "time/tzdata"
 
 	"github.com/zitadel/logging"
 	"golang.org/x/text/language"


### PR DESCRIPTION
# Which Problems Are Solved
- include tzdata in the binary to correctly validate time zones in the scim layer if the os doesn't have timezone data available.

# How the Problems Are Solved
- by importing the go pkg `"time/tzdata"`

# Additional Context
Part of https://github.com/zitadel/zitadel/issues/8140