### PR TITLE
fix: correctly use single matching user (by loginname)

### DIFF
--- a/internal/query/user_by_login_name.sql
+++ b/internal/query/user_by_login_name.sql
@@ -10,7 +10,7 @@ WITH found_users AS (
     LEFT JOIN projections.login_names3_policies p_custom
       ON  u.instance_id = p_custom.instance_id
         AND p_custom.instance_id = $4 AND p_custom.resource_owner = u.resource_owner
-    LEFT JOIN projections.login_names3_policies p_default
+    JOIN projections.login_names3_policies p_default
       ON  u.instance_id = p_default.instance_id
       AND p_default.instance_id = $4 AND p_default.is_default IS TRUE
       AND (

--- a/internal/query/user_notify_by_login_name.sql
+++ b/internal/query/user_notify_by_login_name.sql
@@ -10,7 +10,7 @@ WITH found_users AS (
     LEFT JOIN projections.login_names3_policies p_custom
       ON  u.instance_id = p_custom.instance_id
       AND p_custom.instance_id = $4 AND p_custom.resource_owner = u.resource_owner
-    LEFT JOIN projections.login_names3_policies p_default
+    JOIN projections.login_names3_policies p_default
       ON  u.instance_id = p_default.instance_id
       AND p_default.instance_id = $4 AND p_default.is_default IS TRUE
       AND (


### PR DESCRIPTION
# Which Problems Are Solved

In rare cases there was a possibility that multiple users were found by a loginname. This prevented the corresponding user to sign in.

# How the Problems Are Solved

Fixed the corresponding query (to correctly respect the org domain policy).

# Additional Changes

None

# Additional Context

Found during the investigation of a support request
