### PR TITLE
fix: correct unique constraints and field when org remove event is created

### DIFF
--- a/cmd/setup/47.go
+++ b/cmd/setup/47.go
@@ -1,0 +1,39 @@
+package setup
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	"github.com/zitadel/logging"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+type CleanupOrgDomainRemoved struct {
+	eventstoreClient *database.DB
+}
+
+var (
+	//go:embed 47/*.sql
+	cleanupOrgDomainRemoved embed.FS
+)
+
+func (mig *CleanupOrgDomainRemoved) Execute(ctx context.Context, _ eventstore.Event) error {
+	statements, err := readStatements(cleanupOrgDomainRemoved, "47", "")
+	if err != nil {
+		return err
+	}
+	for _, stmt := range statements {
+		logging.WithFields("file", stmt.file, "migration", mig.String()).Info("execute statement")
+		if _, err := mig.eventstoreClient.ExecContext(ctx, stmt.query); err != nil {
+			return fmt.Errorf("%s %s: %w", mig.String(), stmt.file, err)
+		}
+	}
+	return nil
+}
+
+func (*CleanupOrgDomainRemoved) String() string {
+	return "47_cleanup_org_domain_removed"
+}

--- a/cmd/setup/47/01-unique-constraints.sql
+++ b/cmd/setup/47/01-unique-constraints.sql
@@ -1,0 +1,43 @@
+WITH removed_domains AS (
+    select
+        e.instance_id
+        , e.payload::json->>'domain' as domain
+    from eventstore.events2 e
+    where e.instance_id = $1
+        and e.aggregate_type = 'org'
+        and e.event_type = 'org.domain.removed'
+        and not exists (
+            select 1
+            from eventstore.events2 e2
+            where e2.instance_id = e.instance_id
+                and e2.aggregate_type = e.aggregate_type
+                and e2.aggregate_id = e.aggregate_id
+                and e2.payload = e.payload
+                and e2.event_type = 'org.domain.verified'
+                and e2.sequence > e.sequence
+        )
+), delete_unique_constraints_dry as (
+    delete from eventstore.unique_constraints as uc
+        using removed_domains as rd
+    where uc.instance_id = rd.instance_id
+           and uc.unique_type = 'org_domain'
+           and uc.unique_field = rd.domain
+           returning *
+), delete_unique_constraints as (
+    delete from eventstore.unique_constraints as uc
+        using delete_unique_constraints_dry as d
+    where uc.instance_id = d.instance_id
+           and uc.unique_type = d.unique_type
+           and uc.unique_field = d.unique_field
+)
+SELECT
+    rd.instance_id
+    , STRING_AGG ( uc.unique_field, ',') deleted_constraints
+FROM removed_domains rd
+    left join delete_unique_constraints_dry uc
+        on uc.instance_id = rd.instance_id
+group by
+    instance_id
+;
+
+

--- a/cmd/setup/47/02-fields.sql
+++ b/cmd/setup/47/02-fields.sql
@@ -1,0 +1,54 @@
+WITH removed_domains AS (
+    select
+        e.instance_id
+        , e.aggregate_type
+        , e.aggregate_id
+        , e.payload::json->>'domain' as domain
+    from eventstore.events2 e
+    where e.instance_id = $1
+        and e.aggregate_type = 'org'
+        and e.event_type = 'org.domain.removed'
+        and not exists (
+            select 1
+            from eventstore.events2 e2
+            where e2.instance_id = e.instance_id
+                and e2.aggregate_type = e.aggregate_type
+                and e2.aggregate_id = e.aggregate_id
+                and e2.payload = e.payload
+                and e2.event_type = 'org.domain.verified'
+                and e2.sequence > e.sequence
+        )
+), delete_fields_dry as (
+    delete from eventstore.fields as f
+        using removed_domains as rd
+        where f.instance_id = rd.instance_id
+            and f.resource_owner = rd.aggregate_id
+            and f.aggregate_type = rd.aggregate_type
+            and f.object_type = 'org_domain'
+            and f.object_id = rd.domain
+            and f.field_name = 'verified'
+           returning *
+), delete_fields as(
+    delete from eventstore.fields as f
+    using delete_fields_dry as d
+    where f.id = d.id
+        and f.instance_id = d.instance_id
+        and f.resource_owner = d.aggregate_id
+        and f.aggregate_type = d.aggregate_type
+        and f.object_type = d.object_type
+        and f.object_id = d.object_id
+        and f.field_name = d.field_name
+)
+SELECT
+    rd.instance_id
+    , rd.aggregate_type
+    , rd.aggregate_id
+    , STRING_AGG ( f.object_id, ',') deleted_fields
+FROM removed_domains rd
+    left join delete_fields_dry f
+      on f.instance_id = rd.instance_id
+          and f.resource_owner = rd.aggregate_id
+          and f.aggregate_type = rd.aggregate_type
+group by
+    instance_id, aggregate_type, aggregate_id
+;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -135,6 +135,7 @@ type Steps struct {
 	s44ReplaceCurrentSequencesIndex         *ReplaceCurrentSequencesIndex
 	s45CorrectProjectOwners                 *CorrectProjectOwners
 	s46InitPermissionFunctions              *InitPermissionFunctions
+	s47CleanupOrgDomainRemoved              *CleanupOrgDomainRemoved
 }
 
 func MustNewSteps(v *viper.Viper) *Steps {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -170,6 +170,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s44ReplaceCurrentSequencesIndex = &ReplaceCurrentSequencesIndex{dbClient: dbClient}
 	steps.s45CorrectProjectOwners = &CorrectProjectOwners{eventstore: eventstoreClient}
 	steps.s46InitPermissionFunctions = &InitPermissionFunctions{eventstoreClient: dbClient}
+	steps.s47CleanupOrgDomainRemoved = &CleanupOrgDomainRemoved{eventstoreClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	logging.OnError(err).Fatal("unable to start projections")

--- a/internal/repository/org/domain.go
+++ b/internal/repository/org/domain.go
@@ -295,22 +295,9 @@ func (e *DomainRemovedEvent) UniqueConstraints() []*eventstore.UniqueConstraint 
 
 func (e *DomainRemovedEvent) Fields() []*eventstore.FieldOperation {
 	return []*eventstore.FieldOperation{
-		eventstore.SetField(
+		eventstore.RemoveSearchFieldsByAggregateAndObject(
 			e.Aggregate(),
 			domainSearchObject(e.Domain),
-			OrgDomainVerifiedSearchField,
-			&eventstore.Value{
-				Value:       false,
-				ShouldIndex: false,
-			},
-
-			eventstore.FieldTypeInstanceID,
-			eventstore.FieldTypeResourceOwner,
-			eventstore.FieldTypeAggregateType,
-			eventstore.FieldTypeAggregateID,
-			eventstore.FieldTypeObjectType,
-			eventstore.FieldTypeObjectID,
-			eventstore.FieldTypeFieldName,
 		),
 	}
 }


### PR DESCRIPTION
# Which Problems Are Solved

In a specific situation of a name change of the organization, the unique constraint is still existing even though the org domain is removed, and the fields get only set to org domain not verified and not removed.

# How the Problems Are Solved

Remove unique constraints which should not exist anymore.
Remove field which should not exist anymore.
Fix logic for OrgDomainRemoved event, so that fields are removed in the future.

# Additional Changes

None

# Additional Context

None
