### PR TITLE
fix: generated project grant id

### DIFF
--- a/internal/api/grpc/internal_permission/v2beta/administrator.go
+++ b/internal/api/grpc/internal_permission/v2beta/administrator.go
@@ -85,10 +85,10 @@ func createAdministratorProjectToCommand(req *internal_permission.ResourceType_P
 
 func createAdministratorProjectGrantToCommand(req *internal_permission.ResourceType_ProjectGrant_, userID string, roles []string) *command.AddProjectGrantMember {
 	return &command.AddProjectGrantMember{
-		GrantID:   req.ProjectGrant.ProjectGrantId,
-		ProjectID: req.ProjectGrant.ProjectId,
-		UserID:    userID,
-		Roles:     roles,
+		OrganizationID: req.ProjectGrant.OrganizationId,
+		ProjectID:      req.ProjectGrant.ProjectId,
+		UserID:         userID,
+		Roles:          roles,
 	}
 }
 
@@ -165,10 +165,10 @@ func updateAdministratorProjectToCommand(req *internal_permission.ResourceType_P
 
 func updateAdministratorProjectGrantToCommand(req *internal_permission.ResourceType_ProjectGrant_, userID string, roles []string) *command.ChangeProjectGrantMember {
 	return &command.ChangeProjectGrantMember{
-		GrantID:   req.ProjectGrant.ProjectGrantId,
-		ProjectID: req.ProjectGrant.ProjectId,
-		UserID:    userID,
-		Roles:     roles,
+		OrganizationID: req.ProjectGrant.OrganizationId,
+		ProjectID:      req.ProjectGrant.ProjectId,
+		UserID:         userID,
+		Roles:          roles,
 	}
 }
 
@@ -203,7 +203,7 @@ func (s *Server) DeleteAdministrator(ctx context.Context, req *connect.Request[i
 			deletionDate = timestamppb.New(member.EventDate)
 		}
 	case *internal_permission.ResourceType_ProjectGrant_:
-		member, err := s.command.RemoveProjectGrantMember(ctx, resource.ProjectGrant.ProjectId, req.Msg.UserId, resource.ProjectGrant.ProjectGrantId)
+		member, err := s.command.RemoveProjectGrantMember(ctx, resource.ProjectGrant.ProjectId, req.Msg.UserId, "", resource.ProjectGrant.OrganizationId)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/grpc/internal_permission/v2beta/integration_test/administrator_test.go
+++ b/internal/api/grpc/internal_permission/v2beta/integration_test/administrator_test.go
@@ -239,7 +239,7 @@ func TestServer_CreateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: "notexisting",
+							OrganizationId: "notexisting",
 						},
 					},
 				}
@@ -263,7 +263,7 @@ func TestServer_CreateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -289,7 +289,7 @@ func TestServer_CreateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -333,6 +333,13 @@ func TestServer_CreateAdministrator_Permission(t *testing.T) {
 	instance.CreateProjectGrantMembership(t, iamOwnerCtx, projectResp.GetId(), orgResp.GetOrganizationId(), userProjectGrantResp.GetUserId())
 	patProjectGrantResp := instance.CreatePersonalAccessToken(iamOwnerCtx, userProjectGrantResp.GetUserId())
 	projectGrantOwnerCtx := integration.WithAuthorizationToken(CTX, patProjectGrantResp.Token)
+
+	grantedProjectResp := instance.CreateProject(iamOwnerCtx, t, orgResp.GetOrganizationId(), integration.ProjectName(), false, false)
+	userGrantedProjectResp := instance.CreateMachineUser(iamOwnerCtx)
+	instance.CreateProjectMembership(t, iamOwnerCtx, grantedProjectResp.GetId(), userGrantedProjectResp.GetUserId())
+	patGrantedProjectResp := instance.CreatePersonalAccessToken(iamOwnerCtx, userGrantedProjectResp.GetUserId())
+	grantedProjectOwnerCtx := integration.WithAuthorizationToken(CTX, patGrantedProjectResp.Token)
+	instance.CreateProjectGrant(iamOwnerCtx, t, grantedProjectResp.GetId(), instance.DefaultOrg.GetId())
 
 	type want struct {
 		creationDate bool
@@ -509,6 +516,50 @@ func TestServer_CreateAdministrator_Permission(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "project grant, org owner, ok",
+			ctx:  instance.WithAuthorizationToken(CTX, integration.UserTypeOrgOwner),
+			prepare: func(request *internal_permission.CreateAdministratorRequest) {
+				userResp := instance.CreateUserTypeHuman(iamOwnerCtx, integration.Email())
+
+				request.UserId = userResp.GetId()
+			},
+			req: &internal_permission.CreateAdministratorRequest{
+				Resource: &internal_permission.ResourceType{
+					Resource: &internal_permission.ResourceType_ProjectGrant_{
+						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
+							ProjectId:      grantedProjectResp.GetId(),
+							OrganizationId: instance.DefaultOrg.GetId(),
+						},
+					},
+				},
+				Roles: []string{"PROJECT_GRANT_OWNER"},
+			},
+			want: want{
+				creationDate: true,
+			},
+		},
+		{
+			name: "project grant, project owner, error",
+			ctx:  grantedProjectOwnerCtx,
+			prepare: func(request *internal_permission.CreateAdministratorRequest) {
+				userResp := instance.CreateUserTypeHuman(iamOwnerCtx, integration.Email())
+
+				request.UserId = userResp.GetId()
+			},
+			req: &internal_permission.CreateAdministratorRequest{
+				Resource: &internal_permission.ResourceType{
+					Resource: &internal_permission.ResourceType_ProjectGrant_{
+						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
+							ProjectId:      grantedProjectResp.GetId(),
+							OrganizationId: instance.DefaultOrg.GetId(),
+						},
+					},
+				},
+				Roles: []string{"PROJECT_GRANT_OWNER"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "project grant, project grant owner, ok",
 			ctx:  projectGrantOwnerCtx,
 			prepare: func(request *internal_permission.CreateAdministratorRequest) {
@@ -521,7 +572,7 @@ func TestServer_CreateAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -544,7 +595,7 @@ func TestServer_CreateAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -869,7 +920,7 @@ func TestServer_UpdateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: "notexisting",
+							OrganizationId: "notexisting",
 						},
 					},
 				}
@@ -894,7 +945,7 @@ func TestServer_UpdateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -922,7 +973,7 @@ func TestServer_UpdateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -949,7 +1000,7 @@ func TestServer_UpdateAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -1192,7 +1243,7 @@ func TestServer_UpdateAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -1215,7 +1266,7 @@ func TestServer_UpdateAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -1236,7 +1287,7 @@ func TestServer_UpdateAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -1487,7 +1538,7 @@ func TestServer_DeleteAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: "notexisting",
+							OrganizationId: "notexisting",
 						},
 					},
 				}
@@ -1512,7 +1563,7 @@ func TestServer_DeleteAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -1538,7 +1589,7 @@ func TestServer_DeleteAdministrator(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				}
@@ -1766,7 +1817,7 @@ func TestServer_DeleteAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -1788,7 +1839,7 @@ func TestServer_DeleteAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},
@@ -1808,7 +1859,7 @@ func TestServer_DeleteAdministrator_Permission(t *testing.T) {
 					Resource: &internal_permission.ResourceType_ProjectGrant_{
 						ProjectGrant: &internal_permission.ResourceType_ProjectGrant{
 							ProjectId:      projectResp.GetId(),
-							ProjectGrantId: orgResp.GetOrganizationId(),
+							OrganizationId: orgResp.GetOrganizationId(),
 						},
 					},
 				},

--- a/internal/api/grpc/internal_permission/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/internal_permission/v2beta/integration_test/query_test.go
@@ -535,6 +535,10 @@ func TestServer_ListAdministrators(t *testing.T) {
 				// always first check length, otherwise its failed anyway
 				if assert.Len(ttt, got.Administrators, len(tt.want.Administrators)) {
 					for i := range tt.want.Administrators {
+						// need to set the project grant ID as it is generated
+						if grant := got.Administrators[i].GetProjectGrant(); grant != nil {
+							tt.want.Administrators[i].GetProjectGrant().Id = grant.Id
+						}
 						assert.EqualExportedValues(ttt, tt.want.Administrators[i], got.Administrators[i])
 					}
 				}
@@ -631,7 +635,8 @@ func createProjectGrantAdministrator(ctx context.Context, instance *integration.
 		},
 		Resource: &internal_permission.Administrator_ProjectGrant{
 			ProjectGrant: &internal_permission.ProjectGrant{
-				Id:                    grantedOrgID,
+				// left empty as generated
+				Id:                    "",
 				ProjectId:             projectID,
 				ProjectName:           projectName,
 				OrganizationId:        orgID,
@@ -1162,6 +1167,10 @@ func TestServer_ListAdministrators_PermissionV2(t *testing.T) {
 				// always first check length, otherwise its failed anyway
 				if assert.Len(ttt, got.Administrators, len(tt.want.Administrators)) {
 					for i := range tt.want.Administrators {
+						// set as project grant id is generated
+						if grant := got.Administrators[i].GetProjectGrant(); grant != nil {
+							tt.want.Administrators[i].GetProjectGrant().Id = grant.Id
+						}
 						assert.EqualExportedValues(ttt, tt.want.Administrators[i], got.Administrators[i])
 					}
 				}

--- a/internal/api/grpc/management/project_grant.go
+++ b/internal/api/grpc/management/project_grant.go
@@ -204,7 +204,7 @@ func (s *Server) UpdateProjectGrantMember(ctx context.Context, req *mgmt_pb.Upda
 }
 
 func (s *Server) RemoveProjectGrantMember(ctx context.Context, req *mgmt_pb.RemoveProjectGrantMemberRequest) (*mgmt_pb.RemoveProjectGrantMemberResponse, error) {
-	details, err := s.command.RemoveProjectGrantMember(ctx, req.ProjectId, req.UserId, req.GrantId)
+	details, err := s.command.RemoveProjectGrantMember(ctx, req.ProjectId, req.UserId, req.GrantId, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/management/project_grant_converter.go
+++ b/internal/api/grpc/management/project_grant_converter.go
@@ -147,19 +147,19 @@ func ListProjectGrantMembersRequestToModel(ctx context.Context, req *mgmt_pb.Lis
 
 func AddProjectGrantMemberRequestToCommand(req *mgmt_pb.AddProjectGrantMemberRequest, orgID string) *command.AddProjectGrantMember {
 	return &command.AddProjectGrantMember{
-		ResourceOwner: orgID,
-		ProjectID:     req.ProjectId,
-		GrantID:       req.GrantId,
-		UserID:        req.UserId,
-		Roles:         req.Roles,
+		ResourceOwner:  orgID,
+		ProjectID:      req.ProjectId,
+		ProjectGrantID: req.GrantId,
+		UserID:         req.UserId,
+		Roles:          req.Roles,
 	}
 }
 
 func UpdateProjectGrantMemberRequestToCommand(req *mgmt_pb.UpdateProjectGrantMemberRequest) *command.ChangeProjectGrantMember {
 	return &command.ChangeProjectGrantMember{
-		ProjectID: req.ProjectId,
-		GrantID:   req.GrantId,
-		UserID:    req.UserId,
-		Roles:     req.Roles,
+		ProjectID:      req.ProjectId,
+		ProjectGrantID: req.GrantId,
+		UserID:         req.UserId,
+		Roles:          req.Roles,
 	}
 }

--- a/internal/api/grpc/oidc/v2beta/integration_test/oidc_test.go
+++ b/internal/api/grpc/oidc/v2beta/integration_test/oidc_test.go
@@ -427,7 +427,7 @@ func TestServer_CreateCallback_Permission(t *testing.T) {
 				orgResp := Instance.CreateOrganization(ctx, integration.OrganizationName(), integration.Email())
 				Instance.CreateProjectGrant(ctx, t, projectID, orgResp.GetOrganizationId())
 				user := Instance.CreateHumanUserVerified(ctx, orgResp.GetOrganizationId(), integration.Email(), integration.Phone())
-				createProjectGrantUserGrant(ctx, t, orgResp.GetOrganizationId(), projectID, orgResp.GetOrganizationId(), user.GetUserId())
+				createProjectGrantUserGrant(ctx, t, projectID, orgResp.GetOrganizationId(), user.GetUserId())
 
 				return createSessionAndAuthRequestForCallback(ctx, t, clientID, Instance.Users.Get(integration.UserTypeLogin).ID, user.GetUserId())
 			},
@@ -564,7 +564,7 @@ func TestServer_CreateCallback_Permission(t *testing.T) {
 				orgResp := Instance.CreateOrganization(ctx, integration.OrganizationName(), integration.Email())
 				Instance.CreateProjectGrant(ctx, t, projectID, orgResp.GetOrganizationId())
 				user := Instance.CreateHumanUserVerified(ctx, orgResp.GetOrganizationId(), integration.Email(), integration.Phone())
-				createProjectGrantUserGrant(ctx, t, orgResp.GetOrganizationId(), projectID, orgResp.GetOrganizationId(), user.GetUserId())
+				createProjectGrantUserGrant(ctx, t, projectID, orgResp.GetOrganizationId(), user.GetUserId())
 				return createSessionAndAuthRequestForCallback(ctx, t, clientID, Instance.Users.Get(integration.UserTypeLogin).ID, user.GetUserId())
 			},
 			want: &oidc_pb.CreateCallbackResponse{
@@ -693,26 +693,26 @@ func createOIDCApplication(ctx context.Context, t *testing.T, projectRoleCheck, 
 }
 
 func createProjectUserGrant(ctx context.Context, t *testing.T, orgID, projectID, userID string) {
-	resp := Instance.CreateProjectUserGrant(t, ctx, orgID, projectID, userID)
+	resp := Instance.CreateAuthorizationProject(t, ctx, projectID, userID)
 
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, orgID), &mgmt.GetUserGrantByIDRequest{
 			UserId:  userID,
-			GrantId: resp.GetUserGrantId(),
+			GrantId: resp.GetId(),
 		})
 		assert.NoError(collect, err)
 	}, retryDuration, tick)
 }
 
-func createProjectGrantUserGrant(ctx context.Context, t *testing.T, orgID, projectID, projectGrantID, userID string) {
-	resp := Instance.CreateProjectGrantUserGrant(ctx, orgID, projectID, projectGrantID, userID)
+func createProjectGrantUserGrant(ctx context.Context, t *testing.T, projectID, grantedOrgID, userID string) {
+	resp := Instance.CreateAuthorizationProjectGrant(t, ctx, projectID, grantedOrgID, userID)
 
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, orgID), &mgmt.GetUserGrantByIDRequest{
+		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, grantedOrgID), &mgmt.GetUserGrantByIDRequest{
 			UserId:  userID,
-			GrantId: resp.GetUserGrantId(),
+			GrantId: resp.GetId(),
 		})
 		assert.NoError(collect, err)
 	}, retryDuration, tick)

--- a/internal/api/grpc/project/v2beta/project_grant.go
+++ b/internal/api/grpc/project/v2beta/project_grant.go
@@ -6,10 +6,11 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	project_pb "github.com/zitadel/zitadel/pkg/grpc/project/v2beta"
+
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/eventstore/v1/models"
 	"github.com/zitadel/zitadel/internal/query"
-	project_pb "github.com/zitadel/zitadel/pkg/grpc/project/v2beta"
 )
 
 func (s *Server) CreateProjectGrant(ctx context.Context, req *connect.Request[project_pb.CreateProjectGrantRequest]) (*connect.Response[project_pb.CreateProjectGrantResponse], error) {
@@ -32,7 +33,6 @@ func projectGrantCreateToCommand(req *project_pb.CreateProjectGrantRequest) *com
 		ObjectRoot: models.ObjectRoot{
 			AggregateID: req.ProjectId,
 		},
-		GrantID:      req.GrantedOrganizationId,
 		GrantedOrgID: req.GrantedOrganizationId,
 		RoleKeys:     req.RoleKeys,
 	}
@@ -113,7 +113,7 @@ func (s *Server) userGrantsFromProjectGrant(ctx context.Context, projectID, gran
 	if err != nil {
 		return nil, err
 	}
-	grantQuery, err := query.NewUserGrantGrantIDSearchQuery(grantedOrganizationID)
+	grantQuery, err := query.NewUserGrantWithGrantedQuery(grantedOrganizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/project/v2beta/project_grant.go
+++ b/internal/api/grpc/project/v2beta/project_grant.go
@@ -6,11 +6,10 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	project_pb "github.com/zitadel/zitadel/pkg/grpc/project/v2beta"
-
 	"github.com/zitadel/zitadel/internal/command"
 	"github.com/zitadel/zitadel/internal/eventstore/v1/models"
 	"github.com/zitadel/zitadel/internal/query"
+	project_pb "github.com/zitadel/zitadel/pkg/grpc/project/v2beta"
 )
 
 func (s *Server) CreateProjectGrant(ctx context.Context, req *connect.Request[project_pb.CreateProjectGrantRequest]) (*connect.Response[project_pb.CreateProjectGrantResponse], error) {

--- a/internal/api/grpc/saml/v2/integration_test/saml_test.go
+++ b/internal/api/grpc/saml/v2/integration_test/saml_test.go
@@ -416,7 +416,7 @@ func TestServer_CreateResponse_Permission(t *testing.T) {
 				orgResp := Instance.CreateOrganization(ctx, integration.OrganizationName(), integration.Email())
 				Instance.CreateProjectGrant(ctx, t, projectID, orgResp.GetOrganizationId())
 				user := Instance.CreateHumanUserVerified(ctx, orgResp.GetOrganizationId(), integration.Email(), integration.Phone())
-				createProjectGrantUserGrant(ctx, t, orgResp.GetOrganizationId(), projectID, orgResp.GetOrganizationId(), user.GetUserId())
+				createProjectGrantUserGrant(ctx, t, projectID, orgResp.GetOrganizationId(), user.GetUserId())
 
 				return createSessionAndSmlRequestForCallback(ctx, t, sp, Instance.Users[integration.UserTypeLogin].ID, acsRedirect, user.GetUserId(), saml.HTTPRedirectBinding)
 			},
@@ -550,7 +550,7 @@ func TestServer_CreateResponse_Permission(t *testing.T) {
 				orgResp := Instance.CreateOrganization(ctx, integration.OrganizationName(), integration.Email())
 				Instance.CreateProjectGrant(ctx, t, projectID, orgResp.GetOrganizationId())
 				user := Instance.CreateHumanUserVerified(ctx, orgResp.GetOrganizationId(), integration.Email(), integration.Phone())
-				createProjectGrantUserGrant(ctx, t, orgResp.GetOrganizationId(), projectID, orgResp.GetOrganizationId(), user.GetUserId())
+				createProjectGrantUserGrant(ctx, t, projectID, orgResp.GetOrganizationId(), user.GetUserId())
 
 				return createSessionAndSmlRequestForCallback(ctx, t, sp, Instance.Users[integration.UserTypeLogin].ID, acsRedirect, user.GetUserId(), saml.HTTPRedirectBinding)
 			},
@@ -694,26 +694,26 @@ func createSAMLApplication(ctx context.Context, t *testing.T, idpMetadata *saml.
 }
 
 func createProjectUserGrant(ctx context.Context, t *testing.T, orgID, projectID, userID string) {
-	resp := Instance.CreateProjectUserGrant(t, ctx, orgID, projectID, userID)
+	resp := Instance.CreateAuthorizationProject(t, ctx, projectID, userID)
 
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, orgID), &mgmt.GetUserGrantByIDRequest{
 			UserId:  userID,
-			GrantId: resp.GetUserGrantId(),
+			GrantId: resp.GetId(),
 		})
 		assert.NoError(collect, err)
 	}, retryDuration, tick)
 }
 
-func createProjectGrantUserGrant(ctx context.Context, t *testing.T, orgID, projectID, projectGrantID, userID string) {
-	resp := Instance.CreateProjectGrantUserGrant(ctx, orgID, projectID, projectGrantID, userID)
+func createProjectGrantUserGrant(ctx context.Context, t *testing.T, projectID, grantedOrgID, userID string) {
+	resp := Instance.CreateAuthorizationProjectGrant(t, ctx, projectID, grantedOrgID, userID)
 
 	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, orgID), &mgmt.GetUserGrantByIDRequest{
+		_, err := Instance.Client.Mgmt.GetUserGrantByID(integration.SetOrgID(ctx, grantedOrgID), &mgmt.GetUserGrantByIDRequest{
 			UserId:  userID,
-			GrantId: resp.GetUserGrantId(),
+			GrantId: resp.GetId(),
 		})
 		assert.NoError(collect, err)
 	}, retryDuration, tick)

--- a/internal/command/permission_checks.go
+++ b/internal/command/permission_checks.go
@@ -133,19 +133,11 @@ func (c *Commands) checkPermissionDeleteProjectMember(ctx context.Context, resou
 }
 
 func (c *Commands) checkPermissionUpdateProjectGrantMember(ctx context.Context, grantedOrgID, projectGrantID string) (err error) {
-	// TODO: add permission check for project grant owners
-	//if err := c.newPermissionCheck(ctx, domain.PermissionProjectGrantMemberWrite, project.AggregateType)(resourceOwner, projectGrantID); err != nil {
 	return c.newPermissionCheck(ctx, domain.PermissionProjectGrantMemberWrite, project.AggregateType)(grantedOrgID, projectGrantID)
-	//}
-	//return nil
 }
 
 func (c *Commands) checkPermissionDeleteProjectGrantMember(ctx context.Context, grantedOrgID, projectGrantID string) (err error) {
-	// TODO: add permission check for project grant owners
-	//if err := c.newPermissionCheck(ctx, domain.PermissionProjectGrantMemberDelete, project.AggregateType)(resourceOwner, projectGrantID); err != nil {
 	return c.newPermissionCheck(ctx, domain.PermissionProjectGrantMemberDelete, project.AggregateType)(grantedOrgID, projectGrantID)
-	//}
-	//return nil
 }
 
 func (c *Commands) newUserGrantPermissionCheck(ctx context.Context, permission string) UserGrantPermissionCheck {

--- a/internal/command/project_grant.go
+++ b/internal/command/project_grant.go
@@ -234,15 +234,15 @@ func (c *Commands) DeactivateProjectGrant(ctx context.Context, projectID, grantI
 	return writeModelToObjectDetails(&existingGrant.WriteModel), nil
 }
 
-func (c *Commands) checkProjectGrantExists(ctx context.Context, grantID, grantedOrgID, projectID, resourceOwner string) (string, string, error) {
+func (c *Commands) checkProjectGrantExists(ctx context.Context, grantID, grantedOrgID, projectID, resourceOwner string) (string, string, string, error) {
 	existingGrant, err := c.projectGrantWriteModelByID(ctx, grantID, grantedOrgID, projectID, resourceOwner)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	if !existingGrant.State.Exists() {
-		return "", "", zerrors.ThrowNotFound(nil, "PROJECT-D8JxR", "Errors.Project.Grant.NotFound")
+		return "", "", "", zerrors.ThrowNotFound(nil, "PROJECT-D8JxR", "Errors.Project.Grant.NotFound")
 	}
-	return existingGrant.GrantedOrgID, existingGrant.ResourceOwner, nil
+	return existingGrant.FoundGrantID, existingGrant.GrantedOrgID, existingGrant.ResourceOwner, nil
 }
 
 func (c *Commands) ReactivateProjectGrant(ctx context.Context, projectID, grantID, grantedOrgID, resourceOwner string) (details *domain.ObjectDetails, err error) {

--- a/internal/command/project_grant_member_test.go
+++ b/internal/command/project_grant_member_test.go
@@ -57,10 +57,10 @@ func TestCommandSide_AddProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &AddProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -82,10 +82,10 @@ func TestCommandSide_AddProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &AddProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -142,10 +142,10 @@ func TestCommandSide_AddProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &AddProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -202,10 +202,10 @@ func TestCommandSide_AddProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &AddProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -257,10 +257,10 @@ func TestCommandSide_AddProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &AddProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -331,10 +331,10 @@ func TestCommandSide_ChangeProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &ChangeProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_OWNER"},
 				},
 			},
 			res: res{
@@ -366,10 +366,10 @@ func TestCommandSide_ChangeProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &ChangeProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -410,10 +410,10 @@ func TestCommandSide_ChangeProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &ChangeProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER"},
 				},
 			},
 			res: res{
@@ -467,10 +467,10 @@ func TestCommandSide_ChangeProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &ChangeProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER", "PROJECT_GRANT_VIEWER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER", "PROJECT_GRANT_VIEWER"},
 				},
 			},
 			res: res{
@@ -516,10 +516,10 @@ func TestCommandSide_ChangeProjectGrantMember(t *testing.T) {
 			},
 			args: args{
 				member: &ChangeProjectGrantMember{
-					ProjectID: "project1",
-					GrantID:   "projectgrant1",
-					UserID:    "user1",
-					Roles:     []string{"PROJECT_GRANT_OWNER", "PROJECT_GRANT_VIEWER"},
+					ProjectID:      "project1",
+					ProjectGrantID: "projectgrant1",
+					UserID:         "user1",
+					Roles:          []string{"PROJECT_GRANT_OWNER", "PROJECT_GRANT_VIEWER"},
 				},
 			},
 			res: res{
@@ -554,10 +554,11 @@ func TestCommandSide_RemoveProjectGrantMember(t *testing.T) {
 		checkPermission domain.PermissionCheck
 	}
 	type args struct {
-		ctx       context.Context
-		projectID string
-		grantID   string
-		userID    string
+		ctx            context.Context
+		projectID      string
+		grantID        string
+		organizationID string
+		userID         string
 	}
 	type res struct {
 		want *domain.ObjectDetails
@@ -694,6 +695,52 @@ func TestCommandSide_RemoveProjectGrantMember(t *testing.T) {
 			},
 		},
 		{
+			name: "member remove, organizationID, ok",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							project.NewGrantAddedEvent(context.Background(),
+								&project.NewAggregate("project1", "org1").Aggregate,
+								"projectgrant1",
+								"org2",
+								[]string{"rol1", "role2"},
+							),
+						),
+					),
+					expectFilter(
+						eventFromEventPusher(
+							project.NewProjectGrantMemberAddedEvent(context.Background(),
+								&project.NewAggregate("project1", "org1").Aggregate,
+								"user1",
+								"projectgrant1",
+								[]string{"PROJECT_OWNER"}...,
+							),
+						),
+					),
+					expectPush(
+						project.NewProjectGrantMemberRemovedEvent(context.Background(),
+							&project.NewAggregate("project1", "org1").Aggregate,
+							"user1",
+							"projectgrant1",
+						),
+					),
+				),
+				checkPermission: newMockPermissionCheckAllowed(),
+			},
+			args: args{
+				ctx:            context.Background(),
+				projectID:      "project1",
+				userID:         "user1",
+				organizationID: "org2",
+			},
+			res: res{
+				want: &domain.ObjectDetails{
+					ResourceOwner: "org1",
+				},
+			},
+		},
+		{
 			name: "member remove, no permission",
 			fields: fields{
 				eventstore: expectEventstore(
@@ -737,7 +784,7 @@ func TestCommandSide_RemoveProjectGrantMember(t *testing.T) {
 				eventstore:      tt.fields.eventstore(t),
 				checkPermission: tt.fields.checkPermission,
 			}
-			got, err := r.RemoveProjectGrantMember(tt.args.ctx, tt.args.projectID, tt.args.userID, tt.args.grantID)
+			got, err := r.RemoveProjectGrantMember(tt.args.ctx, tt.args.projectID, tt.args.userID, tt.args.grantID, tt.args.organizationID)
 			if tt.res.err == nil {
 				assert.NoError(t, err)
 			}

--- a/internal/command/user_grant_model.go
+++ b/internal/command/user_grant_model.go
@@ -171,7 +171,8 @@ func projectExistsOnOrganization(requiredOrganization, projectResourceOwner stri
 func projectGrantExistsOnOrganization(requiredGrantID, requiredOrganization, projectGrantID, grantedOrganization string) bool {
 	// Depending on the API, a request can either require a project grant (ID) and/or an organization (ID),
 	// where the project must be granted to.
-	return (requiredGrantID == "" || requiredGrantID == projectGrantID) &&
+	return (requiredGrantID != "" || requiredOrganization != "") &&
+		(requiredGrantID == "" || requiredGrantID == projectGrantID) &&
 		(requiredOrganization == "" || requiredOrganization == grantedOrganization)
 }
 

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -959,6 +959,25 @@ func (i *Instance) ActivateProjectGrant(ctx context.Context, t *testing.T, proje
 	return resp
 }
 
+func (i *Instance) CreateAuthorizationProject(t *testing.T, ctx context.Context, projectID, userID string) *authorization.CreateAuthorizationResponse {
+	resp, err := i.Client.AuthorizationV2Beta.CreateAuthorization(ctx, &authorization.CreateAuthorizationRequest{
+		UserId:    userID,
+		ProjectId: projectID,
+	})
+	require.NoError(t, err)
+	return resp
+}
+
+func (i *Instance) CreateAuthorizationProjectGrant(t *testing.T, ctx context.Context, projectID, orgID, userID string) *authorization.CreateAuthorizationResponse {
+	resp, err := i.Client.AuthorizationV2Beta.CreateAuthorization(ctx, &authorization.CreateAuthorizationRequest{
+		UserId:         userID,
+		ProjectId:      projectID,
+		OrganizationId: gu.Ptr(orgID),
+	})
+	require.NoError(t, err)
+	return resp
+}
+
 func (i *Instance) CreateProjectUserGrant(t *testing.T, ctx context.Context, orgID, projectID, userID string) *mgmt.AddUserGrantResponse {
 	//nolint:staticcheck
 	resp, err := i.Client.Mgmt.AddUserGrant(SetOrgID(ctx, orgID), &mgmt.AddUserGrantRequest{
@@ -1042,12 +1061,12 @@ func (i *Instance) DeleteProjectMembership(t *testing.T, ctx context.Context, pr
 	require.NoError(t, err)
 }
 
-func (i *Instance) CreateProjectGrantMembership(t *testing.T, ctx context.Context, projectID, grantID, userID string) *internal_permission_v2beta.CreateAdministratorResponse {
+func (i *Instance) CreateProjectGrantMembership(t *testing.T, ctx context.Context, projectID, orgID, userID string) *internal_permission_v2beta.CreateAdministratorResponse {
 	resp, err := i.Client.InternalPermissionv2Beta.CreateAdministrator(ctx, &internal_permission_v2beta.CreateAdministratorRequest{
 		Resource: &internal_permission_v2beta.ResourceType{
 			Resource: &internal_permission_v2beta.ResourceType_ProjectGrant_{ProjectGrant: &internal_permission_v2beta.ResourceType_ProjectGrant{
 				ProjectId:      projectID,
-				ProjectGrantId: grantID,
+				OrganizationId: orgID,
 			}},
 		},
 		UserId: userID,
@@ -1057,12 +1076,12 @@ func (i *Instance) CreateProjectGrantMembership(t *testing.T, ctx context.Contex
 	return resp
 }
 
-func (i *Instance) DeleteProjectGrantMembership(t *testing.T, ctx context.Context, projectID, grantID, userID string) {
+func (i *Instance) DeleteProjectGrantMembership(t *testing.T, ctx context.Context, projectID, orgID, userID string) {
 	_, err := i.Client.InternalPermissionv2Beta.DeleteAdministrator(ctx, &internal_permission_v2beta.DeleteAdministratorRequest{
 		Resource: &internal_permission_v2beta.ResourceType{
 			Resource: &internal_permission_v2beta.ResourceType_ProjectGrant_{ProjectGrant: &internal_permission_v2beta.ResourceType_ProjectGrant{
 				ProjectId:      projectID,
-				ProjectGrantId: grantID,
+				OrganizationId: orgID,
 			}},
 		},
 		UserId: userID,

--- a/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
+++ b/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
@@ -317,7 +317,7 @@ message ResourceType {
     reserved 2;
     // ProjectID is required to grant administrator privileges for a specific project.
     string project_id = 1;
-    // ProjectGrantID is required to grant administrator privileges for a specific project grant.
+    // OrganizationID is required to grant administrator privileges for a specific project grant.
     string organization_id = 3;
   }
 

--- a/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
+++ b/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
@@ -313,10 +313,12 @@ message CreateAdministratorRequest {
 
 message ResourceType {
   message ProjectGrant {
+    reserved "project_grant_id";
+    reserved 2;
     // ProjectID is required to grant administrator privileges for a specific project.
     string project_id = 1;
     // ProjectGrantID is required to grant administrator privileges for a specific project grant.
-    string project_grant_id = 2;
+    string organization_id = 3;
   }
 
   // Resource is the type of the resource the administrator roles should be granted for.


### PR DESCRIPTION
# Which Problems Are Solved

Project Grant ID would have needed to be unique to be handled properly on the projections, but was defined as the organization ID the project was granted to, so could be non-unique.

# How the Problems Are Solved

Generate the Project Grant ID even in the v2 APIs, which also includes fixes in the integration tests.
Additionally to that, the logic for some functionality had to be extended as the Project Grant ID is not provided anymore in the API, so had to be queried before creating events for Project Grants.

# Additional Changes

Included fix for authorizations, when an authorization was intended to be created for a project, without providing any organization information, which also showed some faulty integration tests.

# Additional Context

Partially closes #10745 
