### PR TITLE
chore: only download release relevant artifacts

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -32,6 +32,7 @@ jobs:
       if: ${{ !inputs.dry_run }}
       with:
         path: .artifacts
+        pattern: "{checksums.txt,zitadel-*}"
     -
       name: Semantic Release
       uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

https://github.com/zitadel/zitadel/pull/9765 fixed an issue for with actions cache service. The PR updated the push action, which now also provides a build summary. The "release" step tries to download all artifacts, which now fails: https://github.com/zitadel/zitadel/actions/runs/14660464768/job/41145285454

# How the Problems Are Solved

Only download relevant artifacts, which are published as part of the release.

# Additional Changes

None

# Additional Context

None
