### PR TITLE
fix(setup): reenable index creation

### DIFF
--- a/cmd/setup/54.go
+++ b/cmd/setup/54.go
@@ -23,5 +23,5 @@ func (mig *InstancePositionIndex) Execute(ctx context.Context, _ eventstore.Even
 }
 
 func (mig *InstancePositionIndex) String() string {
-	return "54_instance_position_index_remove"
+	return "54_instance_position_index_again"
 }

--- a/cmd/setup/54.sql
+++ b/cmd/setup/54.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS eventstore.es_instance_position;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS es_instance_position ON eventstore.events2 (instance_id, position);

--- a/internal/execution/handlers.go
+++ b/internal/execution/handlers.go
@@ -84,6 +84,9 @@ func (u *eventHandler) Reducers() []handler.AggregateReducer {
 	return aggReducers
 }
 
+// FilterGlobalEvents implements [handler.GlobalProjection]
+func (u *eventHandler) FilterGlobalEvents() {}
+
 func groupsFromEventType(s string) []string {
 	parts := strings.Split(s, ".")
 	groups := make([]string, len(parts))


### PR DESCRIPTION
# Which Problems Are Solved

We saw high CPU usage if many events were created on the database. This was caused by the new actions which query for all event types and aggregate types.

# How the Problems Are Solved

- the handler of action execution does not filter for aggregate and event types. 
- the index for `instance_id` and `position` is reenabled.

# Additional Changes

none

# Additional Context

none
