### PR TITLE
fix(login): cache scripts and other assets correctly

### DIFF
--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/csrf"
 	"github.com/zitadel/logging"
 
+	"github.com/zitadel/zitadel/cmd/build"
 	"github.com/zitadel/zitadel/internal/api/authz"
 	http_mw "github.com/zitadel/zitadel/internal/api/http/middleware"
 	"github.com/zitadel/zitadel/internal/domain"
@@ -87,10 +88,10 @@ func CreateRenderer(pathPrefix string, staticStorage static.Storage, cookieName 
 	}
 	funcs := map[string]interface{}{
 		"resourceUrl": func(file string) string {
-			return path.Join(r.pathPrefix, EndpointResources, file)
+			return path.Join(r.pathPrefix, EndpointResources, file) + "?v=" + build.Date().Format(time.RFC3339)
 		},
 		"resourceThemeUrl": func(file, theme string) string {
-			return path.Join(r.pathPrefix, EndpointResources, "themes", theme, file)
+			return path.Join(r.pathPrefix, EndpointResources, "themes", theme, file) + "?v=" + build.Date().Format(time.RFC3339)
 		},
 		"hasCustomPolicy": func(policy *domain.LabelPolicy) bool {
 			return policy != nil


### PR DESCRIPTION
# Which Problems Are Solved

Scripts and other assets for the hosted login UI are served with a public cache with `max-age` and `s-maxage`. After changing scripts or assets, old versions might be still used as they might be cached locally or in a shared cache (CDN, proxy, ...). This can lead to unwanted behaviour or even errors.

# How the Problems Are Solved

To ensure the correct file is served a query parameter with the build time is added to the assets filename dynamically. (`?v=2025-03-17...`)

# Additional Changes

None

# Additional Context

- relates to #9485
- requires backport to at least 2.70.x
