### PR TITLE
chore(workflow): temporarily use bigger runners

### DIFF
--- a/.github/workflows/console.yml
+++ b/.github/workflows/console.yml
@@ -20,7 +20,8 @@ jobs:
     outputs:
       cache_key: ${{ steps.cache.outputs.cache-primary-key }}
       cache_path: ${{ env.cache_path }}
-    runs-on: ubuntu-latest
+    runs-on: 
+      group:  zitadel-public
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4

--- a/.github/workflows/core-unit-test.yml
+++ b/.github/workflows/core-unit-test.yml
@@ -18,7 +18,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 
+      group: zitadel-public
     steps:
       - 
         uses: actions/checkout@v3

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -29,7 +29,8 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: zitadel-public
     outputs:
       cache_key: ${{ steps.cache.outputs.cache-primary-key }}
       cache_path: ${{ env.cache_path }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         browser: [firefox, chrome]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: zitadel-public
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Which Problems Are Solved

Unit tests can pass again.

# How the Problems Are Solved

As we don't want to waist too much time on this, we just use runners with bigger disks for now.
Probably we anyway use distributed task execution with Nx Cloud instead of GitHub runners soon.

# Additional Context

Reverts zitadel/zitadel#9643
Reported internally https://zitadel.slack.com/archives/C081HPPECKU/p1756470129164019
Failing Actions:
- https://github.com/zitadel/zitadel/actions/runs/17323362823/job/49181555445?pr=10564
- https://github.com/zitadel/zitadel/actions/runs/17435007449/job/49502354609?pr=10560#step:7:227