### PR TITLE
chore: use postgres 17

### DIFF
--- a/.github/workflows/core-integration-test.yml
+++ b/.github/workflows/core-integration-test.yml
@@ -19,7 +19,7 @@ jobs:
       group: zitadel-public
     services:
       postgres:
-        image: postgres
+        image: postgres:17
         ports:
           - 5432:5432
         env:

--- a/docs/docs/self-hosting/manage/database/_postgres.mdx
+++ b/docs/docs/self-hosting/manage/database/_postgres.mdx
@@ -2,9 +2,9 @@
 
 PostgreSQL is the default database for ZITADEL due to its reliability, robustness, and adherence to SQL standards. It is well-suited for handling the complex data requirements of an identity management system.
 
-If you are using Zitadel v2 and want to use a PostgreSQL database you can [overwrite the default configuration](../configure/configure.mdx).
+If you are using Zitadel v2 and want to use a PostgreSQL database, you can [overwrite the default configuration](../configure/configure.mdx).
 
-Currently versions >= 14 are supported.
+Currently, versions 14 to 17 are supported.
 
 Postgres can be configured as follows:
 ```yaml

--- a/internal/integration/config/docker-compose.yaml
+++ b/internal/integration/config/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   postgres:
     restart: 'always'
-    image: 'postgres:latest'
+    image: 'postgres:17'
     environment:
       - POSTGRES_USER=zitadel
       - PGUSER=zitadel


### PR DESCRIPTION
# Which Problems Are Solved

The current cache interface implementation for postgres is not compatible with Postgres18, since we rely on partitioned unlogged tables, which are no longer supported.

# How the Problems Are Solved

Use postgres 17 and update compatibility in the docs.

# Additional Changes

None

# Additional Context

- requires backport to v3.x, v4.x