### PR TITLE
docs: add invalid information to member requests

### DIFF
--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -9209,7 +9209,7 @@ message AddOrgMemberRequest {
     repeated string roles = 2  [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"ORG_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }
@@ -9222,7 +9222,7 @@ message UpdateOrgMemberRequest {
     repeated string roles = 2 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"IAM_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }
@@ -9643,7 +9643,7 @@ message AddProjectMemberRequest {
     repeated string roles = 3 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"PROJECT_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }
@@ -9658,7 +9658,7 @@ message UpdateProjectMemberRequest {
     repeated string roles = 3 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"PROJECT_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }
@@ -10313,7 +10313,7 @@ message AddProjectGrantMemberRequest {
     repeated string roles = 4 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"PROJECT_GRANT_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }
@@ -10337,7 +10337,7 @@ message UpdateProjectGrantMemberRequest {
     repeated string roles = 4 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"PROJECT_GRANT_OWNER\"]";
-            description: "If no roles are provided the user won't have any rights"
+            description: "If no roles are provided the user won't have any rights, so the member definition will be regarded as invalid."
         }
     ];
 }


### PR DESCRIPTION
# Which Problems Are Solved

Misleading information on member endpoint requests.

# How the Problems Are Solved

Add comment to member endpoint requests that the request is invalid if no roles are provided.

# Additional Changes

None

# Additional Context

Closes #9415 