### PR TITLE
LoginV2 - CUSTOM_REQUEST_HEADERS - parsing

### DIFF
--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -1536,9 +1536,9 @@ export function createServerTransport(token: string, baseUrl: string) {
               process.env
                 .CUSTOM_REQUEST_HEADERS!.split(",")
                 .forEach((header) => {
-                  const kv = header.split(":");
-                  if (kv.length === 2) {
-                    req.header.set(kv[0].trim(), kv[1].trim());
+                  const kv = header.indexOf(":");
+                  if (kv > 0) {
+                    req.header.set(header.slice(0,kv).trim(), header.slice(kv+1).trim());
                   } else {
                     console.warn(`Skipping malformed header: ${header}`);
                   }


### PR DESCRIPTION
# Which Problems Are Solved

If CUSTOM_REQUEST_HEADERS is set to "Host:tester.admin-auth.localhost:30443" it gets ignored, because of the second colon inside the string. If your external port is set to 30443 (non default port) this is necessary to match the instance.

# How the Problems Are Solved

It sets the header as expected, if there is at least a single colon and at least one char before it.