### PR TITLE
docs: corrected the links for the client-libraries from the instroduction page

### DIFF
--- a/docs/frameworks.json
+++ b/docs/frameworks.json
@@ -3,21 +3,21 @@
 		"id": "client-php",
 		"title": "PHP",
 		"imgSrcDark": "/docs/img/tech/php.svg",
-		"docsLink": "/docs/sdk-examples/java",
+		"docsLink": "/docs/sdk-examples/client-libraries/php",
 		"client": true
 	},
 	{
 		"id": "client-java",
 		"title": "Java",
 		"imgSrcDark": "/docs/img/tech/java.svg",
-		"docsLink": "/docs/sdk-examples/java",
+		"docsLink": "/docs/sdk-examples/client-libraries/java",
 		"client": true
 	},
 	{
 		"id": "client-go",
 		"title": "Go",
 		"imgSrcDark": "/docs/img/tech/golang.svg",
-		"docsLink": "/docs/sdk-examples/java",
+		"docsLink": "/docs/sdk-examples/go",
 		"client": true,
 		"sdk": true
 	},
@@ -25,14 +25,14 @@
 		"id": "client-ruby",
 		"title": "Ruby",
 		"imgSrcDark": "/docs/img/tech/ruby.svg",
-		"docsLink": "/docs/sdk-examples/java",
+		"docsLink": "/docs/sdk-examples/client-libraries/ruby",
 		"client": true
 	},
 	{
 		"id": "client-python",
 		"title": "Python",
 		"imgSrcDark": "/docs/img/tech/python.svg",
-		"docsLink": "/docs/sdk-examples/java",
+		"docsLink": "/docs/sdk-examples/client-libraries/python",
 		"client": true
 	},
 


### PR DESCRIPTION
# Which Problems Are Solved

- Broken or incorrect links on the "SDK Examples" introduction page. The links to the new client libraries section all reference the "java" section. This fixes it.

# How the Problems Are Solved

- Fixed the links to ensure they correctly point to the relevant sections in the documentation.

# Additional Changes

None.

# Additional Context

None.
