### PR TITLE
chore: use ephemeral GitHub runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
   turbo-lint-unit:
     if: ${{ github.event_name == 'pull_request' }}
     name: turbo-lint-unit
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/login-container.yml
+++ b/.github/workflows/login-container.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   login-container:
     name: Build Login Container
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
# Which Problems Are Solved

The persistent depot runner lost connection to GitHub.

# How the Problems Are Solved

We mitigate by switching to GitHub ephemeral runners.

# Additional Context

- Example of a failing run https://github.com/zitadel/zitadel/actions/runs/16505756293/job/46675827321
- Might be caused by https://github.com/zitadel/zitadel/actions/runs/16500656577/job/46658046270 