### PR TITLE
fix: allow disabling projections for specific instances

### DIFF
--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -45,6 +45,7 @@ type Config struct {
 	ActiveInstancer interface {
 		ActiveInstances() []string
 	}
+	SkipInstanceIDs []string
 }
 
 type Handler struct {
@@ -70,6 +71,8 @@ type Handler struct {
 	queryInstances func() ([]string, error)
 
 	metrics *ProjectionMetrics
+
+	skipInstanceIDs []string
 }
 
 var _ migration.Migration = (*Handler)(nil)
@@ -188,7 +191,8 @@ func NewHandler(
 			}
 			return nil, nil
 		},
-		metrics: metrics,
+		metrics:         metrics,
+		skipInstanceIDs: config.SkipInstanceIDs,
 	}
 
 	if _, ok := projection.(GlobalProjection); ok {
@@ -420,6 +424,9 @@ func WithMinPosition(position decimal.Decimal) TriggerOpt {
 }
 
 func (h *Handler) Trigger(ctx context.Context, opts ...TriggerOpt) (_ context.Context, err error) {
+	if slices.Contains(h.skipInstanceIDs, authz.GetInstance(ctx).InstanceID()) {
+		return call.ResetTimestamp(ctx), nil
+	}
 	config := new(triggerConfig)
 	for _, opt := range opts {
 		opt(config)

--- a/internal/query/projection/config.go
+++ b/internal/query/projection/config.go
@@ -26,4 +26,5 @@ type CustomConfig struct {
 	ConcurrentInstances *uint
 	BulkLimit           *uint16
 	TransactionDuration *time.Duration
+	SkipInstanceIDs     []string
 }

--- a/internal/query/projection/projection.go
+++ b/internal/query/projection/projection.go
@@ -275,6 +275,7 @@ func applyCustomConfig(config handler.Config, customConfig CustomConfig) handler
 	if customConfig.TransactionDuration != nil {
 		config.TransactionDuration = *customConfig.TransactionDuration
 	}
+	config.SkipInstanceIDs = append(config.SkipInstanceIDs, customConfig.SkipInstanceIDs...)
 
 	return config
 }


### PR DESCRIPTION
# Which Problems Are Solved

The current handling of event subscriptions for actions is bad, esp. on instances with a lot of events (https://github.com/zitadel/zitadel/issues/9832#issuecomment-2866236414). This led to severe problems on zitadel.cloud for such instances.

# How the Problems Are Solved

As a workaround until the handling can be improved, we introduce an option for projections to be disabled completely for specific instances: `SkipInstanceIDs`

# Additional Changes

None

# Additional Context

- relates to https://github.com/zitadel/zitadel/issues/9832
