### PR TITLE
fix(auth): allow LDAP sign-in with special characters (#10798)

### DIFF
--- a/proto/zitadel/resources/user/v3alpha/authenticator.proto
+++ b/proto/zitadel/resources/user/v3alpha/authenticator.proto
@@ -416,7 +416,7 @@ message LDAPCredentials {
   ];
   // Password used to login through LDAP.
   string password = 2 [
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 200},
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       min_length: 1;

--- a/proto/zitadel/user/v2/idp.proto
+++ b/proto/zitadel/user/v2/idp.proto
@@ -20,7 +20,7 @@ message LDAPCredentials {
     }
   ];
   string password = 2[
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 200},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Password used to login through LDAP"
       min_length: 1;

--- a/proto/zitadel/user/v2beta/idp.proto
+++ b/proto/zitadel/user/v2beta/idp.proto
@@ -20,7 +20,7 @@ message LDAPCredentials {
     }
   ];
   string password = 2[
-    (validate.rules).string = {min_len: 1, max_len: 200, uri_ref: true},
+    (validate.rules).string = {min_len: 1, max_len: 200},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Password used to login through LDAP"
       min_length: 1;


### PR DESCRIPTION
# Which Problems Are Solved
- Users were unable to sign in via LDAP when their password contained special characters (%, #, &), because URI validation rejected valid credentials #10798 
- This occurs specifically when using a custom login implementation for LDAP authentication during the LDAP user intent flow.

# How the Problems Are Solved
Removed the URI validation from LDAP password handling, allowing all special characters.

# Additional Changes
- Applied changes in v2 and v2beta LDAP flows.
- Verified other authentication flows remain unaffected.

# Additional Context
- Closes #10798 
