### PR TITLE
End session logout hint

### DIFF
--- a/docs/docs/apis/openidoauth/endpoints.mdx
+++ b/docs/docs/apis/openidoauth/endpoints.mdx
@@ -656,12 +656,14 @@ The endpoint has to be opened in the user agent (browser) to terminate the user 
 
 No parameters are needed apart from the user agent cookie, but you can provide the following to customize the behavior:
 
-| Parameter                | Description                                                                                                                      |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| id_token_hint            | the id_token that was previously issued to the client                                                                            |
-| client_id                | client_id of the application                                                                                                     |
-| post_logout_redirect_uri | Callback uri of the logout where the user (agent) will be redirected to. Must match exactly one of the preregistered in Console. |
-| state                    | Opaque value used to maintain state between the request and the callback                                                         |
+| Parameter                | Description                                                                                                                                                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id_token_hint            | the id_token that was previously issued to the client                                                                                                                                                                                  |
+| client_id                | client_id of the application                                                                                                                                                                                                           |
+| post_logout_redirect_uri | Callback uri of the logout where the user (agent) will be redirected to. Must match exactly one of the preregistered in Console.                                                                                                       |
+| state                    | Opaque value used to maintain state between the request and the callback                                                                                                                                                               |
+| logout_hint              | A valid login name of a user. Will be used to select the user to logout. Only supported when using the login UI V2.                                                                                                                    |
+| ui_locales               | Spaces delimited list of preferred locales for the login UI, e.g. `de-CH de en`. If none is provided or matches the possible locales provided by the login UI, the `accept-language` header of the browser will be taken into account. |
 
 The `post_logout_redirect_uri` will be checked against the previously registered uris of the client provided by the `azp` claim of the `id_token_hint` or the `client_id` parameter.
 If both parameters are provided, they must be equal.

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/twilio/twilio-go v1.26.1
 	github.com/zitadel/exifremove v0.1.0
 	github.com/zitadel/logging v0.6.2
-	github.com/zitadel/oidc/v3 v3.37.0
+	github.com/zitadel/oidc/v3 v3.39.0
 	github.com/zitadel/passwap v0.9.0
 	github.com/zitadel/saml v0.3.5
 	github.com/zitadel/schema v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,8 @@ github.com/zitadel/exifremove v0.1.0 h1:qD50ezWsfeeqfcvs79QyyjVfK+snN12v0U0deaU8
 github.com/zitadel/exifremove v0.1.0/go.mod h1:rzKJ3woL/Rz2KthVBiSBKIBptNTvgmk9PLaeUKTm+ek=
 github.com/zitadel/logging v0.6.2 h1:MW2kDDR0ieQynPZ0KIZPrh9ote2WkxfBif5QoARDQcU=
 github.com/zitadel/logging v0.6.2/go.mod h1:z6VWLWUkJpnNVDSLzrPSQSQyttysKZ6bCRongw0ROK4=
-github.com/zitadel/oidc/v3 v3.37.0 h1:nYATWlnP7f18XiAbw6upUruBaqfB1kUrXrSTf1EYGO8=
-github.com/zitadel/oidc/v3 v3.37.0/go.mod h1:/xDan4OUQhguJ4Ur73OOJrtugvR164OMnidXP9xfVNw=
+github.com/zitadel/oidc/v3 v3.39.0 h1:WK3eNqmgshiYo1oEqONfXXbPbve+Qzgjl8KhKDFUvxc=
+github.com/zitadel/oidc/v3 v3.39.0/go.mod h1:JwdgdU/WxkmBtWuE8/pEjAbDTWXxJGqBix/gUoeEig4=
 github.com/zitadel/passwap v0.9.0 h1:QvDK8OHKdb73C0m+mwXvu87UJSBqix3oFwTVENHdv80=
 github.com/zitadel/passwap v0.9.0/go.mod h1:6QzwFjDkIr3FfudzSogTOx5Ydhq4046dRJtDM/kX+G8=
 github.com/zitadel/saml v0.3.5 h1:L1RKWS5y66cGepVxUGjx/WSBOtrtSpRA/J3nn5BJLOY=

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -383,9 +383,9 @@ func buildLoginV2LogoutURL(baseURI *url.URL, redirectURI, logoutHint string, uiL
 		q.Set(LoginLogoutHintParam, logoutHint)
 	}
 	if len(uiLocales) > 0 {
-		var locales []string
-		for _, locale := range uiLocales {
-			locales = append(locales, locale.String())
+		locales := make([]string, len(uiLocales))
+		for i, locale := range uiLocales {
+			locales[i] = locale.String()
 		}
 		q.Set(LoginUILocalesParam, strings.Join(locales, " "))
 	}


### PR DESCRIPTION
# Which Problems Are Solved

The OIDC session endpoint allows to pass a `id_token_hint` to identify the session to terminate. In case the application is not able to pass that, e.g. Console currently allows multiple sessions to be open, but will only store the id_token of the current session, allowing to pass the `logout_hint` to identify the user adds some new possibilities.

# How the Problems Are Solved

In case the end_session_endpoint is called with no `id_token_hint`, but a `logout_hint` and the v2 login UI is configured, the information is passed to the login UI also as `login_hint` parameter to allow the login UI to determine the session to be terminated, resp. let the user decide.

# Additional Changes

Also added the `ui_locales` as parameter to handle and pass to the V2 login UI.

# Additional Context

closes #9847 