### PR TITLE
docs: correct documentation and tagging of deprecated api endpoints

### DIFF
--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -1153,6 +1153,11 @@ service AdminService {
         };
     }
 
+    // Get Organization By ID
+    //
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    //
+    // Returns an organization by its ID. Make sure the user has the permissions to access the organization.
     rpc GetOrgByID(GetOrgByIDRequest) returns (GetOrgByIDResponse) {
         option (google.api.http) = {
             get: "/orgs/{id}";
@@ -1164,8 +1169,7 @@ service AdminService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Get Organization By ID";
-            description: "Returns an organization by its ID. Make sure the user has the permissions to access the organization."
+            deprecated: true;
             responses: {
                 key: "200";
                 value: {
@@ -1175,6 +1179,11 @@ service AdminService {
         };
     }
 
+    // Is Organization Unique
+    //
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    //
+    // Checks if an organization with the searched parameters already exists or not.
     rpc IsOrgUnique(IsOrgUniqueRequest) returns (IsOrgUniqueResponse) {
         option (google.api.http) = {
             get: "/orgs/_is_unique";
@@ -1186,8 +1195,7 @@ service AdminService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Is Organization Unique";
-            description: "Checks if an organization with the searched parameters already exists or not."
+            deprecated: true;
             responses: {
                 key: "200";
                 value: {
@@ -1220,6 +1228,11 @@ service AdminService {
         };
     }
 
+    // Get Default Organization
+    //
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    //
+    // Get the default organization of the ZITADEL instance. If no specific organization is given on the register form, a user will be registered to the default organization.
     rpc GetDefaultOrg(GetDefaultOrgRequest) returns (GetDefaultOrgResponse) {
         option (google.api.http) = {
             get: "/orgs/default";
@@ -1232,13 +1245,16 @@ service AdminService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Settings";
-            summary: "Get Default Organization";
-            description: "Get the default organization of the ZITADEL instance. If no specific organization is given on the register form, a user will be registered to the default organization."
+            deprecated: true;
         };
     }
 
-    // Deprecated: use ListOrganization [apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx] API instead
-    rpc ListOrgs(ListOrgsRequest) returns (ListOrgsResponse) {
+    // Search Organizations
+    //
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    //
+    // Returns a list of organizations that match the requesting filters. All filters are applied with an AND condition.
+     rpc ListOrgs(ListOrgsRequest) returns (ListOrgsResponse) {
         option (google.api.http) = {
             post: "/orgs/_search";
             body: "*";
@@ -1250,8 +1266,6 @@ service AdminService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Search Organization";
-            description: "Returns a list of organizations that match the requesting filters. All filters are applied with an AND condition."
             responses: {
                 key: "200";
                 value: {
@@ -1273,7 +1287,11 @@ service AdminService {
         };
     }
 
-    // Deprecated: use CreateOrganization [apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx] API instead
+    // Setup Organization
+    //
+    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx) instead.
+    //
+    // Create a new organization with an administrative user. If no specific roles are sent for the first user, the user will get the role ORG_OWNER.
     rpc SetUpOrg(SetUpOrgRequest) returns (SetUpOrgResponse) {
         option (google.api.http) = {
             post: "/orgs/_setup";
@@ -1286,8 +1304,6 @@ service AdminService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Setup Organization";
-            description: "Create a new organization with an administrative user. If no specific roles are sent for the first user, the user will get the role ORG_OWNER."
             responses: {
                 key: "200";
                 value: {
@@ -1309,7 +1325,11 @@ service AdminService {
         };
     }
 
-    // Deprecated: use DeleteOrganization [apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx] API instead
+    // Remove Organization
+    //
+    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx) instead.
+    //
+    // Deletes the organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in.
     rpc RemoveOrg(RemoveOrgRequest) returns (RemoveOrgResponse) {
         option (google.api.http) = {
             delete: "/orgs/{org_id}"
@@ -1320,8 +1340,6 @@ service AdminService {
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Remove Organization";
-            description: "Deletes the organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in."
             responses: {
                 key: "200";
                 value: {
@@ -1342,7 +1360,6 @@ service AdminService {
             };
         };
     }
-
 
     rpc GetIDPByID(GetIDPByIDRequest) returns (GetIDPByIDResponse) {
         option (google.api.http) = {

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -1155,7 +1155,7 @@ service AdminService {
 
     // Get Organization By ID
     //
-    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2/organization-service-list-organizations.api.mdx) instead.
     //
     // Returns an organization by its ID. Make sure the user has the permissions to access the organization.
     rpc GetOrgByID(GetOrgByIDRequest) returns (GetOrgByIDResponse) {
@@ -1181,7 +1181,7 @@ service AdminService {
 
     // Is Organization Unique
     //
-    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2/organization-service-list-organizations.api.mdx) instead.
     //
     // Checks if an organization with the searched parameters already exists or not.
     rpc IsOrgUnique(IsOrgUniqueRequest) returns (IsOrgUniqueResponse) {
@@ -1230,7 +1230,7 @@ service AdminService {
 
     // Get Default Organization
     //
-    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2/organization-service-list-organizations.api.mdx) instead.
     //
     // Get the default organization of the ZITADEL instance. If no specific organization is given on the register form, a user will be registered to the default organization.
     rpc GetDefaultOrg(GetDefaultOrgRequest) returns (GetDefaultOrgResponse) {
@@ -1251,7 +1251,7 @@ service AdminService {
 
     // Search Organizations
     //
-    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2beta/organization-service-list-organizations.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizations](apis/resources/org_service_v2/organization-service-list-organizations.api.mdx) instead.
     //
     // Returns a list of organizations that match the requesting filters. All filters are applied with an AND condition.
      rpc ListOrgs(ListOrgsRequest) returns (ListOrgsResponse) {
@@ -1289,7 +1289,7 @@ service AdminService {
 
     // Setup Organization
     //
-    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-create-organization.api.mdx) instead.
     //
     // Create a new organization with an administrative user. If no specific roles are sent for the first user, the user will get the role ORG_OWNER.
     rpc SetUpOrg(SetUpOrgRequest) returns (SetUpOrgResponse) {
@@ -1327,7 +1327,7 @@ service AdminService {
 
     // Remove Organization
     //
-    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-delete-organization.api.mdx) instead.
     //
     // Deletes the organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in.
     rpc RemoveOrg(RemoveOrgRequest) returns (RemoveOrgResponse) {

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -1464,7 +1464,7 @@ service ManagementService {
 
     // Remove Multi-Factor U2F
     //
-    // Deprecated: use [user service v2 RemoveU2F](apis/resources/user_service_v2/user-service-remove-u2f.api.mdx) instead.
+    // Deprecated: use [user service v2 RemoveU2F](apis/resources/user_service_v2/user-service-remove-u-2-f.api.mdx) instead.
     //
     // Remove the configured Universal Second Factor (U2F) as a factor from the user. U2F is a device-dependent factor like FingerPrint, Windows-Hello, etc.
     rpc RemoveHumanAuthFactorU2F(RemoveHumanAuthFactorU2FRequest) returns (RemoveHumanAuthFactorU2FResponse) {
@@ -1499,7 +1499,7 @@ service ManagementService {
 
     // Remove Multi-Factor OTP SMS
     //
-    // Deprecated: use [user service v2 RemoveOTPSMS](apis/resources/user_service_v2/user-service-remove-otp-sms.api.mdx) instead.
+    // Deprecated: use [user service v2 RemoveOTPSMS](apis/resources/user_service_v2/user-service-remove-otpsms.api.mdx) instead.
     //
     // Remove the configured One-Time Password (OTP) SMS as a factor from the user. As only one OTP SMS per user is allowed, the user will not have OTP SMS as a second factor afterward.
     rpc RemoveHumanAuthFactorOTPSMS(RemoveHumanAuthFactorOTPSMSRequest) returns (RemoveHumanAuthFactorOTPSMSResponse) {
@@ -2103,7 +2103,7 @@ service ManagementService {
 
     // List Social Logins
     //
-    // Deprecated: use [user service v2 ListLinkedIDPs](apis/resources/user_service_v2/user-service-list-linked-idps.api.mdx) instead.
+    // Deprecated: use [user service v2 ListLinkedIDPs](apis/resources/user_service_v2/user-service-list-idp-links.api.mdx) instead.
     //
     // Returns a list of all linked identity providers/social logins of the user. (e. Google, Microsoft, AzureAD, etc.).
     rpc ListHumanLinkedIDPs(ListHumanLinkedIDPsRequest) returns (ListHumanLinkedIDPsResponse) {
@@ -2132,7 +2132,7 @@ service ManagementService {
 
     // Remove Social Login
     //
-    // Deprecated: use [user service v2 ListLinkedIDPs](apis/resources/user_service_v2/user-service-list-linked-idps.api.mdx) instead.
+    // Deprecated: use [user service v2 RemoveIDPLink](apis/resources/user_service_v2/user-service-remove-idp-link.api.mdx) instead.
     //
     // Remove a configured social logins/identity providers of the user (e.g. Google, Microsoft, AzureAD, etc.). The user will not be able to log in with the given provider afterward. Make sure the user does have other possibilities to authenticate.
     rpc RemoveHumanLinkedIDP(RemoveHumanLinkedIDPRequest) returns (RemoveHumanLinkedIDPResponse) {

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -2250,7 +2250,7 @@ service ManagementService {
 
     // Create Organization
     //
-    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx) instead
+    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-create-organization.api.mdx) instead
     //
     // Create a new organization. Based on the given name a domain will be generated to be able to identify users within an organization.
     rpc AddOrg(AddOrgRequest) returns (AddOrgResponse) {
@@ -2279,7 +2279,7 @@ service ManagementService {
 
     // Update Organization
     //
-    // Deprecated: use [organization service v2 UpdateOrganization](apis/resources/org_service_v2beta/organization-service-update-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 UpdateOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-update-organization.api.mdx) instead.
     //
     // Change the name of the organization.
     rpc UpdateOrg(UpdateOrgRequest) returns (UpdateOrgResponse) {
@@ -2308,7 +2308,7 @@ service ManagementService {
 
     // Deactivate Organization
     //
-    // Deprecated: use [organization service v2 DeactivateOrganization](apis/resources/org_service_v2beta/organization-service-deactivate-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeactivateOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-deactivate-organization.api.mdx) instead.
     //
     // Sets the state of my organization to deactivated. Users of this organization will not be able to log in.
     rpc DeactivateOrg(DeactivateOrgRequest) returns (DeactivateOrgResponse) {
@@ -2337,7 +2337,7 @@ service ManagementService {
 
     // Reactivate Organization
     //
-    // Deprecated: use [organization service v2 ActivateOrganization](apis/resources/org_service_v2beta/organization-service-activate-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 ActivateOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-activate-organization.api.mdx) instead.
     //
     // Set the state of my organization to active. The state of the organization has to be deactivated to perform the request. Users of this organization will be able to log in again.
     rpc ReactivateOrg(ReactivateOrgRequest) returns (ReactivateOrgResponse) {
@@ -2366,7 +2366,7 @@ service ManagementService {
 
     // Delete Organization
     //
-    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-delete-organization.api.mdx) instead.
     //
     // Deletes my organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in.
     rpc RemoveOrg(RemoveOrgRequest) returns (RemoveOrgResponse) {
@@ -2394,7 +2394,7 @@ service ManagementService {
 
     // Set Organization Metadata
     //
-    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-set-organization-metadata.api.mdx) instead.
     //
     // This endpoint either adds or updates a metadata value for the requested key. Make sure the value is base64 encoded.
     rpc SetOrgMetadata(SetOrgMetadataRequest) returns (SetOrgMetadataResponse) {
@@ -2424,7 +2424,7 @@ service ManagementService {
 
     // Bulk Set Organization Metadata
     //
-    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-set-organization-metadata.api.mdx) instead.
     //
     // This endpoint sets a list of metadata to the organization. Make sure the values are base64 encoded.
     rpc BulkSetOrgMetadata(BulkSetOrgMetadataRequest) returns (BulkSetOrgMetadataResponse) {
@@ -2454,7 +2454,7 @@ service ManagementService {
 
     // Search Organization Metadata
     //
-    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-list-organization-metadata.api.mdx) instead.
     //
     // Get the metadata of an organization filtered by your query.
     rpc ListOrgMetadata(ListOrgMetadataRequest) returns (ListOrgMetadataResponse) {
@@ -2484,7 +2484,7 @@ service ManagementService {
 
     // Get Organization Metadata By Key
     //
-    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-list-organization-metadata.api.mdx) instead.
     //
     // Get a metadata object from an organization by a specific key.
     rpc GetOrgMetadata(GetOrgMetadataRequest) returns (GetOrgMetadataResponse) {
@@ -2513,7 +2513,7 @@ service ManagementService {
 
     // Delete Organization Metadata By Key
     //
-    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-delete-organization-metadata.api.mdx) instead.
     //
     // Remove a metadata object from an organization with a specific key.
     rpc RemoveOrgMetadata(RemoveOrgMetadataRequest) returns (RemoveOrgMetadataResponse) {
@@ -2542,7 +2542,7 @@ service ManagementService {
 
     // Bulk Delete Metadata
     //
-    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-delete-organization-metadata.api.mdx) instead.
     //
     // Remove a list of metadata objects from an organization with a list of keys.
     rpc BulkRemoveOrgMetadata(BulkRemoveOrgMetadataRequest) returns (BulkRemoveOrgMetadataResponse) {
@@ -2572,7 +2572,7 @@ service ManagementService {
 
     // Add Domain
     //
-    // Deprecated: use [organization service v2 AddOrganizationDomain](apis/resources/org_service_v2beta/organization-service-add-organization-domain.api.mdx) instead.
+    // Deprecated: use [organization service v2 AddOrganizationDomain](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-add-organization-domain.api.mdx) instead.
     //
     // Add a new domain to an organization. The domains are used to identify to which organization a user belongs.
     rpc AddOrgDomain(AddOrgDomainRequest) returns (AddOrgDomainResponse) {
@@ -2601,7 +2601,7 @@ service ManagementService {
 
     // Search Domains
     //
-    // Deprecated: use [organization service v2 ListOrganizationDomains](apis/resources/org_service_v2beta/organization-service-list-organization-domains.api.mdx) instead.
+    // Deprecated: use [organization service v2 ListOrganizationDomains](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-list-organization-domains.api.mdx) instead.
     //
     // Returns the list of registered domains of an organization. The domains are used to identify to which organization a user belongs.
     rpc ListOrgDomains(ListOrgDomainsRequest) returns (ListOrgDomainsResponse) {
@@ -2630,7 +2630,7 @@ service ManagementService {
 
     // Remove Domain
     //
-    // Deprecated: use [organization service v2 DeleteOrganizationDomain](apis/resources/org_service_v2beta/organization-service-delete-organization-domain.api.mdx) instead.
+    // Deprecated: use [organization service v2 DeleteOrganizationDomain](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-delete-organization-domain.api.mdx) instead.
     //
     // Delete a new domain from an organization. The domains are used to identify to which organization a user belongs. If the uses use the domain for login, this will not be possible afterwards. They have to use another domain instead.
     rpc RemoveOrgDomain(RemoveOrgDomainRequest) returns (RemoveOrgDomainResponse) {
@@ -2658,7 +2658,7 @@ service ManagementService {
 
     // Generate Domain Verification
     //
-    // Deprecated: use [organization service v2 GenerateOrganizationDomainValidation](apis/resources/org_service_v2beta/organization-service-generate-organization-domain-validation.api.mdx) instead.
+    // Deprecated: use [organization service v2 GenerateOrganizationDomainValidation](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-generate-organization-domain-validation.api.mdx) instead.
     //
     // Generate a new file to be able to verify your domain with DNS or HTTP challenge.
     rpc GenerateOrgDomainValidation(GenerateOrgDomainValidationRequest) returns (GenerateOrgDomainValidationResponse) {
@@ -2687,7 +2687,7 @@ service ManagementService {
 
     // Verify Domain
     //
-    // Deprecated: use [organization service v2 VerifyOrganizationDomain](apis/resources/org_service_v2beta/organization-service-verify-organization-domain.api.mdx) instead.
+    // Deprecated: use [organization service v2 VerifyOrganizationDomain](apis/resources/org_service_v2beta/zitadel-org-v-2-beta-organization-service-verify-organization-domain.api.mdx) instead.
     //
     // Make sure you have added the required verification to your domain, depending on the method you have chosen (HTTP or DNS challenge). ZITADEL will check it and set the domain as verified if it was successful. A verify domain has to be unique.
     rpc ValidateOrgDomain(ValidateOrgDomainRequest) returns (ValidateOrgDomainResponse) {

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -26,7 +26,7 @@ import "validate/validate.proto";
 
 package zitadel.management.v1;
 
-option go_package ="github.com/zitadel/zitadel/pkg/grpc/management";
+option go_package = "github.com/zitadel/zitadel/pkg/grpc/management";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     info: {
@@ -191,11 +191,11 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
         }
     }
     extensions: {
-		key: "x-zitadel-orgid";
-		value: {
-			string_value: "$YOUR-ORGANIZATION";
-		}
-	}
+        key: "x-zitadel-orgid";
+        value: {
+            string_value: "$YOUR-ORGANIZATION";
+        }
+    }
 };
 
 service ManagementService {
@@ -280,7 +280,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListUsers, with InUserIDQuery
+    // User by ID
+    //
+    // Deprecated: use [user service v2 ListUsers with InUserIDQuery](apis/resources/user_service_v2/user-service-list-users.api.mdx) instead.
+    //
+    // Returns the full user object (human or machine) including the profile, email, etc.
     rpc GetUserByID(GetUserByIDRequest) returns (GetUserByIDResponse) {
         option (google.api.http) = {
             get: "/users/{id}"
@@ -291,8 +295,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "User by ID";
-            description: "Returns the full user object (human or machine) including the profile, email, etc.\n\nDeprecated: please use user service v2 GetUserByID"
             tags: "Users";
             deprecated: true;
             responses: {
@@ -312,7 +314,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListUsers, with LoginNameQuery
+    // Get User by login name (globally)
+    //
+    // Deprecated: use [user service v2 ListUsers with LoginNameQuery](apis/resources/user_service_v2/user-service-list-users.api.mdx) instead.
+    //
+    // Get a user by login name searched over all organizations. The request only returns data if the login name matches exactly.
     rpc GetUserByLoginNameGlobal(GetUserByLoginNameGlobalRequest) returns (GetUserByLoginNameGlobalResponse) {
         option (google.api.http) = {
             get: "/global/users/_by_login_name"
@@ -323,8 +329,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Get User by login name (globally)";
-            description: "Get a user by login name searched over all organizations. The request only returns data if the login name matches exactly.\n\nDeprecated: please use user service v2 ListUsers, with LoginNameQuery"
             tags: "Users";
             tags: "Global";
             deprecated: true;
@@ -337,7 +341,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListUsers
+    // Search Users
+    //
+    // Deprecated: use [user service v2 ListUsers](apis/resources/user_service_v2/user-service-list-users.api.mdx) instead.
+    //
+    // Search for users within an organization. By default, we will return users of your organization. Make sure to include a limit and sorting for pagination.
     rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
         option (google.api.http) = {
             post: "/users/_search"
@@ -351,8 +359,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             deprecated: true;
-            summary: "Search Users";
-            description: "Search for users within an organization. By default, we will return users of your organization. Make sure to include a limit and sorting for pagination.\n\nDeprecated: please use user service v2 ListUsers"
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -406,7 +412,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListUsers, is unique when no user is returned
+    // Check for existing user
+    //
+    // Deprecated: use [user service v2 ListUsers](apis/resources/user_service_v2/user-service-list-users.api.mdx) instead, is unique if no user returned.
+    //
+    // Returns if a user with the requested email or username is unique. So you can create the user.
     rpc IsUserUnique(IsUserUniqueRequest) returns (IsUserUniqueResponse) {
         option (google.api.http) = {
             get: "/users/_is_unique"
@@ -419,8 +429,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             deprecated: true;
-            summary: "Check for existing user";
-            description: "Returns if a user with the requested email or username is unique. So you can create the user. \n\nDeprecated: please use user service v2 ListUsers, is unique when no user is returned"
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -434,7 +442,7 @@ service ManagementService {
 
     // Create User (Human)
     //
-    // Deprecated: use [ImportHumanUser](apis/resources/mgmt/management-service-import-human-user.api.mdx) instead.
+    // Deprecated: use [user service v2 CreateUser](apis/resources/user_service_v2/user-service-create-user.api.mdx) instead.
     //
     // Create a new user with the type human. The newly created user will get an initialization email if either the email address is not marked as verified or no password is set. If a password is set the user will not be requested to set a new one on the first login.
     rpc AddHumanUser(AddHumanUserRequest) returns (AddHumanUserResponse) {
@@ -463,7 +471,7 @@ service ManagementService {
 
     // Create/Import User (Human)
     //
-    // Deprecated: use [UpdateHumanUser](apis/resources/user_service_v2/user-service-update-human-user.api.mdx) instead.
+    // Deprecated: use [user service v2 UpdateHumanUser](apis/resources/user_service_v2/user-service-update-human-user.api.mdx) instead.
     //
     // Create/import a new user with the type human. The newly created user will get an initialization email if either the email address is not marked as verified or no password is set. If a password is set the user will not be requested to set a new one on the first login.
     rpc ImportHumanUser(ImportHumanUserRequest) returns (ImportHumanUserResponse) {
@@ -492,6 +500,8 @@ service ManagementService {
     }
 
     // Create User (Machine)
+    //
+    // Deprecated: use [user service v2 CreateUser](apis/resources/user_service_v2/user-service-create-user.api.mdx) instead.
     //
     // Create a new user with the type machine for your API, service or device. These users are used for non-interactive authentication flows.
     rpc AddMachineUser(AddMachineUserRequest) returns (AddMachineUserResponse) {
@@ -524,7 +534,13 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 DeactivateUser
+    // Deactivate User
+    //
+    // Deprecated: use [user service v2 DeactivateUser](apis/resources/user_service_v2/user-service-deactivate-user.api.mdx) instead.
+    //
+    // The state of the user will be changed to 'deactivated'. The user will not be able to log in anymore.
+    // The endpoint returns an error if the user is already in the state 'deactivated'.
+    // Use deactivate user when the user should not be able to use the account anymore, but you still need access to the user data.
     rpc DeactivateUser(DeactivateUserRequest) returns (DeactivateUserResponse) {
         option (google.api.http) = {
             post: "/users/{id}/_deactivate"
@@ -536,8 +552,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Deactivate user";
-            description: "The state of the user will be changed to 'deactivated'. The user will not be able to log in anymore. The endpoint returns an error if the user is already in the state 'deactivated'. Use deactivate user when the user should not be able to use the account anymore, but you still need access to the user data.\n\nDeprecated: please use user service v2 DeactivateUser"
             tags: "Users";
             deprecated: true;
             responses: {
@@ -557,7 +571,12 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ReactivateUser
+    // Deactivate User
+    //
+    // Deprecated: use [user service v2 ReactivateUser](apis/resources/user_service_v2/user-service-reactivate-user.api.mdx) instead.
+    //
+    // Reactivate a user with the state 'deactivated'. The user will be able to log in again afterward.
+    // The endpoint returns an error if the user is not in the state 'deactivated'.
     rpc ReactivateUser(ReactivateUserRequest) returns (ReactivateUserResponse) {
         option (google.api.http) = {
             post: "/users/{id}/_reactivate"
@@ -569,8 +588,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Reactivate user";
-            description: "Reactivate a user with the state 'deactivated'. The user will be able to log in again afterward. The endpoint returns an error if the user is not in the state 'deactivated'.\n\nDeprecated: please use user service v2 ReactivateUser"
             tags: "Users";
             deprecated: true;
             responses: {
@@ -590,7 +607,13 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 LockUser
+    // Lock User
+    //
+    // Deprecated: use [user service v2 LockUser](apis/resources/user_service_v2/user-service-lock-user.api.mdx) instead.
+    //
+    // The state of the user will be changed to 'locked'. The user will not be able to log in anymore.
+    // The endpoint returns an error if the user is already in the state 'locked'.
+    // Use this endpoint if the user should not be able to log in temporarily because of an event that happened (wrong password, etc.).
     rpc LockUser(LockUserRequest) returns (LockUserResponse) {
         option (google.api.http) = {
             post: "/users/{id}/_lock"
@@ -602,8 +625,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Lock user";
-            description: "The state of the user will be changed to 'locked'. The user will not be able to log in anymore. The endpoint returns an error if the user is already in the state 'locked'. Use this endpoint if the user should not be able to log in temporarily because of an event that happened (wrong password, etc.),\n\nDeprecated: please use user service v2 LockUser"
             tags: "Users";
             deprecated: true;
             responses: {
@@ -623,7 +644,12 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 UnlockUser
+    // Unlock User
+    //
+    // Deprecated: use [user service v2 UnlockUser](apis/resources/user_service_v2/user-service-unlock-user.api.mdx) instead.
+    //
+    // Unlock a user with the state 'locked'. The user will be able to log in again afterward.
+    // The endpoint returns an error if the user is not in the state 'locked'.
     rpc UnlockUser(UnlockUserRequest) returns (UnlockUserResponse) {
         option (google.api.http) = {
             post: "/users/{id}/_unlock"
@@ -656,7 +682,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemoveUser
+    // Unlock User
+    //
+    // Deprecated: use [user service v2 DeleteUser](apis/resources/user_service_v2/user-service-delete-user.api.mdx) instead.
+    //
+    // The state of the user will be changed to 'deleted'. The user will not be able to log in anymore. Endpoints requesting this user will return an error 'User not found.
     rpc RemoveUser(RemoveUserRequest) returns (RemoveUserResponse) {
         option (google.api.http) = {
             delete: "/users/{id}"
@@ -667,8 +697,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Delete user";
-            description: "The state of the user will be changed to 'deleted'. The user will not be able to log in anymore. Endpoints requesting this user will return an error 'User not found.\n\nDeprecated: please use user service v2 RemoveUser"
             tags: "Users";
             deprecated: true;
             responses: {
@@ -690,7 +718,9 @@ service ManagementService {
 
     // Change user name
     //
-    // Change the username of the user. Be aware that the user has to log in with the newly added username afterward
+    // Deprecated: use [user service v2 UpdateUser](apis/resources/user_service_v2/user-service-update-user.api.mdx) instead.
+    //
+    // Change the username of the user. Be aware that the user has to log in with the newly added username afterward.
     rpc UpdateUserName(UpdateUserNameRequest) returns (UpdateUserNameResponse) {
         option (google.api.http) = {
             put: "/users/{user_id}/username"
@@ -703,6 +733,7 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -874,7 +905,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 GetUserByID
+    // Get User Profile (Human)
+    //
+    // Deprecated: use [user service v2 GetUserByID](apis/resources/user_service_v2/user-service-get-user-by-id.api.mdx) instead.
+    //
+    // Get basic information like first_name and last_name of a user.
     rpc GetHumanProfile(GetHumanProfileRequest) returns (GetHumanProfileResponse) {
         option (google.api.http) = {
             get: "/users/{user_id}/profile"
@@ -885,8 +920,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Get User Profile (Human)";
-            description: "Get basic information like first_name and last_name of a user.\n\nDeprecated: please use user service v2 GetUserByID"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -943,7 +976,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 GetUserByID
+    // Get User Email (Human)
+    //
+    // Deprecated: use [user service v2 GetUserByID](apis/resources/user_service_v2/user-service-get-user-by-id.api.mdx) instead.
+    //
+    // Get the email address and the verification state of the address.
     rpc GetHumanEmail(GetHumanEmailRequest) returns (GetHumanEmailResponse) {
         option (google.api.http) = {
             get: "/users/{user_id}/email"
@@ -954,8 +991,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Get User Email (Human)";
-            description: "Get the email address and the verification state of the address.\n\nDeprecated: please use user service v2 GetUserByID"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1012,8 +1047,12 @@ service ManagementService {
         };
     }
 
-    // Deprecated: not used anymore in user state
-    // To resend a verification email use the user service v2 ResendEmailCode
+
+    // Resend User Initialization Email
+    //
+    // Deprecated: not used anymore in user state so will be removed.
+    //
+    // A newly created user will get an initialization email to verify the email address and set a password. Resend the email with this request to the user's email address, or a newly added address.
     rpc ResendHumanInitialization(ResendHumanInitializationRequest) returns (ResendHumanInitializationResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/_resend_initialization"
@@ -1025,8 +1064,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Resend User Initialization Email";
-            description: "A newly created user will get an initialization email to verify the email address and set a password. Resend the email with this request to the user's email address, or a newly added address.\n\nDeprecated: not used anymore in user state"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1083,7 +1120,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 GetUserByID
+    // Get User Phone (Human)
+    //
+    // Deprecated: use [user service v2 GetUserByID](apis/resources/user_service_v2/user-service-get-user-by-id.api.mdx) instead.
+    //
+    // Get the phone number and the verification state of the number. The phone number is only for informational purposes and to send messages, not for Authentication (2FA).
     rpc GetHumanPhone(GetHumanPhoneRequest) returns (GetHumanPhoneResponse) {
         option (google.api.http) = {
             get: "/users/{user_id}/phone"
@@ -1094,8 +1135,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Get User Phone (Human)";
-            description: "Get the phone number and the verification state of the number. The phone number is only for informational purposes and to send messages, not for Authentication (2FA).\n\nDeprecated: please use user service v2 GetUserByID"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1118,6 +1157,8 @@ service ManagementService {
 
     // Update User Phone (Human)
     //
+    // Deprecated: use [user service v2 UpdateUser](apis/resources/user_service_v2/user-service-update-user.api.mdx) instead.
+    //
     // Change the phone number of a user. If the state is set to not verified, the user will get an SMS to verify (if a notification provider is configured). The phone number is only for informational purposes and to send messages, not for Authentication (2FA).
     rpc UpdateHumanPhone(UpdateHumanPhoneRequest) returns (UpdateHumanPhoneResponse) {
         option (google.api.http) = {
@@ -1132,6 +1173,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Human";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1220,6 +1262,9 @@ service ManagementService {
         };
     }
 
+    // Delete User Avatar (Human)
+    //
+    // Removes the avatar that is currently set on the user.
     rpc RemoveHumanAvatar(RemoveHumanAvatarRequest) returns (RemoveHumanAvatarResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/avatar"
@@ -1230,8 +1275,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Delete User Avatar (Human)";
-            description: "Removes the avatar that is currently set on the user."
             tags: "Users";
             tags: "User Human"
             responses: {
@@ -1349,7 +1392,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListAuthenticationMethodTypes
+    // Get User Authentication Factors (2FA/MFA)
+    //
+    // Deprecated: use [user service v2 ListAuthenticationMethodTypes](apis/resources/user_service_v2/user-service-list-authentication-method-types.api.mdx) instead.
+    //
+    // Get a list of authentication factors the user has set. Including Second Factors (2FA) and Multi-Factors (MFA).
     rpc ListHumanAuthFactors(ListHumanAuthFactorsRequest) returns (ListHumanAuthFactorsResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/auth_factors/_search"
@@ -1360,8 +1407,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Get User Authentication Factors (2FA/MFA)";
-            description: "Get a list of authentication factors the user has set. Including Second Factors (2FA) and Multi-Factors (MFA).\n\nDeprecated: please use user service v2 ListAuthenticationMethodTypes"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1382,7 +1427,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemoveTOTP
+    // Remove Multi-Factor OTP
+    //
+    // Deprecated: use [user service v2 RemoveTOTP](apis/resources/user_service_v2/user-service-remove-totp.api.mdx) instead.
+    //
+    // Remove the configured One-Time Password (OTP) as a factor from the user. OTP is an authentication app, like Authy or Google/Microsoft Authenticator.
     rpc RemoveHumanAuthFactorOTP(RemoveHumanAuthFactorOTPRequest) returns (RemoveHumanAuthFactorOTPResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/auth_factors/otp"
@@ -1393,8 +1442,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Remove Multi-Factor OTP";
-            description: "Remove the configured One-Time Password (OTP) as a factor from the user. OTP is an authentication app, like Authy or Google/Microsoft Authenticator.\n\nDeprecated: please use user service v2 RemoveTOTP"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1415,7 +1462,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemoveU2F
+    // Remove Multi-Factor U2F
+    //
+    // Deprecated: use [user service v2 RemoveU2F](apis/resources/user_service_v2/user-service-remove-u2f.api.mdx) instead.
+    //
+    // Remove the configured Universal Second Factor (U2F) as a factor from the user. U2F is a device-dependent factor like FingerPrint, Windows-Hello, etc.
     rpc RemoveHumanAuthFactorU2F(RemoveHumanAuthFactorU2FRequest) returns (RemoveHumanAuthFactorU2FResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/auth_factors/u2f/{token_id}"
@@ -1426,9 +1477,7 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Remove Multi-Factor U2F";
             deprecated: true;
-            description: "Remove the configured Universal Second Factor (U2F) as a factor from the user. U2F is a device-dependent factor like FingerPrint, Windows-Hello, etc.\n\nDeprecated: please use user service v2 RemoveU2F"
             tags: "Users";
             tags: "User Human";
             responses: {
@@ -1448,7 +1497,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemoveOTPSMS
+    // Remove Multi-Factor OTP SMS
+    //
+    // Deprecated: use [user service v2 RemoveOTPSMS](apis/resources/user_service_v2/user-service-remove-otp-sms.api.mdx) instead.
+    //
+    // Remove the configured One-Time Password (OTP) SMS as a factor from the user. As only one OTP SMS per user is allowed, the user will not have OTP SMS as a second factor afterward.
     rpc RemoveHumanAuthFactorOTPSMS(RemoveHumanAuthFactorOTPSMSRequest) returns (RemoveHumanAuthFactorOTPSMSResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/auth_factors/otp_sms"
@@ -1459,8 +1512,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Remove Multi-Factor OTP SMS";
-            description: "Remove the configured One-Time Password (OTP) SMS as a factor from the user. As only one OTP SMS per user is allowed, the user will not have OTP SMS as a second factor afterward.\n\nDeprecated: please use user service v2 RemoveOTPSMS"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1481,7 +1532,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemoveOTPEmail
+    // Remove Multi-Factor OTP Email
+    //
+    // Deprecated: use [user service v2 RemoveOTPEmail](apis/resources/user_service_v2/user-service-remove-otp-email.api.mdx) instead.
+    //
+    // Remove the configured One-Time Password (OTP) Email as a factor from the user. As only one OTP Email per user is allowed, the user will not have OTP Email as a second factor afterward.
     rpc RemoveHumanAuthFactorOTPEmail(RemoveHumanAuthFactorOTPEmailRequest) returns (RemoveHumanAuthFactorOTPEmailResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/auth_factors/otp_email"
@@ -1492,8 +1547,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Remove Multi-Factor OTP SMS";
-            description: "Remove the configured One-Time Password (OTP) Email as a factor from the user. As only one OTP Email per user is allowed, the user will not have OTP Email as a second factor afterward.\n\nDeprecated: please use user service v2 RemoveOTPEmail"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1514,7 +1567,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListPasskeys
+    // Search Passwordless/Passkey authentication
+    //
+    // Deprecated: use [user service v2 ListPasskeys](apis/resources/user_service_v2/user-service-list-passkeys.api.mdx) instead.
+    //
+    // Get a list of configured passwordless/passkey authentication methods from the user. Passwordless/passkey is a device-dependent authentication like FingerScan, WindowsHello or a Hardware Token.
     rpc ListHumanPasswordless(ListHumanPasswordlessRequest) returns (ListHumanPasswordlessResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/passwordless/_search"
@@ -1525,9 +1582,7 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Search Passwordless/Passkey authentication";
             deprecated: true;
-            description: "Get a list of configured passwordless/passkey authentication methods from the user. Passwordless/passkey is a device-dependent authentication like FingerScan, WindowsHello or a Hardware Token.\n\nDeprecated: please use user service v2 ListPasskeys"
             tags: "Users";
             tags: "User Human";
             responses: {
@@ -1547,7 +1602,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RegisterPasskey
+    // Add Passwordless/Passkey Registration Link
+    //
+    // Deprecated: use [user service v2 RegisterPasskey](apis/resources/user_service_v2/user-service-register-passkey.api.mdx) instead.
+    //
+    // Adds a new passwordless/passkey authenticator link to the user and returns it in the response. The link enables the user to register a new device if current passwordless/passkey devices are all platform authenticators. e.g. User has already registered Windows Hello and wants to register FaceID on the iPhone.
     rpc AddPasswordlessRegistration(AddPasswordlessRegistrationRequest) returns (AddPasswordlessRegistrationResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/passwordless/_link"
@@ -1557,8 +1616,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Add Passwordless/Passkey Registration Link";
-            description: "Adds a new passwordless/passkey authenticator link to the user and returns it in the response. The link enables the user to register a new device if current passwordless/passkey devices are all platform authenticators. e.g. User has already registered Windows Hello and wants to register FaceID on the iPhone\n\nDeprecated: please use user service v2 RegisterPasskey"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1579,7 +1636,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RegisterPasskey
+    // Send Passwordless/Passkey Registration Link
+    //
+    // Deprecated: use [user service v2 RegisterPasskey](apis/resources/user_service_v2/user-service-register-passkey.api.mdx) instead.
+    //
+    // Adds a new passwordless/passkey authenticator link to the user and sends it to the user per email. The link enables the user to register a new device if current passwordless/passkey devices are all platform authenticators. e.g. User has already registered Windows Hello and wants to register FaceID on the iPhone.
     rpc SendPasswordlessRegistration(SendPasswordlessRegistrationRequest) returns (SendPasswordlessRegistrationResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/passwordless/_send_link"
@@ -1590,8 +1651,6 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Send Passwordless/Passkey Registration Link";
-            description: "Adds a new passwordless/passkey authenticator link to the user and sends it to the user per email. The link enables the user to register a new device if current passwordless/passkey devices are all platform authenticators. e.g. User has already registered Windows Hello and wants to register FaceID on the iPhone.\n\nDeprecated: please use user service v2 RegisterPasskey"
             tags: "Users";
             tags: "User Human";
             deprecated: true;
@@ -1612,7 +1671,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 RemovePasskey
+    // Delete Passwordless/Passkey
+    //
+    // Deprecated: use [user service v2 RemovePasskey](apis/resources/user_service_v2/user-service-remove-passkey.api.mdx) instead.
+    //
+    // Remove a configured passwordless/passkey authentication method from the user. (e.g FaceID, FingerScane, WindowsHello, etc.).
     rpc RemoveHumanPasswordless(RemoveHumanPasswordlessRequest) returns (RemoveHumanPasswordlessResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/passwordless/{token_id}"
@@ -1623,9 +1686,7 @@ service ManagementService {
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "Delete Passwordless/Passkey";
             deprecated: true;
-            description: "Remove a configured passwordless/passkey authentication method from the user. (e.g FaceID, FingerScane, WindowsHello, etc.).\n\nDeprecated: please use user service v2 RemovePasskey"
             tags: "Users";
             tags: "User Human";
             responses: {
@@ -1647,6 +1708,8 @@ service ManagementService {
 
     // Update Machine User
     //
+    // Deprecated: use [user service v2 UpdateUser](apis/resources/user_service_v2/user-service-update-user.api.mdx) instead.
+    //
     // Change a service account/machine user. It is used for accounts with non-interactive authentication possibilities.
     rpc UpdateMachine(UpdateMachineRequest) returns (UpdateMachineResponse) {
         option (google.api.http) = {
@@ -1661,6 +1724,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1680,6 +1744,8 @@ service ManagementService {
 
     // Create Secret for Machine User
     //
+    // Deprecated: use [user service v2 AddSecret](apis/resources/user_service_v2/user-service-add-secret.api.mdx) instead.
+    //
     // Create a new secret for a machine user/service account. It is used to authenticate the user (client credential grant).
     rpc GenerateMachineSecret(GenerateMachineSecretRequest) returns (GenerateMachineSecretResponse) {
         option (google.api.http) = {
@@ -1694,6 +1760,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1713,6 +1780,8 @@ service ManagementService {
 
     // Delete Secret of Machine User
     //
+    // Deprecated: use [user service v2 RemoveSecret](apis/resources/user_service_v2/user-service-remove-secret.api.mdx) instead.
+    //
     // Delete a secret of a machine user/service account. The user will not be able to authenticate with the secret afterward.
     rpc RemoveMachineSecret(RemoveMachineSecretRequest) returns (RemoveMachineSecretResponse) {
         option (google.api.http) = {
@@ -1726,6 +1795,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1745,6 +1815,8 @@ service ManagementService {
 
     // Get Machine user Key By ID
     //
+    // Deprecated: use [user service v2 ListUsers](apis/resources/user_service_v2/user-service-list-users.api.mdx) instead.
+    //
     // Get a specific Key of a machine user by its id. Machine keys are used to authenticate with jwt profile authentication.
     rpc GetMachineKeyByIDs(GetMachineKeyByIDsRequest) returns (GetMachineKeyByIDsResponse) {
         option (google.api.http) = {
@@ -1758,6 +1830,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1777,6 +1850,8 @@ service ManagementService {
 
     // List Machine Keys
     //
+    // Deprecated: use [user service v2 ListKeys](apis/resources/user_service_v2/user-service-list-keys.api.mdx) instead.
+    //
     // Get the list of keys of a machine user. Machine keys are used to authenticate with jwt profile authentication.
     rpc ListMachineKeys(ListMachineKeysRequest) returns (ListMachineKeysResponse) {
         option (google.api.http) = {
@@ -1791,6 +1866,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1810,6 +1886,8 @@ service ManagementService {
 
     // Create Key for machine user
     //
+    // Deprecated: use [user service v2 AddKey](apis/resources/user_service_v2/user-service-add-key.api.mdx) instead.
+    //
     // If a public key is not supplied, a new key is generated and will be returned in the response.
     // Make sure to store the returned key.
     // If an RSA public key is supplied, the private key is omitted from the response.
@@ -1827,6 +1905,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1846,6 +1925,8 @@ service ManagementService {
 
     // Delete Key for machine user
     //
+    // Deprecated: use [user service v2 RemoveKey](apis/resources/user_service_v2/user-service-remove-key.api.mdx) instead.
+    //
     // Delete a specific key from a user.
     // The user will not be able to authenticate with that key afterward.
     rpc RemoveMachineKey(RemoveMachineKeyRequest) returns (RemoveMachineKeyResponse) {
@@ -1860,6 +1941,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1879,6 +1961,8 @@ service ManagementService {
 
     // Get Personal-Access-Token (PAT) by ID
     //
+    // Deprecated: use [user service v2 ListPersonalAccessTokens](apis/resources/user_service_v2/user-service-list-personal-access-tokens.api.mdx) instead.
+    //
     // Returns the PAT for a user, currently only available for machine users/service accounts. PATs are ready-to-use tokens and can be sent directly in the authentication header.
     rpc GetPersonalAccessTokenByIDs(GetPersonalAccessTokenByIDsRequest) returns (GetPersonalAccessTokenByIDsResponse) {
         option (google.api.http) = {
@@ -1892,6 +1976,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1910,6 +1995,8 @@ service ManagementService {
     }
 
     // List Personal-Access-Tokens (PATs)
+    //
+    // Deprecated: use [user service v2 ListPersonalAccessTokens](apis/resources/user_service_v2/user-service-list-personal-access-tokens.api.mdx) instead.
     //
     // Returns a list of PATs for a user, currently only available for machine users/service accounts. PATs are ready-to-use tokens and can be sent directly in the authentication header.
     rpc ListPersonalAccessTokens(ListPersonalAccessTokensRequest) returns (ListPersonalAccessTokensResponse) {
@@ -1944,6 +2031,8 @@ service ManagementService {
 
     // Create a Personal-Access-Token (PAT)
     //
+    // Deprecated: use [user service v2 AddPersonalAccessToken](apis/resources/user_service_v2/user-service-add-personal-access-token.api.mdx) instead.
+    //
     // Generates a new PAT for the user. Currently only available for machine users.
     // The token will be returned in the response, make sure to store it.
     // PATs are ready-to-use tokens and can be sent directly in the authentication header.
@@ -1960,6 +2049,7 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users";
             tags: "User Machine";
+            deprecated: true;
             responses: {
                 key: "200"
                 value: {
@@ -1978,6 +2068,8 @@ service ManagementService {
     }
 
     // Remove a Personal-Access-Token (PAT) by ID
+    //
+    // Deprecated: use [user service v2 RemovePersonalAccessToken](apis/resources/user_service_v2/user-service-remove-personal-access-token.api.mdx) instead.
     //
     // Delete a PAT from a user. Afterward, the user will not be able to authenticate with that token anymore.
     rpc RemovePersonalAccessToken(RemovePersonalAccessTokenRequest) returns (RemovePersonalAccessTokenResponse) {
@@ -2009,7 +2101,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use user service v2 ListLinkedIDPs
+    // List Social Logins
+    //
+    // Deprecated: use [user service v2 ListLinkedIDPs](apis/resources/user_service_v2/user-service-list-linked-idps.api.mdx) instead.
+    //
+    // Returns a list of all linked identity providers/social logins of the user. (e. Google, Microsoft, AzureAD, etc.).
     rpc ListHumanLinkedIDPs(ListHumanLinkedIDPsRequest) returns (ListHumanLinkedIDPsResponse) {
         option (google.api.http) = {
             post: "/users/{user_id}/idps/_search"
@@ -2022,9 +2118,7 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users"
-            summary: "List Social Logins";
             deprecated: true;
-            description: "Returns a list of all linked identity providers/social logins of the user. (e. Google, Microsoft, AzureAD, etc.).\n\nDeprecated: please use user service v2 ListLinkedIDPs"
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -2036,7 +2130,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: please use [user service v2 RemoveIDPLink](apis/resources/user_service_v2/user-service-remove-idp-link.api.mdx)
+    // Remove Social Login
+    //
+    // Deprecated: use [user service v2 ListLinkedIDPs](apis/resources/user_service_v2/user-service-list-linked-idps.api.mdx) instead.
+    //
+    // Remove a configured social logins/identity providers of the user (e.g. Google, Microsoft, AzureAD, etc.). The user will not be able to log in with the given provider afterward. Make sure the user does have other possibilities to authenticate.
     rpc RemoveHumanLinkedIDP(RemoveHumanLinkedIDPRequest) returns (RemoveHumanLinkedIDPResponse) {
         option (google.api.http) = {
             delete: "/users/{user_id}/idps/{idp_id}/{linked_user_id}"
@@ -2048,9 +2146,7 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Users"
-            summary: "Remove Social Login";
             deprecated: true;
-            description: "Remove a configured social logins/identity providers of the user (e.g. Google, Microsoft, AzureAD, etc.). The user will not be able to log in with the given provider afterward. Make sure the user does have other possibilities to authenticate.\n\nDeprecated: please use user service v2 RemoveLinkedIDP"
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -2152,7 +2248,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use CreateOrganization [apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx] API instead
+    // Create Organization
+    //
+    // Deprecated: use [organization service v2 CreateOrganization](apis/resources/org_service_v2beta/organization-service-create-organization.api.mdx) instead
+    //
+    // Create a new organization. Based on the given name a domain will be generated to be able to identify users within an organization.
     rpc AddOrg(AddOrgRequest) returns (AddOrgResponse) {
         option (google.api.http) = {
             post: "/orgs"
@@ -2165,8 +2265,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Create Organization";
-            description: "Create a new organization. Based on the given name a domain will be generated to be able to identify users within an organization."
             deprecated: true
             parameters: {
                 headers: {
@@ -2179,7 +2277,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use UpdateOrganization [apis/resources/org_service_v2beta/organization-service-update-organization.api.mdx] API instead
+    // Update Organization
+    //
+    // Deprecated: use [organization service v2 UpdateOrganization](apis/resources/org_service_v2beta/organization-service-update-organization.api.mdx) instead.
+    //
+    // Change the name of the organization.
     rpc UpdateOrg(UpdateOrgRequest) returns (UpdateOrgResponse) {
         option (google.api.http) = {
             put: "/orgs/me"
@@ -2192,8 +2294,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Update Organization";
-            description: "Change the name of the organization."
             deprecated: true
             parameters: {
                 headers: {
@@ -2206,7 +2306,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use DeactivateOrganization [apis/resources/org_service_v2beta/organization-service-deactivate-organization.api.mdx] API instead
+    // Deactivate Organization
+    //
+    // Deprecated: use [organization service v2 DeactivateOrganization](apis/resources/org_service_v2beta/organization-service-deactivate-organization.api.mdx) instead.
+    //
+    // Sets the state of my organization to deactivated. Users of this organization will not be able to log in.
     rpc DeactivateOrg(DeactivateOrgRequest) returns (DeactivateOrgResponse) {
         option (google.api.http) = {
             post: "/orgs/me/_deactivate"
@@ -2219,8 +2323,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Deactivate Organization";
-            description: "Sets the state of my organization to deactivated. Users of this organization will not be able to log in."
             deprecated: true
             parameters: {
                 headers: {
@@ -2233,7 +2335,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use ActivateOrganization [apis/resources/org_service_v2beta/organization-service-activate-organization.api.mdx] API instead
+    // Reactivate Organization
+    //
+    // Deprecated: use [organization service v2 ActivateOrganization](apis/resources/org_service_v2beta/organization-service-activate-organization.api.mdx) instead.
+    //
+    // Set the state of my organization to active. The state of the organization has to be deactivated to perform the request. Users of this organization will be able to log in again.
     rpc ReactivateOrg(ReactivateOrgRequest) returns (ReactivateOrgResponse) {
         option (google.api.http) = {
             post: "/orgs/me/_reactivate"
@@ -2246,8 +2352,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Reactivate Organization";
-            description: "Set the state of my organization to active. The state of the organization has to be deactivated to perform the request. Users of this organization will be able to log in again."
             deprecated: true
             parameters: {
                 headers: {
@@ -2260,7 +2364,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use DeleteOrganization [apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx] API instead
+    // Delete Organization
+    //
+    // Deprecated: use [organization service v2 DeleteOrganization](apis/resources/org_service_v2beta/organization-service-delete-organization.api.mdx) instead.
+    //
+    // Deletes my organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in.
     rpc RemoveOrg(RemoveOrgRequest) returns (RemoveOrgResponse) {
         option (google.api.http) = {
             delete: "/orgs/me"
@@ -2272,8 +2380,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Delete Organization";
-            description: "Deletes my organization and all its resources (Users, Projects, Grants to and from the org). Users of this organization will not be able to log in."
             deprecated: true
             parameters: {
                 headers: {
@@ -2286,7 +2392,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use SetOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx] API instead
+    // Set Organization Metadata
+    //
+    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx) instead.
+    //
+    // This endpoint either adds or updates a metadata value for the requested key. Make sure the value is base64 encoded.
     rpc SetOrgMetadata(SetOrgMetadataRequest) returns (SetOrgMetadataResponse) {
         option (google.api.http) = {
             post: "/metadata/{key}"
@@ -2300,8 +2410,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Organization Metadata";
-            summary: "Set Organization Metadata";
-            description: "This endpoint either adds or updates a metadata value for the requested key. Make sure the value is base64 encoded."
             deprecated: true
             parameters: {
                 headers: {
@@ -2314,7 +2422,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use SetOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx] API instead
+    // Bulk Set Organization Metadata
+    //
+    // Deprecated: use [organization service v2 SetOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-set-organization-metadata.api.mdx) instead.
+    //
+    // This endpoint sets a list of metadata to the organization. Make sure the values are base64 encoded.
     rpc BulkSetOrgMetadata(BulkSetOrgMetadataRequest) returns (BulkSetOrgMetadataResponse) {
         option (google.api.http) = {
             post: "/metadata/_bulk"
@@ -2328,8 +2440,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Organization Metadata";
-            summary: "Bulk Set Organization Metadata";
-            description: "This endpoint sets a list of metadata to the organization. Make sure the values are base64 encoded."
             deprecated: true
             parameters: {
                 headers: {
@@ -2342,7 +2452,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use ListOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx] API instead
+    // Search Organization Metadata
+    //
+    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx) instead.
+    //
+    // Get the metadata of an organization filtered by your query.
     rpc ListOrgMetadata(ListOrgMetadataRequest) returns (ListOrgMetadataResponse) {
         option (google.api.http) = {
             post: "/metadata/_search"
@@ -2356,8 +2470,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Organization Metadata";
-            summary: "Search Organization Metadata";
-            description: "Get the metadata of an organization filtered by your query."
             deprecated: true
             parameters: {
                 headers: {
@@ -2370,7 +2482,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use ListOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx] API instead
+    // Get Organization Metadata By Key
+    //
+    // Deprecated: use [organization service v2 ListOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-list-organization-metadata.api.mdx) instead.
+    //
+    // Get a metadata object from an organization by a specific key.
     rpc GetOrgMetadata(GetOrgMetadataRequest) returns (GetOrgMetadataResponse) {
         option (google.api.http) = {
             get: "/metadata/{key}"
@@ -2383,8 +2499,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Organization Metadata";
-            summary: "Get Organization Metadata By Key";
-            description: "Get a metadata object from an organization by a specific key."
             deprecated: true
             parameters: {
                 headers: {
@@ -2397,7 +2511,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use DeleteOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx] API instead
+    // Delete Organization Metadata By Key
+    //
+    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx) instead.
+    //
+    // Remove a metadata object from an organization with a specific key.
     rpc RemoveOrgMetadata(RemoveOrgMetadataRequest) returns (RemoveOrgMetadataResponse) {
         option (google.api.http) = {
             delete: "/metadata/{key}"
@@ -2410,8 +2528,6 @@ service ManagementService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
             tags: "Organization Metadata";
-            summary: "Delete Organization Metadata By Key";
-            description: "Remove a metadata object from an organization with a specific key."
             deprecated: true
             parameters: {
                 headers: {
@@ -2424,7 +2540,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use DeleteOrganizationMetadata [apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx] API instead
+    // Bulk Delete Metadata
+    //
+    // Deprecated: use [organization service v2 DeleteOrganizationMetadata](apis/resources/org_service_v2beta/organization-service-delete-organization-metadata.api.mdx) instead.
+    //
+    // Remove a list of metadata objects from an organization with a list of keys.
     rpc BulkRemoveOrgMetadata(BulkRemoveOrgMetadataRequest) returns (BulkRemoveOrgMetadataResponse) {
         option (google.api.http) = {
             delete: "/metadata/_bulk"
@@ -2439,8 +2559,6 @@ service ManagementService {
             tags: "Organizations";
             tags: "Organization Metadata";
             deprecated: true
-            summary: "Bulk Delete Metadata";
-            description: "Remove a list of metadata objects from an organization with a list of keys."
             parameters: {
                 headers: {
                     name: "x-zitadel-orgid";
@@ -2452,7 +2570,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use AddOrganizationDomain [apis/resources/org_service_v2beta/organization-service-add-organization-domain.api.mdx] API instead
+    // Add Domain
+    //
+    // Deprecated: use [organization service v2 AddOrganizationDomain](apis/resources/org_service_v2beta/organization-service-add-organization-domain.api.mdx) instead.
+    //
+    // Add a new domain to an organization. The domains are used to identify to which organization a user belongs.
     rpc AddOrgDomain(AddOrgDomainRequest) returns (AddOrgDomainResponse) {
         option (google.api.http) = {
             post: "/orgs/me/domains"
@@ -2465,8 +2587,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Add Domain";
-            description: "Add a new domain to an organization. The domains are used to identify to which organization a user belongs."
             deprecated: true
             parameters: {
                 headers: {
@@ -2479,7 +2599,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use ListOrganizationDomains [apis/resources/org_service_v2beta/organization-service-list-organization-domains.api.mdx] API instead
+    // Search Domains
+    //
+    // Deprecated: use [organization service v2 ListOrganizationDomains](apis/resources/org_service_v2beta/organization-service-list-organization-domains.api.mdx) instead.
+    //
+    // Returns the list of registered domains of an organization. The domains are used to identify to which organization a user belongs.
     rpc ListOrgDomains(ListOrgDomainsRequest) returns (ListOrgDomainsResponse) {
         option (google.api.http) = {
             post: "/orgs/me/domains/_search"
@@ -2492,8 +2616,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Search Domains";
-            description: "Returns the list of registered domains of an organization. The domains are used to identify to which organization a user belongs."
             deprecated: true
             parameters: {
                 headers: {
@@ -2506,7 +2628,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use DeleteOrganizationDomain [apis/resources/org_service_v2beta/organization-service-delete-organization-domain.api.mdx] API instead
+    // Remove Domain
+    //
+    // Deprecated: use [organization service v2 DeleteOrganizationDomain](apis/resources/org_service_v2beta/organization-service-delete-organization-domain.api.mdx) instead.
+    //
+    // Delete a new domain from an organization. The domains are used to identify to which organization a user belongs. If the uses use the domain for login, this will not be possible afterwards. They have to use another domain instead.
     rpc RemoveOrgDomain(RemoveOrgDomainRequest) returns (RemoveOrgDomainResponse) {
         option (google.api.http) = {
             delete: "/orgs/me/domains/{domain}"
@@ -2518,8 +2644,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Remove Domain";
-            description: "Delete a new domain from an organization. The domains are used to identify to which organization a user belongs. If the uses use the domain for login, this will not be possible afterwards. They have to use another domain instead."
             deprecated: true
             parameters: {
                 headers: {
@@ -2532,7 +2656,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use GenerateOrganizationDomainValidation [apis/resources/org_service_v2beta/organization-service-generate-organization-domain-validation.api.mdx] API instead
+    // Generate Domain Verification
+    //
+    // Deprecated: use [organization service v2 GenerateOrganizationDomainValidation](apis/resources/org_service_v2beta/organization-service-generate-organization-domain-validation.api.mdx) instead.
+    //
+    // Generate a new file to be able to verify your domain with DNS or HTTP challenge.
     rpc GenerateOrgDomainValidation(GenerateOrgDomainValidationRequest) returns (GenerateOrgDomainValidationResponse) {
         option (google.api.http) = {
             post: "/orgs/me/domains/{domain}/validation/_generate"
@@ -2545,8 +2673,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Generate Domain Verification";
-            description: "Generate a new file to be able to verify your domain with DNS or HTTP challenge."
             deprecated: true
             parameters: {
                 headers: {
@@ -2559,7 +2685,11 @@ service ManagementService {
         };
     }
 
-    // Deprecated: use VerifyOrganizationDomain [apis/resources/org_service_v2beta/organization-service-verify-organization-domain.api.mdx] API instead
+    // Verify Domain
+    //
+    // Deprecated: use [organization service v2 VerifyOrganizationDomain](apis/resources/org_service_v2beta/organization-service-verify-organization-domain.api.mdx) instead.
+    //
+    // Make sure you have added the required verification to your domain, depending on the method you have chosen (HTTP or DNS challenge). ZITADEL will check it and set the domain as verified if it was successful. A verify domain has to be unique.
     rpc ValidateOrgDomain(ValidateOrgDomainRequest) returns (ValidateOrgDomainResponse) {
         option (google.api.http) = {
             post: "/orgs/me/domains/{domain}/validation/_validate"
@@ -2572,8 +2702,6 @@ service ManagementService {
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Organizations";
-            summary: "Verify Domain";
-            description: "Make sure you have added the required verification to your domain, depending on the method you have chosen (HTTP or DNS challenge). ZITADEL will check it and set the domain as verified if it was successful. A verify domain has to be unique."
             deprecated: true
             parameters: {
                 headers: {
@@ -2743,7 +2871,7 @@ service ManagementService {
         };
     }
 
-   rpc GetProjectByID(GetProjectByIDRequest) returns (GetProjectByIDResponse) {
+    rpc GetProjectByID(GetProjectByIDRequest) returns (GetProjectByIDResponse) {
         option (google.api.http) = {
             get: "/projects/{id}"
         };
@@ -3398,13 +3526,13 @@ service ManagementService {
     // Deprecated: Use [CreateApplication](/apis/resources/application_service_v2/application-service-create-application.api.mdx) instead to create a SAML application
     rpc AddSAMLApp(AddSAMLAppRequest) returns (AddSAMLAppResponse) {
         option (google.api.http) = {
-        post: "/projects/{project_id}/apps/saml"
-        body: "*"
+            post: "/projects/{project_id}/apps/saml"
+            body: "*"
         };
 
         option (zitadel.v1.auth_option) = {
-        permission: "project.app.write"
-        check_field_name: "ProjectId"
+            permission: "project.app.write"
+            check_field_name: "ProjectId"
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -3431,14 +3559,14 @@ service ManagementService {
     // Deprecated: Use [CreateApplication](/apis/resources/application_service_v2/application-service-create-application.api.mdx) instead to create an API application
     rpc AddAPIApp(AddAPIAppRequest) returns (AddAPIAppResponse) {
         option (google.api.http) = {
-        post: "/projects/{project_id}/apps/api"
-        body: "*"
+            post: "/projects/{project_id}/apps/api"
+            body: "*"
         };
 
-            option (zitadel.v1.auth_option) = {
-                permission: "project.app.write"
-                check_field_name: "ProjectId"
-            };
+        option (zitadel.v1.auth_option) = {
+            permission: "project.app.write"
+            check_field_name: "ProjectId"
+        };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Applications";
@@ -3486,7 +3614,7 @@ service ManagementService {
         };
     }
 
-    // Deprecated: Use [PatchApplication](/apis/resources/application_service_v2/application-service-patch-application.api.mdx) instead to update the config of an OIDC app 
+    // Deprecated: Use [PatchApplication](/apis/resources/application_service_v2/application-service-patch-application.api.mdx) instead to update the config of an OIDC app
     rpc UpdateOIDCAppConfig(UpdateOIDCAppConfigRequest) returns (UpdateOIDCAppConfigResponse) {
         option (google.api.http) = {
             put: "/projects/{project_id}/apps/{app_id}/oidc_config"
@@ -3517,13 +3645,13 @@ service ManagementService {
     // Deprecated: Use [PatchApplication](/apis/resources/application_service_v2/application-service-patch-application.api.mdx) instead to update the config of a SAML app
     rpc UpdateSAMLAppConfig(UpdateSAMLAppConfigRequest) returns (UpdateSAMLAppConfigResponse) {
         option (google.api.http) = {
-        put: "/projects/{project_id}/apps/{app_id}/saml_config"
-        body: "*"
+            put: "/projects/{project_id}/apps/{app_id}/saml_config"
+            body: "*"
         };
 
         option (zitadel.v1.auth_option) = {
-        permission: "project.app.write"
-        check_field_name: "ProjectId"
+            permission: "project.app.write"
+            check_field_name: "ProjectId"
         };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -3545,14 +3673,14 @@ service ManagementService {
     // Deprecated: Use [PatchApplication](/apis/resources/application_service_v2/application-service-patch-application.api.mdx) instead to update the config of an API app
     rpc UpdateAPIAppConfig(UpdateAPIAppConfigRequest) returns (UpdateAPIAppConfigResponse) {
         option (google.api.http) = {
-        put: "/projects/{project_id}/apps/{app_id}/api_config"
-        body: "*"
+            put: "/projects/{project_id}/apps/{app_id}/api_config"
+            body: "*"
         };
 
-            option (zitadel.v1.auth_option) = {
-                permission: "project.app.write"
-                check_field_name: "ProjectId"
-            };
+        option (zitadel.v1.auth_option) = {
+            permission: "project.app.write"
+            check_field_name: "ProjectId"
+        };
 
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: "Applications";
@@ -9049,8 +9177,8 @@ message AddMachineKeyRequest {
     ];
     bytes public_key = 4 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-           example: "\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1...\"";
-           description: "Optionally provide a public key of your own generated RSA private key.";
+            example: "\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1...\"";
+            description: "Optionally provide a public key of your own generated RSA private key.";
         }
     ];
 }
@@ -9159,7 +9287,7 @@ message GetMyOrgResponse {
 
 message GetOrgByDomainGlobalRequest {
     string domain = 1 [
-        (validate.rules).string = {min_len: 1, max_len: 200} ,
+        (validate.rules).string = {min_len: 1, max_len: 200},
         (google.api.field_behavior) = REQUIRED,
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             min_length: 1;
@@ -9976,31 +10104,31 @@ message AddOIDCAppResponse {
 }
 
 message AddSAMLAppRequest {
-  string project_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
-  string name = 2 [
-      (validate.rules).string = {min_len: 1, max_len: 200},
-      (google.api.field_behavior) = REQUIRED,
-      (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-          min_length: 1;
-          max_length: 200;
-          example: "\"MySAMLApp\"";
-      }
-  ];
-  oneof metadata {
-      option (validate.required) = true;
-      bytes metadata_xml = 3 [(validate.rules).bytes.max_len = 500000];
-      string metadata_url = 4 [(validate.rules).string.max_len = 200];
-  }
-  zitadel.app.v1.LoginVersion login_version = 5 [
-      (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-          description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
-      }
-  ];
+    string project_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
+    string name = 2 [
+        (validate.rules).string = {min_len: 1, max_len: 200},
+        (google.api.field_behavior) = REQUIRED,
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            min_length: 1;
+            max_length: 200;
+            example: "\"MySAMLApp\"";
+        }
+    ];
+    oneof metadata {
+        option (validate.required) = true;
+        bytes metadata_xml = 3 [(validate.rules).bytes.max_len = 500000];
+        string metadata_url = 4 [(validate.rules).string.max_len = 200];
+    }
+    zitadel.app.v1.LoginVersion login_version = 5 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
+        }
+    ];
 }
 
 message AddSAMLAppResponse {
-  string app_id = 1;
-  zitadel.v1.ObjectDetails details = 2;
+    string app_id = 1;
+    zitadel.v1.ObjectDetails details = 2;
 }
 
 message AddAPIAppRequest {
@@ -10148,27 +10276,27 @@ message UpdateOIDCAppConfigRequest {
 }
 
 message UpdateOIDCAppConfigResponse {
-  zitadel.v1.ObjectDetails details = 1;
+    zitadel.v1.ObjectDetails details = 1;
 }
 
 message UpdateSAMLAppConfigRequest {
-  string project_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
-  string app_id = 2 [(validate.rules).string = {min_len: 1, max_len: 200}];
+    string project_id = 1 [(validate.rules).string = {min_len: 1, max_len: 200}];
+    string app_id = 2 [(validate.rules).string = {min_len: 1, max_len: 200}];
 
-  oneof metadata {
-      option (validate.required) = true;
-      bytes metadata_xml = 3 [(validate.rules).bytes.max_len = 500000];
-      string metadata_url = 4 [(validate.rules).string.max_len = 200];
-  }
-  zitadel.app.v1.LoginVersion login_version = 5 [
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
+    oneof metadata {
+        option (validate.required) = true;
+        bytes metadata_xml = 3 [(validate.rules).bytes.max_len = 500000];
+        string metadata_url = 4 [(validate.rules).string.max_len = 200];
     }
-  ];
+    zitadel.app.v1.LoginVersion login_version = 5 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
+        }
+    ];
 }
 
 message UpdateSAMLAppConfigResponse {
-  zitadel.v1.ObjectDetails details = 1;
+    zitadel.v1.ObjectDetails details = 1;
 }
 
 message UpdateAPIAppConfigRequest {
@@ -13623,7 +13751,7 @@ message UpdateAppleProviderRequest {
     bytes private_key = 6 [
         (validate.rules).bytes = {max_len: 5000},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-          max_length: 5000,
+            max_length: 5000,
             example: "\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1...\"";
             description: "Private Key generated by Apple";
         }
@@ -13737,12 +13865,12 @@ message UpdateActionRequest {
     ];
     string script = 3 [
         (validate.rules).string = {min_len: 1, max_bytes: 40000},
-         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-             example: "\"function log(context, calls){console.log(context)}\"";
-             description: "Javascript code that should be executed"
-             min_length: 1;
-             max_length: 10000;
-         }
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"function log(context, calls){console.log(context)}\"";
+            description: "Javascript code that should be executed"
+            min_length: 1;
+            max_length: 10000;
+        }
     ];
     google.protobuf.Duration timeout = 4 [
         (validate.rules).duration = {gte: {}, lte: {seconds: 20}},
@@ -13847,7 +13975,7 @@ message SetTriggerActionsRequest {
     string trigger_type = 2 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "\"1\"";
-         }
+        }
     ];
     repeated string action_ids = 3;
 }

--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -134,6 +134,13 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc CreateUser (CreateUserRequest) returns (CreateUserResponse) {
+    option (google.api.http) = {
+      // The /new path segment does not follow Zitadels API design.
+      // The only reason why it is used here is to avoid a conflict with the ListUsers endpoint, which already handles POST /v2/users.
+      post: "/v2/users/new"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -163,6 +170,8 @@ service UserService {
 
   // Create a new human user
   //
+  // Deprecated: Use [CreateUser](apis/resources/user_service_v2/user-service-create-user.api.mdx) to create a new user of type human instead.
+  //
   // Create/import a new user with the type human. The newly created user will get a verification email if either the email address is not marked as verified and you did not request the verification to be returned.
   rpc AddHumanUser (AddHumanUserRequest) returns (AddHumanUserResponse) {
     option (google.api.http) = {
@@ -181,6 +190,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -261,6 +271,8 @@ service UserService {
 
   // Change the user email
   //
+  // Deprecated: [Update the users email field](apis/resources/user_service_v2/user-service-update-user.api.mdx).
+  //
   // Change the email address of a user. If the state is set to not verified, a verification code will be generated, which can be either returned or sent to the user by email..
   rpc SetEmail (SetEmailRequest) returns (SetEmailResponse) {
     option (google.api.http) = {
@@ -275,6 +287,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -381,6 +394,8 @@ service UserService {
 
   // Set the user phone
   //
+  // Deprecated: [Update the users phone field](apis/resources/user_service_v2/user-service-update-user.api.mdx).
+  //
   // Set the phone number of a user. If the state is set to not verified, a verification code will be generated, which can be either returned or sent to the user by sms..
   rpc SetPhone(SetPhoneRequest) returns (SetPhoneResponse) {
     option (google.api.http) = {
@@ -395,6 +410,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -412,6 +428,8 @@ service UserService {
 
   // Delete the user phone
   //
+  // Deprecated: [Update the users phone field](apis/resources/user_service_v2/user-service-update-user.api.mdx) to remove the phone number.
+  //
   // Delete the phone number of a user.
   rpc RemovePhone(RemovePhoneRequest) returns (RemovePhoneResponse) {
     option (google.api.http) = {
@@ -426,6 +444,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -512,6 +531,10 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
+    option (google.api.http) = {
+      patch: "/v2/users/{user_id}"
+      body: "*"
+    };
 
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
@@ -553,7 +576,9 @@ service UserService {
 
   // Update Human User
   //
-  // Update all information from a user..
+  // Deprecated: Use [UpdateUser](apis/resources/user_service_v2/user-service-update-user.api.mdx) to update a user of type human instead.
+  //
+  // Update all information from a user.
   rpc UpdateHumanUser(UpdateHumanUserRequest) returns (UpdateHumanUserResponse) {
     option (google.api.http) = {
       put: "/v2/users/human/{user_id}"
@@ -567,6 +592,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -1354,6 +1380,8 @@ service UserService {
 
   // Change password
   //
+  // Deprecated: [Update the users password](apis/resources/user_service_v2/user-service-update-user.api.mdx) instead.
+  //
   // Change the password of a user with either a verification code or the current password..
   rpc SetPassword (SetPasswordRequest) returns (SetPasswordResponse) {
     option (google.api.http) = {
@@ -1368,6 +1396,7 @@ service UserService {
     };
 
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      deprecated: true;
       responses: {
         key: "200"
         value: {
@@ -1394,6 +1423,11 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc AddSecret(AddSecretRequest) returns (AddSecretResponse) {
+    option (google.api.http) = {
+      post: "/v2/users/{user_id}/secret"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1428,6 +1462,10 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc RemoveSecret(RemoveSecretRequest) returns (RemoveSecretResponse) {
+    option (google.api.http) = {
+      delete: "/v2/users/{user_id}/secret"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1453,6 +1491,11 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc AddKey(AddKeyRequest) returns (AddKeyResponse) {
+    option (google.api.http) = {
+      post: "/v2/users/{user_id}/keys"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1487,6 +1530,10 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc RemoveKey(RemoveKeyRequest) returns (RemoveKeyResponse) {
+    option (google.api.http) = {
+      delete: "/v2/users/{user_id}/keys/{key_id}"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1511,6 +1558,11 @@ service UserService {
   // Required permission:
   //   - user.read
   rpc ListKeys(ListKeysRequest) returns (ListKeysResponse) {
+    option (google.api.http) = {
+      post: "/v2/users/keys/search"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1542,6 +1594,11 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc AddPersonalAccessToken(AddPersonalAccessTokenRequest) returns (AddPersonalAccessTokenResponse) {
+    option (google.api.http) = {
+      post: "/v2/users/{user_id}/pats"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1576,6 +1633,10 @@ service UserService {
   // Required permission:
   //   - user.write
   rpc RemovePersonalAccessToken(RemovePersonalAccessTokenRequest) returns (RemovePersonalAccessTokenResponse) {
+    option (google.api.http) = {
+      delete: "/v2/users/{user_id}/pats/{token_id}"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
@@ -1600,6 +1661,11 @@ service UserService {
   // Required permission:
   //   - user.read
   rpc ListPersonalAccessTokens(ListPersonalAccessTokensRequest) returns (ListPersonalAccessTokensResponse) {
+    option (google.api.http) = {
+      post: "/v2/users/pats/search"
+      body: "*"
+    };
+
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"

--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -441,7 +441,9 @@ service UserService {
     };
   }
 
-  // Resend code to verify user phone
+  // Resend code to verify user phone number
+  //
+  // Resend code to verify user phone number.
   rpc ResendPhoneCode (ResendPhoneCodeRequest) returns (ResendPhoneCodeResponse) {
     option (google.api.http) = {
       post: "/v2/users/{user_id}/phone/resend"
@@ -470,9 +472,9 @@ service UserService {
     };
   }
 
-  // Verify the phone
+  // Verify the phone number
   //
-  // Verify the phone with the generated code..
+  // Verify the phone number with the generated code.
   rpc VerifyPhone (VerifyPhoneRequest) returns (VerifyPhoneResponse) {
     option (google.api.http) = {
       post: "/v2/users/{user_id}/phone/verify"


### PR DESCRIPTION
# Which Problems Are Solved

Currently some endpoints have the wrong documentation associated to it.

# How the Problems Are Solved

Correct documentation for endpoints which get deprecated through organization service v2 and user service v2.
Defined in the [API_DESIGN.md](https://github.com/zitadel/zitadel/blob/main/API_DESIGN.md).

# Additional Changes

None

# Additional Context

None
