### PR TITLE
fix(actionsV1): disable org metadata projection triggers

### DIFF
--- a/internal/actions/object/metadata.go
+++ b/internal/actions/object/metadata.go
@@ -81,7 +81,7 @@ func UserMetadataListFromSlice(c *actions.FieldConfig, metadata []query.UserMeta
 func GetOrganizationMetadata(ctx context.Context, queries *query.Queries, c *actions.FieldConfig, organizationID string) goja.Value {
 	metadata, err := queries.SearchOrgMetadata(
 		ctx,
-		true,
+		false,
 		organizationID,
 		&query.OrgMetadataSearchQueries{},
 		false,

--- a/internal/api/ui/login/custom_action.go
+++ b/internal/api/ui/login/custom_action.go
@@ -127,7 +127,7 @@ func (l *Login) runPostExternalAuthenticationActions(
 						return func(goja.FunctionCall) goja.Value {
 							metadata, err := l.query.SearchOrgMetadata(
 								ctx,
-								true,
+								false,
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
 								false,
@@ -321,7 +321,7 @@ func (l *Login) runPreCreationActions(
 						return func(goja.FunctionCall) goja.Value {
 							metadata, err := l.query.SearchOrgMetadata(
 								ctx,
-								true,
+								false,
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
 								false,
@@ -397,7 +397,7 @@ func (l *Login) runPostCreationActions(
 						return func(goja.FunctionCall) goja.Value {
 							metadata, err := l.query.SearchOrgMetadata(
 								ctx,
-								true,
+								false,
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
 								false,


### PR DESCRIPTION
disables trigger of org metadata projection in actions v1 when using `api.v1.getOrgMetadata()`