### PR TITLE
fix(login): handle requests without auth request correctly

### DIFF
--- a/internal/actions/object/auth_request.go
+++ b/internal/actions/object/auth_request.go
@@ -18,6 +18,9 @@ func AuthRequestField(authRequest *domain.AuthRequest) func(c *actions.FieldConf
 }
 
 func AuthRequestFromDomain(c *actions.FieldConfig, request *domain.AuthRequest) goja.Value {
+	if request == nil {
+		return c.Runtime.ToValue(nil)
+	}
 	var maxAuthAge *time.Duration
 	if request.MaxAuthAge != nil {
 		maxAuthAgeCopy := *request.MaxAuthAge

--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -633,6 +633,10 @@ func (l *Login) autoCreateExternalUser(w http.ResponseWriter, r *http.Request, a
 // renderExternalNotFoundOption renders a page, where the user is able to edit the IDP data,
 // create a new externalUser of link to existing on (based on the IDP template)
 func (l *Login) renderExternalNotFoundOption(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, orgIAMPolicy *query.DomainPolicy, human *domain.Human, idpLink *domain.UserIDPLink, err error) {
+	if authReq == nil {
+		l.renderError(w, r, nil, err)
+		return
+	}
 	resourceOwner := determineResourceOwner(r.Context(), authReq)
 	if orgIAMPolicy == nil {
 		orgIAMPolicy, err = l.getOrgDomainPolicy(r, resourceOwner)


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

We found some paths in the login UI, where requests without any `AuthRequest` were not handled correctly and could potentially panic.
This also includes providing the `AuthRequest` as part of `ctx` object in actions V1.

# How the Problems Are Solved

- Check for the existance of an `AuthRequest` were needed and return an error otherwise.
- Provide correct state of the `AuthRequest` for actions V1

# Additional Changes

None

# Additional Context

- Noticed as part of a support request
- requires backport to at least 2.70.x