### PR TITLE
fix(service ping): correct endpoint, validate and randomize default interval

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -1213,8 +1213,10 @@ ServicePing:
   Endpoint: "https://zitadel.com/api/ping" # ZITADEL_SERVICEPING_ENDPOINT
   # Interval at which the service ping is sent to the endpoint.
   # The interval is in the format of a cron expression.
-  # By default, it is set to every day at midnight:
-  Interval: "0 0 * * *" # ZITADEL_SERVICEPING_INTERVAL
+  # By default, it is set to every daily.
+  # Note that if the interval is set to `@daily`, we randomize the time to prevent all systems from sending their reports at the same time.
+  # If you want to send the service ping at a specific time, you can set the interval to a cron expression like "@midnight" or "15 4 * * *".
+  Interval: "@daily" # ZITADEL_SERVICEPING_INTERVAL
   # Maximum number of attempts for each individual report to be sent.
   # If one report fails, it will be retried up to this number of times.
   # Other reports will still be handled in parallel and have their own retry count.
@@ -1232,6 +1234,7 @@ ServicePing:
     # This includes the number of users, organizations, projects, and other resources.
     ResourceCount:
         Enabled: true # ZITADEL_SERVICEPING_TELEMETRY_RESOURCECOUNT_ENABLED
+        # The number of counts that are sent in one batch.
         BulkSize: 10000 # ZITADEL_SERVICEPING_TELEMETRY_RESOURCECOUNT_BULKSIZE
 
 InternalAuthZ:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -1210,7 +1210,7 @@ ServicePing:
   # By setting Enabled to false, the service ping is disabled completely.
   Enabled: true # ZITADEL_SERVICEPING_ENABLED
   # The endpoint to which the reports are sent. The endpoint is used as a base path. Individual reports are sent to the endpoint with a specific path.
-  Endpoint: "https://zitadel.cloud/api/ping" # ZITADEL_SERVICEPING_ENDPOINT
+  Endpoint: "https://zitadel.com/api/ping" # ZITADEL_SERVICEPING_ENDPOINT
   # Interval at which the service ping is sent to the endpoint.
   # The interval is in the format of a cron expression.
   # By default, it is set to every day at midnight:

--- a/internal/serviceping/worker.go
+++ b/internal/serviceping/worker.go
@@ -3,7 +3,10 @@ package serviceping
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/muhlemmer/gu"
 	"github.com/riverqueue/river"
@@ -15,11 +18,13 @@ import (
 	"github.com/zitadel/zitadel/internal/query"
 	"github.com/zitadel/zitadel/internal/queue"
 	"github.com/zitadel/zitadel/internal/v2/system"
+	"github.com/zitadel/zitadel/internal/zerrors"
 	analytics "github.com/zitadel/zitadel/pkg/grpc/analytics/v2beta"
 )
 
 const (
-	QueueName = "service_ping_report"
+	QueueName   = "service_ping_report"
+	minInterval = 30 * time.Minute
 )
 
 var (
@@ -238,7 +243,7 @@ func Start(config *Config, q *queue.Queue) error {
 	if !config.Enabled {
 		return nil
 	}
-	schedule, err := cron.ParseStandard(config.Interval)
+	schedule, err := parseAndValidateSchedule(config.Interval)
 	if err != nil {
 		return err
 	}
@@ -249,4 +254,38 @@ func Start(config *Config, q *queue.Queue) error {
 		queue.WithMaxAttempts(config.MaxAttempts),
 	)
 	return nil
+}
+
+func parseAndValidateSchedule(interval string) (cron.Schedule, error) {
+	if interval == "@daily" {
+		interval = randomizeDaily()
+	}
+	schedule, err := cron.ParseStandard(interval)
+	if err != nil {
+		return nil, zerrors.ThrowInvalidArgument(err, "SERV-NJqiof", "invalid interval")
+	}
+	var intervalDuration time.Duration
+	switch s := schedule.(type) {
+	case *cron.SpecSchedule:
+		// For cron.SpecSchedule, we need to calculate the interval duration
+		// by getting the next time and subtracting it from the time after that.
+		// This is because the schedule could be a specific time, that is less than 30 minutes away,
+		// but still run only once a day and therefore is valid.
+		next := s.Next(time.Now())
+		intervalDuration = s.Next(next).Sub(next)
+	case cron.ConstantDelaySchedule:
+		intervalDuration = s.Delay
+	}
+	if intervalDuration < minInterval {
+		return nil, zerrors.ThrowInvalidArgumentf(nil, "SERV-FJ12", "interval must be at least %s", minInterval)
+	}
+	return schedule, nil
+}
+
+// randomizeDaily generates a random time for the daily cron job
+// to prevent all systems from sending the report at the same time.
+func randomizeDaily() string {
+	minute := rand.Intn(60)
+	hour := rand.Intn(24)
+	return fmt.Sprintf("%d %d * * *", minute, hour)
 }


### PR DESCRIPTION
# Which Problems Are Solved

The production endpoint of the service ping was wrong.
Additionally we discussed in the sprint review, that we could randomize the default interval to prevent all systems to report data at the very same time and also require a minimal interval.

# How the Problems Are Solved

- fixed the endpoint
- If the interval is set to @daily (default), we generate a random time (minute, hour) as a cron format.
- Check if the interval is more than 30min and return an error if not.

# Additional Changes

None

# Additional Context

as discussed internally
