### PR TITLE
fix(console): correct count for users list, show create timestamp in user details

### DIFF
--- a/console/src/app/modules/info-row/info-row.component.ts
+++ b/console/src/app/modules/info-row/info-row.component.ts
@@ -73,7 +73,7 @@ export class InfoRowComponent {
     if (!this.user) {
       return undefined;
     }
-    return '$typeName' in this.user ? undefined : this.user.details?.creationDate;
+    return '$typeName' in this.user ? this.user.details?.creationDate : undefined;
   }
 
   private getEmail(user: User.AsObject | UserV2 | UserV1) {

--- a/console/src/app/modules/info-row/info-row.component.ts
+++ b/console/src/app/modules/info-row/info-row.component.ts
@@ -66,14 +66,11 @@ export class InfoRowComponent {
   }
 
   public get changeDate() {
-    return this?.user?.details?.changeDate;
+    return this.user?.details?.changeDate;
   }
 
   public get creationDate() {
-    if (!this.user) {
-      return undefined;
-    }
-    return '$typeName' in this.user ? this.user.details?.creationDate : undefined;
+    return this.user?.details?.creationDate;
   }
 
   private getEmail(user: User.AsObject | UserV2 | UserV1) {

--- a/console/src/app/pages/users/user-list/user-table/user-table.component.ts
+++ b/console/src/app/pages/users/user-list/user-table/user-table.component.ts
@@ -119,7 +119,7 @@ export class UserTableComponent implements OnInit {
 
     this.dataSize = toSignal(
       this.users$.pipe(
-        map((users) => users.result.length),
+        map((users) => Number(users.details?.totalResult ?? 0)),
         distinctUntilChanged(),
       ),
       { initialValue: 0 },

--- a/console/src/app/pages/users/user-list/user-table/user-table.component.ts
+++ b/console/src/app/pages/users/user-list/user-table/user-table.component.ts
@@ -119,7 +119,7 @@ export class UserTableComponent implements OnInit {
 
     this.dataSize = toSignal(
       this.users$.pipe(
-        map((users) => Number(users.details?.totalResult ?? 0)),
+        map((users) => Number(users.details?.totalResult ?? users.result.length)),
         distinctUntilChanged(),
       ),
       { initialValue: 0 },


### PR DESCRIPTION
This pull request fixes a couple of minor issues with the user list and details pages in Console.

# Which Problems Are Solved

1. The total count in the users list was the total number of results
returned. This made the pagination not work when there were more than
`pageSize * 2` users.
2. The user details page did not show the created timestamp when viewing a
user.

# How the Problems Are Solved

1. The response includes the total number calculated by the backend. Use
that instead.
2. Inverse the ternary returning the creation date.

# Additional Changes

None

# Additional Context

None
