### PR TITLE
chore: ensure core integration

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -70,7 +70,6 @@ jobs:
           path: ${{ steps.go-cache-path.outputs.GO_CACHE_PATH }}
       - 
         name: test
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         env:
           ZITADEL_MASTERKEY: MasterkeyNeedsToHave32Characters
         run: make core_integration_test
@@ -94,7 +93,7 @@ jobs:
       - 
         uses: actions/cache/save@v4
         name: cache results
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: always()
         with:
           key: integration-test-postgres-${{ inputs.core_cache_key }}
           path: ${{ steps.go-cache-path.outputs.GO_CACHE_PATH }}


### PR DESCRIPTION
# Which Problems Are Solved

Integration tests are skipped if cached results are found. This means, failing tests can be rerun and if a cache is found, the check is marked as successful. This can lead to bugs being merged to main.

Example of a skipped test run: https://github.com/zitadel/zitadel/actions/runs/16516540513/job/46708487426

# How the Problems Are Solved

- The tests are run whether the cache was hit or not.
- The results are uploaded whether they failed or not, so they can be reused in the next run.