### PR TITLE
fix: deny machine user self deletion

### DIFF
--- a/internal/api/grpc/user/v2/integration_test/user_test.go
+++ b/internal/api/grpc/user/v2/integration_test/user_test.go
@@ -1756,9 +1756,8 @@ func TestServer_DeleteUser(t *testing.T) {
 	projectResp, err := Instance.CreateProject(CTX)
 	require.NoError(t, err)
 	type args struct {
-		ctx     context.Context
 		req     *user.DeleteUserRequest
-		prepare func(request *user.DeleteUserRequest) error
+		prepare func(*testing.T, *user.DeleteUserRequest) context.Context
 	}
 	tests := []struct {
 		name    string
@@ -1769,23 +1768,21 @@ func TestServer_DeleteUser(t *testing.T) {
 		{
 			name: "remove, not existing",
 			args: args{
-				CTX,
 				&user.DeleteUserRequest{
 					UserId: "notexisting",
 				},
-				func(request *user.DeleteUserRequest) error { return nil },
+				func(*testing.T, *user.DeleteUserRequest) context.Context { return CTX },
 			},
 			wantErr: true,
 		},
 		{
 			name: "remove human, ok",
 			args: args{
-				ctx: CTX,
 				req: &user.DeleteUserRequest{},
-				prepare: func(request *user.DeleteUserRequest) error {
+				prepare: func(_ *testing.T, request *user.DeleteUserRequest) context.Context {
 					resp := Instance.CreateHumanUser(CTX)
 					request.UserId = resp.GetUserId()
-					return err
+					return CTX
 				},
 			},
 			want: &user.DeleteUserResponse{
@@ -1798,12 +1795,11 @@ func TestServer_DeleteUser(t *testing.T) {
 		{
 			name: "remove machine, ok",
 			args: args{
-				ctx: CTX,
 				req: &user.DeleteUserRequest{},
-				prepare: func(request *user.DeleteUserRequest) error {
+				prepare: func(_ *testing.T, request *user.DeleteUserRequest) context.Context {
 					resp := Instance.CreateMachineUser(CTX)
 					request.UserId = resp.GetUserId()
-					return err
+					return CTX
 				},
 			},
 			want: &user.DeleteUserResponse{
@@ -1816,15 +1812,14 @@ func TestServer_DeleteUser(t *testing.T) {
 		{
 			name: "remove dependencies, ok",
 			args: args{
-				ctx: CTX,
 				req: &user.DeleteUserRequest{},
-				prepare: func(request *user.DeleteUserRequest) error {
+				prepare: func(_ *testing.T, request *user.DeleteUserRequest) context.Context {
 					resp := Instance.CreateHumanUser(CTX)
 					request.UserId = resp.GetUserId()
 					Instance.CreateProjectUserGrant(t, CTX, projectResp.GetId(), request.UserId)
 					Instance.CreateProjectMembership(t, CTX, projectResp.GetId(), request.UserId)
 					Instance.CreateOrgMembership(t, CTX, request.UserId)
-					return err
+					return CTX
 				},
 			},
 			want: &user.DeleteUserResponse{
@@ -1834,13 +1829,59 @@ func TestServer_DeleteUser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove self human, ok",
+			args: args{
+				req: &user.DeleteUserRequest{},
+				prepare: func(t *testing.T, request *user.DeleteUserRequest) context.Context {
+					removeUser, err := Client.AddHumanUser(CTX, &user.AddHumanUserRequest{
+						Organization: &object.Organization{Org: &object.Organization_OrgId{OrgId: Instance.DefaultOrg.Id}},
+						Profile: &user.SetHumanProfile{
+							GivenName:  "givenName",
+							FamilyName: "familyName",
+						},
+						Email: &user.SetHumanEmail{
+							Email:        gofakeit.Email(),
+							Verification: &user.SetHumanEmail_IsVerified{IsVerified: true},
+						},
+					})
+					require.NoError(t, err)
+					request.UserId = removeUser.UserId
+					Instance.RegisterUserPasskey(CTX, removeUser.UserId)
+					_, token, _, _ := Instance.CreateVerifiedWebAuthNSession(t, CTX, removeUser.UserId)
+					return integration.WithAuthorizationToken(UserCTX, token)
+				},
+			},
+			want: &user.DeleteUserResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+		},
+		{
+			name: "remove self machine, error",
+			args: args{
+				req: &user.DeleteUserRequest{},
+				prepare: func(t *testing.T, request *user.DeleteUserRequest) context.Context {
+					removeUser, err := Instance.Client.Mgmt.AddMachineUser(CTX, &mgmt.AddMachineUserRequest{
+						UserName: gofakeit.Username(),
+						Name:     gofakeit.Name(),
+					})
+					request.UserId = removeUser.UserId
+					require.NoError(t, err)
+					tokenResp, err := Instance.Client.Mgmt.AddPersonalAccessToken(CTX, &mgmt.AddPersonalAccessTokenRequest{UserId: removeUser.UserId})
+					require.NoError(t, err)
+					return integration.WithAuthorizationToken(UserCTX, tokenResp.Token)
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.args.prepare(tt.args.req)
-			require.NoError(t, err)
-
-			got, err := Client.DeleteUser(tt.args.ctx, tt.args.req)
+			ctx := tt.args.prepare(t, tt.args.req)
+			got, err := Client.DeleteUser(ctx, tt.args.req)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/api/grpc/user/v2/user.go
+++ b/internal/api/grpc/user/v2/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zitadel/zitadel/internal/api/grpc/object/v2"
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/pkg/grpc/user/v2"
 )
@@ -266,7 +267,9 @@ func (s *Server) DeleteUser(ctx context.Context, req *user.DeleteUserRequest) (_
 	if err != nil {
 		return nil, err
 	}
-	details, err := s.command.RemoveUserV2(ctx, req.UserId, "", memberships, grants...)
+	details, err := s.command.RemoveUserV2(ctx, req.UserId, "", func(isHuman bool) eventstore.PermissionCheck {
+		return s.command.CheckPermissionUserDelete(ctx, isHuman)
+	}, memberships, grants...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/user/v2beta/user.go
+++ b/internal/api/grpc/user/v2beta/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/idp"
 	"github.com/zitadel/zitadel/internal/idp/providers/ldap"
 	"github.com/zitadel/zitadel/internal/query"
@@ -278,7 +279,9 @@ func (s *Server) DeleteUser(ctx context.Context, req *user.DeleteUserRequest) (_
 	if err != nil {
 		return nil, err
 	}
-	details, err := s.command.RemoveUserV2(ctx, req.UserId, "", memberships, grants...)
+	details, err := s.command.RemoveUserV2(ctx, req.UserId, "", func(isHuman bool) eventstore.PermissionCheck {
+		return s.command.CheckPermissionUserDelete(ctx, isHuman)
+	}, memberships, grants...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/scim/resources/user.go
+++ b/internal/api/scim/resources/user.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -203,8 +204,9 @@ func (h *UsersHandler) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-
-	_, err = h.command.RemoveUserV2(ctx, id, authz.GetCtxData(ctx).OrgID, memberships, grants...)
+	_, err = h.command.RemoveUserV2(ctx, id, authz.GetCtxData(ctx).OrgID, func(isHuman bool) eventstore.PermissionCheck {
+		return h.command.CheckPermissionUserDelete(ctx, isHuman)
+	}, memberships, grants...)
 	return err
 }
 

--- a/internal/command/permission_checks.go
+++ b/internal/command/permission_checks.go
@@ -1,0 +1,65 @@
+package command
+
+import (
+	"context"
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/v2/user"
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+func (c *Commands) NewPermissionCheck(ctx context.Context, permission string, aggregateType eventstore.AggregateType) eventstore.PermissionCheck {
+	return func(resourceOwner, aggregateID string) error {
+		if aggregateID == "" {
+			return zerrors.ThrowInternal(nil, "PermissionCheck", "aggregate ID is empty")
+		}
+		// For example if a write model didn't query any events, the resource owner is probably empty.
+		// In this case, we have to query an event on the given aggregate to get the resource owner.
+		if resourceOwner == "" {
+			r := NewResourceOwnerModel(authz.GetInstance(ctx).InstanceID(), aggregateType, aggregateID)
+			err := c.eventstore.FilterToQueryReducer(ctx, r)
+			if err != nil {
+				return err
+			}
+			resourceOwner = r.resourceOwner
+		}
+		if resourceOwner == "" {
+			return zerrors.ThrowPreconditionFailed(nil, "COMMAND-4g3xq", "Errors.ResourceOwnerMissing")
+		}
+		return c.checkPermission(ctx, permission, resourceOwner, aggregateID)
+	}
+}
+
+func (c *Commands) checkPermissionOnUser(ctx context.Context, permission string, allowSelf bool) eventstore.PermissionCheck {
+	return func(resourceOwner, aggregateID string) error {
+		if allowSelf && aggregateID != "" && aggregateID == authz.GetCtxData(ctx).UserID {
+			return nil
+		}
+		return c.NewPermissionCheck(ctx, permission, user.AggregateType)(resourceOwner, aggregateID)
+	}
+}
+
+func (c *Commands) CheckPermissionUserWrite(ctx context.Context, allowSelf bool) eventstore.PermissionCheck {
+	return c.checkPermissionOnUser(ctx, domain.PermissionUserWrite, allowSelf)
+}
+
+func (c *Commands) CheckPermissionUserDelete(ctx context.Context, allowSelf bool) eventstore.PermissionCheck {
+	return c.checkPermissionOnUser(ctx, domain.PermissionUserDelete, allowSelf)
+}
+
+// Deprecated: use CheckPermissionUserWrite and set the returned PermissionCheck to the eventstore.WriteModel to safely protect an API.
+func (c *Commands) checkPermissionUpdateUser(ctx context.Context, resourceOwner, userID string) error {
+	return c.CheckPermissionUserWrite(ctx, true)(resourceOwner, userID)
+}
+
+// Deprecated: use NewPermissionCheck, allow self and use the returned function as PermissionCheck in eventstore.WriteModel to protect an API
+func (c *Commands) checkPermissionUpdateUserCredentials(ctx context.Context, resourceOwner, userID string) error {
+	if userID != "" && userID == authz.GetCtxData(ctx).UserID {
+		return nil
+	}
+	if err := c.checkPermission(ctx, domain.PermissionUserCredentialWrite, resourceOwner, userID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/command/permission_checks_test.go
+++ b/internal/command/permission_checks_test.go
@@ -1,0 +1,332 @@
+package command
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/eventstore/repository"
+	"github.com/zitadel/zitadel/internal/zerrors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+func TestCommands_CheckPermission(t *testing.T) {
+	type fields struct {
+		eventstore            func(*testing.T) *eventstore.Eventstore
+		domainPermissionCheck func(*testing.T) domain.PermissionCheck
+	}
+	type args struct {
+		ctx                        context.Context
+		permission                 string
+		aggregateType              eventstore.AggregateType
+		resourceOwner, aggregateID string
+	}
+	type want struct {
+		err func(error) bool
+	}
+	ctx := context.Background()
+	filterErr := errors.New("filter error")
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			name: "resource owner is given, no query",
+			fields: fields{
+				domainPermissionCheck: mockDomainPermissionCheck(
+					ctx,
+					"permission",
+					"resourceOwner",
+					"aggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				permission:    "permission",
+				resourceOwner: "resourceOwner",
+				aggregateID:   "aggregateID",
+			},
+		},
+		{
+			name: "resource owner is empty, query for resource owner",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilter(&repository.Event{
+						AggregateID:   "aggregateID",
+						ResourceOwner: sql.NullString{String: "resourceOwner"},
+					}),
+				),
+				domainPermissionCheck: mockDomainPermissionCheck(ctx, "permission", "resourceOwner", "aggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				permission:    "permission",
+				resourceOwner: "",
+				aggregateID:   "aggregateID",
+			},
+		},
+		{
+			name: "resource owner is empty, query for resource owner, error",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilterError(filterErr),
+				),
+			},
+			args: args{
+				ctx:           ctx,
+				permission:    "permission",
+				resourceOwner: "",
+				aggregateID:   "aggregateID",
+			},
+			want: want{
+				err: func(err error) bool {
+					return errors.Is(err, filterErr)
+				},
+			},
+		},
+		{
+			name: "resource owner is empty, query for resource owner, no events",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilter(),
+				),
+			},
+			args: args{
+				ctx:           ctx,
+				permission:    "permission",
+				resourceOwner: "",
+				aggregateID:   "aggregateID",
+			},
+			want: want{
+				err: zerrors.IsPreconditionFailed,
+			},
+		},
+		{
+			name: "no aggregateID, internal error",
+			args: args{
+				ctx: ctx,
+			},
+			want: want{
+				err: zerrors.IsInternal,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Commands{
+				checkPermission: func(ctx context.Context, permission, orgID, resourceID string) (err error) {
+					assert.Failf(t, "Domain permission check should not be called", "Called c.checkPermission(%v,%v,%v,%v)", ctx, permission, orgID, resourceID)
+					return nil
+				},
+				eventstore: expectEventstore()(t),
+			}
+			if tt.fields.domainPermissionCheck != nil {
+				c.checkPermission = tt.fields.domainPermissionCheck(t)
+			}
+			if tt.fields.eventstore != nil {
+				c.eventstore = tt.fields.eventstore(t)
+			}
+			err := c.NewPermissionCheck(tt.args.ctx, tt.args.permission, tt.args.aggregateType)(tt.args.resourceOwner, tt.args.aggregateID)
+			if tt.want.err != nil {
+				assert.True(t, tt.want.err(err))
+			}
+		})
+	}
+}
+
+func TestCommands_CheckPermissionUserWrite(t *testing.T) {
+	type fields struct {
+		domainPermissionCheck func(*testing.T) domain.PermissionCheck
+	}
+	type args struct {
+		ctx                        context.Context
+		resourceOwner, aggregateID string
+		allowSelf                  bool
+	}
+	type want struct {
+		err func(error) bool
+	}
+	ctx := authz.SetCtxData(context.Background(), authz.CtxData{
+		UserID: "aggregateID",
+	})
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			name: "allow self and matches, no permission check",
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "aggregateID",
+				allowSelf:     true,
+			},
+		},
+		{
+			name: "allow self and doesn't match, permission check",
+			fields: fields{
+				domainPermissionCheck: mockDomainPermissionCheck(
+					ctx,
+					"user.write",
+					"resourceOwner",
+					"foreignAggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "foreignAggregateID",
+				allowSelf:     true,
+			},
+		},
+		{
+			name: "disallow self, permission check",
+			fields: fields{
+				domainPermissionCheck: mockDomainPermissionCheck(
+					ctx,
+					"user.write",
+					"resourceOwner",
+					"aggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "aggregateID",
+				allowSelf:     false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Commands{
+				checkPermission: func(ctx context.Context, permission, orgID, resourceID string) (err error) {
+					assert.Failf(t, "Domain permission check should not be called", "Called c.checkPermission(%v,%v,%v,%v)", ctx, permission, orgID, resourceID)
+					return nil
+				},
+			}
+			if tt.fields.domainPermissionCheck != nil {
+				c.checkPermission = tt.fields.domainPermissionCheck(t)
+			}
+			err := c.CheckPermissionUserWrite(tt.args.ctx, tt.args.allowSelf)(tt.args.resourceOwner, tt.args.aggregateID)
+			if tt.want.err != nil {
+				assert.True(t, tt.want.err(err))
+			}
+		})
+	}
+}
+
+func TestCommands_CheckPermissionUserDelete(t *testing.T) {
+	type fields struct {
+		domainPermissionCheck func(*testing.T) domain.PermissionCheck
+	}
+	type args struct {
+		ctx                        context.Context
+		resourceOwner, aggregateID string
+		allowSelf                  bool
+	}
+	type want struct {
+		err func(error) bool
+	}
+	ctx := authz.SetCtxData(context.Background(), authz.CtxData{
+		UserID: "aggregateID",
+	})
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   want
+	}{
+		{
+			name: "allow self and matches, no permission check",
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "aggregateID",
+				allowSelf:     true,
+			},
+		},
+		{
+			name: "allow self and doesn't match, permission check",
+			fields: fields{
+				domainPermissionCheck: mockDomainPermissionCheck(
+					ctx,
+					"user.delete",
+					"resourceOwner",
+					"foreignAggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "foreignAggregateID",
+				allowSelf:     true,
+			},
+		},
+		{
+			name: "disallow self, permission check",
+			fields: fields{
+				domainPermissionCheck: mockDomainPermissionCheck(
+					ctx,
+					"user.delete",
+					"resourceOwner",
+					"aggregateID"),
+			},
+			args: args{
+				ctx:           ctx,
+				resourceOwner: "resourceOwner",
+				aggregateID:   "aggregateID",
+				allowSelf:     false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Commands{
+				checkPermission: func(ctx context.Context, permission, orgID, resourceID string) (err error) {
+					assert.Failf(t, "Domain permission check should not be called", "Called c.checkPermission(%v,%v,%v,%v)", ctx, permission, orgID, resourceID)
+					return nil
+				},
+			}
+			if tt.fields.domainPermissionCheck != nil {
+				c.checkPermission = tt.fields.domainPermissionCheck(t)
+			}
+			err := c.CheckPermissionUserDelete(tt.args.ctx, tt.args.allowSelf)(tt.args.resourceOwner, tt.args.aggregateID)
+			if tt.want.err != nil {
+				assert.True(t, tt.want.err(err))
+			}
+		})
+	}
+}
+
+func mockDomainPermissionCheck(expectCtx context.Context, expectPermission, expectResourceOwner, expectResourceID string) func(t *testing.T) domain.PermissionCheck {
+	return func(t *testing.T) domain.PermissionCheck {
+		return func(ctx context.Context, permission, orgID, resourceID string) (err error) {
+			assert.Equal(t, expectCtx, ctx)
+			assert.Equal(t, expectPermission, permission)
+			assert.Equal(t, expectResourceOwner, orgID)
+			assert.Equal(t, expectResourceID, resourceID)
+			return nil
+		}
+	}
+}
+
+var errPermissionDenied = errors.New("permission denied")
+
+func isPermissionDenied(err error) bool {
+	return errors.Is(err, errPermissionDenied)
+}
+
+func permissionCheck(allow bool) eventstore.PermissionCheck {
+	return func(_, _ string) error {
+		if allow {
+			return nil
+		}
+		return errPermissionDenied
+	}
+}

--- a/internal/command/user_v2_model_test.go
+++ b/internal/command/user_v2_model_test.go
@@ -2441,7 +2441,8 @@ func TestCommandSide_userHumanWriteModel_idpLinks(t *testing.T) {
 			r := &Commands{
 				eventstore: tt.fields.eventstore(t),
 			}
-			wm, err := r.userRemoveWriteModel(tt.args.ctx, tt.args.userID, "")
+			// TODO: Looking at the test function name: Is this the right function to test?
+			wm, err := r.userRemoveWriteModel(tt.args.ctx, tt.args.userID, "", nil)
 			if tt.res.err == nil {
 				if !assert.NoError(t, err) {
 					t.FailNow()

--- a/internal/eventstore/write_model.go
+++ b/internal/eventstore/write_model.go
@@ -1,17 +1,22 @@
 package eventstore
 
-import "time"
+import (
+	"time"
+)
+
+type PermissionCheck func(resourceOwner, aggregateID string) error
 
 // WriteModel is the minimum representation of a command side write model.
 // It implements a basic reducer
 // it's purpose is to reduce events to create new ones
 type WriteModel struct {
-	AggregateID       string    `json:"-"`
-	ProcessedSequence uint64    `json:"-"`
-	Events            []Event   `json:"-"`
-	ResourceOwner     string    `json:"-"`
-	InstanceID        string    `json:"-"`
-	ChangeDate        time.Time `json:"-"`
+	AggregateID       string          `json:"-"`
+	ProcessedSequence uint64          `json:"-"`
+	Events            []Event         `json:"-"`
+	ResourceOwner     string          `json:"-"`
+	InstanceID        string          `json:"-"`
+	ChangeDate        time.Time       `json:"-"`
+	PermissionCheck   PermissionCheck `json:"-"`
 }
 
 // AppendEvents adds all the events to the read model.
@@ -23,17 +28,24 @@ func (rm *WriteModel) AppendEvents(events ...Event) {
 // Reduce is the basic implementation of reducer
 // If this function is extended the extending function should be the last step
 func (wm *WriteModel) Reduce() error {
+	// We have to call checkPermission before we overwrite wm.ResourceOwner from the events.
+	if err := wm.checkPermission(); err != nil {
+		return err
+	}
 	if len(wm.Events) == 0 {
 		return nil
 	}
-
 	if wm.AggregateID == "" {
 		wm.AggregateID = wm.Events[0].Aggregate().ID
 	}
+
 	if wm.ResourceOwner == "" {
+		// TODO: use the latest events resource owner for cases where the resource is recreated with the same ID and different resource owner?
 		wm.ResourceOwner = wm.Events[0].Aggregate().ResourceOwner
 	}
+
 	if wm.InstanceID == "" {
+		// TODO: use the latest events instance ID for cases where the resource is recreated with the same ID and different instance?
 		wm.InstanceID = wm.Events[0].Aggregate().InstanceID
 	}
 
@@ -43,5 +55,22 @@ func (wm *WriteModel) Reduce() error {
 	// all events processed and not needed anymore
 	wm.Events = nil
 	wm.Events = []Event{}
+
 	return nil
+}
+
+// checkPermission succeeds, if no permission check is set
+// If there are no events on the write model, it checks the permission on the given resource owner
+// If there are events on the write model, it checks the permission on the resource owner of the last event.
+// This makes sure that the correct resource owner is checked in cases where an aggregate is recreated with the same ID and different resource owner.
+// checkPermission has to be called before the resource owner is set from the events.
+func (wm *WriteModel) checkPermission() error {
+	if wm.PermissionCheck == nil {
+		return nil
+	}
+	resourceOwner := wm.ResourceOwner
+	if len(wm.Events) > 0 {
+		resourceOwner = wm.Events[len(wm.Events)-1].Aggregate().ResourceOwner
+	}
+	return wm.PermissionCheck(resourceOwner, wm.AggregateID)
 }

--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -539,7 +539,7 @@ service UserService {
 
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
-        permission: "user.delete"
+        permission: "authenticated"
       }
     };
 

--- a/proto/zitadel/user/v2beta/user_service.proto
+++ b/proto/zitadel/user/v2beta/user_service.proto
@@ -563,7 +563,7 @@ service UserService {
 
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
-        permission: "user.delete"
+        permission: "authenticated"
       }
     };
 


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- If the property XY is not given, the system crashes with a nil pointer exception.

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
