### PR TITLE
fix(OIDC): back channel logout work for custom UI

### DIFF
--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -568,6 +568,7 @@ func (s *Server) CreateTokenCallbackURL(ctx context.Context, req op.AuthRequest)
 		req.GetID(),
 		implicitFlowComplianceChecker(),
 		slices.Contains(client.GrantTypes(), oidc.GrantTypeRefreshToken),
+		client.client.BackChannelLogoutURI,
 	)
 	if err != nil {
 		return "", err

--- a/internal/api/oidc/token_code.go
+++ b/internal/api/oidc/token_code.go
@@ -41,6 +41,7 @@ func (s *Server) CodeExchange(ctx context.Context, r *op.ClientRequest[oidc.Acce
 			plainCode,
 			codeExchangeComplianceChecker(client, r.Data),
 			slices.Contains(client.GrantTypes(), oidc.GrantTypeRefreshToken),
+			client.client.BackChannelLogoutURI,
 		)
 	} else {
 		session, err = s.codeExchangeV1(ctx, client, r.Data, r.Data.Code)

--- a/internal/api/oidc/token_device.go
+++ b/internal/api/oidc/token_device.go
@@ -25,7 +25,7 @@ func (s *Server) DeviceToken(ctx context.Context, r *op.ClientRequest[oidc.Devic
 	if !ok {
 		return nil, zerrors.ThrowInternal(nil, "OIDC-Ae2ph", "Error.Internal")
 	}
-	session, err := s.command.CreateOIDCSessionFromDeviceAuth(ctx, r.Data.DeviceCode)
+	session, err := s.command.CreateOIDCSessionFromDeviceAuth(ctx, r.Data.DeviceCode, client.client.BackChannelLogoutURI)
 	if err == nil {
 		return response(s.accessTokenResponseFromSession(ctx, client, session, "", client.client.ProjectID, client.client.ProjectRoleAssertion, client.client.AccessTokenRoleAssertion, client.client.IDTokenRoleAssertion, client.client.IDTokenUserinfoAssertion))
 	}

--- a/internal/command/device_auth.go
+++ b/internal/command/device_auth.go
@@ -174,7 +174,7 @@ func (e DeviceAuthStateError) Error() string {
 // As devices can poll at various intervals, an explicit state takes precedence over expiry.
 // This is to prevent cases where users might approve or deny the authorization on time, but the next poll
 // happens after expiry.
-func (c *Commands) CreateOIDCSessionFromDeviceAuth(ctx context.Context, deviceCode string) (_ *OIDCSession, err error) {
+func (c *Commands) CreateOIDCSessionFromDeviceAuth(ctx context.Context, deviceCode, backChannelLogoutURI string) (_ *OIDCSession, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
@@ -219,6 +219,7 @@ func (c *Commands) CreateOIDCSessionFromDeviceAuth(ctx context.Context, deviceCo
 		deviceAuthModel.PreferredLanguage,
 		deviceAuthModel.UserAgent,
 	)
+	cmd.RegisterLogout(ctx, deviceAuthModel.SessionID, deviceAuthModel.UserID, deviceAuthModel.ClientID, backChannelLogoutURI)
 	if err = cmd.AddAccessToken(ctx, deviceAuthModel.Scopes, deviceAuthModel.UserID, deviceAuthModel.UserOrgID, domain.TokenReasonAuthRequest, nil); err != nil {
 		return nil, err
 	}

--- a/internal/command/oidc_session_test.go
+++ b/internal/command/oidc_session_test.go
@@ -49,10 +49,11 @@ func TestCommands_CreateOIDCSessionFromAuthRequest(t *testing.T) {
 		keyAlgorithm                    crypto.EncryptionAlgorithm
 	}
 	type args struct {
-		ctx              context.Context
-		authRequestID    string
-		complianceCheck  AuthRequestComplianceChecker
-		needRefreshToken bool
+		ctx                  context.Context
+		authRequestID        string
+		complianceCheck      AuthRequestComplianceChecker
+		needRefreshToken     bool
+		backChannelLogoutURI string
 	}
 	type res struct {
 		session *OIDCSession
@@ -439,6 +440,151 @@ func TestCommands_CreateOIDCSessionFromAuthRequest(t *testing.T) {
 			},
 		},
 		{
+			"add successful, backChannelLogout (feature enabled)",
+			fields{
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							authrequest.NewAddedEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate,
+								"loginClient",
+								"clientID",
+								"redirectURI",
+								"state",
+								"nonce",
+								[]string{"openid", "offline_access"},
+								[]string{"audience"},
+								domain.OIDCResponseTypeCode,
+								domain.OIDCResponseModeQuery,
+								&domain.OIDCCodeChallenge{
+									Challenge: "challenge",
+									Method:    domain.CodeChallengeMethodS256,
+								},
+								[]domain.Prompt{domain.PromptNone},
+								[]string{"en", "de"},
+								gu.Ptr(time.Duration(0)),
+								gu.Ptr("loginHint"),
+								gu.Ptr("hintUserID"),
+								true,
+							),
+						),
+						eventFromEventPusher(
+							authrequest.NewCodeAddedEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate),
+						),
+						eventFromEventPusher(
+							authrequest.NewSessionLinkedEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate,
+								"sessionID",
+								"userID",
+								testNow,
+								[]domain.UserAuthMethodType{domain.UserAuthMethodTypePassword},
+							),
+						),
+					),
+					expectFilter(
+						eventFromEventPusher(
+							session.NewAddedEvent(context.Background(),
+								&session.NewAggregate("sessionID", "instance1").Aggregate,
+								&domain.UserAgent{
+									FingerprintID: gu.Ptr("fp1"),
+									IP:            net.ParseIP("1.2.3.4"),
+									Description:   gu.Ptr("firefox"),
+									Header:        http.Header{"foo": []string{"bar"}},
+								},
+							),
+						),
+						eventFromEventPusher(
+							session.NewUserCheckedEvent(context.Background(), &session.NewAggregate("sessionID", "instanceID").Aggregate,
+								"userID", "org1", testNow, &language.Afrikaans),
+						),
+						eventFromEventPusher(
+							session.NewPasswordCheckedEvent(context.Background(), &session.NewAggregate("sessionID", "instanceID").Aggregate,
+								testNow),
+						),
+					),
+					expectFilter(
+						user.NewHumanAddedEvent(
+							context.Background(),
+							&user.NewAggregate("userID", "org1").Aggregate,
+							"username",
+							"firstname",
+							"lastname",
+							"nickname",
+							"displayname",
+							language.Afrikaans,
+							domain.GenderUnspecified,
+							"email",
+							false,
+						),
+					),
+					expectFilter(), // token lifetime
+					expectPush(
+						authrequest.NewCodeExchangedEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate),
+						oidcsession.NewAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
+							"userID", "org1", "sessionID", "clientID", []string{"audience"}, []string{"openid", "offline_access"},
+							[]domain.UserAuthMethodType{domain.UserAuthMethodTypePassword}, testNow, "nonce", &language.Afrikaans,
+							&domain.UserAgent{
+								FingerprintID: gu.Ptr("fp1"),
+								IP:            net.ParseIP("1.2.3.4"),
+								Description:   gu.Ptr("firefox"),
+								Header:        http.Header{"foo": []string{"bar"}},
+							},
+						),
+						sessionlogout.NewBackChannelLogoutRegisteredEvent(context.Background(),
+							&sessionlogout.NewAggregate("sessionID", "instanceID").Aggregate,
+							"V2_oidcSessionID",
+							"userID",
+							"clientID",
+							"backChannelLogoutURI",
+						),
+						oidcsession.NewAccessTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
+							"at_accessTokenID", []string{"openid", "offline_access"}, time.Hour, domain.TokenReasonAuthRequest, nil),
+						user.NewUserTokenV2AddedEvent(context.Background(), &user.NewAggregate("userID", "org1").Aggregate, "at_accessTokenID"),
+						oidcsession.NewRefreshTokenAddedEvent(context.Background(), &oidcsession.NewAggregate("V2_oidcSessionID", "org1").Aggregate,
+							"rt_refreshTokenID", 7*24*time.Hour, 24*time.Hour),
+						authrequest.NewSucceededEvent(context.Background(), &authrequest.NewAggregate("V2_authRequestID", "instanceID").Aggregate),
+					),
+				),
+				idGenerator:                     mock.NewIDGeneratorExpectIDs(t, "oidcSessionID", "accessTokenID", "refreshTokenID"),
+				defaultAccessTokenLifetime:      time.Hour,
+				defaultRefreshTokenLifetime:     7 * 24 * time.Hour,
+				defaultRefreshTokenIdleLifetime: 24 * time.Hour,
+				keyAlgorithm:                    crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+			},
+			args{
+
+				ctx: authz.WithFeatures(authz.WithInstanceID(context.Background(), "instanceID"), feature.Features{
+					EnableBackChannelLogout: true,
+				}),
+				authRequestID:        "V2_authRequestID",
+				complianceCheck:      mockAuthRequestComplianceChecker(nil),
+				needRefreshToken:     true,
+				backChannelLogoutURI: "backChannelLogoutURI",
+			},
+			res{
+				session: &OIDCSession{
+					SessionID:         "sessionID",
+					TokenID:           "V2_oidcSessionID-at_accessTokenID",
+					ClientID:          "clientID",
+					UserID:            "userID",
+					Audience:          []string{"audience"},
+					Expiration:        time.Time{}.Add(time.Hour),
+					Scope:             []string{"openid", "offline_access"},
+					AuthMethods:       []domain.UserAuthMethodType{domain.UserAuthMethodTypePassword},
+					AuthTime:          testNow,
+					Nonce:             "nonce",
+					PreferredLanguage: &language.Afrikaans,
+					UserAgent: &domain.UserAgent{
+						FingerprintID: gu.Ptr("fp1"),
+						IP:            net.ParseIP("1.2.3.4"),
+						Description:   gu.Ptr("firefox"),
+						Header:        http.Header{"foo": []string{"bar"}},
+					},
+					Reason:       domain.TokenReasonAuthRequest,
+					RefreshToken: "VjJfb2lkY1Nlc3Npb25JRC1ydF9yZWZyZXNoVG9rZW5JRDp1c2VySUQ", //V2_oidcSessionID-rt_refreshTokenID:userID
+				},
+				state: "state",
+			},
+		},
+		{
 			"disable user token event",
 			fields{
 				eventstore: expectEventstore(
@@ -708,7 +854,7 @@ func TestCommands_CreateOIDCSessionFromAuthRequest(t *testing.T) {
 				keyAlgorithm:                    tt.fields.keyAlgorithm,
 			}
 			c.setMilestonesCompletedForTest("instanceID")
-			gotSession, gotState, err := c.CreateOIDCSessionFromAuthRequest(tt.args.ctx, tt.args.authRequestID, tt.args.complianceCheck, tt.args.needRefreshToken)
+			gotSession, gotState, err := c.CreateOIDCSessionFromAuthRequest(tt.args.ctx, tt.args.authRequestID, tt.args.complianceCheck, tt.args.needRefreshToken, tt.args.backChannelLogoutURI)
 			require.ErrorIs(t, err, tt.res.err)
 
 			if gotSession != nil {

--- a/internal/repository/session/session.go
+++ b/internal/repository/session/session.go
@@ -660,7 +660,7 @@ func NewLifetimeSetEvent(
 type TerminateEvent struct {
 	eventstore.BaseEvent `json:"-"`
 
-	TriggerOrigin string `json:"triggerOrigin,omitempty"`
+	TriggeredAtOrigin string `json:"triggerOrigin,omitempty"`
 }
 
 func (e *TerminateEvent) Payload() interface{} {
@@ -669,6 +669,10 @@ func (e *TerminateEvent) Payload() interface{} {
 
 func (e *TerminateEvent) UniqueConstraints() []*eventstore.UniqueConstraint {
 	return nil
+}
+
+func (e *TerminateEvent) TriggerOrigin() string {
+	return e.TriggeredAtOrigin
 }
 
 func NewTerminateEvent(
@@ -681,6 +685,7 @@ func NewTerminateEvent(
 			aggregate,
 			TerminateType,
 		),
+		TriggeredAtOrigin: http.DomainContext(ctx).Origin(),
 	}
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

When using a custom / new login UI and an OIDC application with registered BackChannelLogoutUI, no logout requests were sent to the URI when the user signed out.
Additionally, as described in #9427, an error was logged:
`level=error msg="event of type *session.TerminateEvent doesn't implement OriginEvent" caller="/home/runner/work/zitadel/zitadel/internal/notification/handlers/origin.go:24"`

# How the Problems Are Solved

- Properly pass `TriggerOrigin` information to session.TerminateEvent creation and implement `OriginEvent` interface.
- Implemented `RegisterLogout` in `CreateOIDCSessionFromAuthRequest` and `CreateOIDCSessionFromDeviceAuth`, both used when interacting with the OIDC v2 API.
- Both functions now receive the `BackChannelLogoutURI` of the client from the OIDC layer.

# Additional Changes

None

# Additional Context

- closes #9427
