### PR TITLE
fix: correct join condition for app keys in searchAuthNKeys function

### DIFF
--- a/internal/query/authn_key.go
+++ b/internal/query/authn_key.go
@@ -169,8 +169,8 @@ func (q *Queries) searchAuthNKeys(ctx context.Context, queries *AuthNKeySearchQu
 	case JoinFilterUnspecified:
 		// Select all authN keys
 	case JoinFilterApp:
-		joinCol := ProjectColumnID
-		query = query.Join(joinCol.table.identifier() + " ON " + AuthNKeyColumnIdentifier.identifier() + " = " + joinCol.identifier())
+		joinCol := AppColumnID
+		query = query.Join(joinCol.table.identifier() + " ON " + AuthNKeyColumnObjectID.identifier() + " = " + joinCol.identifier())
 	case JoinFilterUserMachine:
 		joinCol := MachineUserIDCol
 		query = query.Join(joinCol.table.identifier() + " ON " + AuthNKeyColumnIdentifier.identifier() + " = " + joinCol.identifier())


### PR DESCRIPTION
# Which Problems Are Solved

The issue was in the `authn_key.go` file in the `searchAuthNKeys` method. When the `JoinFilterApp` filter was used (when calling the `ListAppKeys` management API), the join condition was incorrect.

The current SQL:

```sql
JOIN projections.projects4 ON projections.authn_keys2.identifier = projections.projects4.id
```

# How the Problems Are Solved

The fix ensures that when calling `/zitadel.management.v1.ManagementService/ListAppKeys`, the query correctly joins the `authn_keys2` table with the `apps7` table to return the authentication keys that belong to applications, which should resolve the issue of getting no results.

The updated SQL:

```sql
JOIN projections.apps7 ON projections.authn_keys2.object_id = projections.apps7.id
```

# Additional Context

- Closes #10433
