### PR TITLE
chore(init): skip initialization steps if user and/or database already exists

### DIFF
--- a/cmd/initialise/verify_database.go
+++ b/cmd/initialise/verify_database.go
@@ -39,6 +39,11 @@ func VerifyDatabase(databaseName string) func(context.Context, *database.DB) err
 	return func(ctx context.Context, db *database.DB) error {
 		logging.WithFields("database", databaseName).Info("verify database")
 
+		if db.DatabaseName() == databaseName {
+			logging.WithFields("database", databaseName).Info("already connected to database that would be created - will not attempt to create database")
+			return nil
+		}
+
 		return exec(ctx, db, fmt.Sprintf(databaseStmt, databaseName), []string{dbAlreadyExistsCode})
 	}
 }

--- a/cmd/initialise/verify_grant.go
+++ b/cmd/initialise/verify_grant.go
@@ -34,6 +34,11 @@ func VerifyGrant(databaseName, username string) func(context.Context, *database.
 	return func(ctx context.Context, db *database.DB) error {
 		logging.WithFields("user", username, "database", databaseName).Info("verify grant")
 
+		if db.Username() == username {
+			logging.WithFields("username", username).Info("already connected as the user that would be granted access - no granting will be done")
+			return nil
+		}
+
 		return exec(ctx, db, fmt.Sprintf(grantStmt, databaseName, username), nil)
 	}
 }

--- a/cmd/initialise/verify_user.go
+++ b/cmd/initialise/verify_user.go
@@ -39,6 +39,11 @@ func VerifyUser(username, password string) func(context.Context, *database.DB) e
 	return func(ctx context.Context, db *database.DB) error {
 		logging.WithFields("username", username).Info("verify user")
 
+		if db.Username() == username {
+			logging.WithFields("username", username).Info("already connected as the user that would be created - will not attempt to create user")
+			return nil
+		}
+
 		if password != "" {
 			createUserStmt += " WITH PASSWORD '" + password + "'"
 		}


### PR DESCRIPTION


<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- If the admin user does not have permission to create new databases and/or roles/users, the init job fails because it tries to `CREATE USER`, `CREATE DATABASE` and `GRANT ALL ON DATABASE x TO y`.

# How the Problems Are Solved

- checks if the PostgreSQL connection was established with the same username that would be created and skips the `CREATE USER` step, assuming it already exists (otherwise no connection would be possible)
- checks if the PostgreSQL connection was established to the same database that would be created and skips the `CREATE DATABASE` step, assuming it already exists (otherwise no connection would be possible)
-  checks if the PostgreSQL connection was established with the same username that would be created and skips the `GRANT ALL` step, assuming the user already would have permissions (that's harder to verify, so it is a simple assumption, but not worse than before, when it would not even have reached that step)
- Output when steps 1 to 3 are skipped:
```log
2025-09-15T17:13:31.091333475Z time="2025-09-15T17:13:31Z" level=info msg="initialization started" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/init.go:70"
2025-09-15T17:13:31.130375373Z time="2025-09-15T17:13:31Z" level=info msg="verify user" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_user.go:40" username=username1
2025-09-15T17:13:31.130411323Z time="2025-09-15T17:13:31Z" level=info msg="already connected as the user that would be created - will not attempt to create user" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_user.go:43" username=username1
2025-09-15T17:13:31.130415578Z time="2025-09-15T17:13:31Z" level=info msg="verify database" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_database.go:40" database=youthcq_db1
2025-09-15T17:13:31.130418885Z time="2025-09-15T17:13:31Z" level=info msg="already connected to database that would be created - will not attempt to create database" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_database.go:43" database=youthcq_db1
2025-09-15T17:13:31.130422302Z time="2025-09-15T17:13:31Z" level=info msg="verify grant" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_grant.go:35" database=youthcq_db1 user=username1
2025-09-15T17:13:31.130425489Z time="2025-09-15T17:13:31Z" level=info msg="already connected as the user that would be granted access - no granting will be done" caller="/home/runner/work/zitadel/zitadel/cmd/initialise/verify_grant.go:38" username=username1
```

# Additional Changes

I did not yet document the behavior.

# Additional Context

- Closes #10730 
- (not much context here, but for completeness: https://discord.com/channels/927474939156643850/1019901852235616316/1417174852204498945)

# My Questions

- Should the info message be rephrased?