### PR TITLE
fix(defaults): comment default SystemAPIUsers

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -607,14 +607,14 @@ EncryptionKeys:
   UserAgentCookieKeyID: "userAgentCookieKey" # ZITADEL_ENCRYPTIONKEYS_USERAGENTCOOKIEKEYID
 
 SystemAPIUsers:
-  - superuser:
-    Path: /path/to/superuser/key.pem
-    Memberships:
-      - MemberType: Organization
-        Roles: "ORG_OWNER"
-        AggregateID: "123456789012345678"
-      - MemberType: Project
-        Roles: "PROJECT_OWNER"
+  # - superuser:
+  #   Path: /path/to/superuser/key.pem
+  #   Memberships:
+  #     - MemberType: Organization
+  #       Roles: "ORG_OWNER"
+  #       AggregateID: "123456789012345678"
+  #     - MemberType: Project
+  #       Roles: "PROJECT_OWNER"
 
 
 # # Add keys for authentication of the systemAPI here:


### PR DESCRIPTION
# Which Problems Are Solved

If I start a fresh instance and do not overwrite `SystemAPIUsers` I get an error during startup `error="decoding failed due to the following error(s):\n\n'SystemAPIUsers[0][path]' expected a map, got 'string'\n'SystemAPIUsers[0][memberships]' expected a map, got 'slice'"`

# How the Problems Are Solved

the configuration is commented so that the example is still there

# Additional Changes

-

# Additional Context

-
