### PR TITLE
chore(docs): prevent readme overwrite

### DIFF
--- a/docs/buf.gen.yaml
+++ b/docs/buf.gen.yaml
@@ -9,7 +9,7 @@ plugins:
       - allow_delete_body
       - remove_internal_comments=true
       - preserve_rpc_order=true
-  - local: ./protoc-gen-connect-openapi
+  - local: ./protoc-gen-connect-openapi/protoc-gen-connect-openapi
     out: .artifacts/openapi3
     strategy: all
     opt:

--- a/docs/plugin-download.sh
+++ b/docs/plugin-download.sh
@@ -1,5 +1,6 @@
 echo $(uname -m)
-
+mkdir protoc-gen-connect-openapi
+cd ./protoc-gen-connect-openapi/
 if [ "$(uname)" = "Darwin" ]; then
   curl -L -o protoc-gen-connect-openapi.tar.gz https://github.com/sudorandom/protoc-gen-connect-openapi/releases/download/v0.18.0/protoc-gen-connect-openapi_0.18.0_darwin_all.tar.gz
 else
@@ -18,5 +19,4 @@ else
   esac
   curl -L -o protoc-gen-connect-openapi.tar.gz https://github.com/sudorandom/protoc-gen-connect-openapi/releases/download/v0.18.0/protoc-gen-connect-openapi_0.18.0_linux_${ARCH}.tar.gz
 fi
-mkdir protoc-gen-connect-openapi
-tar -xvf protoc-gen-connect-openapi.tar.gz -C protoc-gen-connect-openapi
+tar -xvf protoc-gen-connect-openapi.tar.gz

--- a/docs/plugin-download.sh
+++ b/docs/plugin-download.sh
@@ -18,4 +18,5 @@ else
   esac
   curl -L -o protoc-gen-connect-openapi.tar.gz https://github.com/sudorandom/protoc-gen-connect-openapi/releases/download/v0.18.0/protoc-gen-connect-openapi_0.18.0_linux_${ARCH}.tar.gz
 fi
-tar -xvf protoc-gen-connect-openapi.tar.gz protoc-gen-connect-openapi
+mkdir protoc-gen-connect-openapi
+tar -xvf protoc-gen-connect-openapi.tar.gz -C protoc-gen-connect-openapi

--- a/docs/plugin-download.sh
+++ b/docs/plugin-download.sh
@@ -18,4 +18,4 @@ else
   esac
   curl -L -o protoc-gen-connect-openapi.tar.gz https://github.com/sudorandom/protoc-gen-connect-openapi/releases/download/v0.18.0/protoc-gen-connect-openapi_0.18.0_linux_${ARCH}.tar.gz
 fi
-tar -xvf protoc-gen-connect-openapi.tar.gz
+tar -xvf protoc-gen-connect-openapi.tar.gz protoc-gen-connect-openapi


### PR DESCRIPTION
# Which Problems Are Solved

To generate the docs, we rely on a protoc plugin to generate an openAPI definition from connectRPC / proto.
Since the plugin is not available on buf.build, we currently download the released version. As the tar contains a licence and a readme, this overwrote existing internal files.

# How the Problems Are Solved

Download and extract the plugin in a separate folder and update buf.gen.yaml accordingly.

# Additional Changes

None

# Additional Context

relates to #9483 
