### PR TITLE
fix: resourceowner added for user state write model

### DIFF
--- a/internal/command/oidc_session.go
+++ b/internal/command/oidc_session.go
@@ -295,7 +295,7 @@ func (c *Commands) RevokeOIDCSessionToken(ctx context.Context, token, clientID s
 }
 
 func (c *Commands) newOIDCSessionAddEvents(ctx context.Context, userID, resourceOwner string, pending ...eventstore.Command) (*OIDCSessionEvents, error) {
-	userStateModel, err := c.userStateWriteModel(ctx, userID)
+	userStateModel, err := c.userStateWriteModel(ctx, userID, resourceOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (c *Commands) newOIDCSessionUpdateEvents(ctx context.Context, refreshToken 
 	if err = sessionWriteModel.CheckRefreshToken(refreshTokenID); err != nil {
 		return nil, err
 	}
-	userStateWriteModel, err := c.userStateWriteModel(ctx, sessionWriteModel.UserID)
+	userStateWriteModel, err := c.userStateWriteModel(ctx, sessionWriteModel.UserID, sessionWriteModel.UserResourceOwner)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/saml_session.go
+++ b/internal/command/saml_session.go
@@ -93,7 +93,7 @@ func (c *Commands) CreateSAMLSessionFromSAMLRequest(ctx context.Context, samlReq
 }
 
 func (c *Commands) newSAMLSessionAddEvents(ctx context.Context, userID, resourceOwner string, pending ...eventstore.Command) (*SAMLSessionEvents, error) {
-	userStateModel, err := c.userStateWriteModel(ctx, userID)
+	userStateModel, err := c.userStateWriteModel(ctx, userID, resourceOwner)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/user_v2.go
+++ b/internal/command/user_v2.go
@@ -17,7 +17,7 @@ func (c *Commands) LockUserV2(ctx context.Context, userID string) (*domain.Objec
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-agz3eczifm", "Errors.User.UserIDMissing")
 	}
 
-	existingHuman, err := c.userStateWriteModel(ctx, userID)
+	existingHuman, err := c.userStateWriteModel(ctx, userID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (c *Commands) UnlockUserV2(ctx context.Context, userID string) (*domain.Obj
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-a9ld4xckax", "Errors.User.UserIDMissing")
 	}
 
-	existingHuman, err := c.userStateWriteModel(ctx, userID)
+	existingHuman, err := c.userStateWriteModel(ctx, userID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (c *Commands) DeactivateUserV2(ctx context.Context, userID string) (*domain
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-78iiirat8y", "Errors.User.UserIDMissing")
 	}
 
-	existingHuman, err := c.userStateWriteModel(ctx, userID)
+	existingHuman, err := c.userStateWriteModel(ctx, userID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (c *Commands) ReactivateUserV2(ctx context.Context, userID string) (*domain
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-0nx1ie38fw", "Errors.User.UserIDMissing")
 	}
 
-	existingHuman, err := c.userStateWriteModel(ctx, userID)
+	existingHuman, err := c.userStateWriteModel(ctx, userID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +116,11 @@ func (c *Commands) ReactivateUserV2(ctx context.Context, userID string) (*domain
 	return writeModelToObjectDetails(&existingHuman.WriteModel), nil
 }
 
-func (c *Commands) userStateWriteModel(ctx context.Context, userID string) (writeModel *UserV2WriteModel, err error) {
+func (c *Commands) userStateWriteModel(ctx context.Context, userID, resourceOwner string) (writeModel *UserV2WriteModel, err error) {
 	ctx, span := tracing.NewSpan(ctx)
 	defer func() { span.EndWithError(err) }()
 
-	writeModel = NewUserStateWriteModel(userID, "")
+	writeModel = NewUserStateWriteModel(userID, resourceOwner)
 	err = c.eventstore.FilterToQueryReducer(ctx, writeModel)
 	if err != nil {
 		return nil, err

--- a/internal/command/user_v2_human.go
+++ b/internal/command/user_v2_human.go
@@ -511,7 +511,7 @@ func (c *Commands) HumanMFAInitSkippedV2(ctx context.Context, userID string) (*d
 		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-Wei5kooz1i", "Errors.User.UserIDMissing")
 	}
 
-	existingHuman, err := c.userStateWriteModel(ctx, userID)
+	existingHuman, err := c.userStateWriteModel(ctx, userID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/user_v2_model_test.go
+++ b/internal/command/user_v2_model_test.go
@@ -1992,7 +1992,7 @@ func TestCommandSide_userStateWriteModel(t *testing.T) {
 			r := &Commands{
 				eventstore: tt.fields.eventstore(t),
 			}
-			wm, err := r.userStateWriteModel(tt.args.ctx, tt.args.userID)
+			wm, err := r.userStateWriteModel(tt.args.ctx, tt.args.userID, "")
 			if tt.res.err == nil {
 				if !assert.NoError(t, err) {
 					t.FailNow()


### PR DESCRIPTION
# Which Problems Are Solved

User states are queried without resourceowner.

# How the Problems Are Solved

Add the resourceowner of the user where possible.

# Additional Changes

None

# Additional Context

None
