### PR TITLE
chore: fix make console_dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ console_move:
 
 .PHONY: console_dependencies
 console_dependencies:
-	npx pnpm install --frozen-lockfile --filter=./console
+	npx pnpm install --frozen-lockfile --filter=console...
 
 .PHONY: console_build
 console_build: console_dependencies

--- a/package.json
+++ b/package.json
@@ -10,13 +10,6 @@
     "clean": "turbo run clean",
     "clean:all": "pnpm run clean && rm -rf .turbo node_modules"
   },
-  "pnpm": {
-    "overrides": {
-      "@typescript-eslint/parser": "^8.35.1",
-      "@zitadel/client": "workspace:*",
-      "@zitadel/proto": "workspace:*"
-    }
-  },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@devcontainers/cli": "^0.80.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
-packages:
+  packages:
   - "console"
   - "docs"
   - "e2e"
   - "packages/*"
   - "apps/*"
+
+  overrides:
+    "@typescript-eslint/parser": "^8.35.1"
+    "@zitadel/client": "workspace:*"
+    "@zitadel/proto": "workspace:*"


### PR DESCRIPTION
# Which Problems Are Solved

The PR ensures `make console_dependencies` install all dependencies needed to build the console.

# How the Problems Are Solved

- For the current pnpm version 10, dependency overrides must be moved from the package.json to the pnpm-workspace.yaml.
- The syntax for selecting a pnpm package and its workspace dependencies is fixed. 

# Additional Context

- Closes https://github.com/zitadel/zitadel/issues/10435
