### PR TITLE
perf(eventstore): add instance position index

### DIFF
--- a/cmd/setup/54.go
+++ b/cmd/setup/54.go
@@ -1,0 +1,27 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 54.sql
+	instancePositionIndex string
+)
+
+type InstancePositionIndex struct {
+	dbClient *database.DB
+}
+
+func (mig *InstancePositionIndex) Execute(ctx context.Context, _ eventstore.Event) error {
+	_, err := mig.dbClient.ExecContext(ctx, instancePositionIndex)
+	return err
+}
+
+func (mig *InstancePositionIndex) String() string {
+	return "54_instance_position_index"
+}

--- a/cmd/setup/54.sql
+++ b/cmd/setup/54.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_instance_position ON eventstore.events2 (instance_id, position);


### PR DESCRIPTION
# Which Problems Are Solved

Some projection queries took a long time to run. It seems that 1 or more queries couldn't make proper use of the `es_projection` index. This might be because of a specific complexity aggregate_type and event_type arguments, making the index unfeasible for postgres.

# How the Problems Are Solved

Following the index recommendation, add and index that covers just instance_id and position.

# Additional Changes

- none

# Additional Context

- Related to https://github.com/zitadel/zitadel/issues/9832


