### PR TITLE
fix: correct id filter for project service

### DIFF
--- a/internal/api/grpc/project/v2beta/integration/query_test.go
+++ b/internal/api/grpc/project/v2beta/integration/query_test.go
@@ -389,9 +389,7 @@ func TestServer_ListProjects(t *testing.T) {
 					resp2 := createProject(iamOwnerCtx, instance, t, orgID, true, false)
 					resp3 := createProject(iamOwnerCtx, instance, t, orgResp.GetOrganizationId(), false, true)
 					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
-						InProjectIdsFilter: &project.InProjectIDsFilter{
-							ProjectIds: []string{resp1.GetId(), resp2.GetId(), resp3.GetId(), projectResp.GetId()},
-						},
+						InProjectIdsFilter: &filter.InIDsFilter{Ids: []string{resp1.GetId(), resp2.GetId(), resp3.GetId(), projectResp.GetId()}},
 					}
 					response.Projects[0] = grantedProjectResp
 					response.Projects[1] = projectResp
@@ -516,7 +514,7 @@ func TestServer_ListProjects(t *testing.T) {
 					projectResp := instance.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), projectName, true, true)
 					projectGrantResp := instance.CreateProjectGrant(iamOwnerCtx, t, projectResp.GetId(), orgID)
 					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
-						InProjectIdsFilter: &project.InProjectIDsFilter{ProjectIds: []string{projectResp.GetId()}},
+						InProjectIdsFilter: &filter.InIDsFilter{Ids: []string{projectResp.GetId()}},
 					}
 					response.Projects[0] = &project.Project{
 						Id:                      projectResp.GetId(),
@@ -892,7 +890,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 					// projectGrantResp :=
 					instancePermissionV2.CreateProjectGrant(iamOwnerCtx, t, projectResp.GetId(), orgID)
 					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
-						InProjectIdsFilter: &project.InProjectIDsFilter{ProjectIds: []string{projectResp.GetId()}},
+						InProjectIdsFilter: &filter.InIDsFilter{Ids: []string{projectResp.GetId()}},
 					}
 					/*
 						response.Projects[0] = &project.Project{
@@ -1227,9 +1225,7 @@ func TestServer_ListProjectGrants(t *testing.T) {
 					project2Resp := instance.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), name2, false, false)
 					project3Resp := instance.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), name3, false, false)
 					request.Filters[0].Filter = &project.ProjectGrantSearchFilter_InProjectIdsFilter{
-						InProjectIdsFilter: &project.InProjectIDsFilter{
-							ProjectIds: []string{project1Resp.GetId(), project2Resp.GetId(), project3Resp.GetId(), projectResp.GetId()},
-						},
+						InProjectIdsFilter: &filter.InIDsFilter{Ids: []string{project1Resp.GetId(), project2Resp.GetId(), project3Resp.GetId(), projectResp.GetId()}},
 					}
 
 					createProjectGrant(iamOwnerCtx, instance, t, orgID, project1Resp.GetId(), name1)

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/integration/scim"
@@ -271,7 +272,8 @@ func (i *Instance) CreateUserTypeMachine(ctx context.Context) *user_v2.CreateUse
 
 func (i *Instance) CreatePersonalAccessToken(ctx context.Context, userID string) *user_v2.AddPersonalAccessTokenResponse {
 	resp, err := i.Client.UserV2.AddPersonalAccessToken(ctx, &user_v2.AddPersonalAccessTokenRequest{
-		UserId: userID,
+		UserId:         userID,
+		ExpirationDate: timestamppb.New(time.Now().Add(30 * time.Minute)),
 	})
 	logging.OnError(err).Panic("create pat")
 	return resp


### PR DESCRIPTION
# Which Problems Are Solved

IDs filter definition was changed in another PR and not changed in the Project service.

# How the Problems Are Solved

Correctly use the IDs filter.

# Additional Changes

Add timeout to the integration tests.

# Additional Context

None
