### PR TITLE
docs(API_DESIGN.md): adding guidlines around API returns when multiple resources created

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -57,7 +57,7 @@ Do not rely on implicit fallbacks or defaults if the client does not provide cer
 Only use defaults if they are explicitly documented, such as returning a result set for the whole instance if no filter is provided.
 
 Some API calls may create multiple resources such as in the case of `zitadel.org.v2.AddOrganization`, where you can create an organization AND multiple users as admin.
-In such cases the response should include **ALL** created resources and their ids. This removed any amy ambiguity from the users perspective whether or not
+In such cases the response should include **ALL** created resources and their ids. This removes any ambiguity from the users perspective whether or not
 the additional resources were created and it also helps in testing.
 
 ### Naming Conventions

--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -56,6 +56,10 @@ Provide clear and concise documentation for the API.
 Do not rely on implicit fallbacks or defaults if the client does not provide certain parameters.
 Only use defaults if they are explicitly documented, such as returning a result set for the whole instance if no filter is provided.
 
+Some API calls may create multiple resources such as in the case of `zitadel.org.v2.AddOrganization`, where you can create an organization AND multiple users as admin.
+In such cases the response should include **ALL** created resources and their ids. This removed any amy ambiguity from the users perspective whether or not
+the additional resources were created and it also helps in testing.
+
 ### Naming Conventions
 
 Names of resources, fields and methods MUST be descriptive and consistent.


### PR DESCRIPTION
# Which Problems Are Solved

Updating API_Design.md to include guidelines to specify all created resources created from an API call

# How the Problems Are Solved

This makes things clearer to the user if everything requested was actually created and helps with testing.
See  https://github.com/zitadel/zitadel/pull/9352

# Additional Context

- Related https://github.com/zitadel/zitadel/issues/6305
- Related https://github.com/zitadel/zitadel/pull/9352
