### PR TITLE
fix(testing): add more entropy to organization names

### DIFF
--- a/internal/api/grpc/org/v2/integration_test/query_test.go
+++ b/internal/api/grpc/org/v2/integration_test/query_test.go
@@ -311,7 +311,7 @@ func TestServer_ListOrganizations(t *testing.T) {
 					Queries: []*org.SearchQuery{},
 				},
 				func(ctx context.Context, request *org.ListOrganizationsRequest) ([]orgAttr, error) {
-					name := gofakeit.Name()
+					name := integration.FakeOrgName()
 					orgResp := createOrganization(ctx, name)
 					deactivateOrgResp := Instance.DeactivateOrganization(ctx, orgResp.ID)
 					request.Queries = []*org.SearchQuery{

--- a/internal/api/grpc/org/v2beta/integration_test/org_test.go
+++ b/internal/api/grpc/org/v2beta/integration_test/org_test.go
@@ -77,7 +77,7 @@ func TestServer_CreateOrganization(t *testing.T) {
 			wantErr: true,
 		},
 		func() test {
-			orgName := gofakeit.Name()
+			orgName := integration.FakeOrgName()
 			return test{
 				name: "adding org with same name twice",
 				ctx:  CTX,
@@ -235,20 +235,20 @@ func TestServer_CreateOrganization(t *testing.T) {
 			},
 		},
 		func() test {
-			orgID := gofakeit.Name()
+			orgID := integration.FakeOrgName()
 			return test{
 				name: "adding org with same ID twice",
 				ctx:  CTX,
 				req: &v2beta_org.CreateOrganizationRequest{
 					Id:     &orgID,
-					Name:   gofakeit.Name(),
+					Name:   integration.FakeOrgName(),
 					Admins: nil,
 				},
 				testFunc: func(ctx context.Context, t *testing.T) {
 					// create org initially
 					_, err := Client.CreateOrganization(ctx, &v2beta_org.CreateOrganizationRequest{
 						Id:   &orgID,
-						Name: gofakeit.Name(),
+						Name: integration.FakeOrgName(),
 					})
 					require.NoError(t, err)
 				},
@@ -2074,7 +2074,7 @@ func createOrgs(ctx context.Context, client v2beta_org.OrganizationServiceClient
 	orgsName := make([]string, noOfOrgs)
 
 	for i := range noOfOrgs {
-		orgName := gofakeit.Name()
+		orgName := integration.FakeOrgName()
 		orgsName[i] = orgName
 		orgs[i], err = client.CreateOrganization(ctx,
 			&v2beta_org.CreateOrganizationRequest{

--- a/internal/api/grpc/resources/user/v3alpha/integration_test/email_test.go
+++ b/internal/api/grpc/resources/user/v3alpha/integration_test/email_test.go
@@ -33,7 +33,7 @@ func TestServer_SetContactEmail(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want       *resource_object.Details
@@ -378,7 +378,7 @@ func TestServer_VerifyContactEmail(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want *resource_object.Details
@@ -567,7 +567,7 @@ func TestServer_ResendContactEmailCode(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want       *resource_object.Details

--- a/internal/api/grpc/resources/user/v3alpha/integration_test/phone_test.go
+++ b/internal/api/grpc/resources/user/v3alpha/integration_test/phone_test.go
@@ -32,7 +32,7 @@ func TestServer_SetContactPhone(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want       *resource_object.Details
@@ -305,7 +305,7 @@ func TestServer_VerifyContactPhone(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want            *resource_object.Details
@@ -496,7 +496,7 @@ func TestServer_ResendContactPhoneCode(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want       *resource_object.Details

--- a/internal/api/grpc/resources/user/v3alpha/integration_test/user_test.go
+++ b/internal/api/grpc/resources/user/v3alpha/integration_test/user_test.go
@@ -49,7 +49,7 @@ func TestServer_CreateUser(t *testing.T) {
 		}
 	}`)
 	permissionSchemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, permissionSchema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want            *resource_object.Details
@@ -257,7 +257,7 @@ func TestServer_PatchUser(t *testing.T) {
 		}
 	}`)
 	permissionSchemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, permissionSchema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	type res struct {
 		want            *resource_object.Details
@@ -662,7 +662,7 @@ func TestServer_DeleteUser(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	tests := []struct {
 		name    string
@@ -878,7 +878,7 @@ func TestServer_LockUser(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	tests := []struct {
 		name    string
@@ -1079,7 +1079,7 @@ func TestServer_UnlockUser(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	tests := []struct {
 		name    string
@@ -1261,7 +1261,7 @@ func TestServer_DeactivateUser(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	tests := []struct {
 		name    string
@@ -1462,7 +1462,7 @@ func TestServer_ActivateUser(t *testing.T) {
 		}
 	}`)
 	schemaResp := instance.CreateUserSchema(isolatedIAMOwnerCTX, schema)
-	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, gofakeit.Name(), gofakeit.Email())
+	orgResp := instance.CreateOrganization(isolatedIAMOwnerCTX, integration.FakeOrgName(), gofakeit.Email())
 
 	tests := []struct {
 		name    string

--- a/internal/api/scim/integration_test/bulk_test.go
+++ b/internal/api/scim/integration_test/bulk_test.go
@@ -50,7 +50,7 @@ func init() {
 
 func TestBulk(t *testing.T) {
 	iamOwnerCtx := Instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
-	secondaryOrg := Instance.CreateOrganization(iamOwnerCtx, gofakeit.Name(), gofakeit.Email())
+	secondaryOrg := Instance.CreateOrganization(iamOwnerCtx, integration.FakeOrgName(), gofakeit.Email())
 
 	createdSecondaryOrgUser := createHumanUser(t, iamOwnerCtx, secondaryOrg.OrganizationId, 0)
 	bulkMinimalUpdateSecondaryOrgJson := test.Must(json.Marshal(buildMinimalUpdateRequest(createdSecondaryOrgUser.UserId)))

--- a/internal/api/scim/integration_test/scim_test.go
+++ b/internal/api/scim/integration_test/scim_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 		CTX = Instance.WithAuthorization(ctx, integration.UserTypeOrgOwner)
 
 		iamOwnerCtx := Instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
-		SecondaryOrganization = Instance.CreateOrganization(iamOwnerCtx, gofakeit.Name(), gofakeit.Email())
+		SecondaryOrganization = Instance.CreateOrganization(iamOwnerCtx, integration.FakeOrgName(), gofakeit.Email())
 
 		return m.Run()
 	}())

--- a/internal/api/scim/integration_test/users_list_test.go
+++ b/internal/api/scim/integration_test/users_list_test.go
@@ -27,7 +27,7 @@ var totalCountOfHumanUsers = 13
 		// these should never be modified.
 		// This allows testing list requests without filters.
 		iamOwnerCtx := Instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
-		secondaryOrg := Instance.CreateOrganization(iamOwnerCtx, gofakeit.Name(), gofakeit.Email())
+		secondaryOrg := Instance.CreateOrganization(iamOwnerCtx, integration.FakeOrgName(), gofakeit.Email())
 		secondaryOrgCreatedUserIDs := createUsers(t, iamOwnerCtx, secondaryOrg.OrganizationId)
 
 		testsInitializedUtc := time.Now().UTC()
@@ -348,7 +348,7 @@ var totalCountOfHumanUsers = 13
 				name: "do not count user of other org",
 				prepare: func(t require.TestingT) *scim.ListRequest {
 					iamOwnerCtx := Instance.WithAuthorization(CTX, integration.UserTypeIAMOwner)
-					org := Instance.CreateOrganization(iamOwnerCtx, gofakeit.Name(), gofakeit.Email())
+					org := Instance.CreateOrganization(iamOwnerCtx, integration.FakeOrgName(), gofakeit.Email())
 					resp := createHumanUser(t, iamOwnerCtx, org.OrganizationId, 102)
 
 					return &scim.ListRequest{

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1066,7 +1067,7 @@ func (i *Instance) DeleteProjectGrantMembership(t *testing.T, ctx context.Contex
 
 func (i *Instance) CreateTarget(ctx context.Context, t *testing.T, name, endpoint string, ty domain.TargetType, interrupt bool) *action.CreateTargetResponse {
 	if name == "" {
-		name = gofakeit.Name()
+		name = FakeOrgName()
 	}
 	req := &action.CreateTargetRequest{
 		Name:     name,
@@ -1259,4 +1260,16 @@ func (i *Instance) ActivateSchemaUser(ctx context.Context, orgID string, userID 
 	})
 	logging.OnError(err).Fatal("reactivate user")
 	return user
+}
+
+// FakeOrgName generates a fake organization name.
+// It has higher entropy than regular [gofakeit.Name()],
+// to prevent org naming conflicts.
+func FakeOrgName() string {
+	return strings.Join([]string{
+		strings.ToTitle(gofakeit.AdjectivePossessive()),
+		strings.ToTitle(gofakeit.Noun()),
+		strings.ToTitle(gofakeit.Animal()),
+	}, "")
+
 }


### PR DESCRIPTION
#  Which Problems Are Solved

Fixes a pipeline issue where core integration tests fail on duplicate organization names.


# How the Problems Are Solved

Use a concatination of multiple `gofakeit` random strings. Names may become funny ;). 

# Additional Changes

- none

# Additional Context

https://github.com/zitadel/zitadel/actions/runs/17302736060/job/49120521102?pr=10564#step:8:526