### PR TITLE
chore(docker-integration-postgers): adding volume to internal/integration/config/docker-compose.yaml

### DIFF
--- a/internal/integration/config/docker-compose.yaml
+++ b/internal/integration/config/docker-compose.yaml
@@ -18,9 +18,15 @@ services:
       start_period: '20s'
     ports:
       - 5432:5432
+    volumes:
+      - 'zitadel_integration_db:/var/lib/postgresql/data'
 
   cache:
     restart: 'always'
     image: 'redis:latest'
     ports:
       - 6379:6379
+
+volumes:
+  zitadel_integration_db:
+    driver: local


### PR DESCRIPTION
# Which Problems Are Solved

This change makes it easier to delete the integration database

# How the Problems Are Solved

Gives the integration database a volume you can address via name

`docker volume rm config_zitadel_integration_db`
