### PR TITLE
docs: add redirect and post-logout redirect URIs to config

### DIFF
--- a/docs/docs/guides/start/quickstart.mdx
+++ b/docs/docs/guides/start/quickstart.mdx
@@ -303,6 +303,8 @@ The code needed to run this project can be found [here](https://github.com/zitad
   const config: ZitadelConfig = {
     authority: "[YOUR-INSTANCE-URL]",
     client_id: "[YOUR-CLIENT-ID]",
+    redirect_uri: "[YOUR-REDIRECT-URI]",
+    post_logout_redirect_uri: "[YOUR-POST-LOGOUT-REDIRECT-URI]",
   };
 
   const zitadel = createZitadelAuth(config);


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- The Zitadel configuration example in the documentation is incomplete, causing applications to fail even when redirect URIs are properly configured in the Zitadel console.
- Missing required configuration fields (redirect_uri and post_logout_redirect_uri) in the code example lead to authentication flow failures.

# How the Problems Are Solved

- Added the required redirect_uri field to the ZitadelConfig example.
- Added the required post_logout_redirect_uri field to the ZitadelConfig example.
