### PR TITLE
fix(import/export): fix for deactivated user/organization beung imported as active

### DIFF
--- a/internal/api/grpc/admin/export.go
+++ b/internal/api/grpc/admin/export.go
@@ -65,7 +65,7 @@ func (s *Server) ExportData(ctx context.Context, req *admin_pb.ExportDataRequest
 		/******************************************************************************************************************
 		Organization
 		******************************************************************************************************************/
-		org := &admin_pb.DataOrg{OrgId: queriedOrg.ID, Org: &management_pb.AddOrgRequest{Name: queriedOrg.Name}}
+		org := &admin_pb.DataOrg{OrgId: queriedOrg.ID, OrgState: int32(queriedOrg.State), Org: &management_pb.AddOrgRequest{Name: queriedOrg.Name}}
 		orgs[i] = org
 	}
 
@@ -567,6 +567,7 @@ func (s *Server) getUsers(ctx context.Context, org string, withPasswords bool, w
 		case domain.UserTypeHuman:
 			dataUser := &v1_pb.DataHumanUser{
 				UserId: user.ID,
+				State:  int32(user.State),
 				User: &management_pb.ImportHumanUserRequest{
 					UserName: user.Username,
 					Profile: &management_pb.ImportHumanUserRequest_Profile{
@@ -620,6 +621,7 @@ func (s *Server) getUsers(ctx context.Context, org string, withPasswords bool, w
 		case domain.UserTypeMachine:
 			machineUsers = append(machineUsers, &v1_pb.DataMachineUser{
 				UserId: user.ID,
+				State:  int32(user.State),
 				User: &management_pb.AddMachineUserRequest{
 					UserName:    user.Username,
 					Name:        user.Machine.Name,
@@ -647,7 +649,6 @@ func (s *Server) getUsers(ctx context.Context, org string, withPasswords bool, w
 					ExpirationDate: timestamppb.New(key.Expiration),
 					PublicKey:      key.PublicKey,
 				})
-
 			}
 		}
 
@@ -888,7 +889,6 @@ func (s *Server) getNecessaryProjectGrantMembersForOrg(ctx context.Context, org 
 						break
 					}
 				}
-
 			}
 		}
 	}
@@ -940,7 +940,6 @@ func (s *Server) getNecessaryOrgMembersForOrg(ctx context.Context, org string, p
 }
 
 func (s *Server) getNecessaryProjectGrantsForOrg(ctx context.Context, org string, processedOrgs []string, processedProjects []string) ([]*v1_pb.DataProjectGrant, error) {
-
 	projectGrantSearchOrg, err := query.NewProjectGrantResourceOwnerSearchQuery(org)
 	if err != nil {
 		return nil, err
@@ -991,7 +990,7 @@ func (s *Server) getNecessaryUserGrantsForOrg(ctx context.Context, org string, p
 	for _, userGrant := range queriedUserGrants.UserGrants {
 		for _, projectID := range processedProjects {
 			if projectID == userGrant.ProjectID {
-				//if usergrant is on a granted project
+				// if usergrant is on a granted project
 				if userGrant.GrantID != "" {
 					for _, grantID := range processedGrants {
 						if grantID == userGrant.GrantID {
@@ -1024,6 +1023,7 @@ func (s *Server) getNecessaryUserGrantsForOrg(ctx context.Context, org string, p
 	}
 	return userGrants, nil
 }
+
 func (s *Server) getCustomLoginTexts(ctx context.Context, org string, languages []string) ([]*management_pb.SetCustomLoginTextsRequest, error) {
 	customTexts := make([]*management_pb.SetCustomLoginTextsRequest, 0, len(languages))
 	for _, lang := range languages {

--- a/internal/api/grpc/management/user.go
+++ b/internal/api/grpc/management/user.go
@@ -273,7 +273,7 @@ func (s *Server) ImportHumanUser(ctx context.Context, req *mgmt_pb.ImportHumanUs
 	if err != nil {
 		return nil, err
 	}
-	addedHuman, code, err := s.command.ImportHuman(ctx, authz.GetCtxData(ctx).OrgID, human, passwordless, links, initCodeGenerator, phoneCodeGenerator, emailCodeGenerator, passwordlessInitCode)
+	addedHuman, code, err := s.command.ImportHuman(ctx, authz.GetCtxData(ctx).OrgID, human, passwordless, false, links, initCodeGenerator, phoneCodeGenerator, emailCodeGenerator, passwordlessInitCode)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (s *Server) ImportHumanUser(ctx context.Context, req *mgmt_pb.ImportHumanUs
 
 func (s *Server) AddMachineUser(ctx context.Context, req *mgmt_pb.AddMachineUserRequest) (*mgmt_pb.AddMachineUserResponse, error) {
 	machine := AddMachineUserRequestToCommand(req, authz.GetCtxData(ctx).OrgID)
-	objectDetails, err := s.command.AddMachine(ctx, machine)
+	objectDetails, err := s.command.AddMachine(ctx, machine, false)
 	if err != nil {
 		return nil, err
 	}
@@ -901,6 +901,7 @@ func (s *Server) ListHumanLinkedIDPs(ctx context.Context, req *mgmt_pb.ListHuman
 		Details: obj_grpc.ToListDetails(res.Count, res.Sequence, res.LastRun),
 	}, nil
 }
+
 func (s *Server) RemoveHumanLinkedIDP(ctx context.Context, req *mgmt_pb.RemoveHumanLinkedIDPRequest) (*mgmt_pb.RemoveHumanLinkedIDPResponse, error) {
 	objectDetails, err := s.command.RemoveUserIDPLink(ctx, RemoveHumanLinkedIDPRequestToDomain(ctx, req))
 	if err != nil {
@@ -947,18 +948,21 @@ func cascadingIAMMembership(membership *query.IAMMembership) *command.CascadingI
 	}
 	return &command.CascadingIAMMembership{IAMID: membership.IAMID}
 }
+
 func cascadingOrgMembership(membership *query.OrgMembership) *command.CascadingOrgMembership {
 	if membership == nil {
 		return nil
 	}
 	return &command.CascadingOrgMembership{OrgID: membership.OrgID}
 }
+
 func cascadingProjectMembership(membership *query.ProjectMembership) *command.CascadingProjectMembership {
 	if membership == nil {
 		return nil
 	}
 	return &command.CascadingProjectMembership{ProjectID: membership.ProjectID}
 }
+
 func cascadingProjectGrantMembership(membership *query.ProjectGrantMembership) *command.CascadingProjectGrantMembership {
 	if membership == nil {
 		return nil

--- a/internal/command/org.go
+++ b/internal/command/org.go
@@ -300,7 +300,7 @@ func (c *Commands) checkOrgExists(ctx context.Context, orgID string) error {
 	return nil
 }
 
-func (c *Commands) AddOrgWithID(ctx context.Context, name, userID, resourceOwner, orgID string, claimedUserIDs []string) (_ *domain.Org, err error) {
+func (c *Commands) AddOrgWithID(ctx context.Context, name, userID, resourceOwner, orgID string, setOrgInactive bool, claimedUserIDs []string) (_ *domain.Org, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
@@ -312,7 +312,7 @@ func (c *Commands) AddOrgWithID(ctx context.Context, name, userID, resourceOwner
 		return nil, zerrors.ThrowNotFound(nil, "ORG-lapo2m", "Errors.Org.AlreadyExisting")
 	}
 
-	return c.addOrgWithIDAndMember(ctx, name, userID, resourceOwner, orgID, claimedUserIDs)
+	return c.addOrgWithIDAndMember(ctx, name, userID, resourceOwner, orgID, setOrgInactive, claimedUserIDs)
 }
 
 func (c *Commands) AddOrg(ctx context.Context, name, userID, resourceOwner string, claimedUserIDs []string) (*domain.Org, error) {
@@ -325,10 +325,10 @@ func (c *Commands) AddOrg(ctx context.Context, name, userID, resourceOwner strin
 		return nil, zerrors.ThrowInternal(err, "COMMA-OwciI", "Errors.Internal")
 	}
 
-	return c.addOrgWithIDAndMember(ctx, name, userID, resourceOwner, orgID, claimedUserIDs)
+	return c.addOrgWithIDAndMember(ctx, name, userID, resourceOwner, orgID, false, claimedUserIDs)
 }
 
-func (c *Commands) addOrgWithIDAndMember(ctx context.Context, name, userID, resourceOwner, orgID string, claimedUserIDs []string) (_ *domain.Org, err error) {
+func (c *Commands) addOrgWithIDAndMember(ctx context.Context, name, userID, resourceOwner, orgID string, setOrgInactive bool, claimedUserIDs []string) (_ *domain.Org, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
@@ -346,10 +346,15 @@ func (c *Commands) addOrgWithIDAndMember(ctx context.Context, name, userID, reso
 		return nil, err
 	}
 	events = append(events, orgMemberEvent)
+	if setOrgInactive {
+		deactivateOrgEvent := org.NewOrgDeactivatedEvent(ctx, orgAgg)
+		events = append(events, deactivateOrgEvent)
+	}
 	pushedEvents, err := c.eventstore.Push(ctx, events...)
 	if err != nil {
 		return nil, err
 	}
+
 	err = AppendAndReduce(addedOrg, pushedEvents...)
 	if err != nil {
 		return nil, err

--- a/internal/command/user_human_test.go
+++ b/internal/command/user_human_test.go
@@ -1200,7 +1200,8 @@ func TestCommandSide_AddHuman(t *testing.T) {
 				},
 				wantID: "user1",
 			},
-		}, {
+		},
+		{
 			name: "add human (with return code), ok",
 			fields: fields{
 				eventstore: expectEventstore(
@@ -1584,7 +1585,8 @@ func TestCommandSide_ImportHuman(t *testing.T) {
 			res: res{
 				err: zerrors.IsErrorInvalidArgument,
 			},
-		}, {
+		},
+		{
 			name: "add human (with password and initial code), ok",
 			given: func(t *testing.T) (fields, args) {
 				return fields{
@@ -2996,7 +2998,7 @@ func TestCommandSide_ImportHuman(t *testing.T) {
 				newEncryptedCodeWithDefault: f.newEncryptedCodeWithDefault,
 				defaultSecretGenerators:     f.defaultSecretGenerators,
 			}
-			gotHuman, gotCode, err := r.ImportHuman(a.ctx, a.orgID, a.human, a.passwordless, a.links, a.secretGenerator, a.secretGenerator, a.secretGenerator, a.secretGenerator)
+			gotHuman, gotCode, err := r.ImportHuman(a.ctx, a.orgID, a.human, a.passwordless, false, a.links, a.secretGenerator, a.secretGenerator, a.secretGenerator, a.secretGenerator)
 			if tt.res.err == nil {
 				assert.NoError(t, err)
 			}

--- a/internal/command/user_machine_test.go
+++ b/internal/command/user_machine_test.go
@@ -201,7 +201,7 @@ func TestCommandSide_AddMachine(t *testing.T) {
 				eventstore:  tt.fields.eventstore,
 				idGenerator: tt.fields.idGenerator,
 			}
-			got, err := r.AddMachine(tt.args.ctx, tt.args.machine)
+			got, err := r.AddMachine(tt.args.ctx, tt.args.machine, false)
 			if tt.res.err == nil {
 				assert.NoError(t, err)
 			}

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -9007,6 +9007,7 @@ message DataOrg {
     repeated zitadel.management.v1.SetCustomVerifySMSOTPMessageTextRequest verify_sms_otp_messages = 37;
     repeated zitadel.management.v1.SetCustomVerifyEmailOTPMessageTextRequest verify_email_otp_messages = 38;
     repeated zitadel.management.v1.SetCustomInviteUserMessageTextRequest invite_user_messages = 39;
+    int32 org_state = 40;
 }
 
 message ImportDataResponse{

--- a/proto/zitadel/v1.proto
+++ b/proto/zitadel/v1.proto
@@ -172,10 +172,12 @@ message DataOIDCApplication {
 message DataHumanUser {
   string user_id = 1;
   zitadel.management.v1.ImportHumanUserRequest user = 2;
+  int32 state = 3;
 }
 message DataMachineUser {
   string user_id = 1;
   zitadel.management.v1.AddMachineUserRequest user = 2;
+  int32 state = 3;
 }
 message DataAction {
   string action_id = 1;


### PR DESCRIPTION
# Which Problems Are Solved

When importing https://zitadel.com/docs/apis/resources/admin/admin-service-import-data deactivated usrs/organizations get imported as active, this PR fixes this

# How the Problems Are Solved

- Added extra fields in the proto messages for state
- Check added state field and create deactivation events for orgs/uses which have state set to inactive

# Additional Context

- Closes https://github.com/zitadel/zitadel/issues/9345
