### PR TITLE
docs(api): remove unreleased services from api reference

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -807,18 +807,6 @@ module.exports = {
             },
             {
               type: "category",
-              label: "Organization (Beta)",
-              link: {
-                type: "generated-index",
-                title: "Organization Service beta API",
-                slug: "/apis/resources/org_service/v2beta",
-                description:
-                  "This API is intended to manage organizations for ZITADEL. \n",
-              },
-              items: sidebar_api_org_service_v2beta,
-            },
-            {
-              type: "category",
               label: "Identity Provider",
               link: {
                 type: "generated-index",
@@ -867,35 +855,6 @@ module.exports = {
                     "Please make sure to enable the `actions` feature flag on your instance to use this service and that you're running Zitadel V3.",
               },
               items: sidebar_api_actions_v2,
-            },
-            {
-              type: "category",
-              label: "Project (Beta)",
-              link: {
-                type: "generated-index",
-                title: "Project Service API (Beta)",
-                slug: "/apis/resources/project_service_v2",
-                description:
-                  "This API is intended to manage projects and subresources for ZITADEL. \n"+
-                  "\n" +
-                  "This service is in beta state. It can AND will continue breaking until a stable version is released.",
-              },
-              items: sidebar_api_project_service_v2,
-              label: "Instance (Beta)",
-              link: {
-                type: "generated-index",
-                title: "Instance Service API (Beta)",
-                slug: "/apis/resources/instance_service_v2",
-                description:
-                    "This API is intended to manage instances, custom domains and trusted domains in ZITADEL.\n" +
-                    "\n" +
-                    "This service is in beta state. It can AND will continue breaking until a stable version is released.\n"+
-                    "\n" +
-                    "This v2 of the API provides the same functionalities as the v1, but organised on a per resource basis.\n" +
-                    "The whole functionality related to domains (custom and trusted) has been moved under this instance API."
-                    ,
-              },
-              items: sidebar_api_instance_service_v2,
             },
           ],
         },


### PR DESCRIPTION
# Which Problems Are Solved

As we migrate resources to the new API, whenever a an implementation got merged, the API reference was added to the docs sidenav. As these new services and their implementation are not yet released, it can be confusing for developers as the corresponding endpoints return 404 or unimplemented errors.

# How the Problems Are Solved

Currently we just remove it from the sidenav and will add it once they're released. We're looking into a proper solution for the API references.

# Additional Changes

None

# Additional Context

None