### PR TITLE
fix: prevent panic when retrieving session by id in internal calls

### DIFF
--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -235,6 +235,10 @@ func (q *Queries) SessionByID(ctx context.Context, shouldTriggerBulk bool, id, s
 		return nil, err
 	}
 	if sessionToken == "" {
+		// for internal calls, no token or permission check is necessary
+		if permissionCheck == nil {
+			return session, nil
+		}
 		if err := sessionCheckPermission(ctx, session.ResourceOwner, session.Creator, session.UserAgent, session.UserFactor, permissionCheck); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Which Problems Are Solved

#9110 introduced more possibilities to search for "own" sessions. Due to this the permission checks for retrieving a session had to be updated accordingly. Internal calls, such as retrieving them for sending notifications do not require a permission, but the code was not properly adjusted and thus could lead to panics.

# How the Problems Are Solved

- Properly handled (do not require) permission check for internal only calls when retrieving the session by id.

# Additional Changes

None

# Additional Context

- needs backports to 2.68.x, 2.69.x, 2.70.x
- closes zitadel/devops#117
