### PR TITLE
fix: change usage from filepath to path

### DIFF
--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -5,7 +5,7 @@ import (
 	"embed"
 	_ "embed"
 	"net/http"
-	"path/filepath"
+	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -279,7 +279,7 @@ func mustExecuteMigration(ctx context.Context, eventstoreClient *eventstore.Even
 // Typ describes the database dialect and may be omitted if no
 // dialect specific migration is specified.
 func readStmt(fs embed.FS, folder, typ, filename string) (string, error) {
-	stmt, err := fs.ReadFile(filepath.Join(folder, typ, filename))
+	stmt, err := fs.ReadFile(path.Join(folder, typ, filename))
 	return string(stmt), err
 }
 
@@ -293,7 +293,7 @@ type statement struct {
 // Typ describes the database dialect and may be omitted if no
 // dialect specific migration is specified.
 func readStatements(fs embed.FS, folder, typ string) ([]statement, error) {
-	basePath := filepath.Join(folder, typ)
+	basePath := path.Join(folder, typ)
 	dir, err := fs.ReadDir(basePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Which Problems Are Solved

Paths for setup steps are joined with "\" when binary is started under Windows, which results in wrongly joined paths.

# How the Problems Are Solved

Replace the usage of "filepath" with "path" package, which does only join with "/" and nothing OS specific.

# Additional Changes

None

# Additional Context

Closes #9227 
