### PR TITLE
fix(import/export): allow import of deleted resoruces

### DIFF
--- a/internal/command/member_model.go
+++ b/internal/command/member_model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/repository/member"
+	"github.com/zitadel/zitadel/internal/repository/org"
 )
 
 type MemberWriteModel struct {
@@ -30,7 +31,7 @@ func (wm *MemberWriteModel) Reduce() error {
 			wm.State = domain.MemberStateActive
 		case *member.MemberChangedEvent:
 			wm.Roles = e.Roles
-		case *member.MemberRemovedEvent:
+		case *member.MemberRemovedEvent, *org.OrgRemovedEvent:
 			wm.Roles = nil
 			wm.State = domain.MemberStateRemoved
 		}

--- a/internal/command/org_domain_model.go
+++ b/internal/command/org_domain_model.go
@@ -59,6 +59,8 @@ func (wm *OrgDomainWriteModel) AppendEvents(events ...eventstore.Event) {
 				continue
 			}
 			wm.WriteModel.AppendEvents(e)
+		case *org.OrgRemovedEvent:
+			wm.WriteModel.AppendEvents(e)
 		}
 	}
 }
@@ -76,7 +78,7 @@ func (wm *OrgDomainWriteModel) Reduce() error {
 			wm.Verified = true
 		case *org.DomainPrimarySetEvent:
 			wm.Primary = e.Domain == wm.Domain
-		case *org.DomainRemovedEvent:
+		case *org.DomainRemovedEvent, *org.OrgRemovedEvent:
 			wm.State = domain.OrgDomainStateRemoved
 			wm.Verified = false
 			wm.Primary = false
@@ -99,7 +101,8 @@ func (wm *OrgDomainWriteModel) Query() *eventstore.SearchQueryBuilder {
 			org.OrgDomainVerificationAddedEventType,
 			org.OrgDomainVerifiedEventType,
 			org.OrgDomainPrimarySetEventType,
-			org.OrgDomainRemovedEventType).
+			org.OrgDomainRemovedEventType,
+			org.OrgRemovedEventType).
 		Builder()
 }
 

--- a/internal/command/org_member_model.go
+++ b/internal/command/org_member_model.go
@@ -44,6 +44,8 @@ func (wm *OrgMemberWriteModel) AppendEvents(events ...eventstore.Event) {
 				continue
 			}
 			wm.MemberWriteModel.AppendEvents(&e.MemberCascadeRemovedEvent)
+		case *org.OrgRemovedEvent:
+			wm.MemberWriteModel.AppendEvents(e)
 		}
 	}
 }
@@ -62,6 +64,7 @@ func (wm *OrgMemberWriteModel) Query() *eventstore.SearchQueryBuilder {
 			org.MemberAddedEventType,
 			org.MemberChangedEventType,
 			org.MemberRemovedEventType,
-			org.MemberCascadeRemovedEventType).
+			org.MemberCascadeRemovedEventType,
+			org.OrgRemovedEventType).
 		Builder()
 }


### PR DESCRIPTION
# Which Problems Are Solved

If a resource is deleted, it should be possible to import the same resource without any issues (because it no longer exists as it was deleted).

# How the Problems Are Solved

Add check to allow deleted resources to be imported

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not



# Additional Context

- Closes https://github.com/zitadel/zitadel/issues/10058

