### PR TITLE
Fix BUG: Role deletion/update fails when role key contains a slash (/) – returns 404

### DIFF
--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -3036,7 +3036,7 @@ service ManagementService {
 
     rpc UpdateProjectRole(UpdateProjectRoleRequest) returns (UpdateProjectRoleResponse) {
         option (google.api.http) = {
-            put: "/projects/{project_id}/roles/{role_key}"
+            put: "/projects/{project_id}/roles/{role_key=**}"
             body: "*"
         };
 
@@ -3062,7 +3062,7 @@ service ManagementService {
 
     rpc RemoveProjectRole(RemoveProjectRoleRequest) returns (RemoveProjectRoleResponse) {
         option (google.api.http) = {
-            delete: "/projects/{project_id}/roles/{role_key}"
+            delete: "/projects/{project_id}/roles/{role_key=**}"
         };
 
         option (zitadel.v1.auth_option) = {


### PR DESCRIPTION
# Which Problems Are Solved

- Role deletion or update API returns `404 Not Found` when the role key contains a slash (`/`), even if URL encoded.
- This breaks management of hierarchical role keys like `admin/org/reader`.

# How the Problems Are Solved

- Updated the HTTP binding in the protobuf definition for the affected endpoints to use `{role_key=**}` instead of `{role_key}`.
- This change enables proper decoding and handling of slashes in role keys as a single path variable.

# Additional Changes
None

# Additional Context
- Closes https://github.com/zitadel/zitadel/issues/9948
