### PR TITLE
Increase retry tick duration in tests

### DIFF
--- a/internal/api/grpc/app/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/app/v2beta/integration_test/query_test.go
@@ -137,7 +137,7 @@ func TestGetApplication(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 30*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instance.Client.AppV2Beta.GetApplication(tc.inputCtx, tc.inputRequest)
@@ -438,7 +438,7 @@ func TestListApplications(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 30*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instance.Client.AppV2Beta.ListApplications(tc.inputCtx, tc.inputRequest)
@@ -550,7 +550,7 @@ func TestListApplications_WithPermissionV2(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instancePermissionV2.Client.AppV2Beta.ListApplications(tc.inputCtx, tc.inputRequest)
@@ -641,7 +641,7 @@ func TestGetApplicationKey(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 30*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instance.Client.AppV2Beta.GetApplicationKey(tc.inputCtx, tc.inputRequest)
@@ -719,7 +719,7 @@ func TestListApplicationKeys(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instance.Client.AppV2Beta.ListApplicationKeys(tc.inputCtx, tc.inputRequest)
@@ -799,7 +799,7 @@ func TestListApplicationKeys_WithPermissionV2(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			// t.Parallel()
 
-			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, 5*time.Second)
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputCtx, time.Minute)
 			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
 				// When
 				res, err := instancePermissionV2.Client.AppV2Beta.ListApplicationKeys(tc.inputCtx, tc.inputRequest)

--- a/internal/api/grpc/instance/v2beta/integration_test/instance_test.go
+++ b/internal/api/grpc/instance/v2beta/integration_test/instance_test.go
@@ -151,7 +151,7 @@ func TestUpdateInstace(t *testing.T) {
 				require.NotNil(t, res)
 				assert.NotEmpty(t, res.GetChangeDate())
 
-				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputContext, 20*time.Second)
+				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.inputContext, time.Minute)
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					retrievedInstance, err := inst.Client.InstanceV2Beta.GetInstance(tc.inputContext, &instance.GetInstanceRequest{InstanceId: inst.ID()})
 					require.Nil(tt, err)

--- a/internal/api/grpc/user/v2/integration_test/query_test.go
+++ b/internal/api/grpc/user/v2/integration_test/query_test.go
@@ -1181,7 +1181,7 @@ func TestServer_ListUsers(t *testing.T) {
 				setPermissionCheckV2Flag(t, f.SetFlag)
 				infos := tc.args.dep(IamCTX, tc.args.req)
 
-				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.args.ctx, 20*time.Second)
+				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.args.ctx, time.Minute)
 				require.EventuallyWithT(t1, func(ttt *assert.CollectT) {
 					got, err := Client.ListUsers(tc.args.ctx, tc.args.req)
 					if tc.wantErr {

--- a/internal/api/grpc/user/v2beta/integration_test/query_test.go
+++ b/internal/api/grpc/user/v2beta/integration_test/query_test.go
@@ -1138,7 +1138,7 @@ func TestServer_ListUsers(t *testing.T) {
 				infos := tc.args.dep(IamCTX, tc.args.req)
 
 				// retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tt.args.ctx, 10*time.Minute)
-				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.args.ctx, 20*time.Second)
+				retryDuration, tick := integration.WaitForAndTickWithMaxDuration(tc.args.ctx, time.Minute)
 				require.EventuallyWithT(t1, func(ttt *assert.CollectT) {
 					got, err := Client.ListUsers(tc.args.ctx, tc.args.req)
 					if tc.wantErr {

--- a/internal/integration/context.go
+++ b/internal/integration/context.go
@@ -8,7 +8,7 @@ import (
 // WaitForAndTickWithMaxDuration determine a duration and interval for EventuallyWithT-tests from context timeout and desired max duration
 func WaitForAndTickWithMaxDuration(ctx context.Context, max time.Duration) (time.Duration, time.Duration) {
 	// interval which is used to retry the test
-	tick := time.Millisecond * 100
+	tick := time.Second
 	// tolerance which is used to stop the test for the timeout
 	tolerance := tick * 5
 	// default of the WaitFor is always a defined duration, shortened if the context would time out before


### PR DESCRIPTION
Adjust the retry tick duration in various tests to one minute to improve reliability and reduce the frequency of retries.