### PR TITLE
docs(10016): cockroach compatibility

### DIFF
--- a/docs/docs/support/advisory/a10016.md
+++ b/docs/docs/support/advisory/a10016.md
@@ -78,6 +78,7 @@ with
       and s.aggregate_id = b.aggregate_id
       and s.aggregate_type = b.aggregate_type
       and s.sequence = b.sequence
+    returning *
   )
 select
   b.projection_name,


### PR DESCRIPTION
# Which Problems Are Solved

If the sql statement of technical advisory 10016 gets executed on cockroach the following error is raised:

```
ERROR: WITH clause "fixed" does not return any columns
SQLSTATE: 0A000
HINT: missing RETURNING clause?
```

# How the Problems Are Solved

Fixed the statement by adding `returning` to statement
