### PR TITLE
chore: use github for docker build layer caches

### DIFF
--- a/.devcontainer/base/docker-compose.yml
+++ b/.devcontainer/base/docker-compose.yml
@@ -1,9 +1,16 @@
+x-build-cache: &build-cache
+  cache_from:
+    - type=gha
+  cache_to:
+    - type=gha,mode=max
+
 services:
 
   devcontainer:
     container_name: devcontainer
     build:
       context: .
+      <<: *build-cache
     volumes:
       - ../../:/workspaces:cached
       - /tmp/.X11-unix:/tmp/.X11-unix:cached
@@ -36,6 +43,7 @@ services:
     container_name: mock-zitadel
     build:
       context: ../../apps/login/integration/core-mock
+      <<: *build-cache
     ports:
       - 22220:22220
       - 22222:22222
@@ -45,6 +53,7 @@ services:
     build:
       context: ../..
       dockerfile: build/login/Dockerfile
+      <<: *build-cache
     image: "${LOGIN_TAG:-zitadel-login:local}"
     env_file: ../../apps/login/.env.test
     network_mode: service:devcontainer
@@ -80,6 +89,7 @@ services:
     build:
       context: ../../apps/login/acceptance/setup
       dockerfile: ../go-command.Dockerfile
+      <<: *build-cache
     entrypoint: "./setup.sh"
     network_mode: service:devcontainer
     environment:
@@ -116,6 +126,7 @@ services:
       dockerfile: ../go-command.Dockerfile
       args:
         - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
+      <<: *build-cache
     environment:
       PORT: '3333'
     command:
@@ -140,6 +151,7 @@ services:
       dockerfile: ../go-command.Dockerfile
       args:
         - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
+      <<: *build-cache
     network_mode: service:devcontainer
     environment:
       API_URL: 'http://localhost:8080'
@@ -163,6 +175,7 @@ services:
   #      dockerfile: ../../go-command.Dockerfile
   #      args:
   #        - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
+  #      <<: *build-cache
   #    network_mode: service:devcontainer
   #    environment:
   #      API_URL: 'http://localhost:8080'
@@ -184,6 +197,7 @@ services:
       dockerfile: ../go-command.Dockerfile
       args:
         - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
+      <<: *build-cache
     network_mode: service:devcontainer
     environment:
       API_URL: 'http://localhost:8080'
@@ -198,27 +212,27 @@ services:
     depends_on:
       configure-login:
         condition: "service_completed_successfully"
-
-#  mock-samlidp:
-#    container_name: mock-samlidp
-#    build:
-#      context: ../../apps/login/acceptance/idp/saml
-#      dockerfile: ../../go-command.Dockerfile
-#      args:
-#        - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
-#    network_mode: service:devcontainer
-#    environment:
-#      API_URL: 'http://localhost:8080'
-#      API_DOMAIN: 'localhost'
-#      PAT_FILE: '/pat/zitadel-admin-sa.pat'
-#      SCHEMA: 'http'
-#      HOST: 'localhost'
-#      PORT: "8003"
-#    volumes:
-#      - "../apps/login/packages/acceptance/pat:/pat"
-#    depends_on:
-#      configure-login:
-#        condition: "service_completed_successfully"
+  #  mock-samlidp:
+  #    container_name: mock-samlidp
+  #    build:
+  #      context: ../../apps/login/acceptance/idp/saml
+  #      dockerfile: ../../go-command.Dockerfile
+  #      args:
+  #        - LOGIN_TEST_ACCEPTANCE_GOLANG_TAG=${LOGIN_TEST_ACCEPTANCE_GOLANG_TAG:-golang:1.24-alpine}
+  #      <<: *build-cache
+  #    network_mode: service:devcontainer
+  #    environment:
+  #      API_URL: 'http://localhost:8080'
+  #      API_DOMAIN: 'localhost'
+  #      PAT_FILE: '/pat/zitadel-admin-sa.pat'
+  #      SCHEMA: 'http'
+  #      HOST: 'localhost'
+  #      PORT: "8003"
+  #    volumes:
+  #      - "../apps/login/packages/acceptance/pat:/pat"
+  #    depends_on:
+  #      configure-login:
+  #        condition: "service_completed_successfully"
 
 volumes:
   postgres-data:

--- a/.github/workflows/login-container.yml
+++ b/.github/workflows/login-container.yml
@@ -59,6 +59,9 @@ jobs:
           provenance: true
           sbom: true
           targets: login-standalone
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
           files: |
             ./apps/login/docker-bake.hcl
             ./apps/login/docker-bake-release.hcl


### PR DESCRIPTION
# Which Problems Are Solved

Building the login container in the pipeline without build layer caches takes about 20 minutes.

# How the Problems Are Solved

We use cache-from and cache-to arguments to use the GitHub cache API.
Compare 1st and 2nd run [of this PRs pipeline](https://github.com/zitadel/zitadel/actions/runs/16590808510/job/46927893304)

# Additional Context

- Follows up on #10343 