### PR TITLE
feat(api): reworking AddOrganization() API call to return all admins

### DIFF
--- a/internal/api/grpc/admin/org.go
+++ b/internal/api/grpc/admin/org.go
@@ -93,8 +93,8 @@ func (s *Server) SetUpOrg(ctx context.Context, req *admin_pb.SetUpOrgRequest) (*
 		return nil, err
 	}
 	var userID string
-	if len(createdOrg.CreatedAdmins) == 1 {
-		userID = createdOrg.CreatedAdmins[0].ID
+	if len(createdOrg.OrgAdmins) == 1 {
+		userID = createdOrg.OrgAdmins[0].GetID()
 	}
 	return &admin_pb.SetUpOrgResponse{
 		Details: object.DomainToAddDetailsPb(createdOrg.ObjectDetails),
@@ -109,6 +109,9 @@ func (s *Server) getClaimedUserIDsOfOrgDomain(ctx context.Context, orgDomain str
 		return nil, err
 	}
 	users, err := s.query.SearchUsers(ctx, &query.UserSearchQueries{Queries: []query.SearchQuery{loginName}}, nil)
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/org/v2/org.go
+++ b/internal/api/grpc/org/v2/org.go
@@ -68,12 +68,15 @@ func addOrganizationRequestAdminToCommand(admin *org.AddOrganizationRequest_Admi
 }
 
 func createdOrganizationToPb(createdOrg *command.CreatedOrg) (_ *org.AddOrganizationResponse, err error) {
-	admins := make([]*org.AddOrganizationResponse_CreatedAdmin, len(createdOrg.CreatedAdmins))
-	for i, admin := range createdOrg.CreatedAdmins {
-		admins[i] = &org.AddOrganizationResponse_CreatedAdmin{
-			UserId:    admin.ID,
-			EmailCode: admin.EmailCode,
-			PhoneCode: admin.PhoneCode,
+	admins := make([]*org.AddOrganizationResponse_CreatedAdmin, 0, len(createdOrg.OrgAdmins))
+	for _, admin := range createdOrg.OrgAdmins {
+		admin, ok := admin.(*command.CreatedOrgAdmin)
+		if ok {
+			admins = append(admins, &org.AddOrganizationResponse_CreatedAdmin{
+				UserId:    admin.GetID(),
+				EmailCode: admin.EmailCode,
+				PhoneCode: admin.PhoneCode,
+			})
 		}
 	}
 	return &org.AddOrganizationResponse{

--- a/internal/api/grpc/org/v2beta/org.go
+++ b/internal/api/grpc/org/v2beta/org.go
@@ -3,18 +3,14 @@ package org
 import (
 	"context"
 
-	metadata "github.com/zitadel/zitadel/internal/api/grpc/metadata/v2beta"
-	object "github.com/zitadel/zitadel/internal/api/grpc/object/v2beta"
 	user "github.com/zitadel/zitadel/internal/api/grpc/user/v2beta"
 	"github.com/zitadel/zitadel/internal/command"
-	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/zerrors"
 	org "github.com/zitadel/zitadel/pkg/grpc/org/v2beta"
-	v2beta_org "github.com/zitadel/zitadel/pkg/grpc/org/v2beta"
 )
 
-func (s *Server) CreateOrganization(ctx context.Context, request *v2beta_org.CreateOrganizationRequest) (*v2beta_org.CreateOrganizationResponse, error) {
-	orgSetup, err := createOrganizationRequestToCommand(request)
+func (s *Server) CreateOrganization(ctx context.Context, request *org.CreateOrganizationRequest) (*org.CreateOrganizationResponse, error) {
+	orgSetup, err := addOrganizationRequestToCommand(request)
 	if err != nil {
 		return nil, err
 	}
@@ -25,179 +21,8 @@ func (s *Server) CreateOrganization(ctx context.Context, request *v2beta_org.Cre
 	return createdOrganizationToPb(createdOrg)
 }
 
-func (s *Server) UpdateOrganization(ctx context.Context, request *v2beta_org.UpdateOrganizationRequest) (*v2beta_org.UpdateOrganizationResponse, error) {
-	org, err := s.command.UpdateOrg(ctx, request.Id, request.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	return &v2beta_org.UpdateOrganizationResponse{
-		Details: object.DomainToDetailsPb(org),
-	}, nil
-}
-
-func (s *Server) GetOrganizationByID(ctx context.Context, request *v2beta_org.GetOrganizationByIDRequest) (*v2beta_org.GetOrganizationByIDResponse, error) {
-	org, err := s.query.OrgByID(ctx, true, request.Id)
-	if err != nil {
-		return nil, err
-	}
-	return &v2beta_org.GetOrganizationByIDResponse{
-		Organization: OrganizationViewToPb(org),
-	}, nil
-}
-
-func (s *Server) ListOrganizations(ctx context.Context, request *v2beta_org.ListOrganizationsRequest) (*v2beta_org.ListOrganizationsResponse, error) {
-	queries, err := listOrgRequestToModel(request)
-	if err != nil {
-		return nil, err
-	}
-	orgs, err := s.query.SearchOrgs(ctx, queries, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &v2beta_org.ListOrganizationsResponse{
-		Result:  OrgViewsToPb(orgs.Orgs),
-		Details: object.ToListDetails(orgs.SearchResponse),
-	}, nil
-}
-
-func (s *Server) DeleteOrganization(ctx context.Context, request *v2beta_org.DeleteOrganizationRequest) (*v2beta_org.DeleteOrganizationResponse, error) {
-	details, err := s.command.RemoveOrg(ctx, request.Id)
-	if err != nil {
-		return nil, err
-	}
-	return &v2beta_org.DeleteOrganizationResponse{
-		Details: object.DomainToDetailsPb(details),
-	}, nil
-}
-
-func (s *Server) SetOrganizationMetadata(ctx context.Context, request *v2beta_org.SetOrganizationMetadataRequest) (*v2beta_org.SetOrganizationMetadataResponse, error) {
-	result, err := s.command.BulkSetOrgMetadata(ctx, request.Id, BulkSetOrgMetadataToDomain(request)...)
-	if err != nil {
-		return nil, err
-	}
-	return &org.SetOrganizationMetadataResponse{
-		Details: object.DomainToDetailsPb(result),
-	}, nil
-}
-
-func (s *Server) ListOrganizationMetadata(ctx context.Context, request *v2beta_org.ListOrganizationMetadataRequest) (*v2beta_org.ListOrganizationMetadataResponse, error) {
-	metadataQueries, err := ListOrgMetadataToDomain(request)
-	if err != nil {
-		return nil, err
-	}
-	res, err := s.query.SearchOrgMetadata(ctx, true, request.Id, metadataQueries, false)
-	if err != nil {
-		return nil, err
-	}
-	return &v2beta_org.ListOrganizationMetadataResponse{
-		Result:  metadata.OrgMetadataListToPb(res.Metadata),
-		Details: object.ToListDetails(res.SearchResponse),
-	}, nil
-}
-
-func (s *Server) DeleteOrganizationMetadata(ctx context.Context, request *v2beta_org.DeleteOrganizationMetadataRequest) (*v2beta_org.DeleteOrganizationMetadataResponse, error) {
-	result, err := s.command.BulkRemoveOrgMetadata(ctx, request.Id, request.Keys...)
-	if err != nil {
-		return nil, err
-	}
-	return &v2beta_org.DeleteOrganizationMetadataResponse{
-		Details: object.DomainToChangeDetailsPb(result),
-	}, nil
-}
-
-func (s *Server) DeactivateOrganization(ctx context.Context, request *org.DeactivateOrganizationRequest) (*org.DeactivateOrganizationResponse, error) {
-	objectDetails, err := s.command.DeactivateOrg(ctx, request.Id)
-	if err != nil {
-		return nil, err
-	}
-	return &org.DeactivateOrganizationResponse{
-		Details: object.DomainToDetailsPb(objectDetails),
-	}, nil
-}
-
-func (s *Server) ReactivateOrganization(ctx context.Context, request *org.ReactivateOrganizationRequest) (*org.ReactivateOrganizationResponse, error) {
-	objectDetails, err := s.command.ReactivateOrg(ctx, request.Id)
-	if err != nil {
-		return nil, err
-	}
-	return &org.ReactivateOrganizationResponse{
-		Details: object.DomainToDetailsPb(objectDetails),
-	}, err
-}
-
-func (s *Server) AddOrganizationDomain(ctx context.Context, request *org.AddOrganizationDomainRequest) (*org.AddOrganizationDomainResponse, error) {
-	userIDs, err := s.getClaimedUserIDsOfOrgDomain(ctx, request.Domain, request.OrganizationId)
-	if err != nil {
-		return nil, err
-	}
-	details, err := s.command.AddOrgDomain(ctx, request.OrganizationId, request.Domain, userIDs)
-	if err != nil {
-		return nil, err
-	}
-	return &org.AddOrganizationDomainResponse{
-		Details: object.DomainToDetailsPb(details),
-	}, nil
-}
-
-func (s *Server) ListOrganizationDomains(ctx context.Context, req *org.ListOrganizationDomainsRequest) (*org.ListOrganizationDomainsResponse, error) {
-	queries, err := ListOrgDomainsRequestToModel(req)
-	if err != nil {
-		return nil, err
-	}
-	orgIDQuery, err := query.NewOrgDomainOrgIDSearchQuery(req.OrganizationId)
-	if err != nil {
-		return nil, err
-	}
-	queries.Queries = append(queries.Queries, orgIDQuery)
-
-	domains, err := s.query.SearchOrgDomains(ctx, queries, false)
-	if err != nil {
-		return nil, err
-	}
-	return &org.ListOrganizationDomainsResponse{
-		Result:  object.DomainsToPb(domains.Domains),
-		Details: object.ToListDetails(domains.SearchResponse),
-	}, nil
-}
-
-func (s *Server) DeleteOrganizationDomain(ctx context.Context, req *org.DeleteOrganizationDomainRequest) (*org.DeleteOrganizationDomainResponse, error) {
-	details, err := s.command.RemoveOrgDomain(ctx, RemoveOrgDomainRequestToDomain(ctx, req))
-	if err != nil {
-		return nil, err
-	}
-	return &org.DeleteOrganizationDomainResponse{
-		Details: object.DomainToDetailsPb(details),
-	}, err
-}
-
-func (s *Server) GenerateOrganizationDomainValidation(ctx context.Context, req *org.GenerateOrganizationDomainValidationRequest) (*org.GenerateOrganizationDomainValidationResponse, error) {
-	token, url, err := s.command.GenerateOrgDomainValidation(ctx, GenerateOrgDomainValidationRequestToDomain(ctx, req))
-	if err != nil {
-		return nil, err
-	}
-	return &org.GenerateOrganizationDomainValidationResponse{
-		Token: token,
-		Url:   url,
-	}, nil
-}
-
-func (s *Server) VerifyOrganizationDomain(ctx context.Context, request *org.VerifyOrganizationDomainRequest) (*org.VerifyOrganizationDomainResponse, error) {
-	userIDs, err := s.getClaimedUserIDsOfOrgDomain(ctx, request.Domain, request.OrganizationId)
-	if err != nil {
-		return nil, err
-	}
-	details, err := s.command.ValidateOrgDomain(ctx, ValidateOrgDomainRequestToDomain(ctx, request), userIDs)
-	if err != nil {
-		return nil, err
-	}
-	return &org.VerifyOrganizationDomainResponse{
-		Details: object.DomainToChangeDetailsPb(details),
-	}, nil
-}
-
-func createOrganizationRequestToCommand(request *v2beta_org.CreateOrganizationRequest) (*command.OrgSetup, error) {
-	admins, err := createOrganizationRequestAdminsToCommand(request.GetAdmins())
+func addOrganizationRequestToCommand(request *org.CreateOrganizationRequest) (*command.OrgSetup, error) {
+	admins, err := addOrganizationRequestAdminsToCommand(request.GetAdmins())
 	if err != nil {
 		return nil, err
 	}
@@ -208,10 +33,10 @@ func createOrganizationRequestToCommand(request *v2beta_org.CreateOrganizationRe
 	}, nil
 }
 
-func createOrganizationRequestAdminsToCommand(requestAdmins []*v2beta_org.CreateOrganizationRequest_Admin) (admins []*command.OrgSetupAdmin, err error) {
+func addOrganizationRequestAdminsToCommand(requestAdmins []*org.CreateOrganizationRequest_Admin) (admins []*command.OrgSetupAdmin, err error) {
 	admins = make([]*command.OrgSetupAdmin, len(requestAdmins))
 	for i, admin := range requestAdmins {
-		admins[i], err = createOrganizationRequestAdminToCommand(admin)
+		admins[i], err = addOrganizationRequestAdminToCommand(admin)
 		if err != nil {
 			return nil, err
 		}
@@ -219,14 +44,14 @@ func createOrganizationRequestAdminsToCommand(requestAdmins []*v2beta_org.Create
 	return admins, nil
 }
 
-func createOrganizationRequestAdminToCommand(admin *v2beta_org.CreateOrganizationRequest_Admin) (*command.OrgSetupAdmin, error) {
+func addOrganizationRequestAdminToCommand(admin *org.CreateOrganizationRequest_Admin) (*command.OrgSetupAdmin, error) {
 	switch a := admin.GetUserType().(type) {
-	case *v2beta_org.CreateOrganizationRequest_Admin_UserId:
+	case *org.CreateOrganizationRequest_Admin_UserId:
 		return &command.OrgSetupAdmin{
 			ID:    a.UserId,
 			Roles: admin.GetRoles(),
 		}, nil
-	case *v2beta_org.CreateOrganizationRequest_Admin_Human:
+	case *org.CreateOrganizationRequest_Admin_Human:
 		human, err := user.AddUserRequestToAddHuman(a.Human)
 		if err != nil {
 			return nil, err
@@ -236,31 +61,37 @@ func createOrganizationRequestAdminToCommand(admin *v2beta_org.CreateOrganizatio
 			Roles: admin.GetRoles(),
 		}, nil
 	default:
-		return nil, zerrors.ThrowUnimplementedf(nil, "ORGv2-SD2r1", "userType oneOf %T in method AddOrganization not implemented", a)
+		return nil, zerrors.ThrowUnimplementedf(nil, "ORGv2-SD2r1", "userType oneOf %T in method CreateOrganization not implemented", a)
 	}
 }
 
-func (s *Server) getClaimedUserIDsOfOrgDomain(ctx context.Context, orgDomain, orgID string) ([]string, error) {
-	queries := make([]query.SearchQuery, 0, 2)
-	loginName, err := query.NewUserPreferredLoginNameSearchQuery("@"+orgDomain, query.TextEndsWithIgnoreCase)
-	if err != nil {
-		return nil, err
-	}
-	queries = append(queries, loginName)
-	if orgID != "" {
-		owner, err := query.NewUserResourceOwnerSearchQuery(orgID, query.TextNotEquals)
-		if err != nil {
-			return nil, err
-		}
-		queries = append(queries, owner)
-	}
-	users, err := s.query.SearchUsers(ctx, &query.UserSearchQueries{Queries: queries}, nil)
-	if err != nil {
-		return nil, err
-	}
-	userIDs := make([]string, len(users.Users))
-	for i, user := range users.Users {
-		userIDs[i] = user.ID
-	}
-	return userIDs, nil
-}
+// func createdOrganizationToPb(createdOrg *command.CreatedOrg) (_ *org.CreateOrganizationResponse, err error) {
+// 	admins := make([]*org.OrganizationAdmin, len(createdOrg.OrgAdmins))
+// 	for i, admin := range createdOrg.OrgAdmins {
+// 		switch admin := admin.(type) {
+// 		case *command.CreatedOrgAdmin:
+// 			admins[i] = &org.OrganizationAdmin{
+// 				OrganizationAdmin: &org.OrganizationAdmin_CreatedAdmin{
+// 					CreatedAdmin: &org.CreatedAdmin{
+// 						UserId:    admin.ID,
+// 						EmailCode: admin.EmailCode,
+// 						PhoneCode: admin.PhoneCode,
+// 					},
+// 				},
+// 			}
+// 		case *command.AssignedOrgAdmin:
+// 			admins[i] = &org.OrganizationAdmin{
+// 				OrganizationAdmin: &org.OrganizationAdmin_AssignedAdmin{
+// 					AssignedAdmin: &org.AssignedAdmin{
+// 						UserId: admin.ID,
+// 					},
+// 				},
+// 			}
+// 		}
+// 	}
+// 	return &org.CreateOrganizationResponse{
+// 		Details:            object.DomainToDetailsPb(createdOrg.ObjectDetails),
+// 		OrganizationId:     createdOrg.ObjectDetails.ResourceOwner,
+// 		OrganizationAdmins: admins,
+// 	}, nil
+// }

--- a/internal/api/grpc/org/v2beta/org_test.go
+++ b/internal/api/grpc/org/v2beta/org_test.go
@@ -37,7 +37,7 @@ func Test_createOrganizationRequestToCommand(t *testing.T) {
 					},
 				},
 			},
-			wantErr: zerrors.ThrowUnimplementedf(nil, "ORGv2-SD2r1", "userType oneOf %T in method AddOrganization not implemented", nil),
+			wantErr: zerrors.ThrowUnimplementedf(nil, "ORGv2-SD2r1", "userType oneOf %T in method CreateOrganization not implemented", nil),
 		},
 		{
 			name: "user ID",
@@ -109,7 +109,7 @@ func Test_createOrganizationRequestToCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createOrganizationRequestToCommand(tt.args.request)
+			got, err := addOrganizationRequestToCommand(tt.args.request)
 			require.ErrorIs(t, err, tt.wantErr)
 			assert.Equal(t, tt.want, got)
 		})
@@ -136,8 +136,8 @@ func Test_createdOrganizationToPb(t *testing.T) {
 						EventDate:     now,
 						ResourceOwner: "orgID",
 					},
-					CreatedAdmins: []*command.CreatedOrgAdmin{
-						{
+					OrgAdmins: []command.OrgAdmin{
+						&command.CreatedOrgAdmin{
 							ID:        "id",
 							EmailCode: gu.Ptr("emailCode"),
 							PhoneCode: gu.Ptr("phoneCode"),
@@ -152,11 +152,15 @@ func Test_createdOrganizationToPb(t *testing.T) {
 					ResourceOwner: "orgID",
 				},
 				OrganizationId: "orgID",
-				CreatedAdmins: []*org.CreateOrganizationResponse_CreatedAdmin{
+				OrganizationAdmins: []*org.OrganizationAdmin{
 					{
-						UserId:    "id",
-						EmailCode: gu.Ptr("emailCode"),
-						PhoneCode: gu.Ptr("phoneCode"),
+						OrganizationAdmin: &org.OrganizationAdmin_CreatedAdmin{
+							CreatedAdmin: &org.CreatedAdmin{
+								UserId:    "id",
+								EmailCode: gu.Ptr("emailCode"),
+								PhoneCode: gu.Ptr("phoneCode"),
+							},
+						},
 					},
 				},
 			},

--- a/proto/zitadel/org/v2beta/org_service.proto
+++ b/proto/zitadel/org/v2beta/org_service.proto
@@ -569,6 +569,7 @@ service OrganizationService {
 
 }
 
+
 message CreateOrganizationRequest{
   message Admin {
     oneof user_type{
@@ -591,6 +592,22 @@ message CreateOrganizationRequest{
   repeated Admin admins = 2;
 }
 
+message CreatedAdmin {
+  string user_id = 1;
+  optional string email_code = 2;
+  optional string phone_code = 3;
+}
+message AssignedAdmin { string user_id = 1; }
+
+message OrganizationAdmin {
+  oneof OrganizationAdmin {
+    option (validate.required) = true;
+
+    CreatedAdmin created_admin = 3;
+    AssignedAdmin assigned_admin = 4;
+  }
+}
+
 message CreateOrganizationResponse{
   message CreatedAdmin {
     string user_id = 1;
@@ -600,6 +617,7 @@ message CreateOrganizationResponse{
   zitadel.object.v2beta.Details details = 1;
   string organization_id = 2;
   repeated CreatedAdmin created_admins = 3;
+  repeated OrganizationAdmin organization_admins = 4;
 }
 
 message UpdateOrganizationRequest {


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved


When running `zitadel.org.v2.AddOrganization` if you include `user_id` as the admin (a pre-existing user) there is no confirmation whether the `user_id` was added as the admin for the org or not.

This is useful for testing, this has been added now

# How the Problems Are Solved

By returning **all** admins requested when created an organization.
