### PR TITLE
fix: use advisory lock on worker+instance to deduplicate request handling (POC)

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -481,6 +481,8 @@ Notifications:
   MaxRetryDelay: 1m # ZITADEL_NOTIFIACATIONS_MAXRETRYDELAY
   # Any factor below 1 will be set to 1
   RetryDelayFactor: 1.5 # ZITADEL_NOTIFIACATIONS_RETRYDELAYFACTOR
+  # LockToSingleWorker ensures that a single worker processes all events for a single instance
+  LockToSingleWorker: false # ZITADEL_NOTIFIACATIONS_LOCKTOSINGLEWORKER
 
 Auth:
   # See Projections.BulkLimit

--- a/internal/notification/handlers/notification_worker.go
+++ b/internal/notification/handlers/notification_worker.go
@@ -360,12 +360,12 @@ func (w *NotificationWorker) trigger(ctx context.Context, workerID int, retry bo
 	// NB: Lock the instance to a single worker at a time to avoid multiple workers
 	// processing the same events concurrently. Once we fix the "for update skip locked"
 	// issue in the events query following, we should remove this.
-	// if lock, err := tryGetAdvisoryLockForInstance(ctx, tx); err != nil {
-	// 	return false, err
-	// } else if !lock {
-	// 	// we should assume the current worker will handle requeuing the trigger for the next run
-	// 	return false, nil
-	// }
+	if lock, err := tryGetAdvisoryLockForInstance(ctx, tx); err != nil {
+		return false, err
+	} else if !lock {
+		// we should assume the current worker will handle requeuing the trigger for the next run
+		return false, nil
+	}
 	// else, we acquired the lock and can continue
 
 	events, hasMore, err := w.searchEvents(txCtx, tx, retry)

--- a/internal/notification/handlers/notification_worker.go
+++ b/internal/notification/handlers/notification_worker.go
@@ -357,16 +357,18 @@ func (w *NotificationWorker) trigger(ctx context.Context, workerID int, retry bo
 		err = database.CloseTransaction(tx, err)
 	}()
 
-	// NB: Lock the instance to a single worker at a time to avoid multiple workers
-	// processing the same events concurrently. Once we fix the "for update skip locked"
-	// issue in the events query following, we should remove this.
-	if lock, err := tryGetAdvisoryLockForInstance(ctx, tx); err != nil {
-		return false, err
-	} else if !lock {
-		// we should assume the current worker will handle requeuing the trigger for the next run
-		return false, nil
+	if w.config.LockToSingleWorker {
+		// NB: Lock the instance to a single worker at a time to avoid multiple workers
+		// processing the same events concurrently. Once we fix the "for update skip locked"
+		// issue in the events query following, we should remove this.
+		if lock, err := tryGetAdvisoryLockForInstance(ctx, tx); err != nil {
+			return false, err
+		} else if !lock {
+			// we should assume the current worker will handle requeuing the trigger for the next run
+			return false, nil
+		}
+		// else, we acquired the lock and can continue
 	}
-	// else, we acquired the lock and can continue
 
 	events, hasMore, err := w.searchEvents(txCtx, tx, retry)
 	if err != nil {


### PR DESCRIPTION
# Which Problems Are Solved

Testing revealed that the `for update skip locked` is not correctly locking `notification.requested` event rows leading to duplicate sends from different workers. 

# How the Problems Are Solved

Adding a postgres advisory lock on the instance ensures that only a single worker at a time per instance will try to handle a batch of requests. This limits concurrency and as a result my workaround was to add a +1 to the query limit to see if there are more events that need work and then trigger the next wakeup immediately (10ms) so the queue can get cleared out in a reasonable amount of time. 

This definitely isn't an ideal solution. My hope is that at worst it's a good conversation starter and possibly a stopgap solution that ensures exactly-once delivery but with greater latency. 

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
