### PR TITLE
fix(eventstore): correct crdb sql push function

### DIFF
--- a/cmd/setup/40.go
+++ b/cmd/setup/40.go
@@ -48,5 +48,5 @@ func (mig *InitPushFunc) Execute(ctx context.Context, _ eventstore.Event) (err e
 }
 
 func (mig *InitPushFunc) String() string {
-	return "40_init_push_func_v3"
+	return "40_init_push_func_v4"
 }

--- a/cmd/setup/40/cockroach/40_init_push_func.sql
+++ b/cmd/setup/40/cockroach/40_init_push_func.sql
@@ -97,7 +97,7 @@ BEGIN
                 , ("c").payload
                 , ("c").creator
                 , COALESCE(current_owner, ("c").owner) -- AS owner
-                , EXTRACT(EPOCH FROM NOW()) -- AS position
+                , cluster_logical_timestamp() -- AS position
                 , ordinality::INT -- AS in_tx_order
             FROM
                 UNNEST(commands) WITH ORDINALITY AS c


### PR DESCRIPTION
# Which Problems Are Solved

https://github.com/zitadel/zitadel/pull/9186 introduced the new `push` sql function for cockroachdb. The function used the wrong database function to generate the position of the event and would therefore insert events at a position before events created with an old Zitadel version. 

# How the Problems Are Solved

Instead of `EXTRACT(EPOCH FROM NOW())`, `cluster_logical_timestamp()` is used to calculate the position of an event.

# Additional Context

- Introduced in https://github.com/zitadel/zitadel/pull/9186
- Affected versions: https://github.com/zitadel/zitadel/releases/tag/v2.67.3
