### PR TITLE
fix(load-tests): accept any 2xx status as success

### DIFF
--- a/load-test/src/app.ts
+++ b/load-test/src/app.ts
@@ -28,7 +28,7 @@ export function createAPI(name: string, projectId: string, org: Org, accessToken
     );
     response.then((res) => {
       check(res, {
-        'add api status ok': (r) => r.status === 200,
+        'add api status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to add api project: ${projectId} status: ${res.status} body: ${res.body}`);
       resolve(res.json() as API);
 
@@ -60,7 +60,7 @@ export function createAppKey(appId: string, projectId: string, org: Org, accessT
     );
     response.then((res) => {
       check(res, {
-        'add app key status ok': (r) => r.status === 200,
+        'add app key status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to add app key project: ${projectId} app: ${appId} status: ${res.status} body: ${res.body}`);
       resolve(res.json() as AppKey);
 

--- a/load-test/src/login_ui.ts
+++ b/load-test/src/login_ui.ts
@@ -57,7 +57,7 @@ function enterLoginName(page: Response, user: User): Response {
   });
 
   check(response, {
-    'login name status ok': (r) => (r && r.status == 200) || fail('enter login name failed'),
+    'login name status ok': (r) => (r && r.status >= 200 && r.status < 300) || fail('enter login name failed'),
     'login shows password page': (r) => r && r.body !== null && r.body.toString().includes('password'),
     // 'login has no error': (r) => r && r.body != null && r.body.toString().includes('error') || fail(`error in enter login name ${r.body}`)
   });
@@ -86,7 +86,7 @@ function enterPassword(page: Response, user: User): Response {
   }
 
   check(response, {
-    'password status ok': (r) => r.status == 200 || fail('enter password failed'),
+    'password status ok': (r) => r.status >= 200 && r.status < 300 || fail('enter password failed'),
     'password callback': (r) =>
       r.url.startsWith(url('/ui/console/auth/callback?code=')) || fail(`wrong password callback: ${r.url}`),
   });
@@ -117,7 +117,7 @@ function token(code = '') {
 
   tokenTrend.add(response.timings.duration);
   check(response, {
-    'token status ok': (r) => r.status == 200 || fail(`invalid token response status: ${r.status} body: ${r.body}`),
+    'token status ok': (r) => r.status >= 200 && r.status < 300 || fail(`invalid token response status: ${r.status} body: ${r.body}`),
   });
   const token = new Tokens(response.json() as JSONObject);
   check(token, {

--- a/load-test/src/membership.ts
+++ b/load-test/src/membership.ts
@@ -19,7 +19,7 @@ export async function addIAMMember(userId: string, roles: string[], accessToken:
     },
   );
   check(res, {
-    'member added successful': (r) => r.status == 200 || fail(`unable add member: ${JSON.stringify(res)}`),
+    'member added successful': (r) => r.status >= 200 && r.status < 300 || fail(`unable add member: ${JSON.stringify(res)}`),
   });
   addIAMMemberTrend.add(res.timings.duration);
 }

--- a/load-test/src/oidc.ts
+++ b/load-test/src/oidc.ts
@@ -30,7 +30,7 @@ function configuration() {
 
   const res = http.get(url('/.well-known/openid-configuration'));
   check(res, {
-    'openid configuration': (r) => r.status == 200 || fail('unable to load openid configuration'),
+    'openid configuration': (r) => r.status >= 200 && r.status < 300 || fail('unable to load openid configuration'),
   });
 
   oidcConfig = res.json();
@@ -47,7 +47,7 @@ export function userinfo(token: string) {
   });
 
   check(userinfo, {
-    'userinfo status ok': (r) => r.status === 200,
+    'userinfo status ok': (r) => r.status >= 200 && r.status < 300,
   });
 
   userinfoTrend.add(userinfo.timings.duration);
@@ -70,7 +70,7 @@ export function introspect(jwt: string, token: string) {
     },
   );
   check(res, {
-    'introspect status ok': (r) => r.status === 200,
+    'introspect status ok': (r) => r.status >= 200 && r.status < 300,
   });
 
   introspectTrend.add(res.timings.duration);
@@ -96,7 +96,7 @@ export function clientCredentials(clientId: string, clientSecret: string): Promi
     );
     response.then((res) => {
       check(res, {
-        'client credentials status ok': (r) => r.status === 200,
+        'client credentials status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`client credentials request failed (client id: ${clientId}) status: ${res.status} body: ${res.body}`);
 
       clientCredentialsTrend.add(res.timings.duration);
@@ -161,7 +161,7 @@ export async function token(request: TokenRequest): Promise<Tokens> {
     .then((res) => {
       tokenDurationTrend.add(res.timings.duration);
       check(res, {
-        'token status ok': (r) => r.status === 200,
+        'token status ok': (r) => r.status >= 200 && r.status < 300,
         'access token returned': (r) => r.json('access_token')! != undefined && r.json('access_token')! != '',
       });
       return new Tokens(res.json() as JSONObject);
@@ -176,7 +176,7 @@ export async function authRequestByID(id: string, tokens: any): Promise<Response
     },
   });
   check(response, {
-    'authorize status ok': (r) => r.status == 200 || fail(`auth request by failed: ${JSON.stringify(r)}`),
+    'authorize status ok': (r) => r.status >= 200 && r.status < 300 || fail(`auth request by failed: ${JSON.stringify(r)}`),
   });
   authRequestByIDTrend.add(response.timings.duration);
   return response;
@@ -202,7 +202,7 @@ export async function finalizeAuthRequest(id: string, session: any, tokens: any)
     },
   );
   check(res, {
-    'finalize auth request status ok': (r) => r.status == 200 || fail(`finalize auth request failed: ${JSON.stringify(r)}`),
+    'finalize auth request status ok': (r) => r.status >= 200 && r.status < 300 || fail(`finalize auth request failed: ${JSON.stringify(r)}`),
   });
   finalizeAuthRequestTrend.add(res.timings.duration);
 

--- a/load-test/src/org.ts
+++ b/load-test/src/org.ts
@@ -29,7 +29,7 @@ export function createOrg(accessToken: string): Promise<Org> {
     response.then((res) => {
       check(res, {
         'org created': (r) => {
-          return r !== undefined && r.status === 201;
+          return r !== undefined && r.status >= 200 && r.status < 300;
         },
       }) || reject(`unable to create org status: ${res.status} || body: ${res.body}`);
 
@@ -49,7 +49,7 @@ export function removeOrg(org: Org, accessToken: string) {
   });
 
   check(response, {
-    'org removed': (r) => r.status === 200,
+    'org removed': (r) => r.status >= 200 && r.status < 300,
   }) || console.log(`status: ${response.status} || body: ${response.body}|| org: ${JSON.stringify(org)}`);
 
   return response.json();

--- a/load-test/src/project.ts
+++ b/load-test/src/project.ts
@@ -27,7 +27,7 @@ export function createProject(name: string, org: Org, accessToken: string): Prom
     );
     response.then((res) => {
       check(res, {
-        'add project status ok': (r) => r.status === 200,
+        'add project status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to add project status: ${res.status} body: ${res.body}`);
 
       addProjectTrend.add(res.timings.duration);

--- a/load-test/src/session.ts
+++ b/load-test/src/session.ts
@@ -22,7 +22,7 @@ export function createSession(org: Org, accessToken: string, checks?: any): Prom
     });
     response.then((res) => {
       check(res, {
-        'add Session status ok': (r) => r.status === 201,
+        'add Session status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to add Session status: ${res.status} body: ${res.body}`);
 
       addSessionTrend.add(res.timings.duration);
@@ -48,7 +48,7 @@ export function setSession(id: string, session: any, accessToken: string, challe
     });
     response.then((res) => {
       check(res, {
-        'set Session status ok': (r) => r.status === 200,
+        'set Session status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to set Session status: ${res.status} body: ${res.body}`);
 
       setSessionTrend.add(res.timings.duration);

--- a/load-test/src/user.ts
+++ b/load-test/src/user.ts
@@ -50,7 +50,7 @@ export function createHuman(username: string, org: Org, accessToken: string): Pr
     response
       .then((res) => {
         check(res, {
-          'create user is status ok': (r) => r.status === 200,
+          'create user is status ok': (r) => r.status >= 200 && r.status < 300,
         }) || reject(`unable to create user(username: ${username}) status: ${res.status} body: ${res.body}`);
         createHumanTrend.add(res.timings.duration);
 
@@ -79,7 +79,7 @@ export async function setEmailOTPOnHuman(user: User, org: Org, accessToken: stri
     },
   });
   check(response, {
-    'set email otp status ok': (r) => r.status === 200,
+    'set email otp status ok': (r) => r.status >= 200 && r.status < 300,
   });
   setEmailOTPOnHumanTrend.add(response.timings.duration);
 
@@ -144,7 +144,7 @@ export function createMachine(username: string, org: Org, accessToken: string): 
     response
       .then((res) => {
         check(res, {
-          'create user is status ok': (r) => r.status === 200,
+          'create user is status ok': (r) => r.status >= 200 && r.status < 300,
         }) || reject(`unable to create user(username: ${username}) status: ${res.status} body: ${res.body}`);
         createMachineTrend.add(res.timings.duration);
 
@@ -179,7 +179,7 @@ export function addMachinePat(userId: string, org: Org, accessToken: string): Pr
     });
     response.then((res) => {
       check(res, {
-        'add pat status ok': (r) => r.status === 200,
+        'add pat status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to add pat (user id: ${userId}) status: ${res.status} body: ${res.body}`);
 
       addMachinePatTrend.add(res.timings.duration);
@@ -205,7 +205,7 @@ export function addMachineSecret(userId: string, org: Org, accessToken: string):
     });
     response.then((res) => {
       check(res, {
-        'generate machine secret status ok': (r) => r.status === 200,
+        'generate machine secret status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to generate machine secret (user id: ${userId}) status: ${res.status} body: ${res.body}`);
 
       addMachineSecretTrend.add(res.timings.duration);
@@ -240,7 +240,7 @@ export function addMachineKey(userId: string, org: Org, accessToken: string, pub
     );
     response.then((res) => {
       check(res, {
-        'generate machine key status ok': (r) => r.status === 200,
+        'generate machine key status ok': (r) => r.status >= 200 && r.status < 300,
       }) || reject(`unable to generate machine Key (user id: ${userId}) status: ${res.status} body: ${res.body}`);
 
       addMachineKeyTrend.add(res.timings.duration);
@@ -263,7 +263,7 @@ export function lockUser(userId: string, org: Org, accessToken: string): Promise
     response
       .then((res) => {
         check(res, {
-          'update user is status ok': (r) => r.status === 201,
+          'update user is status ok': (r) => r.status >= 200 && r.status < 300,
         });
         lockUserTrend.add(res.timings.duration);
         resolve(res);


### PR DESCRIPTION
Adjust status checks across various functions to accept any 2xx HTTP response instead of only 200, improving the robustness of the API response validation.

fixes #10436