### PR TITLE
chore(integration): set version of postgres service

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -19,7 +19,7 @@ jobs:
       group: zitadel-public
     services:
       postgres:
-        image: postgres
+        image: postgres:17
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
## Which Problems Are solved

Zitadel is currently [not compatible with postgres 18](https://github.com/zitadel/zitadel/issues/10712). Therefore the. integration tests fail.

## How the problem is solved

Update the PostgreSQL service configuration to use version 17 for improved compatibility and features for integration tests.