### PR TITLE
fix(handler): report error correctly

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -64,6 +64,10 @@ func CloseTransaction(tx Tx, err error) error {
 	return commitErr
 }
 
+const (
+	PgUniqueConstraintErrorCode = "23505"
+)
+
 type Config struct {
 	Dialects                   map[string]interface{} `mapstructure:",remain"`
 	EventPushConnRatio         float64

--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -563,7 +563,10 @@ func (h *Handler) processEvents(ctx context.Context, config *triggerConfig) (add
 	currentState.sequence = statements[lastProcessedIndex].Sequence
 	currentState.eventTimestamp = statements[lastProcessedIndex].CreationDate
 
-	err = h.setState(tx, currentState)
+	setStateErr := h.setState(tx, currentState)
+	if setStateErr != nil {
+		err = setStateErr
+	}
 
 	return additionalIteration, err
 }

--- a/internal/query/projection/projection.go
+++ b/internal/query/projection/projection.go
@@ -2,8 +2,10 @@ package projection
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/zitadel/logging"
 
 	internal_authz "github.com/zitadel/zitadel/internal/api/authz"
@@ -204,10 +206,18 @@ func Start(ctx context.Context) {
 
 func ProjectInstance(ctx context.Context) error {
 	for i, projection := range projections {
-		logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(projections))).Info("starting projection")
-		_, err := projection.Trigger(ctx)
-		if err != nil {
-			return err
+		for {
+			logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(projections))).Info("starting projection")
+			_, err := projection.Trigger(ctx)
+			if err == nil {
+				break
+			}
+			var pgErr *pgconn.PgError
+			errors.As(err, &pgErr)
+			if pgErr.Code != database.PgUniqueConstraintErrorCode {
+				return err
+			}
+			logging.WithError(err).Debug("projection failed because of unique constraint, retrying")
 		}
 	}
 	return nil

--- a/internal/query/projection/projection.go
+++ b/internal/query/projection/projection.go
@@ -206,8 +206,8 @@ func Start(ctx context.Context) {
 
 func ProjectInstance(ctx context.Context) error {
 	for i, projection := range projections {
+		logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(projections))).Info("starting projection")
 		for {
-			logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(projections))).Info("starting projection")
 			_, err := projection.Trigger(ctx)
 			if err == nil {
 				break
@@ -217,8 +217,9 @@ func ProjectInstance(ctx context.Context) error {
 			if pgErr.Code != database.PgUniqueConstraintErrorCode {
 				return err
 			}
-			logging.WithError(err).Debug("projection failed because of unique constraint, retrying")
+			logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID()).WithError(err).Debug("projection failed because of unique constraint, retrying")
 		}
+		logging.WithFields("name", projection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(projections))).Info("projection done")
 	}
 	return nil
 }
@@ -226,11 +227,19 @@ func ProjectInstance(ctx context.Context) error {
 func ProjectInstanceFields(ctx context.Context) error {
 	for i, fieldProjection := range fields {
 		logging.WithFields("name", fieldProjection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(fields))).Info("starting fields projection")
-		err := fieldProjection.Trigger(ctx)
-		if err != nil {
-			return err
+		for {
+			err := fieldProjection.Trigger(ctx)
+			if err == nil {
+				break
+			}
+			var pgErr *pgconn.PgError
+			errors.As(err, &pgErr)
+			if pgErr.Code != database.PgUniqueConstraintErrorCode {
+				return err
+			}
+			logging.WithFields("name", fieldProjection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID()).WithError(err).Debug("fields projection failed because of unique constraint, retrying")
 		}
-		logging.WithFields("name", fieldProjection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID()).Info("fields projection done")
+		logging.WithFields("name", fieldProjection.ProjectionName(), "instance", internal_authz.GetInstance(ctx).InstanceID(), "index", fmt.Sprintf("%d/%d", i, len(fields))).Info("fields projection done")
 	}
 	return nil
 }


### PR DESCRIPTION
# Which Problems Are Solved

1. The projection handler reported no error if an error happened but updating the current state was successful. This can lead to skipped projections during setup as soon as the projection has an error but does not correctly report if to the caller.

2. Mirror projections skipped as soon as an error occures, this leads to unprojected projections.

# How the Problems Are Solved

1. the error returned by the `Trigger` method will will only be set to the error of updating current states if there occured an error.

2. triggering projections checks for the error type returned and retries if the error had code `23505`

# Additional Changes

unify logging on mirror projections
