### PR TITLE
feat(typescript): add env variable to set default organization id

### DIFF
--- a/login/apps/login/next-env-vars.d.ts
+++ b/login/apps/login/next-env-vars.d.ts
@@ -29,5 +29,12 @@ declare namespace NodeJS {
      * Split by comma, key value pairs separated by colon
      */
     CUSTOM_REQUEST_HEADERS?: string;
+
+    /**
+     * Optional: the default organization Id to use, when no organization is specified in the url
+     * When no organization is specified and url does not contain an organization id,
+     * the default organization is obtained from the api
+     */
+    DEFAULT_ORGANIZATION_ID?: string;
   }
 }

--- a/login/apps/login/src/app/(login)/accounts/page.tsx
+++ b/login/apps/login/src/app/(login)/accounts/page.tsx
@@ -5,11 +5,10 @@ import { getAllSessionCookieIds } from "@/lib/cookies";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import {
   getBrandingSettings,
-  getDefaultOrg,
   listSessions,
 } from "@/lib/zitadel";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { UserPlusIcon } from "@heroicons/react/24/outline";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 // import { getLocale } from "next-intl/server";
 import { headers } from "next/headers";
 import Link from "next/link";
@@ -40,21 +39,16 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   let sessions = await loadSessions({ serviceUrl });
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
 
   const params = new URLSearchParams();

--- a/login/apps/login/src/app/(login)/device/consent/page.tsx
+++ b/login/apps/login/src/app/(login)/device/consent/page.tsx
@@ -4,10 +4,9 @@ import { Translated } from "@/components/translated";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import {
   getBrandingSettings,
-  getDefaultOrg,
   getDeviceAuthorizationRequest,
 } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: {
@@ -43,19 +42,14 @@ export default async function Page(props: {
     );
   }
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
 
   const params = new URLSearchParams();

--- a/login/apps/login/src/app/(login)/device/page.tsx
+++ b/login/apps/login/src/app/(login)/device/page.tsx
@@ -2,8 +2,8 @@ import { DeviceCodeForm } from "@/components/device-code-form";
 import { DynamicTheme } from "@/components/dynamic-theme";
 import { Translated } from "@/components/translated";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
-import { getBrandingSettings, getDefaultOrg } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getBrandingSettings } from "@/lib/zitadel";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: {
@@ -17,19 +17,14 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
 
   return (

--- a/login/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
+++ b/login/apps/login/src/app/(login)/idp/[provider]/success/page.tsx
@@ -11,7 +11,6 @@ import {
   addHuman,
   addIDPLink,
   getBrandingSettings,
-  getDefaultOrg,
   getIDPByID,
   getLoginSettings,
   getOrgsByDomain,
@@ -19,10 +18,10 @@ import {
   retrieveIDPIntent,
   updateHuman,
 } from "@/lib/zitadel";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { ConnectError, create } from "@zitadel/client";
 import { AutoLinkingOption } from "@zitadel/proto/zitadel/idp/v2/idp_pb";
 import { OrganizationSchema } from "@zitadel/proto/zitadel/object/v2/object_pb";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import {
   AddHumanUserRequest,
   AddHumanUserRequestSchema,
@@ -79,19 +78,17 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  let branding = await getBrandingSettings({
+
+  organization = await getEffectiveOrganizationId({
     serviceUrl,
     organization,
   });
 
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      organization = org.id;
-    }
-  }
+
+  let branding = await getBrandingSettings({
+    serviceUrl,
+    organization,
+  });
 
   if (!provider || !id || !token) {
     return loginFailed(branding, "IDP context missing");

--- a/login/apps/login/src/app/(login)/idp/ldap/page.tsx
+++ b/login/apps/login/src/app/(login)/idp/ldap/page.tsx
@@ -2,8 +2,8 @@ import { DynamicTheme } from "@/components/dynamic-theme";
 import { LDAPUsernamePasswordForm } from "@/components/ldap-username-password-form";
 import { Translated } from "@/components/translated";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
-import { getBrandingSettings, getDefaultOrg } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getBrandingSettings } from "@/lib/zitadel";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: {
@@ -20,19 +20,14 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
 
   // return login failed if no linking or creation is allowed and no user was found

--- a/login/apps/login/src/app/(login)/logout/success/page.tsx
+++ b/login/apps/login/src/app/(login)/logout/success/page.tsx
@@ -1,8 +1,8 @@
 import { DynamicTheme } from "@/components/dynamic-theme";
 import { Translated } from "@/components/translated";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
-import { getBrandingSettings, getDefaultOrg } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getBrandingSettings } from "@/lib/zitadel";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: { searchParams: Promise<any> }) {
@@ -13,19 +13,14 @@ export default async function Page(props: { searchParams: Promise<any> }) {
 
   const { login_hint, organization } = searchParams;
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization,
+    organization: effectiveOrganization,
   });
 
   return (

--- a/login/apps/login/src/app/(login)/password/page.tsx
+++ b/login/apps/login/src/app/(login)/password/page.tsx
@@ -7,10 +7,9 @@ import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import { loadMostRecentSession } from "@/lib/session";
 import {
   getBrandingSettings,
-  getDefaultOrg,
   getLoginSettings,
 } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: {
@@ -22,16 +21,10 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  let defaultOrganization;
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-
-    if (org) {
-      defaultOrganization = org.id;
-    }
-  }
+  const effectiveOrganization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   // also allow no session to be found (ignoreUnkownUsername)
   let sessionFactors;
@@ -50,11 +43,11 @@ export default async function Page(props: {
 
   const branding = await getBrandingSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
   const loginSettings = await getLoginSettings({
     serviceUrl,
-    organization: organization ?? defaultOrganization,
+    organization: effectiveOrganization,
   });
 
   return (

--- a/login/apps/login/src/app/(login)/register/page.tsx
+++ b/login/apps/login/src/app/(login)/register/page.tsx
@@ -7,12 +7,11 @@ import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import {
   getActiveIdentityProviders,
   getBrandingSettings,
-  getDefaultOrg,
   getLegalAndSupportSettings,
   getLoginSettings,
   getPasswordComplexitySettings,
 } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { PasskeysType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import { headers } from "next/headers";
 
@@ -26,14 +25,10 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      organization = org.id;
-    }
-  }
+  organization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const legal = await getLegalAndSupportSettings({
     serviceUrl,

--- a/login/apps/login/src/app/(login)/register/password/page.tsx
+++ b/login/apps/login/src/app/(login)/register/password/page.tsx
@@ -4,12 +4,11 @@ import { Translated } from "@/components/translated";
 import { getServiceUrlFromHeaders } from "@/lib/service-url";
 import {
   getBrandingSettings,
-  getDefaultOrg,
   getLegalAndSupportSettings,
   getLoginSettings,
   getPasswordComplexitySettings,
 } from "@/lib/zitadel";
-import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { getEffectiveOrganizationId } from "@/lib/organization";
 import { headers } from "next/headers";
 
 export default async function Page(props: {
@@ -22,14 +21,10 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  if (!organization) {
-    const org: Organization | null = await getDefaultOrg({
-      serviceUrl,
-    });
-    if (org) {
-      organization = org.id;
-    }
-  }
+  organization = await getEffectiveOrganizationId({
+    serviceUrl,
+    organization,
+  });
 
   const missingData = !firstname || !lastname || !email || !organization;
 

--- a/login/apps/login/src/lib/organization.ts
+++ b/login/apps/login/src/lib/organization.ts
@@ -1,0 +1,21 @@
+import { getDefaultOrg } from "@/lib/zitadel";
+import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+
+export async function getEffectiveOrganizationId({
+  serviceUrl,
+  organization,
+}: {
+  serviceUrl: string;
+  organization?: string;
+}): Promise<string | undefined> {
+  if (organization) {
+    return organization;
+  }
+
+  if (process.env.DEFAULT_ORGANIZATION_ID) {
+    return process.env.DEFAULT_ORGANIZATION_ID;
+  }
+
+  const defaultOrg: Organization | null = await getDefaultOrg({ serviceUrl });
+  return defaultOrg?.id;
+} 

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
     "NEXT_PUBLIC_BASE_PATH",
     "CUSTOM_REQUEST_HEADERS",
     "NODE_ENV",
-    "INKEEP_API_KEY"
+    "INKEEP_API_KEY",
+    "DEFAULT_ORGANIZATION_ID"
   ],
   "tasks": {
     "generate": {


### PR DESCRIPTION
# Which Problems Are Solved

- I can't host multiple Login V2 (each for different organization) for same project and have default organization set per organization for which i host Login V2
- I want user to see his organization logo, even before entering his login, but currently this is not possible in this situation.

# How the Problems Are Solved

- This PR adds optional environment variable `DEFAULT_ORGANIZATION_ID`, that when set, will be used as default organization when url does not contain organization parameter.
- if variable is not set, default organization fill be read from api

# Additional Changes

- logic of getting effective organization moved to new lib file `organization.ts` as method `getEffectiveOrganizationId`

# Additional Context

N.A
