### PR TITLE
fix(login v1): handle password reset when authenticating with email or phone number

### DIFF
--- a/internal/api/ui/login/password_reset_handler.go
+++ b/internal/api/ui/login/password_reset_handler.go
@@ -17,7 +17,11 @@ func (l *Login) handlePasswordReset(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
-	user, err := l.query.GetUserByLoginName(setContext(r.Context(), authReq.UserOrgID), true, authReq.LoginName)
+	// We check if the user really exists or if it is just a placeholder or an unknown user.
+	// In theory, we could also check for the unknownUserID constant. However, that could disclose
+	// information about the existence of a user to an attacker if they check response times,
+	// since those requests would take shorter than the ones for real users.
+	user, err := l.query.GetUserByID(setContext(r.Context(), authReq.UserOrgID), true, authReq.UserID)
 	if err != nil {
 		if authReq.LoginPolicy.IgnoreUnknownUsernames && zerrors.IsNotFound(err) {
 			err = nil


### PR DESCRIPTION
# Which Problems Are Solved

When authenticating with email or phone number in the login V1, users were not able to request a password reset and would be given a "User not found" error.
This was due to a check of the loginname of the auth request, which in those cases would not match the user's stored loginname.

# How the Problems Are Solved

Switch to a check of the resolved userID in the auth request. (We still check the user again, since the ID might be a placeholder for an unknown user and we do not want to disclose any information by omitting a check and reduce the response time.)

# Additional Changes

None

# Additional Context

- reported through support
- requires backport to v3.x
