### PR TITLE
feat(groups): add permission checks for groups resource APIs

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -1378,6 +1378,10 @@ InternalAuthZ:
         - "userschema.read"
         - "userschema.write"
         - "userschema.delete"
+        - "group.create"
+        - "group.write"
+        - "group.read"
+        - "group.delete"
     - Role: "IAM_OWNER_VIEWER"
       Permissions:
         - "iam.read"
@@ -1414,6 +1418,7 @@ InternalAuthZ:
         - "action.execution.read"
         - "userschema.read"
         - "session.read"
+        - "group.read"
     - Role: "IAM_ORG_MANAGER"
       Permissions:
         - "org.read"
@@ -1473,6 +1478,10 @@ InternalAuthZ:
         - "project.grant.member.delete"
         - "session.read"
         - "session.delete"
+        - "group.create"
+        - "group.write"
+        - "group.read"
+        - "group.delete"
     - Role: "IAM_USER_MANAGER"
       Permissions:
         - "org.read"
@@ -1501,6 +1510,8 @@ InternalAuthZ:
         - "project.grant.member.read"
         - "session.read"
         - "session.delete"
+        - "group.read"
+        - "group.write" # todo: review
     - Role: "IAM_ADMIN_IMPERSONATOR"
       Permissions:
         - "admin.impersonation"
@@ -1565,6 +1576,10 @@ InternalAuthZ:
         - "project.grant.member.delete"
         - "session.read"
         - "session.delete"
+        - "group.create"
+        - "group.write"
+        - "group.read"
+        - "group.delete"
     - Role: "IAM_LOGIN_CLIENT"
       Permissions:
         - "iam.read"
@@ -1603,6 +1618,7 @@ InternalAuthZ:
         - "session.link"
         - "session.delete"
         - "userschema.read"
+        - "group.read"
     - Role: "ORG_USER_MANAGER"
       Permissions:
         - "org.read"
@@ -1622,6 +1638,8 @@ InternalAuthZ:
         - "project.role.read"
         - "session.read"
         - "session.delete"
+        - "group.read"
+        - "group.write" # todo: review
     - Role: "ORG_OWNER_VIEWER"
       Permissions:
         - "org.read"
@@ -1643,6 +1661,7 @@ InternalAuthZ:
         - "project.grant.read"
         - "project.grant.member.read"
         - "project.grant.user.grant.read"
+        - "group.read"
     - Role: "ORG_SETTINGS_MANAGER"
       Permissions:
         - "org.read"
@@ -1673,6 +1692,7 @@ InternalAuthZ:
         - "project.app.read"
         - "project.grant.read"
         - "project.grant.member.read"
+        - "group.read"
     - Role: "ORG_PROJECT_PERMISSION_EDITOR"
       Permissions:
         - "org.read"
@@ -1938,6 +1958,10 @@ SystemAuthZ:
         - "userschema.read"
         - "userschema.write"
         - "userschema.delete"
+        - "group.create"
+        - "group.write"
+        - "group.read"
+        - "group.delete"
     - Role: "IAM_OWNER_VIEWER"
       Permissions:
         - "iam.read"
@@ -1974,6 +1998,7 @@ SystemAuthZ:
         - "action.execution.read"
         - "userschema.read"
         - "session.read"
+        - "group.read"
     - Role: "IAM_ORG_MANAGER"
       Permissions:
         - "org.read"
@@ -2033,6 +2058,10 @@ SystemAuthZ:
         - "project.grant.member.delete"
         - "session.read"
         - "session.delete"
+        - "group.create"
+        - "group.write"
+        - "group.read"
+        - "group.delete"
     - Role: "IAM_USER_MANAGER"
       Permissions:
         - "org.read"
@@ -2061,6 +2090,8 @@ SystemAuthZ:
         - "project.grant.member.read"
         - "session.read"
         - "session.delete"
+        - "group.read"
+        - "group.write" # todo: review
     - Role: "IAM_ADMIN_IMPERSONATOR"
       Permissions:
         - "admin.impersonation"
@@ -2106,6 +2137,7 @@ SystemAuthZ:
         - "session.link"
         - "session.delete"
         - "userschema.read"
+        - "group.read"
 
 # If a new projection is introduced it will be prefilled during the setup process (if enabled)
 # This can prevent serving outdated data after a version upgrade, but might require a longer setup / upgrade process:

--- a/internal/api/grpc/group/v2/query.go
+++ b/internal/api/grpc/group/v2/query.go
@@ -15,7 +15,7 @@ import (
 
 // GetGroup returns a group that matches the group ID in the request
 func (s *Server) GetGroup(ctx context.Context, req *connect.Request[group_v2.GetGroupRequest]) (*connect.Response[group_v2.GetGroupResponse], error) {
-	group, err := s.query.GetGroupByID(ctx, req.Msg.GetId())
+	group, err := s.query.GetGroupByID(ctx, req.Msg.GetId(), s.checkPermission)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/permission_checks.go
+++ b/internal/command/permission_checks.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/repository/group"
 	"github.com/zitadel/zitadel/internal/repository/instance"
 	"github.com/zitadel/zitadel/internal/repository/org"
 	"github.com/zitadel/zitadel/internal/repository/project"
@@ -158,4 +159,16 @@ func (c *Commands) NewPermissionCheckUserGrantWrite(ctx context.Context) UserGra
 
 func (c *Commands) NewPermissionCheckUserGrantDelete(ctx context.Context) UserGrantPermissionCheck {
 	return c.newUserGrantPermissionCheck(ctx, domain.PermissionUserGrantDelete)
+}
+
+func (c *Commands) checkPermissionCreateGroup(ctx context.Context, resourceOwner, groupID string) error {
+	return c.newPermissionCheck(ctx, domain.PermissionGroupCreate, group.AggregateType)(resourceOwner, groupID)
+}
+
+func (c *Commands) checkPermissionUpdateGroup(ctx context.Context, resourceOwner, groupID string) error {
+	return c.newPermissionCheck(ctx, domain.PermissionGroupWrite, group.AggregateType)(resourceOwner, groupID)
+}
+
+func (c *Commands) checkPermissionDeleteGroup(ctx context.Context, resourceOwner, groupID string) error {
+	return c.newPermissionCheck(ctx, domain.PermissionGroupDelete, group.AggregateType)(resourceOwner, groupID)
 }

--- a/internal/domain/permission.go
+++ b/internal/domain/permission.go
@@ -70,6 +70,10 @@ const (
 	PermissionIAMPolicyWrite           = "iam.policy.write"
 	PermissionIAMPolicyDelete          = "iam.policy.delete"
 	PermissionPolicyRead               = "policy.read"
+	PermissionGroupCreate              = "group.create"
+	PermissionGroupWrite               = "group.write"
+	PermissionGroupRead                = "group.read"
+	PermissionGroupDelete              = "group.delete"
 )
 
 // ProjectPermissionCheck is used as a check for preconditions dependent on application, project, user resourceowner and usergrants.


### PR DESCRIPTION
# Which Problems Are Solved
Ensuring the user group resource is managed with appropriate permissions

# How the Problems Are Solved
By configuring and checking for the relevant permissions needed to create, read, update, and delete the user groups resource.


# Additional Changes
N/A

# Additional Context
- Related to #9702 
- Follow-up for PRs #10455,  #10758 
