### PR TITLE
FE: Only allow enabled factors to be set up in API

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -82,6 +82,7 @@
     "jasmine-spec-reporter": "~7.0.0",
     "karma": "^6.4.2",
     "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage": "^2.2.1",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",

--- a/console/src/app/components/oidc-configuration/oidc-configuration.component.spec.ts
+++ b/console/src/app/components/oidc-configuration/oidc-configuration.component.spec.ts
@@ -1,16 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { QuickstartComponent } from './quickstart.component';
+import { OIDCConfigurationComponent } from './oidc-configuration.component';
 
 describe('QuickstartComponent', () => {
-  let component: QuickstartComponent;
-  let fixture: ComponentFixture<QuickstartComponent>;
+  let component: OIDCConfigurationComponent;
+  let fixture: ComponentFixture<OIDCConfigurationComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [QuickstartComponent],
+      declarations: [OIDCConfigurationComponent],
     });
-    fixture = TestBed.createComponent(QuickstartComponent);
+    fixture = TestBed.createComponent(OIDCConfigurationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/domains/domains.component.spec.ts
+++ b/console/src/app/modules/domains/domains.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { OrgDomainsComponent } from './org-domains.component';
+import { DomainsComponent } from './domains.component';
 
 describe('OrgDomainsComponent', () => {
-  let component: OrgDomainsComponent;
-  let fixture: ComponentFixture<OrgDomainsComponent>;
+  let component: DomainsComponent;
+  let fixture: ComponentFixture<DomainsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [OrgDomainsComponent],
+      declarations: [DomainsComponent],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(OrgDomainsComponent);
+    fixture = TestBed.createComponent(DomainsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/filter-project/filter-project.component.spec.ts
+++ b/console/src/app/modules/filter-project/filter-project.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { FilterUserComponent } from './filter-user.component';
+import { FilterProjectComponent } from './filter-project.component';
 
 describe('FilterUserComponent', () => {
-  let component: FilterUserComponent;
-  let fixture: ComponentFixture<FilterUserComponent>;
+  let component: FilterProjectComponent;
+  let fixture: ComponentFixture<FilterProjectComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [FilterUserComponent],
+      declarations: [FilterProjectComponent],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(FilterUserComponent);
+    fixture = TestBed.createComponent(FilterProjectComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/input/input.directive.spec.ts
+++ b/console/src/app/modules/input/input.directive.spec.ts
@@ -1,8 +1,49 @@
+import { Component, ElementRef, NgZone } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { InputDirective } from './input.directive';
+import { Platform } from '@angular/cdk/platform';
+import { NgControl, NgForm, FormGroupDirective } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
+import { AutofillMonitor } from '@angular/cdk/text-field';
+import { MatFormField } from '@angular/material/form-field';
+import { MAT_INPUT_VALUE_ACCESSOR } from '@angular/material/input';
+import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  template: `<input appInputDirective />`
+})
+class TestHostComponent {}
 
 describe('InputDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [InputDirective, TestHostComponent],
+      providers: [
+        { provide: ElementRef, useValue: new ElementRef(document.createElement('input')) },
+        Platform,
+        { provide: NgControl, useValue: null },
+        { provide: NgForm, useValue: null },
+        { provide: FormGroupDirective, useValue: null },
+        ErrorStateMatcher,
+        { provide: MAT_INPUT_VALUE_ACCESSOR, useValue: null },
+        {
+          provide: AutofillMonitor,
+          useValue: { monitor: () => of(), stopMonitoring: () => {} }
+        },
+        NgZone,
+        { provide: MatFormField, useValue: null }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
   it('should create an instance', () => {
-    const directive = new InputDirective();
-    expect(directive).toBeTruthy();
+    const directiveEl = fixture.debugElement.query(By.directive(InputDirective));
+    expect(directiveEl).toBeTruthy();
   });
 });

--- a/console/src/app/modules/label/label.component.spec.ts
+++ b/console/src/app/modules/label/label.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { AvatarComponent } from './avatar.component';
+import { LabelComponent } from './label.component';
 
 describe('AvatarComponent', () => {
-  let component: AvatarComponent;
-  let fixture: ComponentFixture<AvatarComponent>;
+  let component: LabelComponent;
+  let fixture: ComponentFixture<LabelComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [AvatarComponent],
+      declarations: [LabelComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AvatarComponent);
+    fixture = TestBed.createComponent(LabelComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/policies/login-policy/login-policy.component.ts
+++ b/console/src/app/modules/policies/login-policy/login-policy.component.ts
@@ -2,14 +2,12 @@ import { Component, Injector, Input, OnDestroy, OnInit, Type } from '@angular/co
 import { AbstractControl, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
-import { firstValueFrom, forkJoin, from, Observable, of, Subject, take } from 'rxjs';
+import { forkJoin, from, of, Subject, take } from 'rxjs';
 import {
   GetLoginPolicyResponse as AdminGetLoginPolicyResponse,
   UpdateLoginPolicyRequest,
-  UpdateLoginPolicyResponse,
 } from 'src/app/proto/generated/zitadel/admin_pb';
 import {
-  AddCustomLoginPolicyRequest,
   GetLoginPolicyResponse as MgmtGetLoginPolicyResponse,
   UpdateCustomLoginPolicyRequest,
 } from 'src/app/proto/generated/zitadel/management_pb';
@@ -24,8 +22,7 @@ import { InfoSectionType } from '../../info-section/info-section.component';
 import { WarnDialogComponent } from '../../warn-dialog/warn-dialog.component';
 import { PolicyComponentServiceType } from '../policy-component-types.enum';
 import { LoginMethodComponentType } from './factor-table/factor-table.component';
-import { catchError, map, takeUntil } from 'rxjs/operators';
-import { error } from 'console';
+import { map, takeUntil } from 'rxjs/operators';
 import { LoginPolicyService } from '../../../services/login-policy.service';
 
 const minValueValidator = (minValue: number) => (control: AbstractControl) => {

--- a/console/src/app/modules/policies/message-texts/message-texts.component.spec.ts
+++ b/console/src/app/modules/policies/message-texts/message-texts.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { LoginPolicyComponent } from './login-policy.component';
+import { MessageTextsComponent } from './message-texts.component';
 
 describe('LoginPolicyComponent', () => {
-  let component: LoginPolicyComponent;
-  let fixture: ComponentFixture<LoginPolicyComponent>;
+  let component: MessageTextsComponent;
+  let fixture: ComponentFixture<MessageTextsComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [LoginPolicyComponent],
+      declarations: [MessageTextsComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(LoginPolicyComponent);
+    fixture = TestBed.createComponent(MessageTextsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/policies/notification-policy/notification-policy.component.spec.ts
+++ b/console/src/app/modules/policies/notification-policy/notification-policy.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { PasswordComplexityPolicyComponent } from './password-complexity-policy.component';
+import { NotificationPolicyComponent } from './notification-policy.component';
 
 describe('PasswordComplexityPolicyComponent', () => {
-  let component: PasswordComplexityPolicyComponent;
-  let fixture: ComponentFixture<PasswordComplexityPolicyComponent>;
+  let component: NotificationPolicyComponent;
+  let fixture: ComponentFixture<NotificationPolicyComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [PasswordComplexityPolicyComponent],
+      declarations: [NotificationPolicyComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(PasswordComplexityPolicyComponent);
+    fixture = TestBed.createComponent(NotificationPolicyComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/policies/notification-sms-provider/password-dialog-sms-provider/password-dialog-sms-provider.component.spec.ts
+++ b/console/src/app/modules/policies/notification-sms-provider/password-dialog-sms-provider/password-dialog-sms-provider.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { PasswordDialogComponent } from './password-dialog-sms-provider.component';
+import { PasswordDialogSMSProviderComponent } from './password-dialog-sms-provider.component';
 
 describe('PasswordDialogComponent', () => {
-  let component: PasswordDialogComponent;
-  let fixture: ComponentFixture<PasswordDialogComponent>;
+  let component: PasswordDialogSMSProviderComponent;
+  let fixture: ComponentFixture<PasswordDialogSMSProviderComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [PasswordDialogComponent],
+      declarations: [PasswordDialogSMSProviderComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(PasswordDialogComponent);
+    fixture = TestBed.createComponent(PasswordDialogSMSProviderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/providers/provider-github-es/provider-github-es.component.spec.ts
+++ b/console/src/app/modules/providers/provider-github-es/provider-github-es.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { ProviderOAuthComponent } from './provider-oauth.component';
+import { ProviderGithubESComponent } from './provider-github-es.component';
 
 describe('ProviderOAuthComponent', () => {
-  let component: ProviderOAuthComponent;
-  let fixture: ComponentFixture<ProviderOAuthComponent>;
+  let component: ProviderGithubESComponent;
+  let fixture: ComponentFixture<ProviderGithubESComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ProviderOAuthComponent],
+      declarations: [ProviderGithubESComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ProviderOAuthComponent);
+    fixture = TestBed.createComponent(ProviderGithubESComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/providers/provider-gitlab-self-hosted/provider-gitlab-self-hosted.component.spec.ts
+++ b/console/src/app/modules/providers/provider-gitlab-self-hosted/provider-gitlab-self-hosted.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { ProviderGoogleComponent } from './provider-google.component';
+import { ProviderGitlabSelfHostedComponent } from './provider-gitlab-self-hosted.component';
 
 describe('ProviderGoogleComponent', () => {
-  let component: ProviderGoogleComponent;
-  let fixture: ComponentFixture<ProviderGoogleComponent>;
+  let component: ProviderGitlabSelfHostedComponent;
+  let fixture: ComponentFixture<ProviderGitlabSelfHostedComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ProviderGoogleComponent],
+      declarations: [ProviderGitlabSelfHostedComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ProviderGoogleComponent);
+    fixture = TestBed.createComponent(ProviderGitlabSelfHostedComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/providers/provider-gitlab/provider-gitlab.component.spec.ts
+++ b/console/src/app/modules/providers/provider-gitlab/provider-gitlab.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { ProviderGoogleComponent } from './provider-google.component';
+import { ProviderGitlabComponent } from './provider-gitlab.component';
 
 describe('ProviderGoogleComponent', () => {
-  let component: ProviderGoogleComponent;
-  let fixture: ComponentFixture<ProviderGoogleComponent>;
+  let component: ProviderGitlabComponent;
+  let fixture: ComponentFixture<ProviderGitlabComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ProviderGoogleComponent],
+      declarations: [ProviderGitlabComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ProviderGoogleComponent);
+    fixture = TestBed.createComponent(ProviderGitlabComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/show-token-dialog/show-token-dialog.component.spec.ts
+++ b/console/src/app/modules/show-token-dialog/show-token-dialog.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { ShowKeyDialogComponent } from './show-key-dialog.component';
+import { ShowTokenDialogComponent } from './show-token-dialog.component';
 
 describe('ShowKeyDialogComponent', () => {
-  let component: ShowKeyDialogComponent;
-  let fixture: ComponentFixture<ShowKeyDialogComponent>;
+  let component: ShowTokenDialogComponent;
+  let fixture: ComponentFixture<ShowTokenDialogComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ShowKeyDialogComponent],
+      declarations: [ShowTokenDialogComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ShowKeyDialogComponent);
+    fixture = TestBed.createComponent(ShowTokenDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/modules/smtp-table/smtp-table.component.spec.ts
+++ b/console/src/app/modules/smtp-table/smtp-table.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { IdpTableComponent } from './smtp-table.component';
+import { SMTPTableComponent } from './smtp-table.component';
 
 describe('UserTableComponent', () => {
-  let component: IdpTableComponent;
-  let fixture: ComponentFixture<IdpTableComponent>;
+  let component: SMTPTableComponent;
+  let fixture: ComponentFixture<SMTPTableComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [IdpTableComponent],
+      declarations: [SMTPTableComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(IdpTableComponent);
+    fixture = TestBed.createComponent(SMTPTableComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/pages/actions/add-action-dialog/add-action-dialog.component.spec.ts
+++ b/console/src/app/pages/actions/add-action-dialog/add-action-dialog.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { AddKeyDialogComponent } from './add-key-dialog.component';
+import { AddActionDialogComponent } from './add-action-dialog.component';
 
 describe('AddKeyDialogComponent', () => {
-  let component: AddKeyDialogComponent;
-  let fixture: ComponentFixture<AddKeyDialogComponent>;
+  let component: AddActionDialogComponent;
+  let fixture: ComponentFixture<AddActionDialogComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [AddKeyDialogComponent],
+      declarations: [AddActionDialogComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AddKeyDialogComponent);
+    fixture = TestBed.createComponent(AddActionDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/pages/actions/add-flow-dialog/add-flow-dialog.component.spec.ts
+++ b/console/src/app/pages/actions/add-flow-dialog/add-flow-dialog.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { AddKeyDialogComponent } from './add-key-dialog.component';
+import { AddFlowDialogComponent } from './add-flow-dialog.component';
 
 describe('AddKeyDialogComponent', () => {
-  let component: AddKeyDialogComponent;
-  let fixture: ComponentFixture<AddKeyDialogComponent>;
+  let component: AddFlowDialogComponent;
+  let fixture: ComponentFixture<AddFlowDialogComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [AddKeyDialogComponent],
+      declarations: [AddFlowDialogComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AddKeyDialogComponent);
+    fixture = TestBed.createComponent(AddFlowDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/pages/users/user-detail/auth-user-detail/auth-factor-dialog/auth-factor-dialog.component.html
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/auth-factor-dialog/auth-factor-dialog.component.html
@@ -7,6 +7,7 @@
 
     <div class="type-selection">
       <button
+        *ngIf="data.otp$ | async"
         mat-stroked-button
         [disabled]="data.otpDisabled$ | async"
         (click)="selectType(AuthFactorType.OTP)"
@@ -56,7 +57,7 @@
           <span>{{ 'USER.MFA.OTP' | translate }}</span>
         </div>
       </button>
-      <button mat-stroked-button (click)="selectType(AuthFactorType.U2F)">
+      <button *ngIf="data.u2f$ | async" mat-stroked-button (click)="selectType(AuthFactorType.U2F)">
         <div class="u2f-btn">
           <div class="icon-row">
             <svg
@@ -78,6 +79,7 @@
         </div>
       </button>
       <button
+        *ngIf="data.otpSms$ | async"
         [disabled]="!data.phoneVerified || (data.otpSmsDisabled$ | async)"
         mat-stroked-button
         (click)="selectType(AuthFactorType.OTPSMS)"
@@ -110,7 +112,11 @@
           </div>
         </div>
       </button>
-      <button [disabled]="data.otpEmailDisabled$ | async" mat-stroked-button (click)="selectType(AuthFactorType.OTPEMAIL)">
+      <button
+        *ngIf="data.otpEmail$ | async"
+        [disabled]="data.otpEmailDisabled$ | async"
+        mat-stroked-button
+        (click)="selectType(AuthFactorType.OTPEMAIL)">
         <div class="otp-btn">
           <div class="icon-row">
             <svg

--- a/console/src/app/pages/users/user-detail/auth-user-detail/auth-user-mfa/auth-user-mfa.component.spec.ts
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/auth-user-mfa/auth-user-mfa.component.spec.ts
@@ -1,24 +1,116 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { of } from 'rxjs';
 import { AuthUserMfaComponent } from './auth-user-mfa.component';
+import { GrpcAuthService } from 'src/app/services/grpc-auth.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { MatDialog } from '@angular/material/dialog';
+import { AuthFactor, AuthFactorState } from 'src/app/proto/generated/zitadel/user_pb';
+import { SecondFactorType } from 'src/app/proto/generated/zitadel/policy_pb';
+import { CardComponent } from '../../../../../modules/card/card.component';
+import { RefreshTableComponent } from '../../../../../modules/refresh-table/refresh-table.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AuthUserMfaComponent', () => {
   let component: AuthUserMfaComponent;
   let fixture: ComponentFixture<AuthUserMfaComponent>;
+  let serviceStub: Partial<GrpcAuthService>;
+  let toastStub: Partial<ToastService>;
+  let dialogStub: Partial<MatDialog>;
 
   beforeEach(waitForAsync(() => {
+    // Create stubs for required services
+    serviceStub = {
+      listMyMultiFactors: jasmine.createSpy('listMyMultiFactors').and.returnValue(Promise.resolve({
+        resultList: [
+          { otp: true, state: AuthFactorState.AUTH_FACTOR_STATE_READY } as AuthFactor.AsObject,
+          { otpSms: true, state: AuthFactorState.AUTH_FACTOR_STATE_READY } as AuthFactor.AsObject,
+          { otpEmail: true, state: AuthFactorState.AUTH_FACTOR_STATE_READY } as AuthFactor.AsObject,
+          { state: AuthFactorState.AUTH_FACTOR_STATE_NOT_READY } as AuthFactor.AsObject
+        ]
+      })),
+      getMyLoginPolicy: jasmine.createSpy('getMyLoginPolicy').and.returnValue(Promise.resolve({
+        policy: {
+          secondFactorsList: [
+            SecondFactorType.SECOND_FACTOR_TYPE_OTP,
+            SecondFactorType.SECOND_FACTOR_TYPE_U2F,
+            SecondFactorType.SECOND_FACTOR_TYPE_OTP_EMAIL,
+            SecondFactorType.SECOND_FACTOR_TYPE_OTP_SMS
+          ]
+        }
+      })),
+      removeMyMultiFactorOTP: jasmine.createSpy('removeMyMultiFactorOTP').and.returnValue(Promise.resolve()),
+      removeMyMultiFactorU2F: jasmine.createSpy('removeMyMultiFactorU2F').and.returnValue(Promise.resolve()),
+      removeMyAuthFactorOTPEmail: jasmine.createSpy('removeMyAuthFactorOTPEmail').and.returnValue(Promise.resolve()),
+      removeMyAuthFactorOTPSMS: jasmine.createSpy('removeMyAuthFactorOTPSMS').and.returnValue(Promise.resolve()),
+    };
+
+    toastStub = {
+      showInfo: jasmine.createSpy('showInfo'),
+      showError: jasmine.createSpy('showError'),
+    };
+
+    dialogStub = {
+      // Opened dialog returns a truthy value after closing
+      open: jasmine.createSpy('open').and.returnValue({
+        afterClosed: () => of(true)
+      })
+    };
+
     TestBed.configureTestingModule({
-      declarations: [AuthUserMfaComponent],
+      declarations: [AuthUserMfaComponent, CardComponent, RefreshTableComponent],
+      imports: [MatIconModule, TranslateModule.forRoot(), MatTooltipModule, MatTableModule, BrowserAnimationsModule],
+      providers: [
+        { provide: GrpcAuthService, useValue: serviceStub },
+        { provide: ToastService, useValue: toastStub },
+        { provide: MatDialog, useValue: dialogStub },
+      ]
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AuthUserMfaComponent);
     component = fixture.componentInstance;
+    // Optionally set the phoneVerified input if needed by your tests
+    component.phoneVerified = true;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call getMFAs and update dataSource and disable flags', async () => {
+    // Call the method and wait for the Promise resolution
+    await component.getMFAs();
+    fixture.detectChanges();
+
+    expect(serviceStub.listMyMultiFactors).toHaveBeenCalled();
+    // Our stub returned 4 items
+    expect(component.dataSource.data.length).toBe(4);
+
+    // Pipes were updated
+    component.otpDisabled$.subscribe(value => {
+      expect(value).toBeTrue();
+    });
+    component.otpSmsDisabled$.subscribe(value => {
+      expect(value).toBeTrue();
+    });
+    component.otpEmailDisabled$.subscribe(value => {
+      expect(value).toBeTrue();
+    });
+  });
+
+  it('should call deleteMFA and remove OTP factor', async () => {
+    // OTP is set
+    const factor = { otp: true, state: AuthFactorState.AUTH_FACTOR_STATE_READY } as AuthFactor.AsObject;
+    await component.deleteMFA(factor);
+
+    // Verify that the service method for OTP removal was called
+    expect(serviceStub.removeMyMultiFactorOTP).toHaveBeenCalled();
+    expect(serviceStub.listMyMultiFactors).toHaveBeenCalled();
   });
 });

--- a/console/src/app/pages/users/user-detail/detail-form-machine/detail-form-machine.component.spec.ts
+++ b/console/src/app/pages/users/user-detail/detail-form-machine/detail-form-machine.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { DetailFormComponent } from './detail-form.component';
+import { DetailFormMachineComponent } from './detail-form-machine.component';
 
 describe('DetailFormComponent', () => {
-  let component: DetailFormComponent;
-  let fixture: ComponentFixture<DetailFormComponent>;
+  let component: DetailFormMachineComponent;
+  let fixture: ComponentFixture<DetailFormMachineComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [DetailFormComponent],
+      declarations: [DetailFormMachineComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DetailFormComponent);
+    fixture = TestBed.createComponent(DetailFormMachineComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/src/app/pages/users/user-detail/user-detail/passwordless/passwordless.component.spec.ts
+++ b/console/src/app/pages/users/user-detail/user-detail/passwordless/passwordless.component.spec.ts
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { AuthPasswordlessComponent } from './auth-passwordless.component';
+import { PasswordlessComponent } from './passwordless.component';
 
 describe('AuthPasswordlessComponent', () => {
-  let component: AuthPasswordlessComponent;
-  let fixture: ComponentFixture<AuthPasswordlessComponent>;
+  let component: PasswordlessComponent;
+  let fixture: ComponentFixture<PasswordlessComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [AuthPasswordlessComponent],
+      declarations: [PasswordlessComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AuthPasswordlessComponent);
+    fixture = TestBed.createComponent(PasswordlessComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/console/yarn.lock
+++ b/console/yarn.lock
@@ -6430,7 +6430,7 @@ istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
 
-istanbul-lib-instrument@^5.0.4:
+istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
   integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
@@ -6461,7 +6461,16 @@ istanbul-lib-source-maps@^3.0.6:
     rimraf "^2.6.3"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2:
+istanbul-lib-source-maps@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.0.2, istanbul-reports@^3.0.5:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
   integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
@@ -6718,6 +6727,18 @@ karma-coverage-istanbul-reporter@^3.0.3:
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^3.0.6"
     istanbul-reports "^3.0.2"
+    minimatch "^3.0.4"
+
+karma-coverage@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/karma-coverage/-/karma-coverage-2.2.1.tgz#e1cc074f93ace9dc4fb7e7aeca7135879c2e358c"
+  integrity sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==
+  dependencies:
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-instrument "^5.1.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.1"
+    istanbul-reports "^3.0.5"
     minimatch "^3.0.4"
 
 karma-jasmine-html-reporter@^2.1.0:


### PR DESCRIPTION
# Which Problems Are Solved

- Hides for users MFA options are not allowed by org policy.
- Fix for "ng test" across "console"

# How the Problems Are Solved

- Before displaying MFA options we call "listMyMultiFactors" from parent component to filter MFA allowed by org

# Additional Changes

- Dependency Injection was fixed around ng unit tests

# Additional Context

admin view
<img width="698" alt="Screenshot 2025-02-06 at 00 26 50" src="https://github.com/user-attachments/assets/1b642c8a-a640-4bdd-a1ca-bde70c263567" />
user view
<img width="751" alt="Screenshot 2025-02-06 at 00 27 16" src="https://github.com/user-attachments/assets/e1c99907-3226-46ce-b8bc-e993af4b4cae" />
test
<img width="1500" alt="Screenshot 2025-02-06 at 00 01 36" src="https://github.com/user-attachments/assets/3b742655-6cbb-4bc9-b09b-b859393bfbe4" />

The issue: https://github.com/zitadel/zitadel/issues/9176
The bug report: https://discord.com/channels/927474939156643850/1307006457815896094
