### PR TITLE
fix: remove index es_instance_position

### DIFF
--- a/cmd/setup/54.go
+++ b/cmd/setup/54.go
@@ -23,5 +23,5 @@ func (mig *InstancePositionIndex) Execute(ctx context.Context, _ eventstore.Even
 }
 
 func (mig *InstancePositionIndex) String() string {
-	return "54_instance_position_index"
+	return "54_instance_position_index_remove"
 }

--- a/cmd/setup/54.sql
+++ b/cmd/setup/54.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY IF NOT EXISTS es_instance_position ON eventstore.events2 (instance_id, position);
+DROP INDEX IF EXISTS eventstore.es_instance_position;


### PR DESCRIPTION
# Which Problems Are Solved

#9837 added a new index `es_instance_position` on the events table with the idea to improve performance for some projections. Unfortunately, it makes it worse for almost all projections and would only improve the situation for the events handler of the actions V2 subscriptions.

# How the Problems Are Solved

Remove the index again.

# Additional Changes

None

# Additional Context

relates to #9837