### PR TITLE
chore: upgrade enumer and stringer deps for go generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ core_static:
 
 .PHONY: core_generate_all
 core_generate_all:
-	go install github.com/dmarkham/enumer@v1.5.10 		# https://pkg.go.dev/github.com/dmarkham/enumer?tab=versions
+	go install github.com/dmarkham/enumer@v1.5.11 		# https://pkg.go.dev/github.com/dmarkham/enumer?tab=versions
 	go install github.com/rakyll/statik@v0.1.7			# https://pkg.go.dev/github.com/rakyll/statik?tab=versions
 	go install go.uber.org/mock/mockgen@v0.4.0			# https://pkg.go.dev/go.uber.org/mock/mockgen?tab=versions
-	go install golang.org/x/tools/cmd/stringer@v0.22.0	# https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
+	go install golang.org/x/tools/cmd/stringer@v0.36.0	# https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
 	go generate ./...
 
 .PHONY: core_assets


### PR DESCRIPTION
# Which Problems Are Solved

This change stems from https://github.com/zitadel/zitadel/pull/10464/files/e2c8f46a41a8173e041b2b1a6d317c7e953df0f4#r2284548483

# How the Problems Are Solved

Upgrade dependencies to their latest version

# Additional Context

Relates to https://github.com/zitadel/zitadel/pull/10464