### PR TITLE
chore(ci): fix container build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -75,7 +75,7 @@ jobs:
       - 
         name: Debug
         id: build-debug
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         timeout-minutes: 3
         with:
           context: .
@@ -90,7 +90,7 @@ jobs:
       - 
         name: Scratch
         id: build-scratch
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         timeout-minutes: 3
         with:
           context: .

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -149,6 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: 'image=moby/buildkit:v0.11.6'
+          version: latest
       -
         name: Login to Docker registry
         uses: docker/login-action@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -53,8 +53,6 @@ jobs:
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: 'image=moby/buildkit:v0.11.6'
       -
         name: Login to Docker registry
         uses: docker/login-action@v3
@@ -147,9 +145,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: 'image=moby/buildkit:v0.11.6'
-          version: latest
       -
         name: Login to Docker registry
         uses: docker/login-action@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: 'image=moby/buildkit:v0.11.6'
       -
         name: Start DB and ZITADEL
         run: |


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

While creating a new release, the [pipeline failed](https://github.com/zitadel/zitadel/actions/runs/14509737111/job/40705906723) as GH sunset the old actions cache service:
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

# How the Problems Are Solved

The `driver-opts` parameter is removed from the buildx actions to use the latest stable image. ([new cache service is used by BuildKit >= v0.20.0](https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api))

# Additional Changes

Updated docker/build-push-action to v6 in a first attempt to solve the issue, but kept it as it gave some more insights (incl. build summary)

# Additional Context

Since the containers are only built on workflow triggers, here's the corresponding pipeline run: https://github.com/zitadel/zitadel/actions/runs/14513926232
