### PR TITLE
chore(tests): disable parallelism in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ core_integration_server_start: core_integration_setup
 
 .PHONY: core_integration_test_packages
 core_integration_test_packages:
-	go test -race -count 1 -tags integration -timeout 30m $$(go list -tags integration ./... | grep "integration_test")
+	go test -race -count 1 -tags integration -timeout 60m -parallel 1 $$(go list -tags integration ./... | grep "integration_test")
 
 .PHONY: core_integration_server_stop
 core_integration_server_stop:

--- a/internal/integration/delete_me.go
+++ b/internal/integration/delete_me.go
@@ -3,3 +3,4 @@ package integration
 // TODO: delete this file. Just adding it to kick off the integration tests in github.
 // just adding another line for another kick
 // again
+// and again

--- a/internal/integration/delete_me.go
+++ b/internal/integration/delete_me.go
@@ -1,0 +1,3 @@
+package integration
+
+// TODO: delete this file. Just adding it to kick off the integration tests in github.

--- a/internal/integration/delete_me.go
+++ b/internal/integration/delete_me.go
@@ -1,3 +1,4 @@
 package integration
 
 // TODO: delete this file. Just adding it to kick off the integration tests in github.
+// just adding another line for another kick

--- a/internal/integration/delete_me.go
+++ b/internal/integration/delete_me.go
@@ -2,3 +2,4 @@ package integration
 
 // TODO: delete this file. Just adding it to kick off the integration tests in github.
 // just adding another line for another kick
+// again


### PR DESCRIPTION
# Which Problems Are Solved

I suspect with the increased amount of integration tests, there's a battle for resources on the test runner between the zitadel binary, test binary and postgreSQL server. This may cause projection handlers to fall behind, resulting in very eventual consistency, many retries in EventuallyWithT and test timeouts if consistency isn't reached within the provided timeout. Retries add to resource consumption, so it might actually make the problem worse as multiple tests are retrying on a loop in parallel.

# How the Problems Are Solved

This change attempts to increase consistency by disabling parallelism in the integration test.

# Additional Changes

- none

# Additional Context

- great many integration-test pipeline failures.