### PR TITLE
fix: add permission check for saml request query

### DIFF
--- a/internal/query/saml_request.go
+++ b/internal/query/saml_request.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/api/call"
+	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore/handler/v2"
 	"github.com/zitadel/zitadel/internal/query/projection"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
@@ -28,9 +29,9 @@ type SamlRequest struct {
 	Binding      string
 }
 
-func (a *SamlRequest) checkLoginClient(ctx context.Context) error {
+func (a *SamlRequest) checkLoginClient(ctx context.Context, permissionCheck domain.PermissionCheck) error {
 	if uid := authz.GetCtxData(ctx).UserID; uid != a.LoginClient {
-		return zerrors.ThrowPermissionDenied(nil, "OIDCv2-aL0ag", "Errors.SamlRequest.WrongLoginClient")
+		return permissionCheck(ctx, domain.PermissionSessionRead, authz.GetInstance(ctx).InstanceID(), "")
 	}
 	return nil
 }
@@ -72,7 +73,7 @@ func (q *Queries) SamlRequestByID(ctx context.Context, shouldTriggerBulk bool, i
 	}
 
 	if checkLoginClient {
-		if err = dst.checkLoginClient(ctx); err != nil {
+		if err = dst.checkLoginClient(ctx, q.checkPermission); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
# Which Problems Are Solved

Without the login client header, there is no possible way to query the SAML requests.

# How the Problems Are Solved

Add a permission check to the query of SAML requests, equal to the AuthRequest query.

# Additional Changes

None

# Additional Context

Related to https://github.com/zitadel/typescript/issues/66
