### PR TITLE
fix(oidc / login v2): always us login v2 if x-zitadel-login-client header is sent

### DIFF
--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -46,6 +46,11 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 	headers, _ := http_utils.HeadersFromCtx(ctx)
 	loginClient := headers.Get(LoginClientHeader)
 
+	// for backwards compatibility we'll use the new login if the header is set (no matter the other configs)
+	if loginClient != "" {
+		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
+	}
+
 	// if the instance requires the v2 login, use it no matter what the application configured
 	if authz.GetFeatures(ctx).LoginV2.Required {
 		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
@@ -64,10 +69,7 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 	case domain.LoginVersionUnspecified:
 		fallthrough
 	default:
-		// if undefined, use the v2 login if the header is sent, to retain the current behavior
-		if loginClient != "" {
-			return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
-		}
+		// since we already checked for a login header, we can fall back to the v1 login
 		return o.createAuthRequest(ctx, req, userID)
 	}
 }


### PR DESCRIPTION
# Which Problems Are Solved

As reported in #9311, even when providing a `x-zitadel-login-client` header, the auth request would be created as hosted login UI / V1 request.
This is due to a change introduced with #9071, where the login UI version can be specified using the app configuration.
The configuration set to V1 was not considering if the header was sent.

# How the Problems Are Solved

- Check presence of `x-zitadel-login-client` before the configuration. Use later only if no header is set.

# Additional Changes

None

# Additional Context

- closes #9311 
- needs back ports to 2.67.x, 2.68.x and 2.69.x