### PR TITLE
chore(queue): use schema config instead of `search_path` and `application_name`

### DIFF
--- a/internal/queue/database.go
+++ b/internal/queue/database.go
@@ -1,45 +1,6 @@
 package queue
 
-import (
-	"context"
-	"sync"
-
-	"github.com/jackc/pgx/v5"
-
-	"github.com/zitadel/zitadel/internal/database/dialect"
-)
-
 const (
 	schema          = "queue"
 	applicationName = "zitadel_queue"
 )
-
-var conns = &sync.Map{}
-
-type queueKey struct{}
-
-func WithQueue(parent context.Context) context.Context {
-	return context.WithValue(parent, queueKey{}, struct{}{})
-}
-
-func init() {
-	dialect.RegisterBeforeAcquire(func(ctx context.Context, c *pgx.Conn) error {
-		if _, ok := ctx.Value(queueKey{}).(struct{}); !ok {
-			return nil
-		}
-		_, err := c.Exec(ctx, "SET search_path TO "+schema+"; SET application_name TO "+applicationName)
-		if err != nil {
-			return err
-		}
-		conns.Store(c, struct{}{})
-		return nil
-	})
-	dialect.RegisterAfterRelease(func(c *pgx.Conn) error {
-		_, ok := conns.LoadAndDelete(c)
-		if !ok {
-			return nil
-		}
-		_, err := c.Exec(context.Background(), "SET search_path TO DEFAULT; SET application_name TO "+dialect.DefaultAppName)
-		return err
-	})
-}

--- a/internal/queue/migrate.go
+++ b/internal/queue/migrate.go
@@ -31,7 +31,6 @@ func (m *Migrator) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = WithQueue(ctx)
 	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
 	return err
 

--- a/internal/queue/migrate.go
+++ b/internal/queue/migrate.go
@@ -27,7 +27,7 @@ func (m *Migrator) Execute(ctx context.Context) error {
 		return err
 	}
 
-	migrator, err := rivermigrate.New(m.driver, nil)
+	migrator, err := rivermigrate.New(m.driver, &rivermigrate.Config{Schema: schema})
 	if err != nil {
 		return err
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -56,7 +56,6 @@ func (q *Queue) Start(ctx context.Context) (err error) {
 	if q == nil || !q.shouldStart {
 		return nil
 	}
-	ctx = WithQueue(ctx)
 
 	q.client, err = river.NewClient(q.driver, q.config)
 	if err != nil {
@@ -92,7 +91,6 @@ func WithQueueName(name string) InsertOpt {
 
 func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOpt) error {
 	options := new(river.InsertOpts)
-	ctx = WithQueue(ctx)
 	for _, opt := range opts {
 		opt(options)
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -40,6 +40,7 @@ func NewQueue(config *Config) (_ *Queue, err error) {
 			Queues:     make(map[string]river.QueueConfig),
 			JobTimeout: -1,
 			Middleware: middleware,
+			Schema:     schema,
 		},
 	}, nil
 }


### PR DESCRIPTION
# Which Problems Are Solved

River provides a configuration flag to set the schema of the queue. Zitadel sets the schema through database statements which is not needed anymore.

# How the Problems Are Solved

Set the schema in the river configuration and removed old code