### PR TITLE
docs: remove knative refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Deploying ZITADEL locally takes less than 3 minutes. Go ahead and give it a try!
 * [Linux](https://zitadel.com/docs/self-hosting/deploy/linux)
 * [MacOS](https://zitadel.com/docs/self-hosting/deploy/macos)
 * [Docker compose](https://zitadel.com/docs/self-hosting/deploy/compose)
-* [Knative](https://zitadel.com/docs/self-hosting/deploy/knative)
 * [Kubernetes](https://zitadel.com/docs/self-hosting/deploy/kubernetes)
 
 See all guides [here](https://zitadel.com/docs/self-hosting/deploy/overview)

--- a/docs/docs/self-hosting/deploy/overview.mdx
+++ b/docs/docs/self-hosting/deploy/overview.mdx
@@ -8,7 +8,6 @@ Choose your platform and run ZITADEL with the most minimal configuration possibl
 - [Linux](./linux)
 - [MacOS](./macos)
 - [Docker Compose](./compose)
-- [Knative](./knative)
 - [Kubernetes](./kubernetes)
 
 ## Prerequisites

--- a/docs/docs/self-hosting/manage/updating_scaling.md
+++ b/docs/docs/self-hosting/manage/updating_scaling.md
@@ -23,8 +23,7 @@ For production setups, we recommend that you [run ZITADEL in a highly available 
 As all shared state is managed in the database,
 the ZITADEL binary itself is stateless.
 You can easily run as many ZITADEL binaries in parallel as you want.
-If you use [Knative](/docs/self-hosting/deploy/knative)
-or [Google Cloud Run](https://cloud.google.com/run) (which uses Knative, too),
+If you use [Google Cloud Run](https://cloud.google.com/run) (which builds on Knative),
 you can even scale to zero.
 Especially if you use an autoscaler that scales to zero,
 it is crucial that you minimize startup times.


### PR DESCRIPTION
# Which Problems Are Solved

Broken links to the removed Knative docs are removed.

# How the Problems Are Solved

I searched for case insensitive knative occurrences in the whole project and handled them.

# Additional Context

Reported internallly: https://zitadel.slack.com/archives/C087ADF8LRX/p1755182839818719?thread_ts=1755170846.959129&cid=C087ADF8LRX