### PR TITLE
fix: use the correct userID column name while listing user auth methods

### DIFF
--- a/internal/query/user_auth_method.go
+++ b/internal/query/user_auth_method.go
@@ -112,7 +112,7 @@ func userAuthMethodPermissionCheckV2(ctx context.Context, query sq.SelectBuilder
 		ctx,
 		UserAuthMethodColumnResourceOwner,
 		domain.PermissionUserRead,
-		OwnedRowsPermissionOption(UserIDCol),
+		OwnedRowsPermissionOption(UserAuthMethodColumnUserID),
 	)
 	return query.JoinClause(join, args...)
 }


### PR DESCRIPTION
# Which Problems Are Solved

When `Permission Check V2` is enabled, calls to the `ListPasskeys` and `ListAuthenticationFactors` APIs fail with the following error: 
```
ERROR:  missing FROM-clause entry for table "users14"
```

# How the Problems Are Solved
By using the right UserID column (`projections.user_auth_methods5.user_id`) in the permission clause in the `userAuthMethod` query

# Additional Changes
N/A

# Additional Context
- Closes #10386
