### PR TITLE
fix(login v1): handle old sessions in logout

### DIFF
--- a/internal/user/repository/view/user_session_view.go
+++ b/internal/user/repository/view/user_session_view.go
@@ -110,6 +110,10 @@ func scanActiveUserAgentUserIDs(rows *sql.Rows) (userAgentID string, sessions ma
 		if err != nil {
 			return "", nil, err
 		}
+		// Sessions created before back-channel logout implementation and never updated
+		// since then, don't have an ID.
+		// In this case, we use the userID as sessionID to ensure uniqueness in the map.
+		// The ID will not be used for logout process itself.
 		if !sessionID.Valid {
 			sessionID.String = userID
 		}


### PR DESCRIPTION
# Which Problems Are Solved

Sessions created through login UI (v1) automatically get assigned an ID after creation. This change was introduced with the OIDC back-channel logout implementation. Sessions created before that don't have an ID and are updated on the next (re-)authentication.
A customer now reached out, that a logout from Console was resulting in an error. This is due to at least one session not having an ID (<null> in sql) in the same user agent.

# How the Problems Are Solved

Since the sessionID is not used in the specific situation, we just assign the userID as sessionID. This way all sessions are properly terminated.

# Additional Changes

None

# Additional Context

- relates to support request
- requires backport to v4.x
