### PR TITLE
chore: use crdb 24.3

### DIFF
--- a/build/workflow.Dockerfile
+++ b/build/workflow.Dockerfile
@@ -234,7 +234,7 @@ FROM test-core-base AS test-core-integration
 ENV DB_FLAVOR=cockroach
 
 # install cockroach
-COPY --from=cockroachdb/cockroach:latest /cockroach/cockroach /usr/local/bin/
+COPY --from=cockroachdb/cockroach:latest-v24.3 /cockroach/cockroach /usr/local/bin/
 ENV COCKROACH_BINARY=/cockroach/cockroach
 
 ENV ZITADEL_MASTERKEY=MasterkeyNeedsToHave32Characters

--- a/deploy/knative/cockroachdb-statefulset-single-node.yaml
+++ b/deploy/knative/cockroachdb-statefulset-single-node.yaml
@@ -86,7 +86,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:latest
+        image: cockroachdb/cockroach:latest-v24.3
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/e2e/config/localhost/docker-compose.yaml
+++ b/e2e/config/localhost/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
 
   db:
     restart: 'always'
-    image: 'cockroachdb/cockroach:latest'
+    image: 'cockroachdb/cockroach:latest-v24.3'
     command: 'start-single-node --insecure --http-addr :9090'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:9090/health?ready=1']


### PR DESCRIPTION
# Which Problems Are Solved

E2E tests in pipelines started to fail randomly. While debugging it, i noticed that we use the `latest` tag of cockroach's docker image. They tagged 25.1 as latest yesterday.

# How the Problems Are Solved

Since we drop support for CRDB with version 3 as there are anyway multiple issues with various versions, I pinned the docker image tag to `latest-v24.3`.

# Additional Changes

None

# Additional Context

relates to https://github.com/zitadel/zitadel/actions/runs/13917603587 and https://github.com/zitadel/zitadel/actions/runs/13904928050