### PR TITLE
fix(login): idp success url

### DIFF
--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -120,7 +120,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
           idpId: activeIdps[0].id,
           urls: {
             successUrl:
-              `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/success?` +
+              `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/process?` +
               new URLSearchParams(params),
             failureUrl:
               `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +
@@ -178,7 +178,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         idpId: idp.id,
         urls: {
           successUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/success?` +
+            `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/process?` +
             new URLSearchParams(params),
           failureUrl:
             `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +


### PR DESCRIPTION
# Which Problems Are Solved

An IDP Intent could not be completed due to a missing change of successUrl property in a recent PR.

# How the Problems Are Solved

The /success page has been replaced by /process to finish the IDP flow in all occurences.
