### PR TITLE
docs: fix typo in email notification provider description

### DIFF
--- a/docs/docs/guides/manage/customize/notification-providers.mdx
+++ b/docs/docs/guides/manage/customize/notification-providers.mdx
@@ -74,7 +74,7 @@ A provider with HTTP type will send the messages and the data to a pre-defined w
   </TabItem>
   <TabItem value="email" label="Email">
 
-    First [add a new Email Provider of type HTTP](/apis/resources/admin/admin-service-add-email-provider-http) to create a new HTTP provider that can be used to send SMS messages:
+    First [add a new Email Provider of type HTTP](/apis/resources/admin/admin-service-add-email-provider-http) to create a new HTTP provider that can be used to send Email messages:
 
   ```bash
   curl -L 'https://$CUSTOM-DOMAIN/admin/v1/email/http' \


### PR DESCRIPTION
# Which Problems Are Solved

Copy Paste typo in the description of the email notification provider, states sms are sent instead of email.

# How the Problems Are Solved

Replaces SMS with Email
