### PR TITLE
fix(oidc): accept localhost redirect URIs without path nor port

### DIFF
--- a/internal/domain/application_oidc.go
+++ b/internal/domain/application_oidc.go
@@ -11,12 +11,16 @@ import (
 
 const (
 	http                          = "http://"
+	httpLocalhost                 = "http://localhost"
 	httpLocalhostWithPort         = "http://localhost:"
 	httpLocalhostWithoutPort      = "http://localhost/"
+	httpLoopbackV4                = "http://127.0.0.1"
 	httpLoopbackV4WithPort        = "http://127.0.0.1:"
 	httpLoopbackV4WithoutPort     = "http://127.0.0.1/"
+	httpLoopbackV6                = "http://[::1]"
 	httpLoopbackV6WithPort        = "http://[::1]:"
 	httpLoopbackV6WithoutPort     = "http://[::1]/"
+	httpLoopbackV6Long            = "http://[0:0:0:0:0:0:0:1]"
 	httpLoopbackV6LongWithPort    = "http://[0:0:0:0:0:0:0:1]:"
 	httpLoopbackV6LongWithoutPort = "http://[0:0:0:0:0:0:0:1]/"
 	https                         = "https://"
@@ -394,12 +398,16 @@ func onlyLocalhostIsHttp(uris []string) bool {
 }
 
 func isHTTPLoopbackLocalhost(uri string) bool {
-	return strings.HasPrefix(uri, httpLocalhostWithoutPort) ||
+	return uri == httpLocalhost ||
+		strings.HasPrefix(uri, httpLocalhostWithoutPort) ||
 		strings.HasPrefix(uri, httpLocalhostWithPort) ||
+		uri == httpLoopbackV4 ||
 		strings.HasPrefix(uri, httpLoopbackV4WithoutPort) ||
 		strings.HasPrefix(uri, httpLoopbackV4WithPort) ||
+		uri == httpLoopbackV6 ||
 		strings.HasPrefix(uri, httpLoopbackV6WithoutPort) ||
 		strings.HasPrefix(uri, httpLoopbackV6WithPort) ||
+		uri == httpLoopbackV6Long ||
 		strings.HasPrefix(uri, httpLoopbackV6LongWithoutPort) ||
 		strings.HasPrefix(uri, httpLoopbackV6LongWithPort)
 }

--- a/internal/domain/application_oidc_test.go
+++ b/internal/domain/application_oidc_test.go
@@ -489,7 +489,7 @@ func TestCheckRedirectUrisImplicit(t *testing.T) {
 		{
 			name: "only http protocol, app type native, only localhost",
 			args: args{
-				redirectUris: []string{"http://localhost:8080"},
+				redirectUris: []string{"http://localhost:8080", "http://localhost/", "http://localhost"},
 				appType:      gu.Ptr(OIDCApplicationTypeNative),
 			},
 			want: &Compliance{


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

Some native OIDC applications use localhost without a path as redirect URI. Currently, setting `http://localhost` as a redirect URI leads to a compliance warning (`Redirect URIs must begin with your own protocol, http://127.0.0.1, http://[::1] or http://localhost.`), while `http://localhost/some/path` and `http://localhost:some-port` are accepted).

# How the Problems Are Solved

This PR adds additional checks to accept `http://localhost`, `http://127.0.0.1`, `http://[::1]` and `http://[0:0:0:0:0:0:0:1]` (their counterpart with port and with path were already accepted).