### PR TITLE
fix(actions): correctly handle api.v1.appendUserGrant

### DIFF
--- a/internal/actions/fields.go
+++ b/internal/actions/fields.go
@@ -62,10 +62,12 @@ func (f *FieldConfig) set(name string, value interface{}) {
 		logging.WithFields("name", name).Error("tried to overwrite field")
 		panic("tried to overwrite field")
 	}
-	v, ok := value.(func(*FieldConfig) interface{})
-	if ok {
+	switch v := value.(type) {
+	case func(config *FieldConfig) interface{}:
 		f.fields[name] = v(f)
-		return
+	case func(config *FieldConfig) func(call goja.FunctionCall) goja.Value:
+		f.fields[name] = v(f)
+	default:
+		f.fields[name] = value
 	}
-	f.fields[name] = value
 }

--- a/internal/actions/object/user_grant.go
+++ b/internal/actions/object/user_grant.go
@@ -158,9 +158,9 @@ func UserGrantsToDomain(userID string, actionUserGrants []UserGrant) []*domain.U
 func mapObjectToGrant(object *goja.Object, grant *UserGrant) {
 	for _, key := range object.Keys() {
 		switch key {
-		case "projectId":
+		case "projectId", "projectID":
 			grant.ProjectID = object.Get(key).String()
-		case "projectGrantId":
+		case "projectGrantId", "projectGrantID":
 			grant.ProjectGrantID = object.Get(key).String()
 		case "roles":
 			if roles, ok := object.Get(key).Export().([]interface{}); ok {


### PR DESCRIPTION
# Which Problems Are Solved

It was not possible to use the `api.v1.appendUserGrant` function in the `postCreation` trigger action as documented.

# How the Problems Are Solved

- Correctly initialize the javascript / Goja function
- Added `projectID` and `projectGrantID` (as documented), but kept `projectId` and `projectGrantId` (for backwards compatibility) when mapping the object in the `appendUserGrant` function

# Additional Changes

None

# Additional Context

- A customer reached out to support regarding this issue.
- requires back port to 2.70.x