### PR TITLE
fix: pass through original triggering event from notification request metrics

### DIFF
--- a/internal/notification/channels/channel.go
+++ b/internal/notification/channels/channel.go
@@ -3,7 +3,7 @@ package channels
 import "github.com/zitadel/zitadel/internal/eventstore"
 
 type Message interface {
-	GetTriggeringEvent() eventstore.Event
+	GetTriggeringEventType() eventstore.EventType
 	GetContent() (string, error)
 }
 

--- a/internal/notification/channels/instrumenting/logging.go
+++ b/internal/notification/channels/instrumenting/logging.go
@@ -13,7 +13,7 @@ func logMessages(ctx context.Context, channel channels.NotificationChannel) chan
 	return channels.HandleMessageFunc(func(message channels.Message) error {
 		logEntry := logging.WithFields(
 			"instance", authz.GetInstance(ctx).InstanceID(),
-			"triggering_event_type", message.GetTriggeringEvent().Type(),
+			"triggering_event_type", message.GetTriggeringEventType(),
 		)
 		logEntry.Debug("sending notification")
 		err := channel.HandleMessage(message)

--- a/internal/notification/channels/instrumenting/metrics.go
+++ b/internal/notification/channels/instrumenting/metrics.go
@@ -25,7 +25,7 @@ func countMessages(ctx context.Context, channel channels.NotificationChannel, su
 
 func addCount(ctx context.Context, metricName string, message channels.Message, err error) {
 	labels := map[string]attribute.Value{
-		"triggering_event_typey": attribute.StringValue(string(message.GetTriggeringEvent().Type())),
+		"triggering_event_typey": attribute.StringValue(string(message.GetTriggeringEventType())),
 		"instance":               attribute.StringValue(authz.GetInstance(ctx).InstanceID()),
 	}
 	if err != nil {

--- a/internal/notification/handlers/back_channel_logout.go
+++ b/internal/notification/handlers/back_channel_logout.go
@@ -191,7 +191,7 @@ func (u *backChannelLogoutNotifier) sendLogoutToken(ctx context.Context, oidcSes
 	if err != nil {
 		return err
 	}
-	err = types.SendSecurityTokenEvent(ctx, set.Config{CallURL: oidcSession.BackChannelLogoutURI}, u.channels, &LogoutTokenMessage{LogoutToken: token}, e).WithoutTemplate()
+	err = types.SendSecurityTokenEvent(ctx, set.Config{CallURL: oidcSession.BackChannelLogoutURI}, u.channels, &LogoutTokenMessage{LogoutToken: token}, e.Type()).WithoutTemplate()
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (b *backChannelLogoutSession) AppendEvents(events ...eventstore.Event) {
 				BackChannelLogoutURI: e.BackChannelLogoutURI,
 			})
 		case *sessionlogout.BackChannelLogoutSentEvent:
-			slices.DeleteFunc(b.sessions, func(session backChannelLogoutOIDCSessions) bool {
+			b.sessions = slices.DeleteFunc(b.sessions, func(session backChannelLogoutOIDCSessions) bool {
 				return session.OIDCSessionID == e.OIDCSessionID
 			})
 		}

--- a/internal/notification/handlers/quota_notifier.go
+++ b/internal/notification/handlers/quota_notifier.go
@@ -72,7 +72,7 @@ func (u *quotaNotifier) reduceNotificationDue(event eventstore.Event) (*handler.
 		if alreadyHandled {
 			return nil
 		}
-		err = types.SendJSON(ctx, webhook.Config{CallURL: e.CallURL, Method: http.MethodPost}, u.channels, e, e).WithoutTemplate()
+		err = types.SendJSON(ctx, webhook.Config{CallURL: e.CallURL, Method: http.MethodPost}, u.channels, e, e.EventType).WithoutTemplate()
 		if err != nil {
 			return err
 		}

--- a/internal/notification/handlers/telemetry_pusher.go
+++ b/internal/notification/handlers/telemetry_pusher.go
@@ -104,7 +104,7 @@ func (t *telemetryPusher) pushMilestone(ctx context.Context, e *milestone.Reache
 				Type:           e.MilestoneType,
 				ReachedDate:    e.GetReachedDate(),
 			},
-			e,
+			e.EventType,
 		).WithoutTemplate(); err != nil {
 			return err
 		}

--- a/internal/notification/handlers/user_notifier_legacy.go
+++ b/internal/notification/handlers/user_notifier_legacy.go
@@ -169,7 +169,7 @@ func (u *userNotifierLegacy) reduceInitCodeAdded(event eventstore.Event) (*handl
 		if err != nil {
 			return err
 		}
-		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
+		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type()).
 			SendUserInitCode(ctx, notifyUser, code, e.AuthRequestID)
 		if err != nil {
 			return err
@@ -226,7 +226,7 @@ func (u *userNotifierLegacy) reduceEmailCodeAdded(event eventstore.Event) (*hand
 		if err != nil {
 			return err
 		}
-		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
+		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type()).
 			SendEmailVerificationCode(ctx, notifyUser, code, e.URLTemplate, e.AuthRequestID)
 		if err != nil {
 			return err
@@ -286,9 +286,9 @@ func (u *userNotifierLegacy) reducePasswordCodeAdded(event eventstore.Event) (*h
 			return err
 		}
 		generatorInfo := new(senders.CodeGeneratorInfo)
-		notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e)
+		notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type())
 		if e.NotificationType == domain.NotificationTypeSms {
-			notify = types.SendSMS(ctx, u.channels, translator, notifyUser, colors, e, generatorInfo)
+			notify = types.SendSMS(ctx, u.channels, translator, notifyUser, colors, e.Type(), generatorInfo)
 		}
 		err = notify.SendPasswordCode(ctx, notifyUser, code, e.URLTemplate, e.AuthRequestID)
 		if err != nil {
@@ -382,7 +382,7 @@ func (u *userNotifierLegacy) reduceOTPSMS(
 		return nil, err
 	}
 	generatorInfo := new(senders.CodeGeneratorInfo)
-	notify := types.SendSMS(ctx, u.channels, translator, notifyUser, colors, event, generatorInfo)
+	notify := types.SendSMS(ctx, u.channels, translator, notifyUser, colors, event.Type(), generatorInfo)
 	err = notify.SendOTPSMSCode(ctx, plainCode, expiry)
 	if err != nil {
 		return nil, err
@@ -504,7 +504,7 @@ func (u *userNotifierLegacy) reduceOTPEmail(
 	if err != nil {
 		return nil, err
 	}
-	notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, event)
+	notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, event.Type())
 	err = notify.SendOTPEmailCode(ctx, url, plainCode, expiry)
 	if err != nil {
 		return nil, err
@@ -554,7 +554,7 @@ func (u *userNotifierLegacy) reduceDomainClaimed(event eventstore.Event) (*handl
 		if err != nil {
 			return err
 		}
-		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
+		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type()).
 			SendDomainClaimed(ctx, notifyUser, e.UserName)
 		if err != nil {
 			return err
@@ -608,7 +608,7 @@ func (u *userNotifierLegacy) reducePasswordlessCodeRequested(event eventstore.Ev
 		if err != nil {
 			return err
 		}
-		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
+		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type()).
 			SendPasswordlessRegistrationLink(ctx, notifyUser, code, e.ID, e.URLTemplate)
 		if err != nil {
 			return err
@@ -667,7 +667,7 @@ func (u *userNotifierLegacy) reducePasswordChanged(event eventstore.Event) (*han
 		if err != nil {
 			return err
 		}
-		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
+		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type()).
 			SendPasswordChange(ctx, notifyUser)
 		if err != nil {
 			return err
@@ -722,7 +722,7 @@ func (u *userNotifierLegacy) reducePhoneCodeAdded(event eventstore.Event) (*hand
 			return err
 		}
 		generatorInfo := new(senders.CodeGeneratorInfo)
-		if err = types.SendSMS(ctx, u.channels, translator, notifyUser, colors, e, generatorInfo).
+		if err = types.SendSMS(ctx, u.channels, translator, notifyUser, colors, e.Type(), generatorInfo).
 			SendPhoneVerificationCode(ctx, code); err != nil {
 			return err
 		}
@@ -776,7 +776,7 @@ func (u *userNotifierLegacy) reduceInviteCodeAdded(event eventstore.Event) (*han
 		if err != nil {
 			return err
 		}
-		notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e)
+		notify := types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e.Type())
 		err = notify.SendInviteCode(ctx, notifyUser, code, e.ApplicationName, e.URLTemplate, e.AuthRequestID)
 		if err != nil {
 			return err

--- a/internal/notification/handlers/user_notifier_legacy_test.go
+++ b/internal/notification/handlers/user_notifier_legacy_test.go
@@ -1539,11 +1539,11 @@ func newUserNotifierLegacy(t *testing.T, ctrl *gomock.Controller, queries *mock.
 	channel := channel_mock.NewMockNotificationChannel(ctrl)
 	if w.err == nil {
 		if w.message != nil {
-			w.message.TriggeringEvent = a.event
+			w.message.TriggeringEventType = a.event.Type()
 			channel.EXPECT().HandleMessage(w.message).Return(nil)
 		}
 		if w.messageSMS != nil {
-			w.messageSMS.TriggeringEvent = a.event
+			w.messageSMS.TriggeringEventType = a.event.Type()
 			channel.EXPECT().HandleMessage(w.messageSMS).DoAndReturn(func(message *messages.SMS) error {
 				message.VerificationID = gu.Ptr(verificationID)
 				return nil

--- a/internal/notification/messages/email.go
+++ b/internal/notification/messages/email.go
@@ -19,15 +19,15 @@ var (
 var _ channels.Message = (*Email)(nil)
 
 type Email struct {
-	Recipients      []string
-	BCC             []string
-	CC              []string
-	SenderEmail     string
-	SenderName      string
-	ReplyToAddress  string
-	Subject         string
-	Content         string
-	TriggeringEvent eventstore.Event
+	Recipients          []string
+	BCC                 []string
+	CC                  []string
+	SenderEmail         string
+	SenderName          string
+	ReplyToAddress      string
+	Subject             string
+	Content             string
+	TriggeringEventType eventstore.EventType
 }
 
 func (msg *Email) GetContent() (string, error) {
@@ -61,8 +61,8 @@ func (msg *Email) GetContent() (string, error) {
 	return message, nil
 }
 
-func (msg *Email) GetTriggeringEvent() eventstore.Event {
-	return msg.TriggeringEvent
+func (msg *Email) GetTriggeringEventType() eventstore.EventType {
+	return msg.TriggeringEventType
 }
 
 func isHTML(input string) bool {

--- a/internal/notification/messages/form.go
+++ b/internal/notification/messages/form.go
@@ -12,8 +12,8 @@ import (
 var _ channels.Message = (*Form)(nil)
 
 type Form struct {
-	Serializable    any
-	TriggeringEvent eventstore.Event
+	Serializable        any
+	TriggeringEventType eventstore.EventType
 }
 
 func (msg *Form) GetContent() (string, error) {
@@ -22,6 +22,6 @@ func (msg *Form) GetContent() (string, error) {
 	return values.Encode(), err
 }
 
-func (msg *Form) GetTriggeringEvent() eventstore.Event {
-	return msg.TriggeringEvent
+func (msg *Form) GetTriggeringEventType() eventstore.EventType {
+	return msg.TriggeringEventType
 }

--- a/internal/notification/messages/json.go
+++ b/internal/notification/messages/json.go
@@ -10,8 +10,8 @@ import (
 var _ channels.Message = (*JSON)(nil)
 
 type JSON struct {
-	Serializable    interface{}
-	TriggeringEvent eventstore.Event
+	Serializable        interface{}
+	TriggeringEventType eventstore.EventType
 }
 
 func (msg *JSON) GetContent() (string, error) {
@@ -19,6 +19,6 @@ func (msg *JSON) GetContent() (string, error) {
 	return string(bytes), err
 }
 
-func (msg *JSON) GetTriggeringEvent() eventstore.Event {
-	return msg.TriggeringEvent
+func (msg *JSON) GetTriggeringEventType() eventstore.EventType {
+	return msg.TriggeringEventType
 }

--- a/internal/notification/messages/sms.go
+++ b/internal/notification/messages/sms.go
@@ -11,7 +11,7 @@ type SMS struct {
 	SenderPhoneNumber    string
 	RecipientPhoneNumber string
 	Content              string
-	TriggeringEvent      eventstore.Event
+	TriggeringEventType  eventstore.EventType
 
 	// VerificationID is set by the sender
 	VerificationID *string
@@ -21,6 +21,6 @@ func (msg *SMS) GetContent() (string, error) {
 	return msg.Content, nil
 }
 
-func (msg *SMS) GetTriggeringEvent() eventstore.Event {
-	return msg.TriggeringEvent
+func (msg *SMS) GetTriggeringEventType() eventstore.EventType {
+	return msg.TriggeringEventType
 }

--- a/internal/notification/types/notification.go
+++ b/internal/notification/types/notification.go
@@ -39,7 +39,7 @@ func SendEmail(
 	translator *i18n.Translator,
 	user *query.NotifyUser,
 	colors *query.LabelPolicy,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) Notify {
 	return func(
 		urlTmpl string,
@@ -66,7 +66,7 @@ func SendEmail(
 			data,
 			args,
 			allowUnverifiedNotificationChannel,
-			triggeringEvent,
+			triggeringEventType,
 		)
 	}
 }
@@ -102,7 +102,7 @@ func SendSMS(
 	translator *i18n.Translator,
 	user *query.NotifyUser,
 	colors *query.LabelPolicy,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 	generatorInfo *senders.CodeGeneratorInfo,
 ) Notify {
 	return func(
@@ -124,7 +124,7 @@ func SendSMS(
 			data,
 			args,
 			allowUnverifiedNotificationChannel,
-			triggeringEvent,
+			triggeringEventType,
 			generatorInfo,
 		)
 	}
@@ -135,7 +135,7 @@ func SendJSON(
 	webhookConfig webhook.Config,
 	channels ChannelChains,
 	serializable interface{},
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) Notify {
 	return func(_ string, _ map[string]interface{}, _ string, _ bool) error {
 		return handleWebhook(
@@ -143,7 +143,7 @@ func SendJSON(
 			webhookConfig,
 			channels,
 			serializable,
-			triggeringEvent,
+			triggeringEventType,
 		)
 	}
 }
@@ -153,7 +153,7 @@ func SendSecurityTokenEvent(
 	setConfig set.Config,
 	channels ChannelChains,
 	token any,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) Notify {
 	return func(_ string, _ map[string]interface{}, _ string, _ bool) error {
 		return handleSecurityTokenEvent(
@@ -161,7 +161,7 @@ func SendSecurityTokenEvent(
 			setConfig,
 			channels,
 			token,
-			triggeringEvent,
+			triggeringEventType,
 		)
 	}
 }

--- a/internal/notification/types/security_token_event.go
+++ b/internal/notification/types/security_token_event.go
@@ -13,11 +13,11 @@ func handleSecurityTokenEvent(
 	setConfig set.Config,
 	channels ChannelChains,
 	token any,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) error {
 	message := &messages.Form{
-		Serializable:    token,
-		TriggeringEvent: triggeringEvent,
+		Serializable:        token,
+		TriggeringEventType: triggeringEventType,
 	}
 	setChannels, err := channels.SecurityTokenEvent(ctx, setConfig)
 	if err != nil {

--- a/internal/notification/types/user_email.go
+++ b/internal/notification/types/user_email.go
@@ -23,7 +23,7 @@ func generateEmail(
 	data templates.TemplateData,
 	args map[string]interface{},
 	lastEmail bool,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) error {
 	emailChannels, config, err := channels.Email(ctx)
 	logging.OnError(err).Error("could not create email channel")
@@ -38,10 +38,10 @@ func generateEmail(
 	}
 	if config.SMTPConfig != nil {
 		message := &messages.Email{
-			Recipients:      []string{recipient},
-			Subject:         data.Subject,
-			Content:         html.UnescapeString(template),
-			TriggeringEvent: triggeringEvent,
+			Recipients:          []string{recipient},
+			Subject:             data.Subject,
+			Content:             html.UnescapeString(template),
+			TriggeringEventType: triggeringEventType,
 		}
 		return emailChannels.HandleMessage(message)
 	}
@@ -52,7 +52,7 @@ func generateEmail(
 		}
 		contextInfo := map[string]interface{}{
 			"recipientEmailAddress": recipient,
-			"eventType":             triggeringEvent.Type(),
+			"eventType":             triggeringEventType,
 			"provider":              config.ProviderConfig,
 		}
 
@@ -62,7 +62,7 @@ func generateEmail(
 				TemplateData: data,
 				Args:         caseArgs,
 			},
-			TriggeringEvent: triggeringEvent,
+			TriggeringEventType: triggeringEventType,
 		}
 		webhookChannels, err := channels.Webhook(ctx, *config.WebhookConfig)
 		if err != nil {

--- a/internal/notification/types/user_phone.go
+++ b/internal/notification/types/user_phone.go
@@ -28,7 +28,7 @@ func generateSms(
 	data templates.TemplateData,
 	args map[string]interface{},
 	lastPhone bool,
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 	generatorInfo *senders.CodeGeneratorInfo,
 ) error {
 	smsChannels, config, err := channels.SMS(ctx)
@@ -51,7 +51,7 @@ func generateSms(
 			SenderPhoneNumber:    number,
 			RecipientPhoneNumber: recipient,
 			Content:              data.Text,
-			TriggeringEvent:      triggeringEvent,
+			TriggeringEventType:  triggeringEventType,
 		}
 		err = smsChannels.HandleMessage(message)
 		if err != nil {
@@ -70,7 +70,7 @@ func generateSms(
 		}
 		contextInfo := map[string]interface{}{
 			"recipientPhoneNumber": recipient,
-			"eventType":            triggeringEvent.Type(),
+			"eventType":            triggeringEventType,
 			"provider":             config.ProviderConfig,
 		}
 
@@ -80,7 +80,7 @@ func generateSms(
 				Args:         caseArgs,
 				ContextInfo:  contextInfo,
 			},
-			TriggeringEvent: triggeringEvent,
+			TriggeringEventType: triggeringEventType,
 		}
 		webhookChannels, err := channels.Webhook(ctx, *config.WebhookConfig)
 		if err != nil {

--- a/internal/notification/types/webhook.go
+++ b/internal/notification/types/webhook.go
@@ -13,11 +13,11 @@ func handleWebhook(
 	webhookConfig webhook.Config,
 	channels ChannelChains,
 	serializable interface{},
-	triggeringEvent eventstore.Event,
+	triggeringEventType eventstore.EventType,
 ) error {
 	message := &messages.JSON{
-		Serializable:    serializable,
-		TriggeringEvent: triggeringEvent,
+		Serializable:        serializable,
+		TriggeringEventType: triggeringEventType,
 	}
 	webhookChannels, err := channels.Webhook(ctx, webhookConfig)
 	if err != nil {

--- a/internal/repository/notification/notification.go
+++ b/internal/repository/notification/notification.go
@@ -56,6 +56,10 @@ type RequestedEvent struct {
 	Request `json:"request"`
 }
 
+func (e *RequestedEvent) GetRequest() Request {
+	return e.Request
+}
+
 func (e *RequestedEvent) TriggerOrigin() string {
 	return e.TriggeredAtOrigin
 }
@@ -184,6 +188,10 @@ type RetryRequestedEvent struct {
 
 func (e *RetryRequestedEvent) Payload() interface{} {
 	return e
+}
+
+func (e *RetryRequestedEvent) GetRequest() Request {
+	return e.Request
 }
 
 func (e *RetryRequestedEvent) UniqueConstraints() []*eventstore.UniqueConstraint {


### PR DESCRIPTION
# Which Problems Are Solved

The new notification worker operates on a new set of events, mainly `notification.requested` and `notifcation.retry.requested`. In the legacy handler, the triggering event type was passed to the prom metrics reporter so we could see if the notification was from a 'sms.code.added' vs 'phone.code.challenged'. Now all metrics show the `notification.requested` event type, which is less helpful. 

# How the Problems Are Solved

Extract the original triggering event type from the `notification.Request.EventType` and pass through to notification metrics layer. 

# Additional Changes

# Additional Context
