### PR TITLE
docs: get rid of empty custom scopes placeholder

### DIFF
--- a/docs/docs/apis/openidoauth/scopes.md
+++ b/docs/docs/apis/openidoauth/scopes.md
@@ -16,10 +16,6 @@ ZITADEL supports the usage of scopes as way of requesting information from the I
 | phone          | Optional scope to request the phone of the subject                             |
 | offline_access | Optional scope to request a refresh_token (only possible when using code flow) |
 
-## Custom Scopes
-
-> This feature is not yet released
-
 ## Reserved Scopes
 
 In addition to the standard compliant scopes we utilize the following scopes.


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

<img width="1402" height="807" alt="image" src="https://github.com/user-attachments/assets/9c931889-600f-475c-8a8e-eff592d9acae" />

# How the Problems Are Solved

Removing the Custom Scopes Placeholder.

