### PR TITLE
feat(login): ZITADEL_API_INTERNAL_URL to overwrite baseUrl

### DIFF
--- a/apps/login/next-env-vars.d.ts
+++ b/apps/login/next-env-vars.d.ts
@@ -15,6 +15,13 @@ declare namespace NodeJS {
     ZITADEL_API_URL: string;
 
     /**
+     * The Zitadel API internal url
+     * If set this url is always used to call zitadel.
+     * The serviceUrl is stripped of schema and used as 
+     */
+    ZITADEL_API_INTERNAL_URL: string;
+
+    /**
      * The service user token
      */
     ZITADEL_SERVICE_USER_TOKEN: string;


### PR DESCRIPTION
# Which Problems Are Solved

If you use kubernetes with helm and need a multi instance setup zitadel is only reachable from within the nodes by it's internal service url (e.g. zitadel:8080). The external domain is unreachable, so you would need to set ZITADEL_API_URL to make sure loginV2 reaches zitadel. This fails because there is no instance on this url but with CUSTOM_REQUEST_HEADERS you can only set x-zitadel-instance-host to a single instance.

# How the Problems Are Solved

By introducing ZITADEL_API_INTERNAL_URL which is used to call zitadel and the original baseUrl stripped of his schema and used in x-zitadel-instance-host it reaches zitadel with the correct instance based on the hostname you called the UI. ZITADEL_API_URL shouldn't  be used with ZITADEL_API_INTERNAL_URL as it overwrites baseUrl.
