### PR TITLE
fix: scim use first email or phone if no primary is set

### DIFF
--- a/internal/api/scim/integration_test/testdata/users_create_test_no_primary_email_phone.json
+++ b/internal/api/scim/integration_test/testdata/users_create_test_no_primary_email_phone.json
@@ -1,0 +1,21 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:User"
+  ],
+  "userName": "acmeUser1",
+  "name": {
+    "familyName": "Ross",
+    "givenName": "Bethany"
+  },
+  "emails": [
+    {
+      "value": "user1@example.com"
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "+41 71 123 45 67",
+      "type": "work"
+    }
+  ]
+}

--- a/internal/api/scim/integration_test/users_create_test.go
+++ b/internal/api/scim/integration_test/users_create_test.go
@@ -33,6 +33,9 @@ var (
 	//go:embed testdata/users_create_test_minimal_inactive.json
 	minimalInactiveUserJson []byte
 
+	//go:embed testdata/users_create_test_no_primary_email_phone.json
+	minimalNoPrimaryEmailPhoneUserJson []byte
+
 	//go:embed testdata/users_create_test_full.json
 	fullUserJson []byte
 
@@ -195,6 +198,24 @@ func TestCreateUser(t *testing.T) {
 			name: "full user",
 			body: fullUserJson,
 			want: fullUser,
+		},
+		{
+			name: "no primary email and phone",
+			body: minimalNoPrimaryEmailPhoneUserJson,
+			want: &resources.ScimUser{
+				Emails: []*resources.ScimEmail{
+					{
+						Value:   "user1@example.com",
+						Primary: true,
+					},
+				},
+				PhoneNumbers: []*resources.ScimPhoneNumber{
+					{
+						Value:   "+41711234567",
+						Primary: true,
+					},
+				},
+			},
 		},
 		{
 			name:          "missing userName",

--- a/internal/api/scim/resources/user_mapping.go
+++ b/internal/api/scim/resources/user_mapping.go
@@ -136,6 +136,15 @@ func (h *UsersHandler) mapPrimaryEmail(scimUser *ScimUser) *command.Email {
 		}
 	}
 
+	// if no primary email was found, the first email will be used
+	for _, email := range scimUser.Emails {
+		email.Primary = true
+		return &command.Email{
+			Address:  domain.EmailAddress(email.Value),
+			Verified: h.config.EmailVerified,
+		}
+	}
+
 	return nil
 }
 
@@ -145,6 +154,15 @@ func (h *UsersHandler) mapPrimaryPhone(scimUser *ScimUser) *command.Phone {
 			continue
 		}
 
+		return &command.Phone{
+			Number:   domain.PhoneNumber(phone.Value),
+			Verified: h.config.PhoneVerified,
+		}
+	}
+
+	// if no primary phone was found, the first phone will be used
+	for _, phone := range scimUser.PhoneNumbers {
+		phone.Primary = true
 		return &command.Phone{
 			Number:   domain.PhoneNumber(phone.Value),
 			Verified: h.config.PhoneVerified,


### PR DESCRIPTION
# Which Problems Are Solved
- scim v2 only maps the primary phone/email to the zitadel user, this does not work if no primary is set

# How the Problems Are Solved
- the first phone / email is mapped if no primary is available

# Additional Context
Part of #8140