### PR TITLE
docs(contributing): run test-integration-run-db

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,15 +295,24 @@ pnpm nx run @zitadel/api:test-unit
 API tests are run as gRPC clients against a running Zitadel server binary.
 The server binary is [built with coverage enabled](https://go.dev/doc/build-cover).
 
+
 ```bash
 pnpm nx run @zitadel/api:test-integration
 ```
 
-To develop and run the test cases from within your IDE or by the command line, start only the API.
+To develop and run the test cases from within your IDE or by the command line, start only the database and the API.
 The actual integration test clients reside in the `integration_test` subdirectory of the package they aim to test.
 Integration test files use the `integration` build tag, in order to be excluded from regular unit tests.
 Because of the server-client split, Go is usually unaware of changes in server code and tends to cache test results.
 Pass `-count 1` to disable test caching.
+
+Start the ephemeral database for integration tests.
+
+```bash
+pnpm nx run @zitadel/api:test-integration-run-db
+```
+
+In another terminal, start the API.
 
 ```bash
 pnpm nx run @zitadel/api:test-integration-run-api
@@ -322,7 +331,13 @@ go test -count 1 -tags integration -parallel 1 $(go list -tags integration ./...
 ```
 
 It is also possible to run the API in a debugger and run the integrations tests against it.
-In order to run the server, a database with correctly set up data is required.
+
+First, start the ephemeral database for integration tests.
+
+```bash
+pnpm nx run @zitadel/api:test-integration-run-db
+```
+
 When starting the debugger, make sure the Zitadel binary starts with `start-from-init --config=./apps/api/test-integration-api.yaml --steps=./apps/api/test-integration-api.yaml --masterkey=MasterkeyNeedsToHave32Characters"`
 
 To cleanup after testing (deletes the ephemeral database!):


### PR DESCRIPTION
# Which Problems Are Solved

Starting only the API (test-integration-run-api) as per the instructions [here](https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md?plain=1#L302) failed because the DB is not available.

# How the Problems Are Solved

The CONTRIBUTING.md is updated for running integration tests against a self-run  API is updated.

Declaring test-integration-run-db as a dependency of test-integration-run-api fails, because with deep continuous target dependency trees, Nx has [problems with sqLite db lock race conditions](https://github.com/zitadel/zitadel/actions/runs/18400036154/job/52427095230).

# Additional Context

- Reported [internally](https://zitadel.slack.com/archives/C07EUL5H83A/p1760080335840269?thread_ts=1759912259.410789&cid=C07EUL5H83A).