### PR TITLE
fix: handle orgID correctly in permission checks

### DIFF
--- a/internal/api/authz/authorization.go
+++ b/internal/api/authz/authorization.go
@@ -35,7 +35,7 @@ func CheckUserAuthorization(ctx context.Context, req interface{}, token, orgID, 
 		}, nil
 	}
 
-	requestedPermissions, allPermissions, err := getUserPermissions(ctx, verifier, requiredAuthOption.Permission, systemRolePermissionMapping, rolePermissionMapping, ctxData, ctxData.OrgID)
+	requestedPermissions, allPermissions, err := getUserPermissions(ctx, verifier, requiredAuthOption.Permission, systemRolePermissionMapping, rolePermissionMapping, ctxData)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/org.go
+++ b/internal/query/org.go
@@ -88,7 +88,7 @@ type Org struct {
 func orgsCheckPermission(ctx context.Context, orgs *Orgs, permissionCheck domain_pkg.PermissionCheck) {
 	orgs.Orgs = slices.DeleteFunc(orgs.Orgs,
 		func(org *Org) bool {
-			if err := permissionCheck(ctx, domain_pkg.PermissionOrgRead, org.ID, org.ID); err != nil {
+			if err := permissionCheck(ctx, domain_pkg.PermissionOrgRead, org.ResourceOwner, org.ID); err != nil {
 				return true
 			}
 			return false


### PR DESCRIPTION
# Which Problems Are Solved

If there is no organization information contained in the request, the permission checks or handled incorrectly.

# How the Problems Are Solved

On requests without any organization information, the organization ID from the permission check is used, instead of returning an error that the context is empty.

# Additional Changes

Add some additional tests to the permission checks.

# Additional Context

Related to a support request
