### PR TITLE
fix(handler): skip retry if trigger didn't fail

### DIFF
--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -495,7 +495,6 @@ func (h *Handler) processEvents(ctx context.Context, config *triggerConfig) (add
 		}
 	}()
 
-	stateStart := time.Now()
 	currentState, err := h.currentState(ctx, tx, config)
 	if err != nil {
 		if errors.Is(err, errJustUpdated) {


### PR DESCRIPTION
# Which Problems Are Solved

The success case of the handler.Trigger function was not handled.

# How the Problems Are Solved

Continue work without wait if there was no error.

