### PR TITLE
Improve CJS support for zitadel-client

### DIFF
--- a/login/packages/zitadel-client/package.json
+++ b/login/packages/zitadel-client/package.json
@@ -13,27 +13,47 @@
       "require": "./dist/index.cjs"
     },
     "./v1": {
-      "types": "./dist/v1.d.ts",
+      "types": {
+        "import": "./dist/v1.d.ts",
+        "require": "./dist/v1.d.cts",
+        "default": "./dist/v1.d.ts"
+      },
       "import": "./dist/v1.js",
       "require": "./dist/v1.cjs"
     },
     "./v2": {
-      "types": "./dist/v2.d.ts",
+      "types": {
+        "import": "./dist/v2.d.ts",
+        "require": "./dist/v2.d.cts",
+        "default": "./dist/v2.d.ts"
+      },
       "import": "./dist/v2.js",
       "require": "./dist/v2.cjs"
     },
     "./v3alpha": {
-      "types": "./dist/v3alpha.d.ts",
+      "types": {
+        "import": "./dist/v3alpha.d.ts",
+        "require": "./dist/v3alpha.d.cts",
+        "default": "./dist/v3alpha.d.ts"
+      },
       "import": "./dist/v3alpha.js",
       "require": "./dist/v3alpha.cjs"
     },
     "./node": {
-      "types": "./dist/node.d.ts",
+      "types": {
+        "import": "./dist/node.d.ts",
+        "require": "./dist/node.d.cts",
+        "default": "./dist/node.d.ts"
+      },
       "import": "./dist/node.js",
       "require": "./dist/node.cjs"
     },
     "./web": {
-      "types": "./dist/web.d.ts",
+      "types": {
+        "import": "./dist/web.d.ts",
+        "require": "./dist/web.d.cts",
+        "default": "./dist/web.d.ts"
+      },
       "import": "./dist/web.js",
       "require": "./dist/web.cjs"
     }

--- a/login/packages/zitadel-proto/.gitignore
+++ b/login/packages/zitadel-proto/.gitignore
@@ -3,3 +3,6 @@ google
 protoc-gen-openapiv2
 validate
 node_modules
+cjs
+es
+types

--- a/login/packages/zitadel-proto/buf.gen.yaml
+++ b/login/packages/zitadel-proto/buf.gen.yaml
@@ -3,8 +3,24 @@ managed:
   enabled: true
 plugins:
   - remote: buf.build/bufbuild/es:v2.2.0
-    out: .
+    out: es
     include_imports: true
     opt:
+      - target=js
+      - json_types=true
+      - import_extension=js
+  - remote: buf.build/bufbuild/es:v2.2.0
+    out: cjs
+    include_imports: true
+    opt:
+      - target=js
+      - json_types=true
+      - import_extension=js
+      - js_import_style=legacy_commonjs 
+  - remote: buf.build/bufbuild/es:v2.2.0
+    out: types
+    include_imports: true
+    opt:
+      - target=dts
       - json_types=true
       - import_extension=js

--- a/login/packages/zitadel-proto/package.json
+++ b/login/packages/zitadel-proto/package.json
@@ -6,16 +6,52 @@
     "access": "public"
   },
   "type": "module",
-  "files": [
-    "zitadel/**",
-    "validate/**",
-    "google/**",
-    "protoc-gen-openapiv2/**"
-  ],
+  "exports": {
+    "./zitadel/*": {
+      "types": "./types/zitadel/*.d.ts",
+      "import": "./es/zitadel/*.js",
+      "require": "./cjs/zitadel/*.cjs"
+    },
+    "./zitadel/*.js": {
+      "types": "./types/zitadel/*.d.ts",
+      "import": "./es/zitadel/*.js",
+      "require": "./cjs/zitadel/*.js"
+    },
+    "./validate/*": {
+      "types": "./types/validate/*.d.ts",
+      "import": "./es/validate/*.js",
+      "require": "./cjs/validate/*.cjs"
+    },
+    "./validate/*.js": {
+      "types": "./types/validate/*.d.ts",
+      "import": "./es/validate/*.js",
+      "require": "./cjs/validate/*.js"
+    },
+    "./google/*": {
+      "types": "./types/google/*.d.ts",
+      "import": "./es/google/*.js",
+      "require": "./cjs/google/*.cjs"
+    },
+    "./google/*.js": {
+      "types": "./types/google/*.d.ts",
+      "import": "./es/google/*.js",
+      "require": "./cjs/google/*.js"
+    },
+    "./protoc-gen-openapiv2/*": {
+      "types": "./types/protoc-gen-openapiv2/*.d.ts",
+      "import": "./es/protoc-gen-openapiv2/*.js",
+      "require": "./cjs/protoc-gen-openapiv2/*.cjs"
+    },
+    "./protoc-gen-openapiv2/*.js": {
+      "types": "./types/protoc-gen-openapiv2/*.d.ts",
+      "import": "./es/protoc-gen-openapiv2/*.js",
+      "require": "./cjs/protoc-gen-openapiv2/*.js"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "generate": "pnpm exec buf generate ../../../proto --path ../../../proto/zitadel",
-    "clean": "rm -rf zitadel .turbo node_modules google protoc-gen-openapiv2 validate"
+    "clean": "rm -rf zitadel .turbo node_modules google protoc-gen-openapiv2 validate cjs types es"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.2"


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

**Disclaimer**: This is a mirror of https://github.com/zitadel/typescript/pull/489 and most of the text below is just copied over/redacted. 

# Which Problems Are Solved

This PR resolves a subtle runtime error in `zitadel-client` when used in CommonJS (CJS) environments, particularly in VM-based setups like Jest. Even after [#398](https://github.com/zitadel/typescript/pull/398), the client was still inadvertently importing non-CJS code from zitadel-proto.

# How the Problems Are Solved

This change adds the generation of CJS code for `zitadel-proto` and improves the export declarations within `zitadel-client`. The previous declarations caused TypeScript to misinterpret zitadel-client as an ES Module when using the latest module resolution strategy, leading to incorrect type definitions.

With this fix, `zitadel-client` is now fully usable in Jest and NestJS without any special configuration.

# Additional Changes

Notice that now we generate three folders from proto-buffers; those folders are added to the gitignore and to the cleanup npm script. 

# Additional Context

- I presented this problem in the dedicated thread https://discord.com/channels/927474939156643850/1329100936127320175/threads/1332345712268283904
