### PR TITLE
fix: invite code generation after multiple verification failures

### DIFF
--- a/internal/command/user_v2_invite_model.go
+++ b/internal/command/user_v2_invite_model.go
@@ -65,7 +65,7 @@ func (wm *UserV2InviteWriteModel) Reduce() error {
 			wm.EmptyInviteCode()
 		case *user.HumanInviteCheckFailedEvent:
 			wm.InviteCheckFailureCount++
-			if wm.InviteCheckFailureCount >= 3 || crypto.IsCodeExpired(wm.InviteCodeCreationDate, wm.InviteCodeExpiry) { //TODO: config?
+			if wm.InviteCheckFailureCount >= 3 || crypto.IsCodeExpired(wm.InviteCodeCreationDate, wm.InviteCodeExpiry) { //TODO: make failure count comparison with wm.InviteCheckFailureCount configurable?
 				// invalidate the invite code after attempting to verify an expired code, or a wrong code three or more times
 				// so that a new invite code can be created for this user
 				wm.EmptyInviteCode()

--- a/internal/command/user_v2_invite_test.go
+++ b/internal/command/user_v2_invite_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestCommands_CreateInviteCode(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		checkPermission             domain.PermissionCheck
 		newEncryptedCodeWithDefault encryptedCodeWithDefaultFunc
@@ -664,6 +665,7 @@ func TestCommands_CreateInviteCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Commands{
 				checkPermission:             tt.fields.checkPermission,
 				newEncryptedCodeWithDefault: tt.fields.newEncryptedCodeWithDefault,
@@ -680,6 +682,7 @@ func TestCommands_CreateInviteCode(t *testing.T) {
 }
 
 func TestCommands_ResendInviteCode(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		checkPermission             domain.PermissionCheck
 		newEncryptedCodeWithDefault encryptedCodeWithDefaultFunc
@@ -1051,6 +1054,7 @@ func TestCommands_ResendInviteCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Commands{
 				checkPermission:             tt.fields.checkPermission,
 				newEncryptedCodeWithDefault: tt.fields.newEncryptedCodeWithDefault,
@@ -1065,6 +1069,7 @@ func TestCommands_ResendInviteCode(t *testing.T) {
 }
 
 func TestCommands_InviteCodeSent(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		eventstore func(*testing.T) *eventstore.Eventstore
 	}
@@ -1183,6 +1188,7 @@ func TestCommands_InviteCodeSent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Commands{
 				eventstore: tt.fields.eventstore(t),
 			}
@@ -1193,6 +1199,7 @@ func TestCommands_InviteCodeSent(t *testing.T) {
 }
 
 func TestCommands_VerifyInviteCode(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		eventstore     func(*testing.T) *eventstore.Eventstore
 		userEncryption crypto.EncryptionAlgorithm
@@ -1278,6 +1285,7 @@ func TestCommands_VerifyInviteCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Commands{
 				eventstore:     tt.fields.eventstore(t),
 				userEncryption: tt.fields.userEncryption,
@@ -1290,6 +1298,7 @@ func TestCommands_VerifyInviteCode(t *testing.T) {
 }
 
 func TestCommands_VerifyInviteCodeSetPassword(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		eventstore         func(*testing.T) *eventstore.Eventstore
 		userEncryption     crypto.EncryptionAlgorithm
@@ -1606,6 +1615,7 @@ func TestCommands_VerifyInviteCodeSetPassword(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Commands{
 				eventstore:         tt.fields.eventstore(t),
 				userEncryption:     tt.fields.userEncryption,


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

If a wrong verification code is used three or more times during verification, or if the verification code is expired, the user state is marked as [deleted](https://github.com/zitadel/zitadel/blob/main/internal/command/user_v2_invite_model.go#L69). This prevents the creation of a new code with the following [error](https://github.com/zitadel/zitadel/blob/main/internal/command/user_v2_invite.go#L60): `Errors.User.NotFound`. 
This PR aims to fix this bug.  

# How the Problems Are Solved

This issue is solved by invalidating the previously issued invite code and setting the value of `UserV2InviteWriteModel.CodeReturned` as `false`

# Additional Changes
N/A

# Additional Context
- Closes #9860 
- Follow-up: API doc update
