### PR TITLE
docs: remove token exchange from "GA" list as we have some open issues

### DIFF
--- a/docs/docs/product/roadmap.mdx
+++ b/docs/docs/product/roadmap.mdx
@@ -394,15 +394,6 @@ Excitingly, v3 introduces the foundational elements for Actions V2, opening up a
         - [Manage Users Guide](https://zitadel.com/docs/guides/manage/user/scim2)
     </details>
 
-
-    <details>
-        <summary>Token Exchange (Impersonation)</summary>
-
-        The Token Exchange grant implements [RFC 8693, OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693) and can be used to exchange tokens to a different scope, audience or subject.
-        Changing the subject of an authenticated token is called impersonation or delegation.
-        Read more in our [Impersonation and delegation using Token Exchange](https://zitadel.com/docs/guides/integrate/token-exchange) Guide
-    </details>
-
     <details>
         <summary>Caches</summary>
 


### PR DESCRIPTION
# Which Problems Are Solved

Token Exchange will not move from Beta to GA feature, as there are still some unsolved issues

# How the Problems Are Solved

Remove from roadmap