### PR TITLE
perf(actionsv2): execution target router

### DIFF
--- a/internal/api/authz/instance.go
+++ b/internal/api/authz/instance.go
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/text/language"
 
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 )
 
@@ -23,6 +24,7 @@ type Instance interface {
 	Block() *bool
 	AuditLogRetention() *time.Duration
 	Features() feature.Features
+	ExecutionRouter() target.Router
 }
 
 type InstanceVerifier interface {
@@ -82,6 +84,10 @@ func (i *instance) EnableImpersonation() bool {
 
 func (i *instance) Features() feature.Features {
 	return i.features
+}
+
+func (i *instance) ExecutionRouter() target.Router {
+	return target.NewRouter(nil)
 }
 
 func GetInstance(ctx context.Context) Instance {

--- a/internal/api/authz/instance_test.go
+++ b/internal/api/authz/instance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
 
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 )
 
@@ -128,4 +129,8 @@ func (m *mockInstance) EnableImpersonation() bool {
 
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
+}
+
+func (m *mockInstance) ExecutionRouter() target.Router {
+	return target.NewRouter(nil)
 }

--- a/internal/api/grpc/server/middleware/instance_interceptor_test.go
+++ b/internal/api/grpc/server/middleware/instance_interceptor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	http_util "github.com/zitadel/zitadel/internal/api/http"
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 	object_v3 "github.com/zitadel/zitadel/pkg/grpc/object/v3alpha"
 )
@@ -294,4 +295,8 @@ func (m *mockInstance) EnableImpersonation() bool {
 
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
+}
+
+func (m *mockInstance) ExecutionRouter() target.Router {
+	return target.NewRouter(nil)
 }

--- a/internal/api/http/middleware/instance_interceptor_test.go
+++ b/internal/api/http/middleware/instance_interceptor_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/zitadel/zitadel/internal/api/authz"
 	zitadel_http "github.com/zitadel/zitadel/internal/api/http"
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 )
 
@@ -350,4 +351,8 @@ func (m *mockInstance) EnableImpersonation() bool {
 
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
+}
+
+func (m *mockInstance) ExecutionRouter() target.Router {
+	return target.NewRouter(nil)
 }

--- a/internal/command/main_test.go
+++ b/internal/command/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/eventstore/repository"
 	"github.com/zitadel/zitadel/internal/eventstore/repository/mock"
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
@@ -218,6 +219,10 @@ func (m *mockInstance) EnableImpersonation() bool {
 
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
+}
+
+func (m *mockInstance) ExecutionRouter() target.Router {
+	return target.NewRouter(nil)
 }
 
 func newMockPermissionCheckAllowed() domain.PermissionCheck {

--- a/internal/execution/target/router.go
+++ b/internal/execution/target/router.go
@@ -1,0 +1,66 @@
+package target
+
+import (
+	"slices"
+	"strings"
+)
+
+type element2 struct {
+	ID      string   `json:"id"`
+	Targets []Target `json:"targets,omitempty"`
+}
+
+type Router []element2
+
+func NewRouter(targets []Target) Router {
+	m := make(map[string][]Target)
+	for _, t := range targets {
+		m[t.ExecutionID] = append(m[t.ExecutionID], t)
+	}
+
+	router := make(Router, 0, len(m))
+	for id, targets := range m {
+		router = append(router, element2{
+			ID:      id,
+			Targets: targets,
+		})
+	}
+	slices.SortFunc(router, func(a, b element2) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return router
+}
+
+// Get execution targets by exact match of the executionID
+func (r Router) Get(executionID string) ([]Target, bool) {
+	i, ok := slices.BinarySearchFunc(r, executionID, func(a element2, b string) int {
+		return strings.Compare(a.ID, b)
+	})
+	if ok {
+		return r[i].Targets, true
+	}
+	return nil, false
+}
+
+// GetEventBestMatch returns the best matching execution targets for an event.
+// The following match priority is used:
+//  1. Exact match
+//  2. Wildcard match
+//  3. Prefix match ("event")
+func (r Router) GetEventBestMatch(executionID string) ([]Target, bool) {
+	t, ok := r.Get(executionID)
+	if ok {
+		return t, true
+	}
+	var bestMatch element2
+	for _, e := range r {
+		if e.ID == "event" && strings.HasPrefix(executionID, e.ID) {
+			bestMatch, ok = e, true
+		}
+		cut, ok := strings.CutSuffix(e.ID, ".*")
+		if ok && strings.HasPrefix(executionID, cut) {
+			bestMatch, ok = e, true
+		}
+	}
+	return bestMatch.Targets, ok
+}

--- a/internal/execution/target/router_test.go
+++ b/internal/execution/target/router_test.go
@@ -1,0 +1,123 @@
+package target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	eventGlobalTarget   = Target{ExecutionID: "event", TargetID: "event_global"}
+	eventGroupTarget    = Target{ExecutionID: "event/foo.*", TargetID: "event_group"}
+	eventMatchTarget    = Target{ExecutionID: "event/foo.bar", TargetID: "event_specific"}
+	functionCallTarget1 = Target{ExecutionID: "function/Call", TargetID: "function_call_1"}
+	functionCallTarget2 = Target{ExecutionID: "function/Call", TargetID: "function_call_2"}
+
+	testTargets = []Target{eventGlobalTarget, eventGroupTarget, eventMatchTarget, functionCallTarget1, functionCallTarget2}
+)
+
+func TestBinarySearchRouter_Get(t *testing.T) {
+	r := NewRouter(testTargets)
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantTargets []Target
+		wantOk      bool
+	}{
+		{
+			name: "event global does not match exactly",
+			args: args{
+				id: "event/bar.foo",
+			},
+			wantTargets: nil,
+			wantOk:      false,
+		},
+		{
+			name: "event group does not match exactly",
+			args: args{
+				id: "event/foo.bar.baz",
+			},
+			wantTargets: nil,
+			wantOk:      false,
+		},
+		{
+			name: "event match",
+			args: args{
+				id: "event/foo.bar",
+			},
+			wantTargets: []Target{eventMatchTarget},
+			wantOk:      true,
+		},
+		{
+			name: "function match",
+			args: args{
+				id: "function/Call",
+			},
+			wantTargets: []Target{functionCallTarget1, functionCallTarget2},
+			wantOk:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := r.Get(tt.args.id)
+			assert.Equal(t, tt.wantTargets, got)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+func TestBinarySearchRouter_GetEventBestMatch(t *testing.T) {
+	r := NewRouter(testTargets)
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantTargets []Target
+		wantOk      bool
+	}{
+		{
+			name: "event global match",
+			args: args{
+				id: "event/bar.foo",
+			},
+			wantTargets: []Target{eventGlobalTarget},
+			wantOk:      true,
+		},
+		{
+			name: "event group match",
+			args: args{
+				id: "event/foo.bar.baz",
+			},
+			wantTargets: []Target{eventGroupTarget},
+			wantOk:      true,
+		},
+		{
+			name: "event match",
+			args: args{
+				id: "event/foo.bar",
+			},
+			wantTargets: []Target{eventMatchTarget},
+			wantOk:      true,
+		},
+		{
+			name: "function match",
+			args: args{
+				id: "function/Call",
+			},
+			wantTargets: []Target{functionCallTarget1, functionCallTarget2},
+			wantOk:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := r.GetEventBestMatch(tt.args.id)
+			assert.Equal(t, tt.wantTargets, got)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}

--- a/internal/execution/target/target.go
+++ b/internal/execution/target/target.go
@@ -1,0 +1,37 @@
+package target
+
+import (
+	"time"
+
+	"github.com/zitadel/zitadel/internal/crypto"
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+type TargetType uint
+
+const (
+	TargetTypeWebhook TargetType = iota
+	TargetTypeCall
+	TargetTypeAsync
+)
+
+type Target struct {
+	ExecutionID      string              `json:"execution_id,omitempty"`
+	TargetID         string              `json:"target_id,omitempty"`
+	TargetType       TargetType          `json:"target_type,omitempty"`
+	Endpoint         string              `json:"endpoint,omitempty"`
+	Timeout          time.Duration       `json:"timeout,omitempty"`
+	InterruptOnError bool                `json:"interrupt_on_error,omitempty"`
+	SigningKey       *crypto.CryptoValue `json:"signing_key,omitempty"`
+}
+
+func (e *Target) DecryptSigningKey(alg crypto.EncryptionAlgorithm) (string, error) {
+	if e.SigningKey == nil {
+		return "", nil
+	}
+	keyValue, err := crypto.DecryptString(e.SigningKey, alg)
+	if err != nil {
+		return "", zerrors.ThrowInternal(err, "QUERY-bxevy3YXwy", "Errors.Internal")
+	}
+	return keyValue, nil
+}

--- a/internal/query/instance.go
+++ b/internal/query/instance.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/eventstore"
 	"github.com/zitadel/zitadel/internal/eventstore/handler/v2"
+	"github.com/zitadel/zitadel/internal/execution/target"
 	"github.com/zitadel/zitadel/internal/feature"
 	"github.com/zitadel/zitadel/internal/query/projection"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
@@ -460,19 +461,20 @@ func prepareInstanceDomainQuery() (sq.SelectBuilder, func(*sql.Rows) (*Instance,
 }
 
 type authzInstance struct {
-	ID              string                     `json:"id,omitempty"`
-	IAMProjectID    string                     `json:"iam_project_id,omitempty"`
-	ConsoleID       string                     `json:"console_id,omitempty"`
-	ConsoleAppID    string                     `json:"console_app_id,omitempty"`
-	DefaultLang     language.Tag               `json:"default_lang,omitempty"`
-	DefaultOrgID    string                     `json:"default_org_id,omitempty"`
-	CSP             csp                        `json:"csp,omitempty"`
-	Impersonation   bool                       `json:"impersonation,omitempty"`
-	IsBlocked       *bool                      `json:"is_blocked,omitempty"`
-	LogRetention    *time.Duration             `json:"log_retention,omitempty"`
-	Feature         feature.Features           `json:"feature,omitempty"`
-	ExternalDomains database.TextArray[string] `json:"external_domains,omitempty"`
-	TrustedDomains  database.TextArray[string] `json:"trusted_domains,omitempty"`
+	ID               string                     `json:"id,omitempty"`
+	IAMProjectID     string                     `json:"iam_project_id,omitempty"`
+	ConsoleID        string                     `json:"console_id,omitempty"`
+	ConsoleAppID     string                     `json:"console_app_id,omitempty"`
+	DefaultLang      language.Tag               `json:"default_lang,omitempty"`
+	DefaultOrgID     string                     `json:"default_org_id,omitempty"`
+	CSP              csp                        `json:"csp,omitempty"`
+	Impersonation    bool                       `json:"impersonation,omitempty"`
+	IsBlocked        *bool                      `json:"is_blocked,omitempty"`
+	LogRetention     *time.Duration             `json:"log_retention,omitempty"`
+	Feature          feature.Features           `json:"feature,omitempty"`
+	ExternalDomains  database.TextArray[string] `json:"external_domains,omitempty"`
+	TrustedDomains   database.TextArray[string] `json:"trusted_domains,omitempty"`
+	ExecutionTargets target.Router              `json:"execution_targets,omitempty"`
 }
 
 type csp struct {
@@ -525,6 +527,10 @@ func (i *authzInstance) AuditLogRetention() *time.Duration {
 
 func (i *authzInstance) Features() feature.Features {
 	return i.Feature
+}
+
+func (i *authzInstance) ExecutionRouter() target.Router {
+	return i.ExecutionTargets
 }
 
 var errPublicDomain = "public domain %q not trusted"

--- a/internal/query/instance_by_domain.sql
+++ b/internal/query/instance_by_domain.sql
@@ -26,6 +26,26 @@ with domain as (
 	from domain d
 	join projections.instance_trusted_domains td on d.instance_id = td.instance_id
 	group by td.instance_id
+), execution_targets as (
+	select e.instance_id, json_arrayagg(json_object(
+		'execution_id' : et.execution_id,
+		'target_id' : t.id,
+		'target_type' : t.target_type,
+		'endpoint' : t.endpoint,
+		'timeout' : t.timeout,
+		'interrupt_on_error' : t.interrupt_on_error,
+		'signing_key' : t.signing_key
+	)) as execution_targets
+	from domain d
+	join projections.executions1 e
+		on d.instance_id = e.instance_id
+	join projections.executions1_targets et
+		on e.instance_id = et.instance_id
+		and e.id = et.execution_id
+	join projections.targets2 t
+		on et.instance_id = t.instance_id
+		and et.target_id = t.id
+	group by e.instance_id
 )
 select
     i.id,
@@ -41,11 +61,13 @@ select
     l.block,
 	f.features,
 	ed.domains as external_domains,
-	td.domains as trusted_domains
+	td.domains as trusted_domains,
+	et.execution_targets
 from domain d
 join projections.instances i on i.id = d.instance_id
 left join projections.security_policies2 s on i.id = s.instance_id
 left join projections.limits l on i.id = l.instance_id
 left join features f on i.id = f.instance_id
 left join external_domains ed on i.id = ed.instance_id
-left join trusted_domains td on i.id = td.instance_id;
+left join trusted_domains td on i.id = td.instance_id
+left join execution_targets et on i.id = et.instance_id;

--- a/internal/query/instance_by_id.sql
+++ b/internal/query/instance_by_id.sql
@@ -17,6 +17,25 @@ with features as (
 	from projections.instance_trusted_domains
     where instance_id = $1
 	group by instance_id
+), execution_targets as (
+	select e.instance_id, json_arrayagg(json_object(
+		'execution_id' : et.execution_id,
+		'target_id' : t.id,
+		'target_type' : t.target_type,
+		'endpoint' : t.endpoint,
+		'timeout' : t.timeout,
+		'interrupt_on_error' : t.interrupt_on_error,
+		'signing_key' : t.signing_key
+	)) as execution_targets
+	from projections.executions1 e
+	join projections.executions1_targets et
+		on e.instance_id = et.instance_id
+		and e.id = et.execution_id
+	join projections.targets2 t
+		on et.instance_id = t.instance_id
+		and et.target_id = t.id
+	where e.instance_id = $1
+	group by e.instance_id
 )
 select
     i.id,
@@ -32,11 +51,13 @@ select
     l.block,
 	f.features,
     ed.domains as external_domains,
-	td.domains as trusted_domains
+	td.domains as trusted_domains,
+	et.execution_targets
 from projections.instances i
 left join projections.security_policies2 s on i.id = s.instance_id
 left join projections.limits l on i.id = l.instance_id
 left join features f on i.id = f.instance_id
 left join external_domains ed on i.id = ed.instance_id
 left join trusted_domains td on i.id = td.instance_id
+left join execution_targets et on i.id = et.instance_id
 where i.id = $1;


### PR DESCRIPTION
WIP, todo:

1. Call the router from each point in the code where we now do a query for execution targets (refactor)
2. Create an index on executions projection for the instance ID
3. Cache invalidation hooks
4. Invalidate cache when the router is missing from the authz.Instance after upgrade.


# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- If the property XY is not given, the system crashes with a nil pointer exception.

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
