### PR TITLE
chore: disable login integration on prs from forks

### DIFF
--- a/.github/workflows/login-container.yml
+++ b/.github/workflows/login-container.yml
@@ -59,7 +59,7 @@ jobs:
           NODE_VERSION: ${{ inputs.node_version }}
         with:
           source: .
-          push: true
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           provenance: true
           targets: login-standalone
           files: |

--- a/.github/workflows/login-integration-test.yml
+++ b/.github/workflows/login-integration-test.yml
@@ -15,6 +15,9 @@ jobs:
     name: login-integration-test
     runs-on: ubuntu-latest
     steps:
+      - name: Check if PR is from a fork
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "PR is from a fork. Exiting job. If login code is changed, ensure locally that the tests pass." && exit 0      
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dev Container CLI

--- a/.github/workflows/login-integration-test.yml
+++ b/.github/workflows/login-integration-test.yml
@@ -14,10 +14,8 @@ jobs:
   login-integration-test:
     name: login-integration-test
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request == null }}
     steps:
-      - name: Check if PR is from a fork
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: echo "PR is from a fork. Exiting job. If login code is changed, ensure locally that the tests pass." && exit 0
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dev Container CLI

--- a/.github/workflows/login-integration-test.yml
+++ b/.github/workflows/login-integration-test.yml
@@ -14,7 +14,7 @@ jobs:
   login-integration-test:
     name: login-integration-test
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request == null }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/login-integration-test.yml
+++ b/.github/workflows/login-integration-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check if PR is from a fork
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: echo "PR is from a fork. Exiting job. If login code is changed, ensure locally that the tests pass." && exit 0      
+        run: echo "PR is from a fork. Exiting job. If login code is changed, ensure locally that the tests pass." && exit 0
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dev Container CLI


### PR DESCRIPTION
# Which Problems Are Solved

PR checks from forks can succeed again. 
This is a temporary solution until we rehauled our pipelines.

# How the Problems Are Solved

- The built login image is not pushed anymore, because fork PRs are not allowed to push to the Zitadel org.
- The login integration tests are not run but instead marked as successful immediately on fork PRs, because the login integration tests depend on the login image. Engineers will be instructed to run them locally if login code is changed.

# Additional Context

- Fixes for example https://github.com/zitadel/zitadel/actions/runs/17094102314/job/48474674440
- This PR is done from a fork, which proves the changes work as intended.