### PR TITLE
fix: project grant permissions v2 remove

### DIFF
--- a/internal/api/grpc/authorization/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/authorization/v2beta/integration_test/query_test.go
@@ -549,7 +549,8 @@ func createGrantedProject(ctx context.Context, instance *integration.Instance, t
 }
 
 func TestServer_ListAuthorizations_PermissionsV2(t *testing.T) {
-	ensureFeaturePermissionV2Enabled(t, InstancePermissionV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// ensureFeaturePermissionV2Enabled(t, InstancePermissionV2)
 	iamOwnerCtx := InstancePermissionV2.WithAuthorizationToken(EmptyCTX, integration.UserTypeIAMOwner)
 
 	projectOwnerResp := InstancePermissionV2.CreateMachineUser(iamOwnerCtx)
@@ -558,11 +559,11 @@ func TestServer_ListAuthorizations_PermissionsV2(t *testing.T) {
 	InstancePermissionV2.CreateProjectMembership(t, iamOwnerCtx, projectResp.GetId(), projectOwnerResp.GetUserId())
 	projectOwnerCtx := integration.WithAuthorizationToken(EmptyCTX, projectOwnerPatResp.Token)
 
-	//projectGrantOwnerResp := InstancePermissionV2.CreateMachineUser(iamOwnerCtx)
-	//projectGrantOwnerPatResp := InstancePermissionV2.CreatePersonalAccessToken(iamOwnerCtx, projectGrantOwnerResp.GetUserId())
+	projectGrantOwnerResp := InstancePermissionV2.CreateMachineUser(iamOwnerCtx)
+	projectGrantOwnerPatResp := InstancePermissionV2.CreatePersonalAccessToken(iamOwnerCtx, projectGrantOwnerResp.GetUserId())
 	grantedProjectResp := createGrantedProject(iamOwnerCtx, InstancePermissionV2, t, projectResp)
-	//InstancePermissionV2.CreateProjectGrantMembership(t, iamOwnerCtx, projectResp.GetId(), grantedProjectResp.GetGrantedOrganizationId(), projectGrantOwnerResp.GetUserId())
-	//projectGrantOwnerCtx := integration.WithAuthorizationToken(EmptyCTX, projectGrantOwnerPatResp.Token)
+	InstancePermissionV2.CreateProjectGrantMembership(t, iamOwnerCtx, projectResp.GetId(), grantedProjectResp.GetGrantedOrganizationId(), projectGrantOwnerResp.GetUserId())
+	projectGrantOwnerCtx := integration.WithAuthorizationToken(EmptyCTX, projectGrantOwnerPatResp.Token)
 
 	type args struct {
 		ctx context.Context
@@ -615,7 +616,7 @@ func TestServer_ListAuthorizations_PermissionsV2(t *testing.T) {
 			},
 			want: &authorization.ListAuthorizationsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  1,
 					AppliedLimit: 100,
 				},
 				Authorizations: []*authorization.Authorization{},
@@ -892,8 +893,8 @@ func TestServer_ListAuthorizations_PermissionsV2(t *testing.T) {
 						},
 					}
 
-					response.Authorizations[1] = createAuthorizationForProject(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), projectResp.GetName(), projectResp.GetId())
-					response.Authorizations[0] = createAuthorizationWithProjectGrant(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), grantedProjectResp.GetName(), grantedProjectResp.GetId())
+					response.Authorizations[0] = createAuthorizationForProject(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), projectResp.GetName(), projectResp.GetId())
+					createAuthorizationWithProjectGrant(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), grantedProjectResp.GetName(), grantedProjectResp.GetId())
 				},
 				req: &authorization.ListAuthorizationsRequest{
 					Filters: []*authorization.AuthorizationsSearchFilter{{}},
@@ -905,43 +906,40 @@ func TestServer_ListAuthorizations_PermissionsV2(t *testing.T) {
 					AppliedLimit: 100,
 				},
 				Authorizations: []*authorization.Authorization{
-					{}, {},
+					{},
 				},
 			},
 		},
-		/*
-			TODO: correct when permission check is added for project grants https://github.com/zitadel/zitadel/issues/9972
-			{
-				name: "list single id, project and project grant, project grant owner",
-				args: args{
-					ctx: projectGrantOwnerCtx,
-					dep: func(request *authorization.ListAuthorizationsRequest, response *authorization.ListAuthorizationsResponse) {
-						userResp := InstancePermissionV2.CreateUserTypeHuman(iamOwnerCtx, gofakeit.Email())
+		{
+			name: "list single id, project and project grant, project grant owner",
+			args: args{
+				ctx: projectGrantOwnerCtx,
+				dep: func(request *authorization.ListAuthorizationsRequest, response *authorization.ListAuthorizationsResponse) {
+					userResp := InstancePermissionV2.CreateUserTypeHuman(iamOwnerCtx, gofakeit.Email())
 
-						request.Filters[0].Filter = &authorization.AuthorizationsSearchFilter_UserId{
-							UserId: &filter.IDFilter{
-								Id: userResp.GetId(),
-							},
-						}
+					request.Filters[0].Filter = &authorization.AuthorizationsSearchFilter_UserId{
+						UserId: &filter.IDFilter{
+							Id: userResp.GetId(),
+						},
+					}
 
-						createAuthorizationForProject(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), projectResp.GetName(), projectResp.GetId())
-						response.Authorizations[0] = createAuthorizationForProjectGrant(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), grantedProjectResp.GetName(), grantedProjectResp.GetId())
-					},
-					req: &authorization.ListAuthorizationsRequest{
-						Filters: []*authorization.AuthorizationsSearchFilter{{}},
-					},
+					createAuthorizationForProject(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), projectResp.GetName(), projectResp.GetId())
+					response.Authorizations[0] = createAuthorizationForProjectGrant(iamOwnerCtx, InstancePermissionV2, t, InstancePermissionV2.DefaultOrg.GetId(), userResp.GetId(), grantedProjectResp.GetName(), grantedProjectResp.GetId(), grantedProjectResp.GetGrantedOrganizationId())
 				},
-				want: &authorization.ListAuthorizationsResponse{
-					Pagination: &filter.PaginationResponse{
-						TotalResult:  2,
-						AppliedLimit: 100,
-					},
-					Authorizations: []*authorization.Authorization{
-						{},
-					},
+				req: &authorization.ListAuthorizationsRequest{
+					Filters: []*authorization.AuthorizationsSearchFilter{{}},
 				},
 			},
-		*/
+			want: &authorization.ListAuthorizationsResponse{
+				Pagination: &filter.PaginationResponse{
+					TotalResult:  2,
+					AppliedLimit: 100,
+				},
+				Authorizations: []*authorization.Authorization{
+					{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/grpc/internal_permission/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/internal_permission/v2beta/integration_test/query_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestServer_ListAdministrators(t *testing.T) {
-	iamOwnerCtx := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	projectName := gofakeit.AppName()
 	projectResp := instance.CreateProject(iamOwnerCtx, t, instance.DefaultOrg.GetId(), projectName, false, false)
@@ -66,7 +66,7 @@ func TestServer_ListAdministrators(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin := createInstanceAdministrator(iamOwnerCtx, instance, t)
 					request.Filters[0].Filter = &internal_permission.AdministratorSearchFilter_InUserIdsFilter{
@@ -90,7 +90,7 @@ func TestServer_ListAdministrators(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin := createInstanceAdministrator(iamOwnerCtx, instance, t)
 					request.Filters[0].Filter = &internal_permission.AdministratorSearchFilter_InUserIdsFilter{
@@ -427,7 +427,7 @@ func TestServer_ListAdministrators(t *testing.T) {
 		{
 			name: "list multiple id, org owner",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin1 := createInstanceAdministrator(iamOwnerCtx, instance, t)
 					admin2 := createOrganizationAdministrator(iamOwnerCtx, instance, t)
@@ -644,8 +644,9 @@ func createProjectGrantAdministrator(ctx context.Context, instance *integration.
 }
 
 func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
-	ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
-	iamOwnerCtx := instancePermissionV2.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
+	iamOwnerCtx := instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	projectName := gofakeit.AppName()
 	projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, instancePermissionV2.DefaultOrg.GetId(), projectName, false, false)
@@ -694,7 +695,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin := createInstanceAdministrator(iamOwnerCtx, instancePermissionV2, t)
 					request.Filters[0].Filter = &internal_permission.AdministratorSearchFilter_InUserIdsFilter{
@@ -709,7 +710,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 			},
 			want: &internal_permission.ListAdministratorsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  1,
 					AppliedLimit: 100,
 				},
 				Administrators: []*internal_permission.Administrator{},
@@ -718,7 +719,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin := createInstanceAdministrator(iamOwnerCtx, instancePermissionV2, t)
 					request.Filters[0].Filter = &internal_permission.AdministratorSearchFilter_InUserIdsFilter{
@@ -733,7 +734,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 			},
 			want: &internal_permission.ListAdministratorsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  1,
 					AppliedLimit: 100,
 				},
 				Administrators: []*internal_permission.Administrator{},
@@ -1055,7 +1056,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 		{
 			name: "list multiple id, org owner",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *internal_permission.ListAdministratorsRequest, response *internal_permission.ListAdministratorsResponse) {
 					admin1 := createInstanceAdministrator(iamOwnerCtx, instancePermissionV2, t)
 					admin2 := createOrganizationAdministrator(iamOwnerCtx, instancePermissionV2, t)
@@ -1076,7 +1077,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 			},
 			want: &internal_permission.ListAdministratorsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  3,
+					TotalResult:  4,
 					AppliedLimit: 100,
 				},
 				Administrators: []*internal_permission.Administrator{
@@ -1107,7 +1108,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 			},
 			want: &internal_permission.ListAdministratorsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  2,
+					TotalResult:  4,
 					AppliedLimit: 100,
 				},
 				Administrators: []*internal_permission.Administrator{
@@ -1115,7 +1116,6 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 				},
 			},
 		},
-		// TODO: correct when permission check is added for project grants https://github.com/zitadel/zitadel/issues/9972
 		{
 			name: "list multiple id, project grant owner",
 			args: args{
@@ -1130,7 +1130,7 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 							Ids: []string{admin1.GetUser().GetId(), admin2.GetUser().GetId(), admin3.GetUser().GetId(), admin4.GetUser().GetId()},
 						},
 					}
-					// response.Administrators[0] = admin4
+					response.Administrators[0] = admin4
 				},
 				req: &internal_permission.ListAdministratorsRequest{
 					Filters: []*internal_permission.AdministratorSearchFilter{{}},
@@ -1138,10 +1138,10 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 			},
 			want: &internal_permission.ListAdministratorsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  4,
 					AppliedLimit: 100,
 				},
-				Administrators: []*internal_permission.Administrator{},
+				Administrators: []*internal_permission.Administrator{{}},
 			},
 		},
 	}

--- a/internal/api/grpc/project/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/project/v2beta/integration_test/query_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestServer_GetProject(t *testing.T) {
-	iamOwnerCtx := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	type args struct {
 		ctx context.Context
@@ -34,7 +34,7 @@ func TestServer_GetProject(t *testing.T) {
 		{
 			name: "missing permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.GetProjectRequest, response *project.GetProjectResponse) {
 					orgID := instance.DefaultOrg.GetId()
 					resp := createProject(iamOwnerCtx, instance, t, orgID, false, false)
@@ -48,7 +48,7 @@ func TestServer_GetProject(t *testing.T) {
 		{
 			name: "missing permission, other org owner",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.GetProjectRequest, response *project.GetProjectResponse) {
 					name := gofakeit.AppName()
 					orgResp := instance.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
@@ -94,7 +94,7 @@ func TestServer_GetProject(t *testing.T) {
 		{
 			name: "get, ok, org owner",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.GetProjectRequest, response *project.GetProjectResponse) {
 					orgID := instance.DefaultOrg.GetId()
 					resp := createProject(iamOwnerCtx, instance, t, orgID, false, false)
@@ -147,7 +147,7 @@ func TestServer_GetProject(t *testing.T) {
 }
 
 func TestServer_ListProjects(t *testing.T) {
-	iamOwnerCtx := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	userResp := instance.CreateMachineUser(iamOwnerCtx)
 	patResp := instance.CreatePersonalAccessToken(iamOwnerCtx, userResp.GetUserId())
@@ -190,7 +190,7 @@ func TestServer_ListProjects(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					name := gofakeit.AppName()
 					orgID := instance.DefaultOrg.GetId()
@@ -210,7 +210,7 @@ func TestServer_ListProjects(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					name := gofakeit.AppName()
 					orgResp := instance.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
@@ -349,7 +349,7 @@ func TestServer_ListProjects(t *testing.T) {
 		{
 			name: "list multiple id, limited permissions",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					orgID := instance.DefaultOrg.GetId()
 					orgResp := instance.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
@@ -505,7 +505,7 @@ func TestServer_ListProjects(t *testing.T) {
 		{
 			name: "list granted project, project id",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					orgID := instance.DefaultOrg.GetId()
 
@@ -577,7 +577,7 @@ func TestServer_ListProjects(t *testing.T) {
 
 func TestServer_ListProjects_PermissionV2(t *testing.T) {
 	ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
-	iamOwnerCtx := instancePermissionV2.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgID := instancePermissionV2.DefaultOrg.GetId()
 
 	type args struct {
@@ -612,7 +612,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					resp := createProject(iamOwnerCtx, instancePermissionV2, t, orgID, false, false)
 					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
@@ -630,7 +630,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					orgResp := instancePermissionV2.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
 					resp := createProject(iamOwnerCtx, instancePermissionV2, t, orgResp.GetOrganizationId(), false, false)
@@ -848,7 +848,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 		{
 			name: "list multiple id, limited permissions",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					orgResp := instancePermissionV2.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
 					resp1 := createProject(iamOwnerCtx, instancePermissionV2, t, orgResp.GetOrganizationId(), false, false)
@@ -880,7 +880,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 		{
 			name: "list granted project, project id",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
 					orgID := instancePermissionV2.DefaultOrg.GetId()
 
@@ -996,7 +996,7 @@ func assertPaginationResponse(t *assert.CollectT, expected *filter.PaginationRes
 }
 
 func TestServer_ListProjectGrants(t *testing.T) {
-	iamOwnerCtx := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	userResp := instance.CreateMachineUser(iamOwnerCtx)
 	patResp := instance.CreatePersonalAccessToken(iamOwnerCtx, userResp.GetUserId())
@@ -1042,7 +1042,7 @@ func TestServer_ListProjectGrants(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					projectResp := instance.CreateProject(iamOwnerCtx, t, instance.DefaultOrg.GetId(), gofakeit.AppName(), false, false)
 					request.Filters[0].Filter = &project.ProjectGrantSearchFilter_InProjectIdsFilter{
@@ -1088,7 +1088,7 @@ func TestServer_ListProjectGrants(t *testing.T) {
 		{
 			name: "list by id",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name := gofakeit.AppName()
 					orgID := instance.DefaultOrg.GetId()
@@ -1118,7 +1118,7 @@ func TestServer_ListProjectGrants(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name := gofakeit.AppName()
 					orgResp := instance.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
@@ -1178,7 +1178,7 @@ func TestServer_ListProjectGrants(t *testing.T) {
 		{
 			name: "list multiple id, limited permissions",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name1 := gofakeit.AppName()
 					name2 := gofakeit.AppName()
@@ -1342,8 +1342,9 @@ func TestServer_ListProjectGrants(t *testing.T) {
 }
 
 func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
-	ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
-	iamOwnerCtx := instancePermissionV2.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
+	iamOwnerCtx := instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	type args struct {
 		ctx context.Context
@@ -1383,7 +1384,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, instancePermissionV2.DefaultOrg.GetId(), gofakeit.AppName(), false, false)
 					request.Filters[0].Filter = &project.ProjectGrantSearchFilter_InProjectIdsFilter{
@@ -1407,7 +1408,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 		{
 			name: "list by id",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name := gofakeit.AppName()
 					orgID := instancePermissionV2.DefaultOrg.GetId()
@@ -1437,7 +1438,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, missing permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name := gofakeit.AppName()
 					orgResp := instancePermissionV2.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
@@ -1456,7 +1457,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 			},
 			want: &project.ListProjectGrantsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  1,
 					AppliedLimit: 100,
 				},
 				ProjectGrants: []*project.ProjectGrant{},
@@ -1497,7 +1498,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 		{
 			name: "list multiple id, limited permissions",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectGrantsRequest, response *project.ListProjectGrantsResponse) {
 					name1 := gofakeit.AppName()
 					name2 := gofakeit.AppName()
@@ -1523,7 +1524,7 @@ func TestServer_ListProjectGrants_PermissionV2(t *testing.T) {
 			},
 			want: &project.ListProjectGrantsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  1,
+					TotalResult:  3,
 					AppliedLimit: 100,
 				},
 				ProjectGrants: []*project.ProjectGrant{
@@ -1578,7 +1579,7 @@ func createProjectGrant(ctx context.Context, instance *integration.Instance, t *
 }
 
 func TestServer_ListProjectRoles(t *testing.T) {
-	iamOwnerCtx := instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	type args struct {
 		ctx context.Context
 		dep func(*project.ListProjectRolesRequest, *project.ListProjectRolesResponse)
@@ -1609,7 +1610,7 @@ func TestServer_ListProjectRoles(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					projectResp := instance.CreateProject(iamOwnerCtx, t, instance.DefaultOrg.GetId(), gofakeit.AppName(), false, false)
 
@@ -1640,7 +1641,7 @@ func TestServer_ListProjectRoles(t *testing.T) {
 		{
 			name: "list single id, missing permission",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					orgResp := instance.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
 					projectResp := instance.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), gofakeit.AppName(), false, false)
@@ -1661,7 +1662,7 @@ func TestServer_ListProjectRoles(t *testing.T) {
 		{
 			name: "list single id",
 			args: args{
-				ctx: instance.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					orgID := instance.DefaultOrg.GetId()
 					projectResp := instance.CreateProject(iamOwnerCtx, t, orgID, gofakeit.AppName(), false, false)
@@ -1736,7 +1737,7 @@ func TestServer_ListProjectRoles(t *testing.T) {
 
 func TestServer_ListProjectRoles_PermissionV2(t *testing.T) {
 	ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
-	iamOwnerCtx := instancePermissionV2.WithAuthorization(CTX, integration.UserTypeIAMOwner)
+	iamOwnerCtx := instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	type args struct {
 		ctx context.Context
@@ -1768,7 +1769,7 @@ func TestServer_ListProjectRoles_PermissionV2(t *testing.T) {
 		{
 			name: "list by id, no permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeNoPermission),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeNoPermission),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, instancePermissionV2.DefaultOrg.GetId(), gofakeit.AppName(), false, false)
 
@@ -1799,7 +1800,7 @@ func TestServer_ListProjectRoles_PermissionV2(t *testing.T) {
 		{
 			name: "list single id, missing permission",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					orgResp := instancePermissionV2.CreateOrganization(iamOwnerCtx, gofakeit.AppName(), gofakeit.Email())
 					projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), gofakeit.AppName(), false, false)
@@ -1820,7 +1821,7 @@ func TestServer_ListProjectRoles_PermissionV2(t *testing.T) {
 		{
 			name: "list single id",
 			args: args{
-				ctx: instancePermissionV2.WithAuthorization(CTX, integration.UserTypeOrgOwner),
+				ctx: instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 				dep: func(request *project.ListProjectRolesRequest, response *project.ListProjectRolesResponse) {
 					orgID := instancePermissionV2.DefaultOrg.GetId()
 					projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, orgID, gofakeit.AppName(), false, false)

--- a/internal/api/grpc/project/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/project/v2beta/integration_test/query_test.go
@@ -576,7 +576,8 @@ func TestServer_ListProjects(t *testing.T) {
 }
 
 func TestServer_ListProjects_PermissionV2(t *testing.T) {
-	ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// ensureFeaturePermissionV2Enabled(t, instancePermissionV2)
 	iamOwnerCtx := instancePermissionV2.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgID := instancePermissionV2.DefaultOrg.GetId()
 
@@ -646,7 +647,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 			},
 			want: &project.ListProjectsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  1,
 					AppliedLimit: 100,
 				},
 				Projects: []*project.Project{},
@@ -868,7 +869,7 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 			},
 			want: &project.ListProjectsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  1,
+					TotalResult:  3,
 					AppliedLimit: 100,
 				},
 				Projects: []*project.Project{
@@ -876,7 +877,6 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 				},
 			},
 		},
-		// TODO: correct when permission check is added for project grants https://github.com/zitadel/zitadel/issues/9972
 		{
 			name: "list granted project, project id",
 			args: args{
@@ -888,28 +888,26 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 					projectName := gofakeit.AppName()
 					orgResp := instancePermissionV2.CreateOrganization(iamOwnerCtx, orgName, gofakeit.Email())
 					projectResp := instancePermissionV2.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), projectName, true, true)
-					// projectGrantResp :=
-					instancePermissionV2.CreateProjectGrant(iamOwnerCtx, t, projectResp.GetId(), orgID)
+					projectGrantResp := instancePermissionV2.CreateProjectGrant(iamOwnerCtx, t, projectResp.GetId(), orgID)
 					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
 						InProjectIdsFilter: &filter.InIDsFilter{Ids: []string{projectResp.GetId()}},
 					}
-					/*
-						response.Projects[0] = &project.Project{
-							Id:                      projectResp.GetId(),
-							Name:                    projectName,
-							OrganizationId:          orgResp.GetOrganizationId(),
-							CreationDate:            projectGrantResp.GetCreationDate(),
-							ChangeDate:              projectGrantResp.GetCreationDate(),
-							State:                   1,
-							ProjectRoleAssertion:    false,
-							ProjectAccessRequired:   true,
-							AuthorizationRequired:   true,
-							PrivateLabelingSetting:  project.PrivateLabelingSetting_PRIVATE_LABELING_SETTING_UNSPECIFIED,
-							GrantedOrganizationId:   gu.Ptr(orgID),
-							GrantedOrganizationName: gu.Ptr(instancePermissionV2.DefaultOrg.GetName()),
-							GrantedState:            1,
-						}
-					*/
+
+					response.Projects[0] = &project.Project{
+						Id:                      projectResp.GetId(),
+						Name:                    projectName,
+						OrganizationId:          orgResp.GetOrganizationId(),
+						CreationDate:            projectGrantResp.GetCreationDate(),
+						ChangeDate:              projectGrantResp.GetCreationDate(),
+						State:                   1,
+						ProjectRoleAssertion:    false,
+						ProjectAccessRequired:   true,
+						AuthorizationRequired:   true,
+						PrivateLabelingSetting:  project.PrivateLabelingSetting_PRIVATE_LABELING_SETTING_UNSPECIFIED,
+						GrantedOrganizationId:   gu.Ptr(orgID),
+						GrantedOrganizationName: gu.Ptr(instancePermissionV2.DefaultOrg.GetName()),
+						GrantedState:            1,
+					}
 				},
 				req: &project.ListProjectsRequest{
 					Filters: []*project.ProjectSearchFilter{{}},
@@ -917,10 +915,10 @@ func TestServer_ListProjects_PermissionV2(t *testing.T) {
 			},
 			want: &project.ListProjectsResponse{
 				Pagination: &filter.PaginationResponse{
-					TotalResult:  0,
+					TotalResult:  2,
 					AppliedLimit: 100,
 				},
-				Projects: []*project.Project{},
+				Projects: []*project.Project{{}},
 			},
 		},
 	}

--- a/internal/query/administrators.go
+++ b/internal/query/administrators.go
@@ -165,12 +165,13 @@ func administratorProjectGrantCheckPermission(ctx context.Context, resourceOwner
 }
 
 func (q *Queries) SearchAdministrators(ctx context.Context, queries *MembershipSearchQuery, permissionCheck domain.PermissionCheck) (*Administrators, error) {
-	permissionCheckV2 := PermissionV2(ctx, permissionCheck)
-	admins, err := q.searchAdministrators(ctx, queries, permissionCheckV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// permissionCheckV2 := PermissionV2(ctx, permissionCheck)
+	admins, err := q.searchAdministrators(ctx, queries, false)
 	if err != nil {
 		return nil, err
 	}
-	if permissionCheck != nil && !authz.GetFeatures(ctx).PermissionCheckV2 {
+	if permissionCheck != nil { // && !authz.GetFeatures(ctx).PermissionCheckV2 {
 		administratorsCheckPermission(ctx, admins, permissionCheck)
 	}
 	return admins, nil

--- a/internal/query/project.go
+++ b/internal/query/project.go
@@ -282,12 +282,13 @@ func projectPermissionCheckV2(ctx context.Context, query sq.SelectBuilder, enabl
 }
 
 func (q *Queries) SearchGrantedProjects(ctx context.Context, queries *ProjectAndGrantedProjectSearchQueries, permissionCheck domain.PermissionCheck) (*GrantedProjects, error) {
-	permissionCheckV2 := PermissionV2(ctx, permissionCheck)
-	projects, err := q.searchGrantedProjects(ctx, queries, permissionCheckV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// permissionCheckV2 := PermissionV2(ctx, permissionCheck)
+	projects, err := q.searchGrantedProjects(ctx, queries, false)
 	if err != nil {
 		return nil, err
 	}
-	if permissionCheck != nil && !authz.GetFeatures(ctx).PermissionCheckV2 {
+	if permissionCheck != nil { // && !authz.GetFeatures(ctx).PermissionCheckV2 {
 		grantedProjectsCheckPermission(ctx, projects, permissionCheck)
 	}
 	return projects, nil

--- a/internal/query/project_grant.go
+++ b/internal/query/project_grant.go
@@ -200,12 +200,13 @@ func (q *Queries) ProjectGrantByIDAndGrantedOrg(ctx context.Context, id, granted
 }
 
 func (q *Queries) SearchProjectGrants(ctx context.Context, queries *ProjectGrantSearchQueries, permissionCheck domain.PermissionCheck) (grants *ProjectGrants, err error) {
-	permissionCheckV2 := PermissionV2(ctx, permissionCheck)
-	projectsGrants, err := q.searchProjectGrants(ctx, queries, permissionCheckV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// permissionCheckV2 := PermissionV2(ctx, permissionCheck)
+	projectsGrants, err := q.searchProjectGrants(ctx, queries, false)
 	if err != nil {
 		return nil, err
 	}
-	if permissionCheck != nil && !authz.GetFeatures(ctx).PermissionCheckV2 {
+	if permissionCheck != nil { // && !authz.GetFeatures(ctx).PermissionCheckV2 {
 		projectGrantsCheckPermission(ctx, projectsGrants, permissionCheck)
 	}
 	return projectsGrants, nil

--- a/internal/query/user_grant.go
+++ b/internal/query/user_grant.go
@@ -305,12 +305,13 @@ func (q *Queries) UserGrant(ctx context.Context, shouldTriggerBulk bool, queries
 }
 
 func (q *Queries) UserGrants(ctx context.Context, queries *UserGrantsQueries, shouldTriggerBulk bool, permissionCheck domain.PermissionCheck) (*UserGrants, error) {
-	permissionCheckV2 := PermissionV2(ctx, permissionCheck)
-	grants, err := q.userGrants(ctx, queries, shouldTriggerBulk, permissionCheckV2)
+	// removed as permission v2 is not implemented yet for project grant level permissions
+	// permissionCheckV2 := PermissionV2(ctx, permissionCheck)
+	grants, err := q.userGrants(ctx, queries, shouldTriggerBulk, false)
 	if err != nil {
 		return nil, err
 	}
-	if permissionCheck != nil && !authz.GetFeatures(ctx).PermissionCheckV2 {
+	if permissionCheck != nil { // && !authz.GetFeatures(ctx).PermissionCheckV2 {
 		userGrantsCheckPermission(ctx, grants, permissionCheck)
 	}
 	return grants, nil


### PR DESCRIPTION
# Which Problems Are Solved

[Permissions v2](https://github.com/zitadel/zitadel/issues/9972) is not possible in the current implementation.

# How the Problems Are Solved

We remove Permissions v2 from project grants related API calls, to alleviate this problems.
Resulting in some removals of testing, implementations and performance impact 

# Additional Changes

None

# Additional Context

None
