### PR TITLE
docs: show proxy link only once

### DIFF
--- a/docs/docs/self-hosting/manage/reverseproxy/_proxy_guide_overview.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/_proxy_guide_overview.mdx
@@ -2,13 +2,13 @@ import CodeBlock from '@theme/CodeBlock';
 import ComposeYaml from "!!raw-loader!./docker-compose.yaml";
 
 <>With these examples, you create and run a minimal {props.link} configuration for ZITADEL with <a href="https://docs.docker.com/compose">Docker Compose</a>.
-Whereas the guide focuses on the configuration for {props.link}, you can inspect the configurations for ZITADEL and the database in the base Docker Compose file.</>
+Whereas the guide focuses on the configuration for {props.name}, you can inspect the configurations for ZITADEL and the database in the base Docker Compose file.</>
 <details>
     <summary>base docker-compose.yaml</summary>
     <CodeBlock language="yaml">{ComposeYaml}</CodeBlock>
 </details>
 
-<>For running {props.link}, you will extend the base Docker Compose file with the {props.link} specific Docker Compose file.</>
+<>For running {props.name}, you will extend the base Docker Compose file with the {props.name} specific Docker Compose file.</>
 
 <details>
     <summary>specific docker-compose.yaml</summary>

--- a/docs/docs/self-hosting/manage/reverseproxy/_proxy_guide_tls_mode.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/_proxy_guide_tls_mode.mdx
@@ -1,25 +1,25 @@
 import CodeBlock from '@theme/CodeBlock';
 
-export const Description = ({mode, link}) => {
+export const Description = ({mode, name}) => {
     let desc
     switch (mode) {
         case "disabled":
-            desc = <>Neither {link} nor ZITADEL terminates TLS.
-                Nevertheless, {link} forwards unencrypted HTTP/2 traffic, aka h2c, to ZITADEL.</>;
+            desc = <>Neither {name} nor ZITADEL terminates TLS.
+                Nevertheless, {name} forwards unencrypted HTTP/2 traffic, aka h2c, to ZITADEL.</>;
             break;
         case "external":
-            desc = <>{link} terminates TLS and forwards the requests to ZITADEL via unencrypted h2c.
-                This example uses an unsafe self-signed certificate for {link}</>;
+            desc = <>{name} terminates TLS and forwards the requests to ZITADEL via unencrypted h2c.
+                This example uses an unsafe self-signed certificate for {name}</>;
             break;
         case "enabled":
-            desc = <>{link} terminates TLS and forwards the requests to ZITADEL via encrypted HTTP/2.
-                This example uses an unsafe self-signed certificate for {link} and the same for ZITADEL.</>;
+            desc = <>{name} terminates TLS and forwards the requests to ZITADEL via encrypted HTTP/2.
+                This example uses an unsafe self-signed certificate for {name} and the same for ZITADEL.</>;
             break;
     }
     return (
         <>
             {desc}
-            <>By executing the commands below, you will download the files necessary to run ZITADEL behind {link} with the following config:</>
+            <>By executing the commands below, you will download the files necessary to run ZITADEL behind {name} with the following config:</>
         </>)
 }
 

--- a/docs/docs/self-hosting/manage/reverseproxy/caddy/caddy.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/caddy/caddy.mdx
@@ -15,7 +15,7 @@ export const providername = 'Caddy';
 export const lower = "caddy";
 export const link = <a href="https://caddyserver.com/">{providername}</a>
 
-<ProxyGuideOverview link={link} compose={Compose}></ProxyGuideOverview>
+<ProxyGuideOverview name={providername} link={link} compose={Compose}></ProxyGuideOverview>
 
 You can either setup your environment for <a href={'#tls-mode-external'}>TLS mode external</a> or <a href={'#tls-mode-enabled'}>TLS mode enabled</a>.
 

--- a/docs/docs/self-hosting/manage/reverseproxy/httpd/httpd.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/httpd/httpd.mdx
@@ -15,7 +15,7 @@ export const providername = "Apache httpd";
 export const lower = "httpd";
 export const link = <a href="https://httpd.apache.org//">{providername}</a>
 
-<ProxyGuideOverview link={link} compose={Compose}></ProxyGuideOverview>
+<ProxyGuideOverview name={providername} link={link} compose={Compose}></ProxyGuideOverview>
 
 You can either setup your environment for <a href={'#tls-mode-disabled'}>TLS mode disabled</a>, <a href={'#tls-mode-external'}>TLS mode external</a> or <a href={'#tls-mode-enabled'}>TLS mode enabled</a>.
 

--- a/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/nginx/nginx.mdx
@@ -15,7 +15,7 @@ export const providername = 'NGINX';
 export const lower = "nginx";
 export const link = <a href="https://nginx.com/">{providername}</a>;
 
-<ProxyGuideOverview link={link} compose={Compose}></ProxyGuideOverview>
+<ProxyGuideOverview name={providername} link={link} compose={Compose}></ProxyGuideOverview>
 
 You can either setup your environment for <a href={'#tls-mode-disabled'}>TLS mode disabled</a>, <a href={'#tls-mode-external'}>TLS mode external</a> or <a href={'#tls-mode-enabled'}>TLS mode enabled</a>.
 

--- a/docs/docs/self-hosting/manage/reverseproxy/traefik/traefik.mdx
+++ b/docs/docs/self-hosting/manage/reverseproxy/traefik/traefik.mdx
@@ -15,7 +15,7 @@ export const providername = 'Traefik';
 export const lower = "traefik";
 export const link = <a href="https://doc.traefik.io/traefik/">{providername}</a>;
 
-<ProxyGuideOverview link={link} compose={Compose}></ProxyGuideOverview>
+<ProxyGuideOverview name={providername} link={link} compose={Compose}></ProxyGuideOverview>
 
 You can either setup your environment for <a href={'#tls-mode-disabled'}>TLS mode disabled</a>, <a href={'#tls-mode-external'}>TLS mode external</a> or <a href={'#tls-mode-enabled'}>TLS mode enabled</a>.
 


### PR DESCRIPTION
# Which Problems Are Solved

The reverse proxy docs have too many links to the third party proxy provider. This is noisy and might result in unintentional redirects.
![image (1)](https://github.com/user-attachments/assets/3127f3bc-a6e1-47c5-a565-4f68ce1650d3)


# How the Problems Are Solved

The link to the proxy provider is only shown on the first occurence of the provider name instead of all occurences.