### PR TITLE
fixup! fix(SetPassword); SetPassword() api call requires either current_password or verification_code

### DIFF
--- a/internal/command/user_human_password.go
+++ b/internal/command/user_human_password.go
@@ -38,6 +38,10 @@ func (c *Commands) SetPassword(ctx context.Context, orgID, userID, password stri
 	if err != nil {
 		return nil, err
 	}
+
+	if !wm.SecretChangeRequired {
+		return nil, zerrors.ThrowInvalidArgument(nil, "COMMAND-SFRK2", "either current_password or verification_code must be provided")
+	}
 	return c.setPassword(
 		ctx,
 		wm,

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -178,6 +178,12 @@ func (i *Instance) CreateHumanUser(ctx context.Context) *user_v2.AddHumanUserRes
 				ReturnCode: &user_v2.ReturnEmailVerificationCode{},
 			},
 		},
+		PasswordType: &user_v2.AddHumanUserRequest_Password{
+			&user_v2.Password{
+				Password:       "Password1!",
+				ChangeRequired: true,
+			},
+		},
 		Phone: &user_v2.SetHumanPhone{
 			Phone: "+41791234567",
 			Verification: &user_v2.SetHumanPhone_ReturnCode{
@@ -252,10 +258,11 @@ func (i *Instance) CreateHumanUserWithTOTP(ctx context.Context, secret string) *
 func (i *Instance) SetUserMetadata(ctx context.Context, id, key, value string) *user_v2.SetUserMetadataResponse {
 	resp, err := i.Client.UserV2.SetUserMetadata(ctx, &user_v2.SetUserMetadataRequest{
 		UserId: id,
-		Metadata: []*user_v2.Metadata{{
-			Key:   key,
-			Value: []byte(base64.StdEncoding.EncodeToString([]byte(value))),
-		},
+		Metadata: []*user_v2.Metadata{
+			{
+				Key:   key,
+				Value: []byte(base64.StdEncoding.EncodeToString([]byte(value))),
+			},
 		},
 	})
 	logging.OnError(err).Panic("set user metadata")


### PR DESCRIPTION
# Which Problems Are Solved

A user is able to set a password using `SetPassword()` api call requires either current_password or verification_code

# How the Problems Are Solved

Only allow a user to set the password if either either current_password or verification_code are set


# Additional Context

- Closes [#xxx](https://github.com/zitadel/zitadel/issues/10412)

