### PR TITLE
fix(cmd): clarify notification config handling

### DIFF
--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -467,10 +467,14 @@ func startCommandsQueries(
 		config.DefaultInstance.SecretGenerators,
 	)
 	logging.OnError(err).Fatal("unable to start commands")
+
+	if !config.Notifications.LegacyEnabled && dbClient.Type() == "cockroach" {
+		logging.Fatal("notifications must be set to LegacyEnabled=true when using CockroachDB")
+	}
 	q, err := queue.NewQueue(&queue.Config{
 		Client: dbClient,
 	})
-	logging.OnError(err).Fatal("unable to start queue")
+	logging.OnError(err).Fatal("unable to init queue")
 
 	notify_handler.Register(
 		ctx,

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	_ "embed"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -268,6 +269,9 @@ func startZitadel(ctx context.Context, config *Config, masterKey string, server 
 	actionsLogstoreSvc := logstore.New(queries, actionsExecutionDBEmitter, actionsExecutionStdoutEmitter)
 	actions.SetLogstoreService(actionsLogstoreSvc)
 
+	if !config.Notifications.LegacyEnabled && dbClient.Type() == "cockroach" {
+		return errors.New("notifications must be set to LegacyEnabled=true when using CockroachDB")
+	}
 	q, err := queue.NewQueue(&queue.Config{
 		Client: dbClient,
 	})

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -27,6 +27,9 @@ type Config struct {
 }
 
 func NewQueue(config *Config) (_ *Queue, err error) {
+	if config.Client.Type() == "cockroach" {
+		return nil, nil
+	}
 	return &Queue{
 		driver: riverpgxv5.New(config.Client.Pool),
 		config: &river.Config{


### PR DESCRIPTION
This PR clarifies configuration handling when using CockroachDB with notifications by enforcing that notifications.LegacyEnabled must be true.

# Which Problems Are Solved

If configuration `notifications.LegacyEnabled` is set to false when using cockroachdb as a database Zitadel start does not work and prints the following error: `level=fatal msg="unable to start zitadel" caller="github.com/zitadel/zitadel/cmd/start/start_from_init.go:44" error="can't scan into dest[0]: cannot scan NULL into *string"`

# How the Problems Are Solved

The combination of the setting and cockraochdb are checked and a better error is provided to the user.

# Additional Context

- introduced with https://github.com/zitadel/zitadel/pull/9321
