### PR TITLE
docs: add clarification for error forwarding in actions v2

### DIFF
--- a/docs/docs/guides/integrate/actions/usage.md
+++ b/docs/docs/guides/integrate/actions/usage.md
@@ -485,3 +485,7 @@ If you want to forward a specific error from the Target through ZITADEL, you can
 Only values from 400 to 499 will be forwarded through ZITADEL, other StatusCodes will end in a PreconditionFailed error.
 
 If the Target returns any other status code than >= 200 and < 299, the execution is looked at as failed, and a PreconditionFailed error is logged.
+
+:::important
+To interrupt the execution while forwarding this error, "interruptOnError" must be **true** for the Target
+:::


### PR DESCRIPTION
When forwarding an error from a target to Zitadel, the target **interruptOnError** must be **true** - this clarification is missing in the document.

