### PR TITLE
fix(actions): handle empty deny list correctly

### DIFF
--- a/cmd/start/config.go
+++ b/cmd/start/config.go
@@ -128,7 +128,9 @@ func MustNewConfig(v *viper.Viper) *Config {
 	logging.OnError(err).Fatal("unable to set profiler")
 
 	id.Configure(config.Machine)
-	actions.SetHTTPConfig(&config.Actions.HTTP)
+	if config.Actions != nil {
+		actions.SetHTTPConfig(&config.Actions.HTTP)
+	}
 
 	// Copy the global role permissions mappings to the instance until we allow instance-level configuration over the API.
 	config.DefaultInstance.RolePermissionMappings = config.InternalAuthZ.RolePermissionMappings

--- a/internal/actions/http_module.go
+++ b/internal/actions/http_module.go
@@ -176,16 +176,16 @@ type transport struct {
 }
 
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if httpConfig == nil {
+	if httpConfig == nil || len(httpConfig.DenyList) == 0 {
 		return http.DefaultTransport.RoundTrip(req)
 	}
-	if t.isHostBlocked(httpConfig.DenyList, req.URL) {
-		return nil, zerrors.ThrowInvalidArgument(nil, "ACTIO-N72d0", "host is denied")
+	if err := t.isHostBlocked(httpConfig.DenyList, req.URL); err != nil {
+		return nil, zerrors.ThrowInvalidArgument(err, "ACTIO-N72d0", "host is denied")
 	}
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-func (t *transport) isHostBlocked(denyList []AddressChecker, address *url.URL) bool {
+func (t *transport) isHostBlocked(denyList []AddressChecker, address *url.URL) error {
 	host := address.Hostname()
 	ip := net.ParseIP(host)
 	ips := []net.IP{ip}
@@ -194,17 +194,17 @@ func (t *transport) isHostBlocked(denyList []AddressChecker, address *url.URL) b
 		var err error
 		ips, err = t.lookup(host)
 		if err != nil {
-			return true
+			return zerrors.ThrowInternal(err, "ACTIO-4m9s2", "lookup failed")
 		}
 	}
-	for _, blocked := range denyList {
-		if blocked.Matches(ips, host) {
-			return true
+	for _, denied := range denyList {
+		if err := denied.CheckBlocked(ips, host); err != nil {
+			return err
 		}
 	}
-	return false
+	return nil
 }
 
 type AddressChecker interface {
-	Matches([]net.IP, string) bool
+	CheckBlocked([]net.IP, string) error
 }

--- a/internal/actions/http_module_test.go
+++ b/internal/actions/http_module_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/zitadel/zitadel/internal/logstore"
 	"github.com/zitadel/zitadel/internal/logstore/record"
@@ -34,21 +36,21 @@ func Test_isHostBlocked(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   bool
+		want   error
 	}{
 		{
 			name: "in range",
 			args: args{
 				address: mustNewURL(t, "https://192.168.5.4/hodor"),
 			},
-			want: true,
+			want: NewAddressBlockedErr("192.168.5.0/24"),
 		},
 		{
 			name: "exact ip",
 			args: args{
 				address: mustNewURL(t, "http://127.0.0.1:8080/hodor"),
 			},
-			want: true,
+			want: NewAddressBlockedErr("127.0.0.1"),
 		},
 		{
 			name: "address match",
@@ -60,7 +62,7 @@ func Test_isHostBlocked(t *testing.T) {
 			args: args{
 				address: mustNewURL(t, "https://test.com:42/hodor"),
 			},
-			want: true,
+			want: NewAddressBlockedErr("test.com"),
 		},
 		{
 			name: "address not match",
@@ -72,7 +74,7 @@ func Test_isHostBlocked(t *testing.T) {
 			args: args{
 				address: mustNewURL(t, "https://test2.com/hodor"),
 			},
-			want: false,
+			want: nil,
 		},
 		{
 			name: "looked up ip matches",
@@ -84,7 +86,19 @@ func Test_isHostBlocked(t *testing.T) {
 			args: args{
 				address: mustNewURL(t, "https://test2.com/hodor"),
 			},
-			want: true,
+			want: NewAddressBlockedErr("127.0.0.1"),
+		},
+		{
+			name: "looked up failure",
+			fields: fields{
+				lookup: func(host string) ([]net.IP, error) {
+					return nil, errors.New("some error")
+				},
+			},
+			args: args{
+				address: mustNewURL(t, "https://test2.com/hodor"),
+			},
+			want: zerrors.ThrowInternal(nil, "ACTIO-4m9s2", "lookup failed"),
 		},
 	}
 	for _, tt := range tests {
@@ -92,9 +106,8 @@ func Test_isHostBlocked(t *testing.T) {
 			trans := &transport{
 				lookup: tt.fields.lookup,
 			}
-			if got := trans.isHostBlocked(denyList, tt.args.address); got != tt.want {
-				t.Errorf("isHostBlocked() = %v, want %v", got, tt.want)
-			}
+			got := trans.isHostBlocked(denyList, tt.args.address)
+			assert.ErrorIs(t, got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

A customer reached out that after an upgrade, actions would always fail with the error "host is denied" when calling an external API.
This is due to a security fix (https://github.com/zitadel/zitadel/security/advisories/GHSA-6cf5-w9h3-4rqv), where a DNS lookup was added to check whether the host name resolves to a denied IP or subnet.
If the lookup fails due to the internal DNS setup, the action fails as well. Additionally, the lookup was also performed when the deny list was empty.

# How the Problems Are Solved

- Prevent DNS lookup when deny list is empty
- Properly initiate deny list and prevent empty entries

# Additional Changes

- Log the reason for blocked address (domain, IP, subnet)

# Additional Context

- reported by a customer
- needs backport to 2.70.x, 2.71.x and 3.0.0 rc
