### PR TITLE
fix(SetPassword); SetPassword() api call requires either current_password or verification_code

### DIFF
--- a/docs/docs/legal/service-description/support-services.mdx
+++ b/docs/docs/legal/service-description/support-services.mdx
@@ -34,7 +34,7 @@ Subscription Plans | Free | Production | Enterprise Cloud
 [Response Time](#slo---initial-response-time) (Severity 1) | n/a | 48 business hours | bespoke (as low as 30min)
 [Community support](#community-support) | yes | yes | yes
 [Professional support](#professional-support) | no | yes | yes
-[Enterprise supported features](https://help.zitadel.com/zitadel-support-states#enterprise) |  no | no | yes
+[Enterprise supported features](/docs/support/software-release-cycles-support.md#enterprise-supported) |  no | no | yes
 [Technical Account Management](#technical-account-manager) | no | no | bespoke
 
 #### Extended support
@@ -48,7 +48,7 @@ Extended support | Default
 [Response Time](#slo---initial-response-time) (Severity 1) | 1 business hour
 [Community support](#community-support) | yes
 [Professional support](#professional-support) | yes
-[Enterprise supported features](https://help.zitadel.com/zitadel-support-states#enterprise) |  no
+[Enterprise supported features](/docs/support/software-release-cycles-support.md#enterprise-supported) |  no
 [Technical Account Management](#technical-account-manager) | no
 
 ### ZITADEL Enterprise / self-hostable
@@ -62,7 +62,7 @@ ZITADEL Enterprise self-hostable| Default
 [Response Time](#slo---initial-response-time) (Severity 1) | bespoke (as low as 30min)
 [Community support](#community-support) | yes
 [Professional support](#professional-support) | yes
-[Enterprise supported features](https://help.zitadel.com/zitadel-support-states#enterprise) |  yes
+[Enterprise supported features](/docs/support/software-release-cycles-support.md#enterprise-supported) |  yes
 [Technical Account Management](#technical-account-manager) | bespoke
 
 ## Description of support services
@@ -117,7 +117,7 @@ eMail Support | support@zitadel.com
 Chat Support | Private chat channel between ZITADEL and Customer that is opened when Subscription becomes active
 Phone Support | +41 43 215 27 34
 
-- ZITADEL Cloud system status, incidents and maintenance windows will be communicated via [our status page](https://zitadelstatus.com).
+- ZITADEL Cloud system status, incidents and maintenance windows will be communicated via [our status page](https://status.zitadel.com).
 - Questions regarding pricing, billing, and invoicing of our services should be addressed to billing@zitadel.com
 - Security related questions and incidents can also be directly addressed to security@zitadel.com
 

--- a/internal/api/grpc/user/v2/integration_test/password_test.go
+++ b/internal/api/grpc/user/v2/integration_test/password_test.go
@@ -4,6 +4,7 @@ package user_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/muhlemmer/gu"
@@ -109,13 +110,15 @@ func TestServer_Deprecated_SetPassword(t *testing.T) {
 		ctx context.Context
 		req *user.SetPasswordRequest
 	}
-	tests := []struct {
+	type test struct {
 		name    string
 		prepare func(request *user.SetPasswordRequest) error
 		args    args
 		want    *user.SetPasswordResponse
 		wantErr bool
-	}{
+		err     error
+	}
+	tests := []test{
 		{
 			name: "missing user id",
 			prepare: func(request *user.SetPasswordRequest) error {
@@ -214,6 +217,104 @@ func TestServer_Deprecated_SetPassword(t *testing.T) {
 				},
 			},
 		},
+		func() test {
+			userID := Instance.CreateHumanUser(CTX).GetUserId()
+			return test{
+				name: "set password without current password/verification code, by the same user",
+				prepare: func(request *user.SetPasswordRequest) error {
+					request.UserId = userID
+					_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+						UserId: userID,
+						NewPassword: &user.Password{
+							Password: "InitialPassw0rd!",
+						},
+					})
+					return err
+				},
+				args: args{
+					ctx: func() context.Context {
+						Instance.RegisterUserPasskey(CTX, userID)
+						_, token, _, _ := Instance.CreateVerifiedWebAuthNSession(t, LoginCTX, userID)
+						return integration.WithAuthorizationToken(context.Background(), token)
+					}(),
+					req: &user.SetPasswordRequest{},
+				},
+				want: &user.SetPasswordResponse{
+					Details: &object.Details{
+						ChangeDate:    timestamppb.Now(),
+						ResourceOwner: Instance.DefaultOrg.Id,
+					},
+				},
+				wantErr: true,
+				err:     errors.New("Cannot change password without verification token or current password (COMMAND-SHr8d2)"),
+			}
+		}(),
+		{
+			name: "set password without current password/verification code, by other user",
+			prepare: func(request *user.SetPasswordRequest) error {
+				userID := Instance.CreateHumanUser(CTX).GetUserId()
+				request.UserId = userID
+				_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+					UserId: userID,
+					NewPassword: &user.Password{
+						Password: "InitialPassw0rd!",
+					},
+				})
+				return err
+			},
+			args: args{
+				ctx: func() context.Context {
+					otherUserID := Instance.CreateHumanUser(CTX).GetUserId()
+					Instance.RegisterUserPasskey(CTX, otherUserID)
+					_, token, _, _ := Instance.CreateVerifiedWebAuthNSession(t, LoginCTX, otherUserID)
+					return integration.WithAuthorizationToken(context.Background(), token)
+				}(),
+				req: &user.SetPasswordRequest{
+					NewPassword: &user.Password{
+						Password: "Secr3tP4ssw0rd!",
+					},
+				},
+			},
+			want: &user.SetPasswordResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+			wantErr: true,
+			err:     errors.New("membership not found (AUTHZ-cdgFk)"),
+		},
+		{
+			name: "set password without current password/verification code, with org owner permission",
+			prepare: func(request *user.SetPasswordRequest) error {
+				userID := Instance.CreateHumanUser(CTX).GetUserId()
+				request.UserId = userID
+				_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+					UserId: userID,
+					NewPassword: &user.Password{
+						Password: "InitialPassw0rd!",
+					},
+				})
+				return err
+			},
+			args: args{
+				ctx: Instance.WithAuthorization(context.Background(), integration.UserTypeOrgOwner),
+				req: &user.SetPasswordRequest{
+					NewPassword: &user.Password{
+						Password: "Secr3tP4ssw0rd!",
+					},
+					Verification: &user.SetPasswordRequest_CurrentPassword{
+						CurrentPassword: "InitialPassw0rd!",
+					},
+				},
+			},
+			want: &user.SetPasswordResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -222,9 +323,14 @@ func TestServer_Deprecated_SetPassword(t *testing.T) {
 
 			got, err := Client.SetPassword(tt.args.ctx, tt.args.req)
 			if tt.wantErr {
-				require.Error(t, err)
+				if tt.err != nil {
+					require.ErrorContains(t, err, tt.err.Error())
+				} else {
+					require.Error(t, err)
+				}
 				return
 			}
+
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			integration.AssertDetails(t, tt.want, got)

--- a/internal/api/grpc/user/v2beta/integration_test/password_test.go
+++ b/internal/api/grpc/user/v2beta/integration_test/password_test.go
@@ -4,6 +4,7 @@ package user_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/muhlemmer/gu"
@@ -111,13 +112,15 @@ func TestServer_SetPassword(t *testing.T) {
 		ctx context.Context
 		req *user.SetPasswordRequest
 	}
-	tests := []struct {
+	type test struct {
 		name    string
 		prepare func(request *user.SetPasswordRequest) error
 		args    args
 		want    *user.SetPasswordResponse
 		wantErr bool
-	}{
+		err     error
+	}
+	tests := []test{
 		{
 			name: "missing user id",
 			prepare: func(request *user.SetPasswordRequest) error {
@@ -216,6 +219,104 @@ func TestServer_SetPassword(t *testing.T) {
 				},
 			},
 		},
+		func() test {
+			userID := Instance.CreateHumanUser(CTX).GetUserId()
+			return test{
+				name: "set password without current password/verification code, by the same user",
+				prepare: func(request *user.SetPasswordRequest) error {
+					request.UserId = userID
+					_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+						UserId: userID,
+						NewPassword: &user.Password{
+							Password: "InitialPassw0rd!",
+						},
+					})
+					return err
+				},
+				args: args{
+					ctx: func() context.Context {
+						Instance.RegisterUserPasskey(CTX, userID)
+						_, token, _, _ := Instance.CreateVerifiedWebAuthNSession(t, LoginCTX, userID)
+						return integration.WithAuthorizationToken(context.Background(), token)
+					}(),
+					req: &user.SetPasswordRequest{},
+				},
+				want: &user.SetPasswordResponse{
+					Details: &object.Details{
+						ChangeDate:    timestamppb.Now(),
+						ResourceOwner: Instance.DefaultOrg.Id,
+					},
+				},
+				wantErr: true,
+				err:     errors.New("Cannot change password without verification token or current password (COMMAND-SHr8d2)"),
+			}
+		}(),
+		{
+			name: "set password without current password/verification code, by other user",
+			prepare: func(request *user.SetPasswordRequest) error {
+				userID := Instance.CreateHumanUser(CTX).GetUserId()
+				request.UserId = userID
+				_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+					UserId: userID,
+					NewPassword: &user.Password{
+						Password: "InitialPassw0rd!",
+					},
+				})
+				return err
+			},
+			args: args{
+				ctx: func() context.Context {
+					otherUserID := Instance.CreateHumanUser(CTX).GetUserId()
+					Instance.RegisterUserPasskey(CTX, otherUserID)
+					_, token, _, _ := Instance.CreateVerifiedWebAuthNSession(t, LoginCTX, otherUserID)
+					return integration.WithAuthorizationToken(context.Background(), token)
+				}(),
+				req: &user.SetPasswordRequest{
+					NewPassword: &user.Password{
+						Password: "Secr3tP4ssw0rd!",
+					},
+				},
+			},
+			want: &user.SetPasswordResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+			wantErr: true,
+			err:     errors.New("membership not found (AUTHZ-cdgFk)"),
+		},
+		{
+			name: "set password without current password/verification code, with org owner permission",
+			prepare: func(request *user.SetPasswordRequest) error {
+				userID := Instance.CreateHumanUser(CTX).GetUserId()
+				request.UserId = userID
+				_, err := Client.SetPassword(CTX, &user.SetPasswordRequest{
+					UserId: userID,
+					NewPassword: &user.Password{
+						Password: "InitialPassw0rd!",
+					},
+				})
+				return err
+			},
+			args: args{
+				ctx: Instance.WithAuthorization(context.Background(), integration.UserTypeOrgOwner),
+				req: &user.SetPasswordRequest{
+					NewPassword: &user.Password{
+						Password: "Secr3tP4ssw0rd!",
+					},
+					Verification: &user.SetPasswordRequest_CurrentPassword{
+						CurrentPassword: "InitialPassw0rd!",
+					},
+				},
+			},
+			want: &user.SetPasswordResponse{
+				Details: &object.Details{
+					ChangeDate:    timestamppb.Now(),
+					ResourceOwner: Instance.DefaultOrg.Id,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,9 +325,14 @@ func TestServer_SetPassword(t *testing.T) {
 
 			got, err := Client.SetPassword(tt.args.ctx, tt.args.req)
 			if tt.wantErr {
-				require.Error(t, err)
+				if tt.err != nil {
+					require.ErrorContains(t, err, tt.err.Error())
+				} else {
+					require.Error(t, err)
+				}
 				return
 			}
+
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			integration.AssertDetails(t, tt.want, got)

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -237,7 +237,7 @@ func (c *Commands) HumanRemoveTOTP(ctx context.Context, userID, resourceOwner st
 	if existingOTP.State == domain.MFAStateUnspecified || existingOTP.State == domain.MFAStateRemoved {
 		return nil, zerrors.ThrowNotFound(nil, "COMMAND-Hd9sd", "Errors.User.MFA.OTP.NotExisting")
 	}
-	if err := c.checkPermissionUpdateUser(ctx, existingOTP.ResourceOwner, userID, true); err != nil {
+	if err := c.checkPermissionUpdateUser(ctx, existingOTP.ResourceOwner, userID); err != nil {
 		return nil, err
 	}
 	userAgg := UserAggregateFromWriteModel(&existingOTP.WriteModel)
@@ -309,7 +309,7 @@ func (c *Commands) RemoveHumanOTPSMS(ctx context.Context, userID, resourceOwner 
 	if err != nil {
 		return nil, err
 	}
-	if err := c.checkPermissionUpdateUser(ctx, existingOTP.WriteModel.ResourceOwner, userID, true); err != nil {
+	if err := c.checkPermissionUpdateUser(ctx, existingOTP.WriteModel.ResourceOwner, userID); err != nil {
 		return nil, err
 	}
 	if !existingOTP.otpAdded {
@@ -439,7 +439,7 @@ func (c *Commands) RemoveHumanOTPEmail(ctx context.Context, userID, resourceOwne
 	if err != nil {
 		return nil, err
 	}
-	if err := c.checkPermissionUpdateUser(ctx, existingOTP.WriteModel.ResourceOwner, userID, true); err != nil {
+	if err := c.checkPermissionUpdateUser(ctx, existingOTP.WriteModel.ResourceOwner, userID); err != nil {
 		return nil, err
 	}
 	if !existingOTP.otpAdded {

--- a/internal/command/user_human_password_test.go
+++ b/internal/command/user_human_password_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/text/language"
 
+	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
@@ -231,6 +232,89 @@ func TestCommandSide_SetOneTimePassword(t *testing.T) {
 				ctx:           context.Background(),
 				userID:        "user1",
 				resourceOwner: "org1",
+				password:      "password",
+				oneTime:       false,
+			},
+			res: res{
+				want: &domain.ObjectDetails{
+					ResourceOwner: "org1",
+				},
+			},
+		},
+		{
+			name: "callers id same as user id",
+			fields: fields{
+				eventstore: expectEventstore(),
+			},
+			args: args{
+				ctx: func() context.Context {
+					return authz.SetCtxData(context.Background(), authz.CtxData{UserID: "callersUserID"})
+				}(),
+				userID: "callersUserID",
+			},
+			res: res{
+				err: zerrors.IsPermissionDenied,
+			},
+		},
+		{
+			name: "change password no one time, no orgID passed",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanAddedEvent(context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								"username",
+								"firstname",
+								"lastname",
+								"nickname",
+								"displayname",
+								language.German,
+								domain.GenderUnspecified,
+								"email@test.ch",
+								true,
+							),
+						),
+						eventFromEventPusher(
+							user.NewHumanEmailVerifiedEvent(context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+							),
+						),
+					),
+					expectFilter(
+						eventFromEventPusher(
+							org.NewPasswordComplexityPolicyAddedEvent(context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								1,
+								false,
+								false,
+								false,
+								false,
+							),
+						),
+					),
+					expectPush(
+						func() *user.HumanPasswordChangedEvent {
+							e := user.NewHumanPasswordChangedEvent(context.Background(),
+								&user.NewAggregate("user1", "org1").Aggregate,
+								"$plain$x$password",
+								false,
+								"",
+							)
+							e.User = "callersUserID"
+							return e
+						}(),
+					),
+				),
+				userPasswordHasher: mockPasswordHasher("x"),
+				checkPermission:    newMockPermissionCheckAllowed(),
+			},
+			args: args{
+				ctx: func() context.Context {
+					return authz.SetCtxData(context.Background(), authz.CtxData{UserID: "callersUserID"})
+				}(),
+				userID:        "user1",
+				resourceOwner: "", // no orgID
 				password:      "password",
 				oneTime:       false,
 			},

--- a/internal/command/user_human_test.go
+++ b/internal/command/user_human_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/text/language"
 
@@ -45,7 +44,6 @@ func TestCommandSide_AddHuman(t *testing.T) {
 		newCode                     encrypedCodeFunc
 		newEncryptedCodeWithDefault encryptedCodeWithDefaultFunc
 		defaultSecretGenerators     *SecretGenerators
-		defaultEmailCodeURLTemplate func(ctx context.Context) string
 	}
 	type args struct {
 		ctx             context.Context
@@ -541,11 +539,10 @@ func TestCommandSide_AddHuman(t *testing.T) {
 						),
 					),
 				),
-				idGenerator:                 id_mock.NewIDGeneratorExpectIDs(t, "user1"),
-				userPasswordHasher:          mockPasswordHasher("x"),
-				codeAlg:                     crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
-				newCode:                     mockEncryptedCode("userinit", time.Hour),
-				defaultEmailCodeURLTemplate: func(_ context.Context) string { return "" },
+				idGenerator:        id_mock.NewIDGeneratorExpectIDs(t, "user1"),
+				userPasswordHasher: mockPasswordHasher("x"),
+				codeAlg:            crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+				newCode:            mockEncryptedCode("userinit", time.Hour),
 			},
 			args: args{
 				ctx:   context.Background(),
@@ -683,17 +680,16 @@ func TestCommandSide_AddHuman(t *testing.T) {
 								Crypted:    []byte("emailCode"),
 							},
 							1*time.Hour,
-							"http://example.com/{{.user}}/email/{{.code}}",
+							"",
 							true,
 							"",
 						),
 					),
 				),
-				idGenerator:                 id_mock.NewIDGeneratorExpectIDs(t, "user1"),
-				userPasswordHasher:          mockPasswordHasher("x"),
-				codeAlg:                     crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
-				newCode:                     mockEncryptedCode("emailCode", time.Hour),
-				defaultEmailCodeURLTemplate: func(_ context.Context) string { return "http://example.com/{{.user}}/email/{{.code}}" },
+				idGenerator:        id_mock.NewIDGeneratorExpectIDs(t, "user1"),
+				userPasswordHasher: mockPasswordHasher("x"),
+				codeAlg:            crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+				newCode:            mockEncryptedCode("emailCode", time.Hour),
 			},
 			args: args{
 				ctx:   context.Background(),
@@ -1481,11 +1477,12 @@ func TestCommandSide_AddHuman(t *testing.T) {
 				newEncryptedCode:            tt.fields.newCode,
 				newEncryptedCodeWithDefault: tt.fields.newEncryptedCodeWithDefault,
 				defaultSecretGenerators:     tt.fields.defaultSecretGenerators,
-				defaultEmailCodeURLTemplate: tt.fields.defaultEmailCodeURLTemplate,
 			}
 			err := r.AddHuman(tt.args.ctx, tt.args.orgID, tt.args.human, tt.args.allowInitMail)
 			if tt.res.err == nil {
-				require.NoError(t, err)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
 			} else if !tt.res.err(err) {
 				t.Errorf("got wrong err: %v ", err)
 				return

--- a/internal/command/user_human_webauthn.go
+++ b/internal/command/user_human_webauthn.go
@@ -601,7 +601,7 @@ func (c *Commands) removeHumanWebAuthN(ctx context.Context, userID, webAuthNID, 
 		return nil, zerrors.ThrowNotFound(nil, "COMMAND-DAfb2", "Errors.User.WebAuthN.NotFound")
 	}
 
-	if err := c.checkPermissionUpdateUser(ctx, existingWebAuthN.ResourceOwner, existingWebAuthN.AggregateID, true); err != nil {
+	if err := c.checkPermissionUpdateUser(ctx, existingWebAuthN.ResourceOwner, existingWebAuthN.AggregateID); err != nil {
 		return nil, err
 	}
 

--- a/internal/static/i18n/bg.yaml
+++ b/internal/static/i18n/bg.yaml
@@ -153,6 +153,7 @@ Errors:
       NotSet: Потребителят не е задал парола
       NotChanged: Новата парола не може да съвпада с текущата парола
       NotSupported: Хеш кодирането на паролата не се поддържа. Вижте https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Не може да се промени паролата без токен за потвърждение или текуща парола
     PasswordComplexityPolicy:
       NotFound: Политиката за парола не е намерена
       MinLength: Паролата е твърде кратка

--- a/internal/static/i18n/cs.yaml
+++ b/internal/static/i18n/cs.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Uživatel nenastavil heslo
       NotChanged: Nové heslo nesmí být stejné jako současné heslo
       NotSupported: Kódování hash hesla není podporováno. Podívejte se na https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Nelze změnit heslo bez ověřovacího tokenu nebo aktuálního hesla
     PasswordComplexityPolicy:
       NotFound: Politika složitosti hesla nenalezena
       MinLength: Heslo je příliš krátké

--- a/internal/static/i18n/de.yaml
+++ b/internal/static/i18n/de.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Benutzer hat kein Passwort gesetzt
       NotChanged: Das neue Passwort darf nicht mit deinem aktuellen Passwort übereinstimmen
       NotSupported: Passwort-Hash-Kodierung wird nicht unterstützt. Siehe https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Kennwort kann ohne Bestätigungstoken oder aktuelles Kennwort nicht geändert werden
     PasswordComplexityPolicy:
       NotFound: Passwort Policy konnte nicht gefunden werden
       MinLength: Passwort ist zu kurz

--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -152,6 +152,7 @@ Errors:
       NotSet: User has not set a password
       NotChanged: New password cannot be the same as your current password
       NotSupported: Password hash encoding not supported. Check out https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Cannot change password without verification token or current password
     PasswordComplexityPolicy:
       NotFound: Password policy not found
       MinLength: Password is too short
@@ -1365,6 +1366,8 @@ EventTypes:
         code:
           added: Phone number verification code generated
           sent: Phone number verification code sent
+
+
   web_key:
     added: Web Key added
     activated: Web Key activated

--- a/internal/static/i18n/es.yaml
+++ b/internal/static/i18n/es.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: El usuario no ha establecido una contraseña
       NotChanged: La nueva contraseña no puede coincidir con la contraseña actual
       NotSupported: No se admite la codificación hash de contraseña. Consulte https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: No se puede cambiar la contraseña sin el token de verificación o la contraseña actual
     PasswordComplexityPolicy:
       NotFound: Política de contraseñas no encontrada
       MinLength: La contraseña es demasiado corta

--- a/internal/static/i18n/fr.yaml
+++ b/internal/static/i18n/fr.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: L'utilisateur n'a pas défini de mot de passe
       NotChanged: Le nouveau mot de passe ne peut pas être le même que votre mot de passe actuel
       NotSupported: Encodage de hachage de mot de passe non pris en charge. Consultez https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Impossible de modifier le mot de passe sans jeton de vérification ou mot de passe actuel
     PasswordComplexityPolicy:
       NotFound: Politique de mot de passe non trouvée
       MinLength: Le mot de passe est trop court

--- a/internal/static/i18n/hu.yaml
+++ b/internal/static/i18n/hu.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: A felhasználó nem állított be jelszót
       NotChanged: Az új jelszó nem egyezhet meg a jelenlegi jelszóval
       NotSupported: 'A jelszó hash kódolása nem támogatott. További információ itt: https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets'
+      NoVerificationTokenOrCurrentPassword: Jelszó nem módosítható ellenőrző token vagy aktuális jelszó nélkül
     PasswordComplexityPolicy:
       NotFound: A jelszó szabályzat nem található
       MinLength: A jelszó túl rövid

--- a/internal/static/i18n/id.yaml
+++ b/internal/static/i18n/id.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Pengguna belum menetapkan kata sandi
       NotChanged: Kata sandi baru tidak boleh sama dengan kata sandi Anda saat ini
       NotSupported: 'Pengkodean hash kata sandi tidak didukung. '
+      NoVerificationTokenOrCurrentPassword: Tidak dapat mengubah kata sandi tanpa token verifikasi atau kata sandi saat ini
     PasswordComplexityPolicy:
       NotFound: Kebijakan kata sandi tidak ditemukan
       MinLength: Kata sandi terlalu pendek

--- a/internal/static/i18n/it.yaml
+++ b/internal/static/i18n/it.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: L'utente non ha impostato una password
       NotChanged: La nuova password non può essere uguale alla password attuale
       NotSupported: Codifica hash password non supportata. Consulta https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Impossibile modificare la password senza token di verifica o password corrente
     PasswordComplexityPolicy:
       NotFound: Impostazioni di complessità password non trovati
       MinLength: La password è troppo corta

--- a/internal/static/i18n/ja.yaml
+++ b/internal/static/i18n/ja.yaml
@@ -152,6 +152,7 @@ Errors:
       NotSet: パスワードが未設置です
       NotChanged: 新しいパスワードは現在のパスワードと同じにすることはできません
       NotSupported: パスワードハッシュエンコードはサポートされていません。 https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets を参照してください。
+      NoVerificationTokenOrCurrentPassword: 検証トークンまたは現在のパスワードがないとパスワードを変更できません
     PasswordComplexityPolicy:
       NotFound: パスワードポリシーが見つかりません
       MinLength: パスワードが短すぎます

--- a/internal/static/i18n/ko.yaml
+++ b/internal/static/i18n/ko.yaml
@@ -152,6 +152,7 @@ Errors:
       NotSet: 사용자가 비밀번호를 설정하지 않았습니다
       NotChanged: 새 비밀번호는 현재 비밀번호와 다르지 않아야 합니다
       NotSupported: 비밀번호 해시 인코딩이 지원되지 않습니다. 자세한 내용은 https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets를 참조하세요
+      NoVerificationTokenOrCurrentPassword: 인증 토큰이나 현재 비밀번호 없이는 비밀번호를 변경할 수 없습니다.
     PasswordComplexityPolicy:
       NotFound: 비밀번호 정책을 찾을 수 없습니다
       MinLength: 비밀번호가 너무 짧습니다

--- a/internal/static/i18n/mk.yaml
+++ b/internal/static/i18n/mk.yaml
@@ -150,6 +150,7 @@ Errors:
       NotSet: Корисникот нема поставено лозинка
       NotChanged: Новата лозинка не може да биде иста со вашата тековна лозинка
       NotSupported: Не е поддржано хаш-кодирањето на лозинката. Проверете го https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Не може да се промени лозинката без токен за верификација или тековна лозинка
     PasswordComplexityPolicy:
       NotFound: Политиката за комплексност на лозинката не е пронајдена
       MinLength: Лозинката е прекратка

--- a/internal/static/i18n/nl.yaml
+++ b/internal/static/i18n/nl.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Gebruiker heeft geen wachtwoord ingesteld
       NotChanged: Nieuw wachtwoord kan niet hetzelfde zijn als uw huidige wachtwoord
       NotSupported: Wachtwoord hash codering wordt niet ondersteund. Raadpleeg https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Wachtwoord kan niet worden gewijzigd zonder verificatietoken of huidig wachtwoord
     PasswordComplexityPolicy:
       NotFound: Wachtwoordbeleid niet gevonden
       MinLength: Wachtwoord is te kort

--- a/internal/static/i18n/pl.yaml
+++ b/internal/static/i18n/pl.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Użytkownik nie ustawił hasła
       NotChanged: Nowe hasło nie może być takie samo jak Twoje obecne hasło
       NotSupported: Kodowanie skrótu hasła nie jest obsługiwane. Sprawdź https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Nie można zmienić hasła bez tokena weryfikacyjnego lub aktualnego hasła
     PasswordComplexityPolicy:
       NotFound: Polityka hasła nie znaleziona
       MinLength: Hasło jest zbyt krótkie

--- a/internal/static/i18n/pt.yaml
+++ b/internal/static/i18n/pt.yaml
@@ -151,7 +151,9 @@ Errors:
       NotSet: O usuário não definiu uma senha
       NotChanged: A nova senha não pode ser igual à sua senha atual
       NotSupported: Codificação hash da senha não suportada. Confira https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
-    PasswordComplexityPolicy:
+      NoVerificationTokenOrCurrentPassword: Não é possível alterar a palavra-passe sem o token de verificação ou a palavra-passe atual
+      PasswordComplexityrolicy: Não é possível alterar a palavra-passe sem o token de verificação ou a palavra-passe atual
+    PasswordComplexityPolrcy:
       NotFound: Política de complexidade de senha não encontrada
       MinLength: A senha é muito curta
       MinLengthNotAllowed: O comprimento mínimo fornecido não é permitido

--- a/internal/static/i18n/ro.yaml
+++ b/internal/static/i18n/ro.yaml
@@ -152,6 +152,7 @@ Errors:
       NotSet: Utilizatorul nu a setat o parolă
       NotChanged: Parola nouă nu poate fi aceeași cu parola curentă
       NotSupported: Codificarea hash a parolei nu este acceptată. Consultați https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Nu se poate schimba parola fără token de verificare sau parola curentă.
     PasswordComplexityPolicy:
       NotFound: Politica de parolă nu a fost găsită
       MinLength: Parola este prea scurtă

--- a/internal/static/i18n/ru.yaml
+++ b/internal/static/i18n/ru.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Пароль не установлен пользователем
       NotChanged: Пароль не изменен
       NotSupported: Кодировка хэша пароля не поддерживается. Проверьте https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Невозможно сменить пароль без проверочного токена или текущего пароля.
     PasswordComplexityPolicy:
       NotFound: Политика паролей не найдена
       MinLength: Пароль слишком короткий

--- a/internal/static/i18n/sv.yaml
+++ b/internal/static/i18n/sv.yaml
@@ -151,6 +151,7 @@ Errors:
       NotSet: Användare har inte ställt in ett lösenord
       NotChanged: Nytt lösenord kan inte vara samma som ditt nuvarande lösenord
       NotSupported: Lösenordshash-kodning stöds inte. Kolla https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Kan inte ändra lösenord utan verifieringstoken eller aktuellt lösenord
     PasswordComplexityPolicy:
       NotFound: Lösenordspolicy hittades inte
       MinLength: Lösenordet är för kort

--- a/internal/static/i18n/tr.yaml
+++ b/internal/static/i18n/tr.yaml
@@ -152,6 +152,7 @@ Errors:
       NotSet: Kullanıcı şifre ayarlamamış
       NotChanged: Yeni şifre mevcut şifrenizle aynı olamaz
       NotSupported: Şifre hash kodlaması desteklenmiyor. Kontrol edin https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: Doğrulama belirteci veya geçerli parola olmadan parola değiştirilemez
     PasswordComplexityPolicy:
       NotFound: Şifre politikası bulunamadı
       MinLength: Şifre çok kısa

--- a/internal/static/i18n/zh.yaml
+++ b/internal/static/i18n/zh.yaml
@@ -53,7 +53,6 @@ Errors:
     NotFound: 未找到 SMS 配置
     AlreadyActive: SMS 配置已启用
     AlreadyDeactivated: SMS 配置已停用
-    NotExternalVerification: SMS 配置不支持验证码
   SMTP:
     NotEmailMessage: 消息不是电子邮件消息
     RequiredAttributes: 必须设置主题、收件人和内容，但部分或全部为空
@@ -152,6 +151,7 @@ Errors:
       NotSet: 用户未设置密码
       NotChanged: 新密码不能与您当前的密码相同
       NotSupported: 不支持密码哈希编码。查看 https://zitadel.com/docs/concepts/architecture/secrets#hashed-secrets
+      NoVerificationTokenOrCurrentPassword: 没有验证令牌或当前密码则无法更改密码
     PasswordComplexityPolicy:
       NotFound: 未找到密码策略
       MinLength: 密码太短
@@ -659,7 +659,6 @@ EventTypes:
     token:
       added: 已创建访问令牌
       v2.added: 已创建访问令牌
-      removed: 已删除访问令牌
     impersonated: 用户冒充
     username:
       reserved: 保留用户名
@@ -1137,7 +1136,7 @@ EventTypes:
       jwt:
         config:
           added: 添加了身份提供者的 JWT 配置
-          changed: 身份提供者的 JWT 配置已删除
+          changed: 身份提供商的 JWT 配置已删除
     customtext:
       set: 设置文本
       removed: 删除文本
@@ -1292,10 +1291,10 @@ EventTypes:
         added: 添加了登录策略
         changed: 登录政策已更改
         idpprovider:
-          added: 身份提供者已添加到登录策略中
+          added: 身份提供商已添加到登录策略中
           cascade:
             removed: 身份提供者级联从登录策略中删除
-          removed: 身份提供者已从登录策略中删除
+          removed: 身份提供商已从登录策略中删除
         multifactor:
           added: 登录策略中添加了多因素
           removed: 从登录策略中删除了多因素

--- a/proto/zitadel/resources/user/v3alpha/user_service.proto
+++ b/proto/zitadel/resources/user/v3alpha/user_service.proto
@@ -571,6 +571,8 @@ service ZITADELUsers {
   // Set a password
   //
   // Add, update or reset a user's password with either a verification code or the current password.
+  //
+  // Organization Admins can change passwords for their users without verification code or current password
   rpc SetPassword (SetPasswordRequest) returns (SetPasswordResponse) {
     option (google.api.http) = {
       post: "/resources/v3alpha/users/{id}/password"

--- a/proto/zitadel/user/v2beta/user_service.proto
+++ b/proto/zitadel/user/v2beta/user_service.proto
@@ -1015,6 +1015,8 @@ service UserService {
   //
   // Change the password of a user with either a verification code or the current password.
   //
+  // Organization Admins can change passwords for their users without verification code or current password
+  //
   // Deprecated: please move to the corresponding endpoint under user service v2 (GA).
   rpc SetPassword (SetPasswordRequest) returns (SetPasswordResponse) {
     option (google.api.http) = {
@@ -1065,7 +1067,6 @@ service UserService {
       };
     };
   }
-
 }
 
 message AddHumanUserRequest{


### PR DESCRIPTION
# Which Problems Are Solved

Users were able to change their password unless they provide either a verification code OR their current password.

# How the Problems Are Solved

Changing the permission checks

# Additional Changes

Admins will still have the ability to change a users' password without a verification code OR their current password.

