### PR TITLE
chore(typescript): improve close PR action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,15 +191,9 @@ login_push: login_ensure_remote
 login_ensure_remote:
 	@if ! git remote get-url $(LOGIN_REMOTE_NAME) > /dev/null 2>&1; then \
 		echo "Adding remote $(LOGIN_REMOTE_NAME)"; \
-		git remote add $(LOGIN_REMOTE_NAME) $(LOGIN_REMOTE_URL); \
+		git remote add --fetch $(LOGIN_REMOTE_NAME) $(LOGIN_REMOTE_URL); \
 	else \
 		echo "Remote $(LOGIN_REMOTE_NAME) already exists."; \
-	fi
-	@if [ ! -d login ]; then \
-		echo "Adding subtree for 'login' from branch $(LOGIN_REMOTE_BRANCH)"; \
-		git subtree add --prefix=login $(LOGIN_REMOTE_NAME) $(LOGIN_REMOTE_BRANCH); \
-	else \
-		echo "Subtree 'login' already exists."; \
 	fi
 
 export LOGIN_DIR := ./login/

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           script: |
             const message = `
-            👋 **Thanks for your contribution!**
+            👋 **Thanks for your contribution @${{ github.event.pull_request.user.login }}!**
             
             This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login`](https://github.com/zitadel/zitadel).
             Therefore, we close this pull request automatically.

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -22,7 +22,7 @@ jobs:
             2. Clone your Zitadel fork \`git clone https://github.com/<your-owner>/zitadel.git\`
             3. Change directory to your Zitadel forks root.
             4. Pull your changes into the Zitadel fork by running \`make login_pull LOGIN_REMOTE_URL=<your-typescript-fork-url> LOGIN_REMOTE_BRANCH=<your-typescript-fork-branch>\`.
-            5. Push your changes and open a pull request to zitadel/zitadel
+            5. Push your changes and [open a pull request to zitadel/zitadel](https://github.com/zitadel/zitadel/compare)
             `.trim();
             await github.rest.issues.createComment({
                 ...context.repo,

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -18,10 +18,11 @@ jobs:
             
             This repository \`${{ github.repository }}\` is a read-only mirror of our internal development in [\`zitadel/zitadel\`](https://github.com/zitadel/zitadel).
             Therefore, we close this pull request automatically, but submitting your changes to the main repository is easy:
-            1. Fork and clone zitadel/zitadel
-            2. Create a new branch for your changes
-            3. Pull your changes into the new fork by running `make login_pull LOGIN_REMOTE_URL=<your-typescript-fork-org>/typescript LOGIN_REMOTE_BRANCH=<your-typescript-fork-branch>`.
-            4. Push your changes and open a pull request to zitadel/zitadel
+            1. [Fork zitadel/zitadel](https://github.com/zitadel/zitadel/fork)
+            2. Clone your Zitadel fork \`git clone https://github.com/<your-owner>/zitadel.git\`
+            3. Change directory to your Zitadel forks root.
+            4. Pull your changes into the Zitadel fork by running \`make login_pull LOGIN_REMOTE_URL=<your-typescript-fork-url> LOGIN_REMOTE_BRANCH=<your-typescript-fork-branch>\`.
+            5. Push your changes and open a pull request to zitadel/zitadel
             `.trim();
             await github.rest.issues.createComment({
                 ...context.repo,

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -22,7 +22,7 @@ jobs:
             1. [Fork zitadel/zitadel](https://github.com/zitadel/zitadel/fork)
             2. Clone your Zitadel fork \`git clone https://github.com/<your-owner>/zitadel.git\`
             3. Change directory to your Zitadel forks root.
-            4. Pull your changes into the Zitadel fork by running \`make login_pull LOGIN_REMOTE_URL=<your-typescript-fork-url> LOGIN_REMOTE_BRANCH=<your-typescript-fork-branch>\`.
+            4. Pull your changes into the Zitadel fork by running \`make login_pull LOGIN_REMOTE_URL=https://github.com/<your-owner>/typescript.git LOGIN_REMOTE_BRANCH=<your-typescript-fork-branch>\`.
             5. Push your changes and [open a pull request to zitadel/zitadel](https://github.com/zitadel/zitadel/compare)
             `.trim();
             await github.rest.issues.createComment({

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -1,6 +1,7 @@
 name: Auto-close PRs and guide to correct repo
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types: [opened]
 

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -17,8 +17,10 @@ jobs:
             const message = `
             👋 **Thanks for your contribution!**
             
-            This repository \`${{ github.repository }}\` is a read-only mirror of our internal development in [\`zitadel/zitadel\`](https://github.com/zitadel/zitadel).
-            Therefore, we close this pull request automatically, but submitting your changes to the main repository is easy:
+            This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login`](https://github.com/zitadel/zitadel).
+            Therefore, we close this pull request automatically.
+
+            Your changes are not lost. Submitting them to the main repository is easy:
             1. [Fork zitadel/zitadel](https://github.com/zitadel/zitadel/fork)
             2. Clone your Zitadel fork \`git clone https://github.com/<your-owner>/zitadel.git\`
             3. Change directory to your Zitadel forks root.

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           script: |
             const message = `
-            👋 **Thanks for your contribution @${{ github.event.pull_request.user.login }}!**
+            👋 **Thanks for your contribution @${{ github.event.pull_request_target.user.login }}!**
             
             This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login`](https://github.com/zitadel/zitadel).
             Therefore, we close this pull request automatically.

--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           script: |
             const message = `
-            👋 **Thanks for your contribution @${{ github.event.pull_request_target.user.login }}!**
+            👋 **Thanks for your contribution @${{ github.event.pull_request.user.login }}!**
             
             This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login`](https://github.com/zitadel/zitadel).
             Therefore, we close this pull request automatically.


### PR DESCRIPTION
# Which Problems Are Solved

The close PR action currently fails because of unescaped backticks.

# How the Problems Are Solved

Backticks are escaped.

# Additional Changes

- Adding a login remote immediately fetches for better UX.
- Adding a subtree is not necessary, as it is already added in the repo.
- Fix and clarify PR migration steps.
- Add workflow dispatch event
