### PR TITLE
chore(ci): increase build-debug timeout

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -74,7 +74,7 @@ jobs:
         name: Debug
         id: build-debug
         uses: docker/build-push-action@v6
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           context: .
           cache-from: type=gha


### PR DESCRIPTION
# Which Problems Are Solved

Docker image build on arm64 was timing out on multiple occasions.

# How the Problems Are Solved

Increase the Debug job timeout from 3 to 5 minutes.

# Additional Changes

- none

# Additional Context

- https://github.com/zitadel/zitadel/actions/runs/17091081442/job/48465066443
- https://github.com/zitadel/zitadel/actions/runs/17071852582/job/48466980148
- https://github.com/zitadel/zitadel/actions/runs/17071852582/job/48403039843