### PR TITLE
fix: Fix typo in keyboard shortcuts popup

### DIFF
--- a/console/src/assets/i18n/en.json
+++ b/console/src/assets/i18n/en.json
@@ -709,7 +709,7 @@
     "SIDEWIDE": "Site-wide shortcuts",
     "SHORTCUTS": {
       "HOME": "<strong>G</strong>o to <strong>H</strong>ome",
-      "INSTANCE": "<strong>G</strong>o to <strong>I</strong>instance",
+      "INSTANCE": "<strong>G</strong>o to <strong>I</strong>nstance",
       "ORG": "<strong>G</strong>o to <strong>O</strong>rganization",
       "ORGSETTINGS": "<strong>G</strong>o to Organization <strong>S</strong>ettings",
       "ORGSWITCHER": "Change Organization",


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

There is a typo in the keyboard shortcuts popup that adds an extra I to the word instance.

# How the Problems Are Solved

Removed the extra I.

# Additional Changes

n/a

# Additional Context

n/a
