### PR TITLE
fix: correct event type for permission removed

### DIFF
--- a/internal/repository/permission/permission.go
+++ b/internal/repository/permission/permission.go
@@ -99,7 +99,7 @@ func (e *RemovedEvent) Fields() []*eventstore.FieldOperation {
 
 func NewRemovedEvent(ctx context.Context, aggregate *eventstore.Aggregate, role, permission string) *RemovedEvent {
 	return &RemovedEvent{
-		BaseEvent:  eventstore.NewBaseEventForPush(ctx, aggregate, AddedType),
+		BaseEvent:  eventstore.NewBaseEventForPush(ctx, aggregate, RemovedType),
 		Role:       role,
 		Permission: permission,
 	}


### PR DESCRIPTION
# Which Problems Are Solved

When we recently changed some permission for the `SYSTEM_OWNER` role on QA, we noticed that there we multiple `permission.added` even when we removed specific permissions.

# How the Problems Are Solved

Fixed the event type when removing permissions.

# Additional Changes

None

# Additional Context

Noticed when rolling out some changes on QA