### PR TITLE
fix: scim 2 filter: the username should be treated case-insensitive

### DIFF
--- a/internal/api/scim/resources/filter/filter_query_builder_test.go
+++ b/internal/api/scim/resources/filter/filter_query_builder_test.go
@@ -20,10 +20,11 @@ var fieldPathColumnMapping = FieldPathMapping{
 		Column:    query.UserChangeDateCol,
 		FieldType: FieldTypeTimestamp,
 	},
-	// a string field
+	// a case-insensitive string field
 	"username": {
-		Column:    query.UserUsernameCol,
-		FieldType: FieldTypeString,
+		Column:          query.UserUsernameCol,
+		FieldType:       FieldTypeString,
+		CaseInsensitive: true,
 	},
 	// a nested string field
 	"name.familyname": {
@@ -76,7 +77,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 		{
 			name:   "simple binary operator",
 			filter: `userName eq "bjensen"`,
-			want:   test.Must(query.NewTextQuery(query.UserUsernameCol, "bjensen", query.TextEquals)),
+			want:   test.Must(query.NewTextQuery(query.UserUsernameCol, "bjensen", query.TextEqualsIgnoreCase)),
 		},
 		{
 			name:   "binary operator equals null",
@@ -176,7 +177,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 		{
 			name:   "urn prefixed binary operator",
 			filter: `urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"`,
-			want:   test.Must(query.NewTextQuery(query.UserUsernameCol, "J", query.TextStartsWith)),
+			want:   test.Must(query.NewTextQuery(query.UserUsernameCol, "J", query.TextStartsWithIgnoreCase)),
 		},
 		{
 			name:   "urn prefixed nested binary operator",
@@ -196,7 +197,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 		{
 			name:   "and logical expression",
 			filter: `name.familyName pr and userName eq "bjensen"`,
-			want:   test.Must(query.NewAndQuery(test.Must(query.NewNotNullQuery(query.HumanLastNameCol)), test.Must(query.NewTextQuery(query.UserUsernameCol, "bjensen", query.TextEquals)))),
+			want:   test.Must(query.NewAndQuery(test.Must(query.NewNotNullQuery(query.HumanLastNameCol)), test.Must(query.NewTextQuery(query.UserUsernameCol, "bjensen", query.TextEqualsIgnoreCase)))),
 		},
 		{
 			name:   "timestamp condition equal",
@@ -243,7 +244,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 			filter: `userName eq "rudolpho" and emails co "example.com" or emails.value co "example2.org"`,
 			want: test.Must(query.NewOrQuery(
 				test.Must(query.NewAndQuery(
-					test.Must(query.NewTextQuery(query.UserUsernameCol, "rudolpho", query.TextEquals)),
+					test.Must(query.NewTextQuery(query.UserUsernameCol, "rudolpho", query.TextEqualsIgnoreCase)),
 					test.Must(query.NewTextQuery(query.HumanEmailCol, "example.com", query.TextContains))),
 				),
 				test.Must(query.NewTextQuery(query.HumanEmailCol, "example2.org", query.TextContains)))),
@@ -252,7 +253,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 			name:   "nested and / or with grouping",
 			filter: `userName ne "rudolpho" and (emails co "example.com" or emails.value co "example.org")`,
 			want: test.Must(query.NewAndQuery(
-				test.Must(query.NewTextQuery(query.UserUsernameCol, "rudolpho", query.TextNotEquals)),
+				test.Must(query.NewTextQuery(query.UserUsernameCol, "rudolpho", query.TextNotEqualsIgnoreCase)),
 				test.Must(query.NewOrQuery(
 					test.Must(query.NewTextQuery(query.HumanEmailCol, "example.com", query.TextContains)),
 					test.Must(query.NewTextQuery(query.HumanEmailCol, "example.org", query.TextContains)),
@@ -263,7 +264,7 @@ func TestFilter_BuildQuery(t *testing.T) {
 			name:   "nested value path path",
 			filter: `userName eq "Hans" and emails[value ew "@example.org" or value ew "@example.com"]`,
 			want: test.Must(query.NewAndQuery(
-				test.Must(query.NewTextQuery(query.UserUsernameCol, "Hans", query.TextEquals)),
+				test.Must(query.NewTextQuery(query.UserUsernameCol, "Hans", query.TextEqualsIgnoreCase)),
 				test.Must(query.NewOrQuery(
 					test.Must(query.NewTextQuery(query.HumanEmailCol, "@example.org", query.TextEndsWith)),
 					test.Must(query.NewTextQuery(query.HumanEmailCol, "@example.com", query.TextEndsWith)),
@@ -288,13 +289,13 @@ func TestFilter_BuildQuery(t *testing.T) {
 			want: test.Must(query.NewAndQuery(
 				test.Must(query.NewTextQuery(query.HumanEmailCol, "@example.com", query.TextEndsWith)),
 				test.Must(query.NewTextQuery(query.HumanLastNameCol, "hans", query.TextContains)),
-				test.Must(query.NewTextQuery(query.UserUsernameCol, "peter", query.TextContains)),
+				test.Must(query.NewTextQuery(query.UserUsernameCol, "peter", query.TextContainsIgnoreCase)),
 			)),
 		},
 		{
 			name:   "negation",
 			filter: `not(username eq "foo")`,
-			want:   test.Must(query.NewNotQuery(test.Must(query.NewTextQuery(query.UserUsernameCol, "foo", query.TextEquals)))),
+			want:   test.Must(query.NewNotQuery(test.Must(query.NewTextQuery(query.UserUsernameCol, "foo", query.TextEqualsIgnoreCase)))),
 		},
 		{
 			name:   "negation with complex filter",

--- a/internal/api/scim/resources/user_query_builder.go
+++ b/internal/api/scim/resources/user_query_builder.go
@@ -29,8 +29,9 @@ var fieldPathColumnMapping = filter.FieldPathMapping{
 		FieldType: filter.FieldTypeString,
 	},
 	"username": {
-		Column:    query.UserUsernameCol,
-		FieldType: filter.FieldTypeString,
+		Column:          query.UserUsernameCol,
+		FieldType:       filter.FieldTypeString,
+		CaseInsensitive: true,
 	},
 	"name.familyname": {
 		Column:    query.HumanLastNameCol,

--- a/internal/query/search_query.go
+++ b/internal/query/search_query.go
@@ -288,6 +288,7 @@ func NewTextQuery(col Column, value string, compare TextComparison) (*textQuery,
 	// handle the comparisons which use (i)like and therefore need to escape potential wildcards in the value
 	switch compare {
 	case TextEqualsIgnoreCase,
+		TextNotEqualsIgnoreCase,
 		TextStartsWith,
 		TextStartsWithIgnoreCase,
 		TextEndsWith,
@@ -334,6 +335,8 @@ func (q *textQuery) comp() sq.Sqlizer {
 		return sq.NotEq{q.Column.identifier(): q.Text}
 	case TextEqualsIgnoreCase:
 		return sq.ILike{q.Column.identifier(): q.Text}
+	case TextNotEqualsIgnoreCase:
+		return sq.NotILike{q.Column.identifier(): q.Text}
 	case TextStartsWith:
 		return sq.Like{q.Column.identifier(): q.Text + "%"}
 	case TextStartsWithIgnoreCase:
@@ -368,6 +371,7 @@ const (
 	TextContainsIgnoreCase
 	TextListContains
 	TextNotEquals
+	TextNotEqualsIgnoreCase
 
 	textCompareMax
 )

--- a/internal/query/search_query_test.go
+++ b/internal/query/search_query_test.go
@@ -906,6 +906,19 @@ func TestNewTextQuery(t *testing.T) {
 			},
 		},
 		{
+			name: "not equal ignore case",
+			args: args{
+				column:  testCol,
+				value:   "h_urst%",
+				compare: TextNotEqualsIgnoreCase,
+			},
+			want: &textQuery{
+				Column:  testCol,
+				Text:    "h\\_urst\\%",
+				Compare: TextNotEqualsIgnoreCase,
+			},
+		},
+		{
 			name: "starts with",
 			args: args{
 				column:  testCol,
@@ -1192,6 +1205,28 @@ func TestTextQuery_comp(t *testing.T) {
 			},
 			want: want{
 				query: sq.ILike{"test_table.test_col": "Hurst"},
+			},
+		},
+		{
+			name: "not equals",
+			fields: fields{
+				Column:  testCol,
+				Text:    "Hurst",
+				Compare: TextNotEquals,
+			},
+			want: want{
+				query: sq.NotEq{"test_table.test_col": "Hurst"},
+			},
+		},
+		{
+			name: "not equals ignore case",
+			fields: fields{
+				Column:  testCol,
+				Text:    "Hurst",
+				Compare: TextNotEqualsIgnoreCase,
+			},
+			want: want{
+				query: sq.NotILike{"test_table.test_col": "Hurst"},
 			},
 		},
 		{


### PR DESCRIPTION
# Which Problems Are Solved
- when listing users via scim v2.0 filters applied to the username are applied case-sensitive

# How the Problems Are Solved
- when a query filter is appleid on the username it is applied case-insensitive

# Additional Context
Part of https://github.com/zitadel/zitadel/issues/8140
