### PR TITLE
fix: saml context usage for issuer

### DIFF
--- a/internal/api/saml/auth_request.go
+++ b/internal/api/saml/auth_request.go
@@ -36,8 +36,7 @@ func (p *Provider) CreateResponse(ctx context.Context, authReq models.AuthReques
 		Audience:        authReq.GetIssuer(),
 	}
 
-	issuer := ContextToIssuer(ctx)
-	req, err := http.NewRequestWithContext(provider.ContextWithIssuer(ctx, issuer), http.MethodGet, issuer, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "", nil)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
# Which Problems Are Solved

Issuer was wrongly processed into context information, which was then never read.

# How the Problems Are Solved

Use the already available context, which then the issuer can be read from correctly.

# Additional Changes

None

# Additional Context

None
