### PR TITLE
test: fix list orgs test with sort

### DIFF
--- a/internal/api/grpc/org/v2/integration_test/query_test.go
+++ b/internal/api/grpc/org/v2/integration_test/query_test.go
@@ -5,7 +5,9 @@ package org_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +91,7 @@ func TestServer_ListOrganizations(t *testing.T) {
 					Queries: []*org.SearchQuery{
 						OrganizationIdQuery(Instance.DefaultOrg.Id),
 					},
+					SortingColumn: org.OrganizationFieldName_ORGANIZATION_FIELD_NAME_NAME,
 				},
 				func(ctx context.Context, request *org.ListOrganizationsRequest) ([]orgAttr, error) {
 					count := 3
@@ -101,6 +104,10 @@ func TestServer_ListOrganizations(t *testing.T) {
 					request.Queries = []*org.SearchQuery{
 						OrganizationNamePrefixQuery(prefix),
 					}
+
+					slices.SortFunc(orgs, func(a, b orgAttr) int {
+						return -1 * strings.Compare(a.Name, b.Name)
+					})
 					return orgs, nil
 				},
 			},


### PR DESCRIPTION
# Which Problems Are Solved

List organization integration test fails sometimes due to incorrect sorting of results.

# How the Problems Are Solved

Add sorting column to request on list organizations endpoint and sort expected results.

# Additional Changes

None

# Additional Context

None
