### PR TITLE
chore: add Zitadel server transport import to README example

### DIFF
--- a/packages/zitadel-client/README.md
+++ b/packages/zitadel-client/README.md
@@ -24,6 +24,7 @@ You can import and use the services provided by this package to interact with ZI
 
 ```ts
 import { createSettingsServiceClient, makeReqCtx } from "@zitadel/client/v2";
+import { createServerTransport } from "@zitadel/client/node";
 
 // Example usage
 const transport = createServerTransport(process.env.ZITADEL_SERVICE_USER_TOKEN!, { baseUrl: process.env.ZITADEL_API_URL! });


### PR DESCRIPTION
<img width="1020" height="765" alt="image" src="https://github.com/user-attachments/assets/5bbc5e97-67c2-49d9-b86c-6d4ac7f28b4d" />
