### PR TITLE
fix(login): CSP img-src to allow instance assets

### DIFF
--- a/apps/login/constants/csp.js
+++ b/apps/login/constants/csp.js
@@ -1,2 +1,6 @@
+const ZITADEL_DOMAIN = process.env.ZITADEL_API_URL 
+  ? new URL(process.env.ZITADEL_API_URL).hostname 
+  : '*.zitadel.cloud';
+
 export const DEFAULT_CSP =
-  "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' https://vercel.com;";
+  `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' https://vercel.com https://${ZITADEL_DOMAIN};`;


### PR DESCRIPTION
Fix CSP img-src to allow ZITADEL instance assets

# Which Problems Are Solved

Login app was failing to load images (logos, branding assets) from ZITADEL instances due to Content Security Policy restrictions. The CSP img-src directive only allowed 'self' and https://vercel.com, blocking images from ZITADEL domains like https://login-*.zitadel.app.

# How the Problems Are Solved

- Dynamic CSP configuration: Extract hostname from ZITADEL_API_URL environment variable
- Fallback support: Use *.zitadel.cloud wildcard when no specific URL is configured
- Environment-aware: Works across dev/staging/prod without hardcoded domains

