### PR TITLE
fix: correct handling of removed targets

### DIFF
--- a/internal/query/execution.go
+++ b/internal/query/execution.go
@@ -1,11 +1,13 @@
 package query
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"slices"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -301,13 +303,15 @@ func executionTargetsUnmarshal(data []byte) ([]*exec.Target, error) {
 	}
 
 	targets := make([]*exec.Target, len(executionTargets))
-	// position starts with 1
-	for _, item := range executionTargets {
+	slices.SortFunc(executionTargets, func(a, b *executionTarget) int {
+		return cmp.Compare(a.Position, b.Position)
+	})
+	for i, item := range executionTargets {
 		if item.Target != "" {
-			targets[item.Position-1] = &exec.Target{Type: domain.ExecutionTargetTypeTarget, Target: item.Target}
+			targets[i] = &exec.Target{Type: domain.ExecutionTargetTypeTarget, Target: item.Target}
 		}
 		if item.Include != "" {
-			targets[item.Position-1] = &exec.Target{Type: domain.ExecutionTargetTypeInclude, Target: item.Include}
+			targets[i] = &exec.Target{Type: domain.ExecutionTargetTypeInclude, Target: item.Include}
 		}
 	}
 	return targets, nil

--- a/internal/query/execution_targets.sql
+++ b/internal/query/execution_targets.sql
@@ -1,11 +1,15 @@
-SELECT instance_id,
-       execution_id,
+SELECT et.instance_id,
+       et.execution_id,
        JSONB_AGG(
                JSON_OBJECT(
-                       'position' : position,
-                       'include' : include,
-                       'target' : target_id
-                   )
-           ) as targets
-FROM projections.executions1_targets
-GROUP BY instance_id, execution_id
+                       'position' : et.position,
+                       'include' : et.include,
+                       'target' : et.target_id
+               )
+       ) as targets
+FROM projections.executions1_targets AS et
+         INNER JOIN projections.targets2 AS t
+                    ON et.instance_id = t.instance_id
+                        AND et.target_id IS NOT NULL
+                        AND et.target_id = t.id
+GROUP BY et.instance_id, et.execution_id

--- a/internal/query/execution_test.go
+++ b/internal/query/execution_test.go
@@ -22,9 +22,10 @@ var (
 		` COUNT(*) OVER ()` +
 		` FROM projections.executions1` +
 		` JOIN (` +
-		`SELECT instance_id, execution_id, JSONB_AGG( JSON_OBJECT( 'position' : position, 'include' : include, 'target' : target_id ) ) as targets` +
-		` FROM projections.executions1_targets` +
-		` GROUP BY instance_id, execution_id` +
+		`SELECT et.instance_id, et.execution_id, JSONB_AGG( JSON_OBJECT( 'position' : et.position, 'include' : et.include, 'target' : et.target_id ) ) as targets` +
+		` FROM projections.executions1_targets AS et` +
+		` INNER JOIN projections.targets2 AS t ON et.instance_id = t.instance_id AND et.target_id IS NOT NULL AND et.target_id = t.id` +
+		` GROUP BY et.instance_id, et.execution_id` +
 		`)` +
 		` AS execution_targets` +
 		` ON execution_targets.instance_id = projections.executions1.instance_id` +
@@ -45,9 +46,10 @@ var (
 		` execution_targets.targets` +
 		` FROM projections.executions1` +
 		` JOIN (` +
-		`SELECT instance_id, execution_id, JSONB_AGG( JSON_OBJECT( 'position' : position, 'include' : include, 'target' : target_id ) ) as targets` +
-		` FROM projections.executions1_targets` +
-		` GROUP BY instance_id, execution_id` +
+		`SELECT et.instance_id, et.execution_id, JSONB_AGG( JSON_OBJECT( 'position' : et.position, 'include' : et.include, 'target' : et.target_id ) ) as targets` +
+		` FROM projections.executions1_targets AS et` +
+		` INNER JOIN projections.targets2 AS t ON et.instance_id = t.instance_id AND et.target_id IS NOT NULL AND et.target_id = t.id` +
+		` GROUP BY et.instance_id, et.execution_id` +
 		`)` +
 		` AS execution_targets` +
 		` ON execution_targets.instance_id = projections.executions1.instance_id` +
@@ -136,6 +138,63 @@ func Test_ExecutionPrepares(t *testing.T) {
 							testNow,
 							testNow,
 							[]byte(`[{"position" : 1, "target" : "target"}, {"position" : 2, "include" : "include"}]`),
+						},
+						{
+							"ro",
+							"id-2",
+							testNow,
+							testNow,
+							[]byte(`[{"position" : 2, "target" : "target"}, {"position" : 1, "include" : "include"}]`),
+						},
+					},
+				),
+			},
+			object: &Executions{
+				SearchResponse: SearchResponse{
+					Count: 2,
+				},
+				Executions: []*Execution{
+					{
+						ObjectDetails: domain.ObjectDetails{
+							ID:            "id-1",
+							EventDate:     testNow,
+							CreationDate:  testNow,
+							ResourceOwner: "ro",
+						},
+						Targets: []*exec.Target{
+							{Type: domain.ExecutionTargetTypeTarget, Target: "target"},
+							{Type: domain.ExecutionTargetTypeInclude, Target: "include"},
+						},
+					},
+					{
+						ObjectDetails: domain.ObjectDetails{
+							ID:            "id-2",
+							EventDate:     testNow,
+							CreationDate:  testNow,
+							ResourceOwner: "ro",
+						},
+						Targets: []*exec.Target{
+							{Type: domain.ExecutionTargetTypeInclude, Target: "include"},
+							{Type: domain.ExecutionTargetTypeTarget, Target: "target"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "prepareExecutionsQuery multiple result, removed target, position missing",
+			prepare: prepareExecutionsQuery,
+			want: want{
+				sqlExpectations: mockQueries(
+					regexp.QuoteMeta(prepareExecutionsStmt),
+					prepareExecutionsCols,
+					[][]driver.Value{
+						{
+							"ro",
+							"id-1",
+							testNow,
+							testNow,
+							[]byte(`[{"position" : 1, "target" : "target"}, {"position" : 3, "include" : "include"}]`),
 						},
 						{
 							"ro",

--- a/internal/query/projection/execution_test.go
+++ b/internal/query/projection/execution_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zitadel/zitadel/internal/eventstore/handler/v2"
 	exec "github.com/zitadel/zitadel/internal/repository/execution"
 	"github.com/zitadel/zitadel/internal/repository/instance"
+	"github.com/zitadel/zitadel/internal/repository/target"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -73,6 +74,35 @@ func TestExecutionProjection_reduces(t *testing.T) {
 								2,
 								"include",
 								"",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reduceTargetRemoved",
+			args: args{
+				event: getEvent(
+					testEvent(
+						target.RemovedEventType,
+						target.AggregateType,
+						[]byte(`{}`),
+					),
+					eventstore.GenericEventMapper[target.RemovedEvent],
+				),
+			},
+			reduce: (&executionProjection{}).reduceTargetRemoved,
+			want: wantReduce{
+				aggregateType: eventstore.AggregateType("target"),
+				sequence:      15,
+				executer: &testExecuter{
+					executions: []execution{
+						{
+							expectedStmt: "DELETE FROM projections.executions1_targets WHERE (instance_id = $1) AND (target_id = $2)",
+							expectedArgs: []interface{}{
+								"instance-id",
+								"agg-id",
 							},
 						},
 					},


### PR DESCRIPTION
# Which Problems Are Solved

In Actions v2, if a target is removed, which is still used in an execution, the target is still listed when list executions.

# How the Problems Are Solved

Removed targets are now also removed from the executions.

# Additional Changes

To be sure the list executions include a check if the target is still existing.

# Additional Context

None
