### PR TITLE
chore: fix lint test build on main

### DIFF
--- a/.github/workflows/lint_test_build.yml
+++ b/.github/workflows/lint_test_build.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
           filter: tree:0
       - name: Fetch main branch
+        if: github.ref != 'refs/heads/main'
         run: git fetch origin main:main
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
# Which Problems Are Solved

In order for golangci-lint to be able to compare what changed against main, we have to check out main on branches.
If the pipeline runs on main, the branch can't be checked out twice and the pipeline fails. 

# How the Problems Are Solved

The step `Fetch main branch` in `lint_test_build` is only executed if the workflow doesn't run on main, which would mean that the `Checkout Repository` already checked out the branch.

# Additional Context

- Resolves https://github.com/zitadel/zitadel/actions/runs/18339015014/job/52229685065