### PR TITLE
test(e2e): increase timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Which Problems Are Solved

E2E tests don't time out anymore

# How the Problems Are Solved

The timeout is raised from 10 to 20 minutes 

# Additional Context

- [Example timed out action](https://github.com/zitadel/zitadel/actions/runs/17100799348/job/48499636298?pr=10518).