### PR TITLE
fix(docs): use internal script

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,6 +18,11 @@ module.exports = {
       "data-domain": "zitadel.com",
       "data-api": "/docs/proxy/api/event",
     },
+    {
+      src: "/docs/proxy/js/feedback",
+      async: true,
+      defer: true,
+    },
   ],
   customFields: {
     description:
@@ -452,7 +457,7 @@ module.exports = {
     },
   ],
   markdown: {
-    mermaid:true,
+    mermaid: true,
   },
   themes: [
     "docusaurus-theme-github-codeblock",

--- a/docs/src/theme/ApiItem/index.jsx
+++ b/docs/src/theme/ApiItem/index.jsx
@@ -7,22 +7,16 @@ export default function ApiItemWrapper(props) {
   const [plausibleLoaded, setPlausibleLoaded] = useState(false);
 
   useEffect(() => {
-    if (!document.getElementById("plausible-script")) {
-      const script = document.createElement("script");
-      script.src = "https://plausible.io/js/plausible.js";
-      script.defer = true;
-      script.async = true;
-      script.dataset.domain = window.location.hostname;
-      script.id = "plausible-script";
-
-      script.onload = () => {
+    // Script is loaded via docusaurus.config.js, just check if it's available
+    const checkPlausible = () => {
+      if (typeof window.plausible === "function") {
         setPlausibleLoaded(true);
-      };
-
-      document.body.appendChild(script);
-    } else {
-      setPlausibleLoaded(true);
-    }
+      } else {
+        // Retry after a short delay if not loaded yet
+        setTimeout(checkPlausible, 100);
+      }
+    };
+    checkPlausible();
   }, []);
 
   const sendPlausibleEvent = (feedbackValue, commentText = "") => {


### PR DESCRIPTION
This changes the source of a script to an internal url to prevent CSP errors.

# Which Problems Are Solved

Our documentation feedback script was not loaded due to being blocked by the CSP

# How the Problems Are Solved

By internally routing to a proxy, we do not have to add external urls to the CSP

