### PR TITLE
fix: drop default otel scope info from metrics

### DIFF
--- a/internal/telemetry/metrics/otel/open_telemetry.go
+++ b/internal/telemetry/metrics/otel/open_telemetry.go
@@ -32,7 +32,7 @@ func NewMetrics(meterName string) (metrics.Metrics, error) {
 	if err != nil {
 		return nil, err
 	}
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutScopeInfo())
 	if err != nil {
 		return &Metrics{}, err
 	}


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- If the property XY is not given, the system crashes with a nil pointer exception.

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
