### PR TITLE
fix(cache): set version in instance by host

### DIFF
--- a/internal/query/instance.go
+++ b/internal/query/instance.go
@@ -225,6 +225,7 @@ func (q *Queries) InstanceByHost(ctx context.Context, instanceHost, publicHost s
 	if err = q.client.QueryRowContext(ctx, scan, instanceByDomainQuery, instanceDomain); err != nil {
 		return nil, err
 	}
+	instance.ZitadelVersion = build.Version()
 	q.caches.instance.Set(ctx, instance)
 
 	return instance, instance.checkDomain(instanceDomain, publicDomain)


### PR DESCRIPTION
# Which Problems Are Solved

We noticed a rapid growth of Redis memory usage. Instance By host did not set the zitadel version, so instance entries got set on every request again.

# How the Problems Are Solved

Set the version

# Additional Changes

- none

# Additional Context

- internal incident