### PR TITLE
fix: create project with the right permission

### DIFF
--- a/internal/api/grpc/project/v2beta/integration_test/project_test.go
+++ b/internal/api/grpc/project/v2beta/integration_test/project_test.go
@@ -10,12 +10,16 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/integration"
+	internal_permission_v2beta "github.com/zitadel/zitadel/pkg/grpc/internal_permission/v2beta"
 	project "github.com/zitadel/zitadel/pkg/grpc/project/v2beta"
 )
 
 func TestServer_CreateProject(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
@@ -74,6 +78,7 @@ func TestServer_CreateProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			got, err := instance.Client.Projectv2Beta.CreateProject(tt.ctx, tt.req)
 			changeDate := time.Now().UTC()
@@ -88,6 +93,7 @@ func TestServer_CreateProject(t *testing.T) {
 }
 
 func TestServer_CreateProject_Permission(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -130,6 +136,30 @@ func TestServer_CreateProject_Permission(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "with ORG_PROJECT_CREATOR permission, same organization, ok",
+			ctx:  integration.WithAuthorizationToken(CTX, getOrgProjectCreatorToken(t, iamOwnerCtx, orgResp.GetOrganizationId(), orgResp.GetOrganizationId())),
+			req: &project.CreateProjectRequest{
+				Name:           integration.ProjectName(),
+				OrganizationId: orgResp.GetOrganizationId(),
+			},
+			want: want{
+				id:           true,
+				creationDate: true,
+			},
+		},
+		{
+			name: "with ORG_PROJECT_CREATOR permission, other organization, ok",
+			ctx:  integration.WithAuthorizationToken(CTX, getOrgProjectCreatorToken(t, iamOwnerCtx, orgResp.GetOrganizationId(), instance.DefaultOrg.GetId())),
+			req: &project.CreateProjectRequest{
+				Name:           integration.ProjectName(),
+				OrganizationId: instance.DefaultOrg.GetId(),
+			},
+			want: want{
+				id:           true,
+				creationDate: true,
+			},
+		},
+		{
 			name: "organization owner, ok",
 			ctx:  instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
 			req: &project.CreateProjectRequest{
@@ -156,6 +186,7 @@ func TestServer_CreateProject_Permission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			got, err := instance.Client.Projectv2Beta.CreateProject(tt.ctx, tt.req)
 			changeDate := time.Now().UTC()
@@ -167,6 +198,23 @@ func TestServer_CreateProject_Permission(t *testing.T) {
 			assertCreateProjectResponse(t, creationDate, changeDate, tt.want.creationDate, tt.want.id, got)
 		})
 	}
+}
+
+func getOrgProjectCreatorToken(t *testing.T, ctx context.Context, orgId1, orgId2 string) string {
+	// create a machine user in Org 1
+	userResp := instance.CreateUserTypeMachine(ctx, orgId1)
+
+	// assign ORG_PROJECT_CREATOR role in Org 2
+	_, err := instance.Client.InternalPermissionv2Beta.CreateAdministrator(ctx, &internal_permission_v2beta.CreateAdministratorRequest{
+		Resource: &internal_permission_v2beta.ResourceType{
+			Resource: &internal_permission_v2beta.ResourceType_OrganizationId{OrganizationId: orgId2},
+		},
+		UserId: userResp.GetId(),
+		Roles:  []string{domain.RoleOrgProjectCreator},
+	})
+	require.NoError(t, err)
+
+	return instance.CreatePersonalAccessToken(ctx, userResp.GetId()).Token
 }
 
 func assertCreateProjectResponse(t *testing.T, creationDate, changeDate time.Time, expectedCreationDate, expectedID bool, actualResp *project.CreateProjectResponse) {
@@ -188,6 +236,7 @@ func assertCreateProjectResponse(t *testing.T, creationDate, changeDate time.Tim
 }
 
 func TestServer_UpdateProject(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -278,6 +327,7 @@ func TestServer_UpdateProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 
@@ -297,6 +347,7 @@ func TestServer_UpdateProject(t *testing.T) {
 }
 
 func TestServer_UpdateProject_Permission(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -430,6 +481,7 @@ func TestServer_UpdateProject_Permission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 
@@ -461,6 +513,7 @@ func assertUpdateProjectResponse(t *testing.T, creationDate, changeDate time.Tim
 }
 
 func TestServer_DeleteProject(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -516,6 +569,7 @@ func TestServer_DeleteProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var creationDate, deletionDate time.Time
 			if tt.prepare != nil {
 				creationDate, deletionDate = tt.prepare(tt.req)
@@ -532,6 +586,7 @@ func TestServer_DeleteProject(t *testing.T) {
 }
 
 func TestServer_DeleteProject_Permission(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -635,6 +690,7 @@ func TestServer_DeleteProject_Permission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var creationDate, deletionDate time.Time
 			if tt.prepare != nil {
 				creationDate, deletionDate = tt.prepare(tt.req)
@@ -663,6 +719,7 @@ func assertDeleteProjectResponse(t *testing.T, creationDate, deletionDate time.T
 }
 
 func TestServer_DeactivateProject(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -725,6 +782,7 @@ func TestServer_DeactivateProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 
@@ -744,6 +802,7 @@ func TestServer_DeactivateProject(t *testing.T) {
 }
 
 func TestServer_DeactivateProject_Permission(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -831,6 +890,7 @@ func TestServer_DeactivateProject_Permission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 
@@ -862,6 +922,7 @@ func assertDeactivateProjectResponse(t *testing.T, creationDate, changeDate time
 }
 
 func TestServer_ActivateProject(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -936,6 +997,7 @@ func TestServer_ActivateProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 
@@ -955,6 +1017,7 @@ func TestServer_ActivateProject(t *testing.T) {
 }
 
 func TestServer_ActivateProject_Permission(t *testing.T) {
+	t.Parallel()
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
 	orgResp := instance.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), gofakeit.Email())
 
@@ -1047,6 +1110,7 @@ func TestServer_ActivateProject_Permission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creationDate := time.Now().UTC()
 			tt.prepare(tt.args.req)
 

--- a/internal/api/grpc/project/v2beta/integration_test/project_test.go
+++ b/internal/api/grpc/project/v2beta/integration_test/project_test.go
@@ -259,7 +259,6 @@ func TestServer_UpdateProject(t *testing.T) {
 			name: "not existing",
 			prepare: func(request *project.UpdateProjectRequest) {
 				request.Id = "notexisting"
-				return
 			},
 			args: args{
 				ctx: iamOwnerCtx,
@@ -742,7 +741,6 @@ func TestServer_DeactivateProject(t *testing.T) {
 			name: "not existing",
 			prepare: func(request *project.DeactivateProjectRequest) {
 				request.Id = "notexisting"
-				return
 			},
 			args: args{
 				ctx: iamOwnerCtx,

--- a/internal/command/permission_checks.go
+++ b/internal/command/permission_checks.go
@@ -64,6 +64,10 @@ func (c *Commands) checkPermissionUpdateUserCredentials(ctx context.Context, res
 	return c.checkPermissionOnUser(ctx, domain.PermissionUserCredentialWrite)(resourceOwner, userID)
 }
 
+func (c *Commands) checkPermissionCreateProject(ctx context.Context, resourceOwner, projectID string) error {
+	return c.newPermissionCheck(ctx, domain.PermissionProjectCreate, project.AggregateType)(resourceOwner, projectID)
+}
+
 func (c *Commands) checkPermissionDeleteProject(ctx context.Context, resourceOwner, projectID string) error {
 	return c.newPermissionCheck(ctx, domain.PermissionProjectDelete, project.AggregateType)(resourceOwner, projectID)
 }

--- a/internal/command/project.go
+++ b/internal/command/project.go
@@ -60,7 +60,7 @@ func (c *Commands) AddProject(ctx context.Context, add *AddProject) (_ *domain.O
 	if isProjectStateExists(wm.State) {
 		return nil, zerrors.ThrowAlreadyExists(nil, "COMMAND-opamwu", "Errors.Project.AlreadyExisting")
 	}
-	if err := c.checkPermissionUpdateProject(ctx, wm.ResourceOwner, wm.AggregateID); err != nil {
+	if err := c.checkPermissionCreateProject(ctx, wm.ResourceOwner, wm.AggregateID); err != nil {
 		return nil, err
 	}
 

--- a/internal/domain/permission.go
+++ b/internal/domain/permission.go
@@ -38,6 +38,7 @@ const (
 	PermissionOrgRead                  = "org.read"
 	PermissionIDPRead                  = "iam.idp.read"
 	PermissionOrgIDPRead               = "org.idp.read"
+	PermissionProjectCreate            = "project.create"
 	PermissionProjectWrite             = "project.write"
 	PermissionProjectRead              = "project.read"
 	PermissionProjectDelete            = "project.delete"

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -295,8 +295,11 @@ func (i *Instance) CreateUserTypeHuman(ctx context.Context, email string) *user_
 }
 
 func (i *Instance) CreateUserTypeMachine(ctx context.Context, orgId string) *user_v2.CreateUserResponse {
+	if orgId == "" {
+		orgId = i.DefaultOrg.GetId()
+	}
 	resp, err := i.Client.UserV2.CreateUser(ctx, &user_v2.CreateUserRequest{
-		OrganizationId: i.DefaultOrg.GetId(),
+		OrganizationId: orgId,
 		UserType: &user_v2.CreateUserRequest_Machine_{
 			Machine: &user_v2.CreateUserRequest_Machine{
 				Name: "machine",


### PR DESCRIPTION
# Which Problems Are Solved

When a user with an `ORG_PROJECT_CREATOR` role tries to create a project, the request fails with `No matching permissions found (AUTH-AWfge)` error. This is because `project.write` was set as the required permission instead of `project.create` during project creation.

# How the Problems Are Solved
By setting the right required permission (`project.create`) while creating new projects. 

# Additional Changes
N/A

# Additional Context
- Closes #10399
