### PR TITLE
docs: deprecate organization v2beta endpoints + remove scim preview notice

### DIFF
--- a/docs/docs/apis/scim2.md
+++ b/docs/docs/apis/scim2.md
@@ -2,15 +2,6 @@
 title: SCIM v2.0 (Preview)
 ---
 
-:::info
-The SCIM v2 interface of Zitadel is currently in a [preview stage](/support/software-release-cycles-support#preview).
-It is not yet feature-complete, may contain bugs, and is not generally available.
-
-Do not use it for production yet.
-
-As long as the feature is in a preview state, it will be available for free, it will be put behind a commercial license once it is fully available.
-:::
-
 The Zitadel [SCIM v2](https://scim.cloud/) service provider interface enables seamless integration of identity and
 access management (IAM) systems with Zitadel,
 following the System for Cross-domain Identity Management (SCIM) v2.0 specification.

--- a/docs/docs/guides/manage/user/scim2.md
+++ b/docs/docs/guides/manage/user/scim2.md
@@ -2,15 +2,6 @@
 title: SCIM v2.0 (Preview)
 ---
 
-:::info
-The SCIM v2 interface of Zitadel is currently in a [preview stage](/support/software-release-cycles-support#preview).
-It is not yet feature-complete, may contain bugs, and is not generally available.
-
-Do not use it for production yet.
-
-As long as the feature is in a preview state, it will be available for free, it will be put behind a commercial license once it is fully available.
-:::
-
 The Zitadel [SCIM v2](https://scim.cloud/) service provider interface enables seamless integration of identity and
 access management (IAM) systems with Zitadel,
 following the System for Cross-domain Identity Management (SCIM) v2.0 specification.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -751,10 +751,10 @@ module.exports = {
               label: "Organization (Beta)",
               link: {
                 type: "generated-index",
-                title: "Organization Service beta API",
+                title: "Deprecated: Organization Service Beta API",
                 slug: "/apis/resources/org_service/v2beta",
                 description:
-                    "This API is intended to manage organizations for ZITADEL. \n",
+                    "This beta API is intended to manage organizations for ZITADEL. It has now been deprecated and may be replaced or removed in future versions of the API. \n",
               },
               items: sidebar_api_org_service_v2beta,
             },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -751,10 +751,10 @@ module.exports = {
               label: "Organization (Beta)",
               link: {
                 type: "generated-index",
-                title: "Deprecated: Organization Service Beta API",
+                title: "Organization Service Beta API",
                 slug: "/apis/resources/org_service/v2beta",
                 description:
-                    "This beta API is intended to manage organizations for ZITADEL. It has now been deprecated and may be replaced or removed in future versions of the API. \n",
+                    "This beta API is intended to manage organizations for ZITADEL. Expect breaking changes to occur. Please use the v2 version for a stable API. \n",
               },
               items: sidebar_api_org_service_v2beta,
             },

--- a/proto/zitadel/org/v2beta/org_service.proto
+++ b/proto/zitadel/org/v2beta/org_service.proto
@@ -115,6 +115,8 @@ service OrganizationService {
   //
   // Required permission:
   //  - `org.create`
+  //
+  // Deprecated: Use [AddOrganization](/apis/resources/org_service_v2/organization-service-add-organization.api.mdx) instead to create an organization.
   rpc CreateOrganization(CreateOrganizationRequest) returns (CreateOrganizationResponse) {
     option (google.api.http) = {
       post: "/v2beta/organizations"
@@ -127,7 +129,7 @@ service OrganizationService {
       }
     };
 
-  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       responses: {
         key: "200";
         value: {
@@ -140,6 +142,7 @@ service OrganizationService {
           description: "The organization to create already exists.";
         }
       };
+      deprecated: true;
     };
   }
 
@@ -190,6 +193,8 @@ service OrganizationService {
   //
   // Required permission:
   //  - `iam.read`
+  //
+  // Deprecated: Use [ListOrganizations](/apis/resources/org_service_v2/organization-service-list-organizations.api.mdx) instead to list organizations.
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
     option (google.api.http) = {
         post: "/v2beta/organizations/search";
@@ -206,6 +211,7 @@ service OrganizationService {
       responses: {
         key: "200";
       };
+      deprecated: true;
     };
   }
 


### PR DESCRIPTION
# Which Problems Are Solved

The documentation API regarding organization v2 beta is not up to date.

The documentation regarding SCIM v2 is not up to date.

# How the Problems Are Solved

  - Deprecate the existing v2beta endpoints `CreateOrganization` and `ListOrganizations` in favour of the v2 counterparst
  - Remove the preview warning from SCIM v2 pages

# Additional Context

- Closes #10311 and #10310
