### PR TITLE
fix(mirror): initialize meter to prevent panic

### DIFF
--- a/cmd/mirror/config.go
+++ b/cmd/mirror/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/id"
+	metrics "github.com/zitadel/zitadel/internal/telemetry/metrics/config"
 )
 
 type Migration struct {
@@ -26,6 +27,7 @@ type Migration struct {
 
 	Log     *logging.Config
 	Machine *id.Config
+	Metrics metrics.Config
 }
 
 var (
@@ -39,6 +41,9 @@ func mustNewMigrationConfig(v *viper.Viper) *Migration {
 
 	err := config.Log.SetLogger()
 	logging.OnError(err).Fatal("unable to set logger")
+
+	err = config.Metrics.NewMeter()
+	logging.OnError(err).Fatal("unable to set meter")
 
 	id.Configure(config.Machine)
 


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

With the change of #9561, the `mirror` command panics as there's no metrics provider configured.

# How the Problems Are Solved

Correctly initialize the provider (no-op by default) for the mirror command.

# Additional Changes

None

# Additional Context

relates to #9561 -> needs backports to 2.66.x - 2.71.x and 3.0.0-rc