### PR TITLE
chore(login): fix close pr action

### DIFF
--- a/login/.github/workflows/close_pr.yml
+++ b/login/.github/workflows/close_pr.yml
@@ -17,7 +17,7 @@ jobs:
             const message = `
             👋 **Thanks for your contribution @${{ github.event.pull_request.user.login }}!**
             
-            This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login`](https://github.com/zitadel/zitadel).
+            This repository \`${{ github.repository }}\` is a read-only mirror of the git subtree at [\`zitadel/zitadel/login\`](https://github.com/zitadel/zitadel).
             Therefore, we close this pull request automatically.
 
             Your changes are not lost. Submitting them to the main repository is easy:


### PR DESCRIPTION
# Which Problems Are Solved

The close PR action fails https://github.com/zitadel/typescript/actions/runs/16196332400/job/45723668837?pr=511

# How the Problems Are Solved

A backtick is escaped.

# Additional Context

- Completes #10229

