### PR TITLE
fix: scim 2.0 patch ignore op casing

### DIFF
--- a/internal/api/scim/integration_test/testdata/users_update_test_full.json
+++ b/internal/api/scim/integration_test/testdata/users_update_test_full.json
@@ -3,7 +3,7 @@
   "Operations": [
     // add without path
     {
-      "op": "add",
+      "op": "Add", // with PascalCase operation type
       "value": {
         "emails":[
           {
@@ -17,7 +17,7 @@
     },
     // add complex attribute with path
     {
-      "op": "add",
+      "op": "add", // with camelCase operation type
       "path":  "name",
       "value": {
         "formatted": "added-formatted",
@@ -30,7 +30,7 @@
     },
     // add complex attribute value
     {
-      "op": "add",
+      "op": "ADD", // with UPPERCASE operation type
       "path": "name.middlename",
       "value": "added-middle-name-2"
     },

--- a/internal/api/scim/resources/patch/patch.go
+++ b/internal/api/scim/resources/patch/patch.go
@@ -60,6 +60,9 @@ func (req *OperationRequest) Validate() error {
 }
 
 func (op *Operation) validate() error {
+	// ignore the casing, as some scim clients send these capitalized
+	op.Operation = OperationType(strings.ToLower(string(op.Operation)))
+
 	if !op.Operation.isValid() {
 		return serrors.ThrowInvalidValue(zerrors.ThrowInvalidArgumentf(nil, "SCIM-opty1", "Patch op %s not supported", op.Operation))
 	}


### PR DESCRIPTION
# Which Problems Are Solved
- Some SCIM clients send "op" of a patch operation in PascalCase

# How the Problems Are Solved
- Well known "op" values of patch operations are matched case-insensitive.

# Additional Context
Related to #8140
