### PR TITLE
fix(webkey): create webKey handling

### DIFF
--- a/internal/api/grpc/webkey/v2beta/webkey.go
+++ b/internal/api/grpc/webkey/v2beta/webkey.go
@@ -25,7 +25,7 @@ func (s *Server) CreateWebKey(ctx context.Context, req *webkey.CreateWebKeyReque
 
 	return &webkey.CreateWebKeyResponse{
 		Id:           webKey.KeyID,
-		CreationDate: timestamppb.New(webKey.ObjectDetails.CreationDate),
+		CreationDate: timestamppb.New(webKey.ObjectDetails.EventDate),
 	}, nil
 }
 

--- a/proto/zitadel/webkey/v2beta/webkey_service.proto
+++ b/proto/zitadel/webkey/v2beta/webkey_service.proto
@@ -285,7 +285,7 @@ message CreateWebKeyRequest {
     ED25519 ed25519 = 3;
   }
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
-    example: "{\"bits\":\"RSA_BITS_2048\",\"hasher\":\"RSA_HASHER_SHA5256\"}";
+    example: "{\"rsa\":{\"bits\":\"RSA_BITS_2048\",\"hasher\":\"RSA_HASHER_SHA256\"}}";
   };
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

During the review of #9489 we noticed that the curl example was wrong. Additionally, the returned `creationDate` was always a zero value.

# How the Problems Are Solved

Fixed example and mapped the correct date.

# Additional Changes

None

# Additional Context

None