### PR TITLE
chore: Replace deprecated `io/ioutil` functions with recommended alternatives

### DIFF
--- a/internal/api/grpc/admin/import.go
+++ b/internal/api/grpc/admin/import.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"strconv"
 	"time"
 
@@ -214,7 +215,7 @@ func (s *Server) transportDataFromFile(ctx context.Context, v1Transformation boo
 		data = s3Data
 	}
 	if localInput != nil {
-		localData, err := ioutil.ReadFile(localInput.Path)
+		localData, err := os.ReadFile(localInput.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +275,7 @@ func getFileFromS3(ctx context.Context, input *admin_pb.ImportDataRequest_S3Inpu
 	}
 
 	defer object.Close()
-	return ioutil.ReadAll(object)
+	return io.ReadAll(object)
 }
 
 func getFileFromGCS(ctx context.Context, input *admin_pb.ImportDataRequest_GCSInput) (_ []byte, err error) {
@@ -297,7 +298,7 @@ func getFileFromGCS(ctx context.Context, input *admin_pb.ImportDataRequest_GCSIn
 		return nil, err
 	}
 	defer reader.Close()
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 func importOrg1(ctx context.Context, s *Server, errors *[]*admin_pb.ImportDataError, ctxData authz.CtxData, org *admin_pb.DataOrg, success *admin_pb.ImportDataSuccess, count *counts, initCodeGenerator, emailCodeGenerator, phoneCodeGenerator, passwordlessInitCode crypto.Generator) (err error) {

--- a/internal/command/project_application_saml_test.go
+++ b/internal/command/project_application_saml_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -882,7 +882,7 @@ func newTestClient(httpStatus int, metadata []byte) *http.Client {
 	fn := roundTripperFunc(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: httpStatus,
-			Body:       ioutil.NopCloser(bytes.NewBuffer(metadata)),
+			Body:       io.NopCloser(bytes.NewBuffer(metadata)),
 			Header:     make(http.Header), //must be non-nil value
 		}
 	})

--- a/internal/id/sonyflake.go
+++ b/internal/id/sonyflake.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -200,7 +200,7 @@ func metadataWebhookID() (uint16, error) {
 	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
 		return 0, fmt.Errorf("metadata endpoint returned an unsuccessful status code %d", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/notification/templates/template.go
+++ b/internal/notification/templates/template.go
@@ -3,7 +3,7 @@ package templates
 import (
 	"bytes"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -51,7 +51,7 @@ func readFile(dir http.FileSystem, fileName string) (*template.Template, error) 
 		return nil, err
 	}
 	defer f.Close()
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func readFileFromDatabase(dir http.FileSystem, fileName string) (*template.Templ
 		return nil, err
 	}
 	defer f.Close()
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/message_text.go
+++ b/internal/query/message_text.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -320,7 +320,7 @@ func (q *Queries) readTranslationFile(namespace i18n.Namespace, filename string)
 	if err != nil {
 		return nil, zerrors.ThrowInternal(err, "QUERY-93njw", "Errors.TranslationFile.ReadError")
 	}
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, zerrors.ThrowInternal(err, "QUERY-l0fse", "Errors.TranslationFile.ReadError")
 	}

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -3,7 +3,7 @@ package renderer
 import (
 	"context"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -107,7 +107,7 @@ func (r *Renderer) addFileToTemplate(dir http.FileSystem, tmpl *template.Templat
 		return err
 	}
 	defer f.Close()
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Which Problems Are Solved

- The `io/ioutil` package was deprecated in Go 1.16.  
  - Reference: https://go.dev/doc/go1.16#ioutil  

# How the Problems Are Solved

- Replaced deprecated functions with their recommended alternatives:  
  - `ioutil.ReadFile` → `os.ReadFile`  
  - `ioutil.ReadAll` → `io.ReadAll`  
  - `ioutil.NopCloser` → `io.NopCloser`  

