### PR TITLE
fix(authrequest): Client-side URL redirect

### DIFF
--- a/docs/src/utils/authrequest.js
+++ b/docs/src/utils/authrequest.js
@@ -34,7 +34,15 @@ export default ({ children }) => {
     const id_token_hint = params.get("id_token_hint");
     const organization_id = params.get("organization_id");
 
-    setInstance(instance_param ?? "https://mydomain-xyza.zitadel.cloud/");
+    const allowedInstances = [
+      "https://mydomain-xyza.zitadel.cloud/",
+      "https://another-trusted-instance.com/",
+    ];
+    setInstance(
+      allowedInstances.includes(instance_param)
+        ? instance_param
+        : "https://mydomain-xyza.zitadel.cloud/"
+    );
     setClientId(client_id ?? "170086824411201793@yourapp");
     setRedirectUri(
       redirect_uri ?? "http://localhost:8080/api/auth/callback/zitadel"


### PR DESCRIPTION
https://github.com/zitadel/zitadel/blob/1a24b107023af4cf605ecdeb4c17fe126341432e/docs/src/components/authrequest.jsx#L643-L663

Redirecting to a URL that is constructed from parts of the DOM that may be controlled by an attacker can facilitate phishing attacks. In these attacks, unsuspecting users can be redirected to a malicious site that looks very similar to the real site they intend to visit, but which is controlled by the attacker.



fix the issue, we need to validate the `instance` variable against a whitelist of allowed URLs before using it to construct the redirection URL. This ensures that only trusted URLs are used for redirection, mitigating the risk of phishing attacks.

1. Create a whitelist of allowed `instance` URLs.
2. Validate the `instance` variable against this whitelist in `docs/src/utils/authrequest.js` before setting it in the state.
3. If the `instance` value is not in the whitelist, fall back to a safe default value.