### PR TITLE
fix(projection): locking behavior based on configuration

### DIFF
--- a/internal/query/auth_request_test.go
+++ b/internal/query/auth_request_test.go
@@ -124,7 +124,7 @@ func TestQueries_AuthRequestByID(t *testing.T) {
 				id:                "123",
 			},
 			expect:  mockQueryScanErr(expQuery, cols, nil, "123", "instanceID"),
-			wantErr: zerrors.ThrowNotFound(sql.ErrNoRows, "QUERY-rojec", "Errors.AuthRequest.NotExisting"),
+			wantErr: zerrors.ThrowNotFound(sql.ErrNoRows, "QUERY-Thee9", "Errors.AuthRequest.NotExisting"),
 		},
 		{
 			name: "query error",


### PR DESCRIPTION
## Problem statement

In a multi-instance ZITADEL deployment, projections are updated by each instance to reflect the latest events. The system uses a non-blocking lock (`pg_try_advisory_xact_lock`) to manage concurrent updates. If one instance has locked a projection, other instances attempting to update the same projection will fail to acquire the lock and skip the update cycle. This leads to eventual consistency, as updates are deferred. For queries that depend on these projections, this can result in reading stale data, as the query might be executed before the projection has been fully updated.

## Solution

The solution enhances the projection processing logic to differentiate between background processing and updates triggered by queries.

* **For Queries**: When a query needs to ensure it has the latest data, the projection update logic now uses a blocking lock (`pg_advisory_xact_lock`). This forces the query to wait until any in-progress updates on the projection are completed and it can acquire a lock itself. This guarantees that the query reads from a fully consistent and up-to-date projection.
* **For Background Processing**: The system continues to use the non-blocking lock (`pg_try_advisory_xact_lock`) for routine, background event processing. This preserves high throughput by allowing instances to skip update cycles if a projection is already locked, aligning with an eventual consistency model for background tasks.

This internal adjustment ensures that queries always return fresh, consistent data while allowing background processing to remain highly efficient.

## Additional Information

closes https://github.com/zitadel/zitadel/issues/10932