### PR TITLE
docs: update login password in self hosting documentation

### DIFF
--- a/docs/docs/self-hosting/deploy/_defaultuser.mdx
+++ b/docs/docs/self-hosting/deploy/_defaultuser.mdx
@@ -1,1 +1,1 @@
-Visit http://localhost:8080/ui/console?login_hint=zitadel-admin@zitadel.localhost and enter `Password1!` to log in.
+Visit http://localhost:8080/ui/console?login_hint=zitadel-admin@zitadel.localhost and enter `RootPassword1!` to log in.


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- The documentation contains an incorrect default password for the self-hosted ZITADEL admin login.
- Users following the self-hosting guide would be unable to log in with the documented password `Password1!`

# How the Problems Are Solved

- Updated the default password in the self-hosting documentation from `Password1!` to `RootPassword1!` to match the actual default admin password.

