### PR TITLE
fix(login): fix migration to allow login by email again

### DIFF
--- a/cmd/setup/25.go
+++ b/cmd/setup/25.go
@@ -23,5 +23,5 @@ func (mig *User11AddLowerFieldsToVerifiedEmail) Execute(ctx context.Context, _ e
 }
 
 func (mig *User11AddLowerFieldsToVerifiedEmail) String() string {
-	return "25_user13_add_lower_fields_to_verified_email"
+	return "25_user14_add_lower_fields_to_verified_email"
 }


### PR DESCRIPTION
# Which Problems Are Solved

The login by email was not possible anymore. This was due to a newly generated user projection because of #9255 .
Internal logs showed that the computed lower case column for verified email was missing.

# How the Problems Are Solved

Update name of setup step 25 to rerun the step, since the underlying sql changed.

# Additional Changes

None

# Additional Context

- relates to #9255