### PR TITLE
fix(setup): ensure in_tx_order column type

### DIFF
--- a/cmd/setup/14/postgres/02_create_and_fill_events2.sql
+++ b/cmd/setup/14/postgres/02_create_and_fill_events2.sql
@@ -27,5 +27,5 @@ CREATE TABLE eventstore.events2 (
     resource_owner,
 
     EXTRACT(EPOCH FROM creation_date),
-    event_sequence
+    event_sequence::INTEGER
 FROM eventstore.events_old;

--- a/cmd/setup/48_fix_in_tx_order_type.go
+++ b/cmd/setup/48_fix_in_tx_order_type.go
@@ -1,0 +1,56 @@
+package setup
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"github.com/zitadel/logging"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 48_fix_in_tx_order_type/01_get_current_type.sql
+	getInTxOrderTypeQuery string
+	//go:embed 48_fix_in_tx_order_type/02_alter_column.sql
+	alterInTxOrderTypeQuery string
+)
+
+type FixInTxOrderType struct {
+	dbClient *database.DB
+}
+
+func (mig *FixInTxOrderType) Execute(ctx context.Context, _ eventstore.Event) error {
+	// The INT type in CockroachDB is actually a BIGINT.
+	// https://www.cockroachlabs.com/docs/v24.3/int
+	// That means altering the type from  BIGINT to INT doesn't make any sense.
+	if mig.dbClient.Database.Type() == "cockroach" {
+		return nil
+	}
+
+	var currentType string
+	err := mig.dbClient.QueryRowContext(ctx, func(row *sql.Row) error {
+		return row.Scan(&currentType)
+	}, getInTxOrderTypeQuery)
+	if err != nil {
+		return err
+	}
+	logging.WithFields("migration", mig.String(), "current_type", currentType).Info("execute statement")
+	if strings.EqualFold(currentType, "integer") {
+		return nil
+	}
+
+	logging.WithFields("migration", mig.String()).Info("executing ALTER TABLE")
+	if _, err := mig.dbClient.ExecContext(ctx, alterInTxOrderTypeQuery); err != nil {
+		return fmt.Errorf("%s %s: %w", mig.String(), alterInTxOrderTypeQuery, err)
+	}
+	return nil
+}
+
+func (mig *FixInTxOrderType) String() string {
+	return "48_fix_in_tx_order_type"
+}

--- a/cmd/setup/48_fix_in_tx_order_type/01_get_current_type.sql
+++ b/cmd/setup/48_fix_in_tx_order_type/01_get_current_type.sql
@@ -1,0 +1,5 @@
+SELECT data_type
+FROM information_schema.columns
+WHERE table_schema = 'eventstore'
+AND table_name = 'events2'
+AND column_name = 'in_tx_order';

--- a/cmd/setup/48_fix_in_tx_order_type/02_add_tmp_column.sql
+++ b/cmd/setup/48_fix_in_tx_order_type/02_add_tmp_column.sql
@@ -1,0 +1,15 @@
+ALTER TABLE IF EXISTS eventstore.events2
+    ADD COLUMN IF NOT EXISTS in_tx_order_tmp INTEGER;
+
+CREATE OR REPLACE FUNCTION eventstore.sync_in_tx_order()
+RETURNS trigger
+AS $$
+    BEGIN
+        NEW.in_tx_order_tmp := NEW.in_tx_order::INTEGER;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER sync_in_tx_order
+BEFORE INSERT ON eventstore.events2
+FOR EACH ROW EXECUTE FUNCTION eventstore.sync_in_tx_order();

--- a/cmd/setup/48_fix_in_tx_order_type/02_alter_column.sql
+++ b/cmd/setup/48_fix_in_tx_order_type/02_alter_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE eventstore.events2
-ALTER COLUMN in_tx_order TYPE INTEGER;

--- a/cmd/setup/48_fix_in_tx_order_type/02_alter_column.sql
+++ b/cmd/setup/48_fix_in_tx_order_type/02_alter_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE eventstore.events2
+ALTER COLUMN in_tx_order TYPE INTEGER;

--- a/cmd/setup/48_fix_in_tx_order_type/04_batch_update.sql
+++ b/cmd/setup/48_fix_in_tx_order_type/04_batch_update.sql
@@ -1,0 +1,19 @@
+WITH target_rows AS (
+	SELECT instance_id, aggregate_type, aggregate_id, sequence
+	FROM eventstore.events2
+	WHERE (instance_id, aggregate_type, aggregate_id, sequence) > ('', '', '', 0)
+	ORDER BY instance_id, aggregate_type, aggregate_id, sequence
+	LIMIT 1000
+), u AS (
+	UPDATE eventstore.events2
+	SET in_tx_order_tmp = in_tx_order
+	WHERE (instance_id,	aggregate_type,	aggregate_id, sequence) IN (
+		SELECT instance_id,	aggregate_type,	aggregate_id, sequence
+		FROM target_rows
+	)
+	RETURNING *
+), n AS (
+	SELECT count(*) FROM u
+)
+SELECT target_rows.*, n.* FROM target_rows, n
+OFFSET 999;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -136,6 +136,7 @@ type Steps struct {
 	s45CorrectProjectOwners                 *CorrectProjectOwners
 	s46InitPermissionFunctions              *InitPermissionFunctions
 	s47FillMembershipFields                 *FillMembershipFields
+	s48FixInTxOrderType                     *FixInTxOrderType
 }
 
 func MustNewSteps(v *viper.Viper) *Steps {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -173,6 +173,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s45CorrectProjectOwners = &CorrectProjectOwners{eventstore: eventstoreClient}
 	steps.s46InitPermissionFunctions = &InitPermissionFunctions{eventstoreClient: dbClient}
 	steps.s47FillMembershipFields = &FillMembershipFields{eventstore: eventstoreClient}
+	steps.s48FixInTxOrderType = &FixInTxOrderType{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	logging.OnError(err).Fatal("unable to start projections")
@@ -203,6 +204,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 
 	for _, step := range []migration.Migration{
 		steps.s14NewEventsTable,
+		steps.s48FixInTxOrderType,
 		steps.s40InitPushFunc,
 		steps.s1ProjectionTable,
 		steps.s2AssetsTable,


### PR DESCRIPTION
# Which Problems Are Solved

Systems running with PostgreSQL before Zitadel v2.39 are likely to have a wrong type for the `in_tx_order` column in the `eventstore.event2` table. The migration at the time used the `event_sequence` as default value without typecast, which results in a `bigint` type for that column. However, when creating the table from scratch, we explicitly specify the type to be `integer`.

Starting from Zitadel v2.67 we use a Pl/PgSQL function to push events. The function requires the types from `eventstore.events2` to the same as the `select` destinations used in the function. In the function `in_tx_order` is also expected to by of `integer` type.

CochroachDB systems are not affected because `bigint` is an alias to the `int` type. In other words, CockroachDB uses `int8` when specifying type `int`. Therefore the types already match.

# How the Problems Are Solved

Adds a migration for PostgreSQL systems where the current `in_tx_order` column type is checked. If it is not `integer` and `ALTER TABLE` is executed to set the correct type.

This migration may take a long time to complete when the system has lots of event.

# Additional Changes

- Detailed logging on migration failure
- Technical advisory with above information

# Additional Context

- Closes #9180