### PR TITLE
fix(makefile): revert wrong integration test settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ core_integration_server_start: core_integration_setup
 
 .PHONY: core_integration_test_packages
 core_integration_test_packages:
-	go test -race -count 1 -tags integration -timeout 5m -parallel 1 $$(go list -tags integration ./... | grep -e "integration_test" -e "events_testing") -run ^TestServer_TestInstanceReduces$
+	go test -race -count 1 -tags integration -timeout 60m -parallel 1 $$(go list -tags integration ./... | grep -e "integration_test" -e "events_testing")
 
 .PHONY: core_integration_server_stop
 core_integration_server_stop:


### PR DESCRIPTION
[This PR](https://github.com/zitadel/zitadel/commit/61cab8878ee18ed32f44a63fd4633223f47f9e88) introduced wrong parameters to the integration tests of the backend. This PR reverts these changes
