### PR TITLE
docs: simplify lb setup

### DIFF
--- a/cmd/setup/steps.yaml
+++ b/cmd/setup/steps.yaml
@@ -35,6 +35,8 @@ FirstInstance:
     # In the FirstInstance.Org.Machine section, the initial organization's admin user with the role IAM_OWNER is defined.
     # If FirstInstance.Org.Machine.Machine is defined, a service user is created with the IAM_OWNER role.
     Machine:
+      Roles: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_ROLES
+        - "IAM_OWNER"
       Machine:
         Username: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME
         Name: # ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/docker-compose.yaml
@@ -94,28 +94,6 @@ services:
       retries: 5
       start_period: 10s
 
-  # The use-new-login service configures Zitadel to use the new login v2 for all applications.
-  # It also gives the setupped machine user the necessary IAM_LOGIN_CLIENT role.
-  use-new-login:
-    restart: 'on-failure'
-    user: "1001"
-    networks:
-      - 'backend'
-    image: 'badouralix/curl-jq:alpine'
-    entrypoint: '/bin/sh'
-    command:
-      - -c
-      - >
-        curl -X PUT -H "Host: 127.0.0.1.sslip.io" -H "Authorization: Bearer $(cat ./.env-file/pat)" --insecure http://zitadel:8080/v2/features/instance -d '{"loginV2": {"required": true}}' &&
-        LOGIN_USER=$(curl --fail-with-body  -H "Host: 127.0.0.1.sslip.io" -H "Authorization: Bearer $(cat ./.env-file/pat)" --insecure http://zitadel:8080/auth/v1/users/me | jq -r '.user.id') &&
-        curl -X PUT  -H "Host: 127.0.0.1.sslip.io" -H "Authorization: Bearer $(cat ./.env-file/pat)" --insecure http://zitadel:8080/admin/v1/members/$${LOGIN_USER} -d '{"roles": ["IAM_OWNER", "IAM_LOGIN_CLIENT"]}'
-    volumes:
-      - './.env-file:/.env-file:ro'
-    depends_on:
-      zitadel:
-        condition: 'service_healthy'
-        restart: false
-
   login:
     restart: 'unless-stopped'
     networks:

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-init-steps.yaml
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/example-zitadel-init-steps.yaml
@@ -2,10 +2,13 @@
 FirstInstance:
   PatPath: '/pat'
   Org:
-    # We want to authenticate immediately at the console without changing the password
     Human:
+      # We want to authenticate immediately at the console without changing the password
       PasswordChangeRequired: false
     Machine:
+      Roles:
+        - "IAM_OWNER"
+        - "IAM_LOGIN_CLIENT"
       Machine:
         Username: 'login-container'
         Name: 'Login Container'

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/loadbalancing-example.mdx
@@ -60,8 +60,11 @@ wget https://raw.githubusercontent.com/zitadel/zitadel/main/docs/docs/self-hosti
 
 # A single ZITADEL instance always needs the same 32 bytes long masterkey
 # Generate one to a file if you haven't done so already and pass it as environment variable
-LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 32 > ./zitadel-masterkey
+LC_ALL=C tr -dc '[:alpha:]' </dev/urandom | head -c 32 > ./zitadel-masterkey
 export ZITADEL_MASTERKEY="$(cat ./zitadel-masterkey)"
+
+# Create the env-file directory with the correct ownership before the docker engine creates it with root ownership
+mkdir ./.env-file
 
 # Run the database and application containers
 docker compose up --detach --wait

--- a/docs/docs/self-hosting/deploy/loadbalancing-example/zitadel-masterkey
+++ b/docs/docs/self-hosting/deploy/loadbalancing-example/zitadel-masterkey
@@ -1,0 +1,1 @@
+HlRwzwmUWZzXmDlWygQlfAEDtwQtTheh


### PR DESCRIPTION
# Which Problems Are Solved

The load balancing compoe setup uses a service that gives the setupped machine user the login role. This is cumbersome and unnecessary.

# How the Problems Are Solved

The unnecessary service is removed and the role is setupped by Zitadel using the --steps config.

# Additional Changes

- The IAM_OWNER role is added to the steps.yaml, so it's clear what the default is and that roles are configurable.
- Uses the `[:alpha:]` regexp pattern to generate the master key, as this avoid quoting problems.

# Additional Context

- Complements https://github.com/zitadel/zitadel/pull/9496