### PR TITLE
chore: create slack-bot-release.yml

### DIFF
--- a/.github/workflows/slack-bot-release.yml
+++ b/.github/workflows/slack-bot-release.yml
@@ -1,0 +1,16 @@
+name: Slackbot on release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  notify_slack:
+    runs-on: ubuntu-latest
+    name: Notify Slack on Release
+    steps:
+      - name: Notify Slack on Releases
+        uses: amendx/slackbot-release@1.0.0
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Which Problems Are Solved

Internal stakeholders have a hard time keeping up to date with the releases we publish.

# How the Problems Are Solved

I added a github action, which should send new published releases to a slack channel
