### PR TITLE
fix: correct permissions for projects on v2 api

### DIFF
--- a/internal/command/project_old.go
+++ b/internal/command/project_old.go
@@ -94,5 +94,5 @@ func (c *Commands) checkProjectGrantPreConditionOld(ctx context.Context, project
 	if domain.HasInvalidRoles(preConditions.ExistingRoleKeys, roles) {
 		return "", zerrors.ThrowPreconditionFailed(err, "COMMAND-6m9gd", "Errors.Project.Role.NotFound")
 	}
-	return preConditions.ResourceOwner, nil
+	return preConditions.ProjectResourceOwner, nil
 }


### PR DESCRIPTION
# Which Problems Are Solved

Permission checks in project v2beta API did not cover projects and granted projects correctly.

# How the Problems Are Solved

Add permission checks v1 correctly to the list queries, add correct permission checks v2 for projects.

# Additional Changes

Correct Pre-Checks for project grants that the right resource owner is used.

# Additional Context

Permission checks v2 for project grants is still outstanding under #9972.
