### PR TITLE
fix(loginV2): allow registration when tos links are not set

### DIFF
--- a/apps/login/src/components/privacy-policy-checkboxes.tsx
+++ b/apps/login/src/components/privacy-policy-checkboxes.tsx
@@ -17,8 +17,8 @@ type AcceptanceState = {
 
 export function PrivacyPolicyCheckboxes({ legal, onChange }: Props) {
   const [acceptanceState, setAcceptanceState] = useState<AcceptanceState>({
-    tosAccepted: false,
-    privacyPolicyAccepted: false,
+    tosAccepted: !legal.tosLink, // set initial state to accepted if tos or privacy policy links are empty
+    privacyPolicyAccepted: !legal.privacyPolicyLink,
   });
 
   return (

--- a/apps/login/src/components/register-form.tsx
+++ b/apps/login/src/components/register-form.tsx
@@ -124,7 +124,9 @@ export function RegisterForm({
 
   const { errors } = formState;
 
-  const [tosAndPolicyAccepted, setTosAndPolicyAccepted] = useState(false);
+  let acceptanceRequired = legal.tosLink || legal.privacyPolicyLink;
+  
+  const [tosAndPolicyAccepted, setTosAndPolicyAccepted] = useState(!acceptanceRequired);
   return (
     <form className="w-full">
       <div className="mb-4 grid grid-cols-2 gap-4">


### PR DESCRIPTION
Set initial state of tos and privacy policy acceptance state depending on whether the links to them are configured. Support following cases:
1. Both ToS and privacy policy links are configured
2. One of ToS or privacy policy links is configured
3. None of the links are configured.

<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

On a fresh self hosted installation of Zitadel, it is impossible to proceed with registration unless both ToS and privacy policy links are configured.

# How the Problems Are Solved

In the registration form, check if links are configured and set initial acceptance state based on that.

# Additional Changes

None

# Additional Context

I've reported it in Discord previously - https://discord.com/channels/927474939156643850/1404875875840819262
