### PR TITLE
test: increase invite timeout

### DIFF
--- a/apps/login/integration/integration/invite.cy.ts
+++ b/apps/login/integration/integration/invite.cy.ts
@@ -93,7 +93,7 @@ describe("verify invite", () => {
     stub("zitadel.user.v2.UserService", "VerifyInviteCode");
 
     cy.visit("/verify?userId=221394658884845598&code=abc&invite=true");
-    cy.url().should("include", Cypress.config().baseUrl + "/authenticator/set");
+    cy.url({timeout: 20_000}).should("include", Cypress.config().baseUrl + "/authenticator/set");
   });
 
   it("shows an error if invite code validation failed", () => {


### PR DESCRIPTION
# Which Problems Are Solved

Login integration tests are fixed.

# How the Problems Are Solved

The invite tests navigation timeout  is increased. 

# Additional Context

- Discussion https://zitadel.slack.com/archives/C087ADF8LRX/p1756291328574109?thread_ts=1756289648.467359&cid=C087ADF8LRX
