### PR TITLE
feat: Display Authentication Method Name on Application Page

### DIFF
--- a/console/src/app/modules/info-row/info-row.component.html
+++ b/console/src/app/modules/info-row/info-row.component.html
@@ -244,6 +244,13 @@
       </p>
     </div>
 
+    <div class="info-wrapper" *ngIf="app && app.oidcConfig && app.oidcConfig.authMethodType">
+      <p class="info-row-title">{{ 'APP.AUTHMETHOD' | translate }}</p>
+      <p class="info-row-desc">
+        {{ 'APP.OIDC.AUTHMETHOD.' + app.oidcConfig.authMethodType | translate }}
+      </p>
+    </div>
+
     <div class="info-wrapper">
       <p class="info-row-title">{{ 'APP.PAGES.ID' | translate }}</p>
       <p *ngIf="app && app.id" class="info-row-desc">{{ app.id }}</p>

--- a/console/src/app/modules/info-row/info-row.component.html
+++ b/console/src/app/modules/info-row/info-row.component.html
@@ -244,7 +244,14 @@
       </p>
     </div>
 
-    <div class="info-wrapper" *ngIf="app && app.oidcConfig && app.oidcConfig.authMethodType">
+    <div class="info-wrapper" *ngIf="app && app.apiConfig && app.apiConfig.authMethodType !== undefined">
+      <p class="info-row-title">{{ 'APP.AUTHMETHOD' | translate }}</p>
+      <p class="info-row-desc">
+        {{ 'APP.API.AUTHMETHOD.' + app.apiConfig.authMethodType | translate }}
+      </p>
+    </div>
+
+    <div class="info-wrapper" *ngIf="app && app.oidcConfig && app.oidcConfig.authMethodType !== undefined">
       <p class="info-row-title">{{ 'APP.AUTHMETHOD' | translate }}</p>
       <p class="info-row-desc">
         {{ 'APP.OIDC.AUTHMETHOD.' + app.oidcConfig.authMethodType | translate }}


### PR DESCRIPTION
# Which Problems Are Solved

The Authentication Method name is currently not displayed on the Application Page, this screenshot is taken from the linked issue:

<img width="946" alt="417991175-a6c8497f-9c4f-4042-8ffa-c5f995ab5039" src="https://github.com/user-attachments/assets/aea0e956-27e3-4e32-bcb1-0a7456480084" />


I can also add other fields if necessary, but the layout may need to be redesigned to keep a good looking UI since there are already a lot of fields.

# How the Problems Are Solved

Display the Authentication Method name between the `Status` and the `ID` fields from either the `oidcConfig` or the `apiConfig` objects.

Here are some screenshots of the result:

None:

![image](https://github.com/user-attachments/assets/776dc3db-5196-413e-bff4-38f1a149f5c5)

Private JWT:

![image](https://github.com/user-attachments/assets/e9279143-1c92-4932-a271-c0865393384c)

Post:

![image](https://github.com/user-attachments/assets/486ca69b-715d-4681-8b5b-5db47ff2cbf1)

API Basic:

![image](https://github.com/user-attachments/assets/3ad923f1-642b-400b-a38a-818c1ce3534e)

# Additional Changes

None

# Additional Context

- Closes #9435
