### PR TITLE
Update entrypoint.sh

### DIFF
--- a/apps/login/scripts/entrypoint.sh
+++ b/apps/login/scripts/entrypoint.sh
@@ -8,4 +8,4 @@ if [ -n "${ZITADEL_SERVICE_USER_TOKEN_FILE}" ] && [ -f "${ZITADEL_SERVICE_USER_T
   export ZITADEL_SERVICE_USER_TOKEN=$(cat "${ZITADEL_SERVICE_USER_TOKEN_FILE}")
 fi
 
-exec node /runtime/apps/login/server.js
+exec node /runtime/server.js


### PR DESCRIPTION
After I packaged a TypeScript project into a Docker image and ran it alone, the container failed to start, and an error occurred:"Cannot find module '/runtime/apps/login/server.js'". Upon checking, I found that the issue was an incorrect path.

