### PR TITLE
fix(setup): Fix query alias on 46-06

### DIFF
--- a/cmd/setup/46/06-permitted_orgs_function.sql
+++ b/cmd/setup/46/06-permitted_orgs_function.sql
@@ -37,14 +37,14 @@ BEGIN
 	END;
 	
 	-- Return the organizations where permission were granted thru org-level roles
-	SELECT array_agg(org_id) INTO org_ids
+	SELECT array_agg(sub.org_id) INTO org_ids
 	FROM (
 		SELECT DISTINCT om.org_id
 		FROM eventstore.org_members om
 		WHERE om.role = ANY(matched_roles)
 		AND om.instance_id = instanceID
 		AND om.user_id = userId
-	);
+	) AS sub;
     RETURN;
 END;
 $$;


### PR DESCRIPTION
# Which Problems Are Solved

After updating to version 2.69.0, my zitadel instance refuse to start with this error log :
```
time="2025-02-03T19:46:47Z" level=info msg="starting migration" caller="/home/runner/work/zitadel/zitadel/internal/migration/migration.go:66" name=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=01-role_permissions_view.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=02-instance_orgs_view.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=03-instance_members_view.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=04-org_members_view.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=05-project_members_view.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=info msg="execute statement" caller="/home/runner/work/zitadel/zitadel/cmd/setup/46.go:29" file=06-permitted_orgs_function.sql migration=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=error msg="migration failed" caller="/home/runner/work/zitadel/zitadel/internal/migration/migration.go:68" error="46_init_permission_functions 06-permitted_orgs_function.sql: ERROR: subquery in FROM must have an alias (SQLSTATE 42601)" name=46_init_permission_functions
time="2025-02-03T19:46:47Z" level=fatal msg="migration failed" caller="/home/runner/work/zitadel/zitadel/cmd/setup/setup.go:274" error="46_init_permission_functions 06-permitted_orgs_function.sql: ERROR: subquery in FROM must have an alias (SQLSTATE 42601)" name=46_init_permission_functions
```

# How the Problems Are Solved

I used the original sql script on my database which gave me the same error.  
So i added an alias for the subquery and the error cas gone

# Additional Context

I was migrating from version 2.58.3

Closes https://github.com/zitadel/zitadel/issues/9300