### PR TITLE
test(org): enahcning test for creating org with custom id

### DIFF
--- a/internal/api/grpc/org/v2beta/integration_test/org_test.go
+++ b/internal/api/grpc/org/v2beta/integration_test/org_test.go
@@ -208,7 +208,9 @@ func TestServer_CreateOrganization(t *testing.T) {
 				Name: gofakeit.AppName(),
 				Id:   gu.Ptr("custom_id"),
 			},
-			want: &v2beta_org.CreateOrganizationResponse{},
+			want: &v2beta_org.CreateOrganizationResponse{
+				Id: "custom_id",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Which Problems Are Solved

Enhancing integration test for creating org; currently the test does not check if the created org has the assigned custom id, this will resolve this issue.