### PR TITLE
fix(token exchange): properly return an error if membership is missing

### DIFF
--- a/internal/api/oidc/integration_test/token_exchange_test.go
+++ b/internal/api/oidc/integration_test/token_exchange_test.go
@@ -429,6 +429,17 @@ func TestServer_TokenExchangeImpersonation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "IMPERSONATION: subject: userID, actor: access token, requested type: JWT, membership not found error",
+			args: args{
+				SubjectToken:       userResp.GetUserId(),
+				SubjectTokenType:   oidc_api.UserIDTokenType,
+				RequestedTokenType: oidc.JWTTokenType,
+				ActorToken:         noPermPAT,
+				ActorTokenType:     oidc.AccessTokenType,
+			},
+			wantErr: true,
+		},
+		{
 			name: "IAM IMPERSONATION: subject: userID, actor: access token, success",
 			args: args{
 				SubjectToken:       userResp.GetUserId(),

--- a/internal/api/oidc/token_exchange.go
+++ b/internal/api/oidc/token_exchange.go
@@ -349,6 +349,9 @@ func (s *Server) createExchangeJWT(
 		"",
 		domain.OIDCResponseTypeUnspecified,
 	)
+	if err != nil {
+		return "", "", 0, err
+	}
 	accessToken, err = s.createJWT(ctx, client, session, getUserInfo, roleAssertion, getSigner)
 	if err != nil {
 		return "", "", 0, err


### PR DESCRIPTION
# Which Problems Are Solved

When requesting a JWT (`urn:ietf:params:oauth:token-type:jwt`) to be returned in a Token Exchange request, ZITADEL would panic if the `actor` was not granted the necessary permission.

# How the Problems Are Solved

Properly check the error and return it.

# Additional Changes

None

# Additional Context

- closes #9436