### PR TITLE
Fix: Copy to clipboard button in MFA login step now compitable in non-chro…

### DIFF
--- a/internal/api/ui/login/static/resources/scripts/copy_to_clipboard.js
+++ b/internal/api/ui/login/static/resources/scripts/copy_to_clipboard.js
@@ -3,4 +3,4 @@ const copyToClipboard = str => {
 };
 
 let copyButton = document.getElementById("copy");
-copyButton.addEventListener("click", copyToClipboard(copyButton.getAttribute("data-copy")));
+copyButton.addEventListener("click", () => copyToClipboard(copyButton.getAttribute("data-copy")));


### PR DESCRIPTION
…me browsers

# Which Problems Are Solved

Copy to clipboard button was not compatible with Webkit/ Firefox browsers. 

# How the Problems Are Solved

The previous function used addEventListener without a callback function as a second argument. I simply added the callback function and left existing code intact to fix the bug.

# Additional Changes

None

# Additional Context

none