### PR TITLE
fix: text buttons overflow in login page

### DIFF
--- a/internal/api/ui/login/static/resources/themes/scss/styles/button/button_base.scss
+++ b/internal/api/ui/login/static/resources/themes/scss/styles/button/button_base.scss
@@ -39,7 +39,9 @@ $lgn-icon-button-line-height: 40px !default;
   padding: $lgn-button-padding;
   border-radius: $lgn-button-border-radius;
 
-  overflow: visible;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
   transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
 
   &[disabled] {


### PR DESCRIPTION
# Which Problems Are Solved

The text of some of the buttons in the login page overflows in some languages

![image](https://github.com/user-attachments/assets/ef3d3bfe-8966-4be5-8d3b-3b0b72ce5e49)

# How the Problems Are Solved

Updated the css to set the overflow to hidden and text-overflow to ellipsis

![image](https://github.com/user-attachments/assets/cdfa1f7b-535a-419d-ba9d-a57ec332d976)


# Additional Changes

None

# Additional Context

I couldn't test the following case locally since I had trouble setting up a SMTP provider locally, but the class affected by my change should also target this case, if someone could test it before merging it :pray::

![315957139-6a630056-82b9-42cd-85a6-8819f2e1873b](https://github.com/user-attachments/assets/f6860db3-d6a0-4e4d-b9e6-0b1968145047)

- Closes #7619