### PR TITLE
chore: add guidelines and licensing comment to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
+Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/v3.x/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
 
 Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+<!--
+Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
+
+Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
+-->
+
 # Which Problems Are Solved
 
 Replace this example text with a concise list of problems that this PR solves.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 <!--
-Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
-
+Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
 Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/v3.x/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
+Please inform yourself about the contribution guidelines on submititng a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
 
 Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
 -->


### PR DESCRIPTION
# Which Problems Are Solved

Sometimes our guidelines are missed by contributors. The same risk exists for the licensing terms under which contributions are submitted.

# How the Problems Are Solved

- Add comment with link to the relevant contribution guideline section
- Add comment with link to LICENSING.md

The comments are added as HTML comment which will be visible to the contributor, but won't be rendered in PR once submitted.

# Additional Changes

- none

# Additional Context

- https://github.com/zitadel/zitadel/pull/9597#pullrequestreview-2716301670