### PR TITLE
Compatible with Facebook

### DIFF
--- a/internal/idp/providers/oauth/session.go
+++ b/internal/idp/providers/oauth/session.go
@@ -2,15 +2,20 @@ package oauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/zitadel/oidc/v3/pkg/client/rp"
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
+	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/idp"
+	"golang.org/x/text/language"
 )
 
 var ErrCodeMissing = errors.New("no auth code provided")
@@ -53,21 +58,173 @@ func (s *Session) PersistentParameters() map[string]any {
 // It will execute an OAuth 2.0 code exchange if needed to retrieve the access token,
 // call the specified userEndpoint and map the received information into an [idp.User].
 func (s *Session) FetchUser(ctx context.Context) (_ idp.User, err error) {
+	// Check if the provider is Facebook
+	if s.isFacebookProvider() {
+		user, err := s.fetchFacebookUser(ctx)
+		return user, err
+	}
+
 	if s.Tokens == nil {
 		if err = s.authorize(ctx); err != nil {
 			return nil, err
 		}
 	}
+
 	req, err := http.NewRequest("GET", s.Provider.userEndpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("authorization", s.Tokens.TokenType+" "+s.Tokens.AccessToken)
+
+	authHeader := s.Tokens.TokenType + " " + s.Tokens.AccessToken
+	req.Header.Set("authorization", authHeader)
+
 	user := s.Provider.User()
 	if err := httphelper.HttpRequest(s.Provider.RelyingParty.HttpClient(), req, &user); err != nil {
 		return nil, err
 	}
+
 	return user, nil
+}
+
+// isFacebookProvider checks if the current provider is Facebook
+func (s *Session) isFacebookProvider() bool {
+	// Check by provider name
+	if strings.Contains(strings.ToLower(s.Provider.Name()), "facebook") {
+		return true
+	}
+
+	// Check by user endpoint
+	if strings.Contains(s.Provider.userEndpoint, "graph.facebook.com") {
+		return true
+	}
+
+	// Check by issuer if available
+	if s.Provider.RelyingParty != nil {
+		issuer := s.Provider.RelyingParty.Issuer()
+		if strings.Contains(issuer, "facebook.com") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// fetchFacebookUser handles Facebook-specific user fetching
+func (s *Session) fetchFacebookUser(ctx context.Context) (user idp.User, err error) {
+	if s.Tokens == nil {
+		if err = s.authorize(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	// Use the access token to get user info from Facebook's /me endpoint
+	endpoint := "https://graph.facebook.com/me?fields=id,name,email,first_name,last_name,picture&access_token=" + s.Tokens.AccessToken
+
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var userInfo struct {
+		ID        string `json:"id"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Picture   struct {
+			Data struct {
+				URL string `json:"url"`
+			} `json:"data"`
+		} `json:"picture"`
+	}
+	if err := json.Unmarshal(body, &userInfo); err != nil {
+		return nil, err
+	}
+
+	// Create a user object that implements the idp.User interface
+	u := &FacebookUser{
+		ID:        userInfo.ID,
+		Email:     userInfo.Email,
+		Name:      userInfo.Name,
+		FirstName: userInfo.FirstName,
+		LastName:  userInfo.LastName,
+		Picture:   userInfo.Picture.Data.URL,
+	}
+
+	return u, nil
+}
+
+// FacebookUser implements the idp.User interface for Facebook users
+type FacebookUser struct {
+	ID        string
+	Email     string
+	Name      string
+	FirstName string
+	LastName  string
+	Picture   string
+}
+
+func (u *FacebookUser) GetID() string {
+	return u.ID
+}
+
+func (u *FacebookUser) GetFirstName() string {
+	return u.FirstName
+}
+
+func (u *FacebookUser) GetLastName() string {
+	return u.LastName
+}
+
+func (u *FacebookUser) GetDisplayName() string {
+	return u.Name
+}
+
+func (u *FacebookUser) GetNickname() string {
+	return ""
+}
+
+func (u *FacebookUser) GetPreferredUsername() string {
+	return ""
+}
+
+func (u *FacebookUser) GetEmail() domain.EmailAddress {
+	return domain.EmailAddress(u.Email)
+}
+
+func (u *FacebookUser) IsEmailVerified() bool {
+	return u.Email != ""
+}
+
+func (u *FacebookUser) GetPhone() domain.PhoneNumber {
+	return ""
+}
+
+func (u *FacebookUser) IsPhoneVerified() bool {
+	return false
+}
+
+func (u *FacebookUser) GetPreferredLanguage() language.Tag {
+	return language.Und
+}
+
+func (u *FacebookUser) GetAvatarURL() string {
+	return u.Picture
+}
+
+func (u *FacebookUser) GetProfile() string {
+	return ""
 }
 
 func (s *Session) ExpiresAt() time.Time {
@@ -81,11 +238,18 @@ func (s *Session) authorize(ctx context.Context) (err error) {
 	if s.Code == "" {
 		return ErrCodeMissing
 	}
+
 	var opts []rp.CodeExchangeOpt
 	if s.CodeVerifier != "" {
 		opts = append(opts, rp.WithCodeVerifier(s.CodeVerifier))
 	}
-	s.Tokens, err = rp.CodeExchange[*oidc.IDTokenClaims](ctx, s.Code, s.Provider.RelyingParty, opts...)
 
+	// Check if the provider is Facebook and set custom token URL
+	if s.isFacebookProvider() {
+		s.Provider.RelyingParty.OAuthConfig().Endpoint.TokenURL = "https://graph.facebook.com/v23.0/oauth/access_token"
+		s.Provider.RelyingParty.OAuthConfig().Scopes = []string{"email", "public_profile"}
+	}
+
+	s.Tokens, err = rp.CodeExchange[*oidc.IDTokenClaims](ctx, s.Code, s.Provider.RelyingParty, opts...)
 	return err
 }


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- Facebook OAuth/OIDC integration was not working properly due to Facebook's non-standard OAuth implementation
- ZITADEL's standard OAuth/OIDC flow was incompatible with Facebook's Graph API endpoints and token exchange process
- Users could not authenticate through Facebook IDP due to missing Facebook-specific configuration and user info mapping

# How the Problems Are Solved

- Added Facebook provider detection logic in both OAuth and OIDC session handlers
- Implemented Facebook-specific token URL configuration (`https://graph.facebook.com/v23.0/oauth/access_token`)
- Set appropriate Facebook OAuth scopes (`email`, `public_profile`) for user data access
- Created dedicated Facebook user fetching logic using Facebook's Graph API `/me` endpoint
- Added `FacebookUser` struct implementing the `idp.User` interface for OAuth flow
- Enhanced OIDC user mapping to handle Facebook user data structure
- Maintained backward compatibility with existing standard OAuth/OIDC providers

# Additional Changes

- Added new imports for JSON handling, HTTP requests, and string operations
- Extended session handling to support provider-specific authentication flows
- Improved error handling for Facebook-specific API calls
- Enhanced user data mapping to support Facebook's user profile structure

# Additional Context

- Facebook uses non-standard OAuth endpoints and requires specific configuration for proper integration
- Facebook Graph API provides user information in a different format than standard OIDC userinfo endpoints
- This change enables ZITADEL users to integrate Facebook as an identity provider while maintaining existing functionality