### PR TITLE
chore(deps): group easily mergable dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/console"
+  groups:
+    console:
+      applies-to: version-updates
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
+  directories:
+    - "/console"
+    - "/e2e"
   schedule:
     interval: weekly
     time: "02:00"
@@ -13,6 +23,14 @@ updates:
     prefix: chore
     include: scope
 - package-ecosystem: gomod
+  groups:
+    go:
+      applies-to: version-updates
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
   directory: "/"
   schedule:
     interval: weekly
@@ -25,6 +43,14 @@ updates:
     prefix: chore
     include: scope
 - package-ecosystem: "docker"
+  groups:
+    docker:
+      applies-to: version-updates
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
   directory: "/build"
   schedule:
     interval: "weekly"
@@ -34,6 +60,11 @@ updates:
     prefix: chore
     include: scope
 - package-ecosystem: "github-actions"
+  groups:
+    actions:
+      applies-to: version-updates
+      patterns:
+        - "*"
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
# Which Problems Are Solved

Dependabot creates a PR for each individual dependency update. This is noisy and toil.

# How the Problems Are Solved

The easily mergable updates are grouped into fewer PRs.
Major updates and security updates are not grouped, as they might need special attention.
For the github-actions updates, also the major updates are grouped, as we have immediate and good enough feedback from the pipeline if a new major doesn't work.

# Additional Changes

The e2e dependencies are also auto-updated.

# Additional Context

- We aggreed on grouping the dependabot PRs in todays Scrum daily.
- I don't know how to test the config. We might just have to merge it and look how it goes :man_shrugging: 