### PR TITLE
perf(cache): use redis unlink for key deletion

### DIFF
--- a/internal/cache/connector/redis/_remove.lua
+++ b/internal/cache/connector/redis/_remove.lua
@@ -3,8 +3,8 @@ local function remove(object_id)
     local keys = redis.call("SMEMBERS", setKey)
     local n = #keys
     for i = 1, n do
-        redis.call("DEL", keys[i])
+        redis.call("UNLINK", keys[i])
     end
-    redis.call("DEL", setKey)
-    redis.call("DEL", object_id)
+    redis.call("UNLINK", setKey)
+    redis.call("UNLINK", object_id)
 end


### PR DESCRIPTION
# Which Problems Are Solved

The usage of the Redis `DEL` command showed blocking and slowdowns during load-tests.

# How the Problems Are Solved

Use [`UNLINK`](https://redis.io/docs/latest/commands/UNLINK/) instead.

# Additional Changes

- none

# Additional Context

- closes https://github.com/zitadel/zitadel/issues/8930
