### PR TITLE
fix: correct mapping of custom texts

### DIFF
--- a/internal/api/grpc/text/custom_text.go
+++ b/internal/api/grpc/text/custom_text.go
@@ -431,7 +431,7 @@ func ExternalUserNotFoundScreenTextToPb(text domain.ExternalUserNotFoundScreenTe
 		AutoRegisterButtonText: text.AutoRegisterButtonText,
 		TosAndPrivacyLabel:     text.TOSAndPrivacyLabel,
 		TosConfirm:             text.TOSConfirm,
-		TosLinkText:            text.PrivacyLinkText,
+		TosLinkText:            text.TOSLinkText,
 		PrivacyConfirm:         text.PrivacyConfirm,
 		PrivacyLinkText:        text.PrivacyLinkText,
 	}
@@ -915,7 +915,7 @@ func ExternalUserNotFoundScreenTextPbToDomain(text *text_pb.ExternalUserNotFound
 		AutoRegisterButtonText: text.AutoRegisterButtonText,
 		TOSAndPrivacyLabel:     text.TosAndPrivacyLabel,
 		TOSConfirm:             text.TosConfirm,
-		TOSLinkText:            text.PrivacyLinkText,
+		TOSLinkText:            text.TosLinkText,
 		PrivacyConfirm:         text.PrivacyConfirm,
 		PrivacyLinkText:        text.PrivacyLinkText,
 	}


### PR DESCRIPTION
# Which Problems Are Solved

Some custom texts are overwritten by incorrect mapped values.

# How the Problems Are Solved

Correct the mapping in the mapping.

# Additional Changes

None

# Additional Context

Closes #10155
