### PR TITLE
chore: Update contrib.rocks link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Join our [Discord Chat](https://zitadel.com/chat) to get help.
   <img src="https://contrib.rocks/image?repo=zitadel/zitadel" />
 </a>
 
-Made with [contrib.rocks](https://contrib.rocks).
+Made with [contrib.rocks](https://contrib.rocks/preview?repo=zitadel/zitadel).
 
 ## Showcase
 


### PR DESCRIPTION
# Which Problems Are Solved

- The current contrib.rocks link (`https://contrib.rocks`) does not directly preview the contributor graph for the zitadel/zitadel repository.

# How the Problems Are Solved

- Updated the contrib.rocks link to `https://contrib.rocks/preview?repo=zitadel/zitadel`, which directly shows the contributor graph for this repository.

