### PR TITLE
fix(actions v1): return org metadata again

### DIFF
--- a/internal/actions/object/metadata.go
+++ b/internal/actions/object/metadata.go
@@ -85,6 +85,7 @@ func GetOrganizationMetadata(ctx context.Context, queries *query.Queries, c *act
 		organizationID,
 		&query.OrgMetadataSearchQueries{},
 		false,
+		false,
 	)
 	if err != nil {
 		logging.WithError(err).Info("unable to get org metadata in action")

--- a/internal/api/grpc/admin/export.go
+++ b/internal/api/grpc/admin/export.go
@@ -290,7 +290,7 @@ func (s *Server) getDomains(ctx context.Context, orgID string) (_ []*org_pb.Doma
 	if err != nil {
 		return nil, err
 	}
-	orgDomainsQuery, err := s.query.SearchOrgDomains(ctx, &query.OrgDomainSearchQueries{Queries: []query.SearchQuery{orgDomainOrgIDQuery}}, false)
+	orgDomainsQuery, err := s.query.SearchOrgDomains(ctx, &query.OrgDomainSearchQueries{Queries: []query.SearchQuery{orgDomainOrgIDQuery}}, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/management/org.go
+++ b/internal/api/grpc/management/org.go
@@ -171,7 +171,7 @@ func (s *Server) ListOrgDomains(ctx context.Context, req *mgmt_pb.ListOrgDomains
 	}
 	queries.Queries = append(queries.Queries, orgIDQuery)
 
-	domains, err := s.query.SearchOrgDomains(ctx, queries, false)
+	domains, err := s.query.SearchOrgDomains(ctx, queries, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (s *Server) ListOrgMetadata(ctx context.Context, req *mgmt_pb.ListOrgMetada
 	if err != nil {
 		return nil, err
 	}
-	res, err := s.query.SearchOrgMetadata(ctx, true, authz.GetCtxData(ctx).OrgID, metadataQueries, false)
+	res, err := s.query.SearchOrgMetadata(ctx, true, authz.GetCtxData(ctx).OrgID, metadataQueries, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/grpc/org/v2beta/org.go
+++ b/internal/api/grpc/org/v2beta/org.go
@@ -83,7 +83,7 @@ func (s *Server) ListOrganizationMetadata(ctx context.Context, request *connect.
 	if err != nil {
 		return nil, err
 	}
-	res, err := s.query.SearchOrgMetadata(ctx, true, request.Msg.GetOrganizationId(), metadataQueries, false)
+	res, err := s.query.SearchOrgMetadata(ctx, true, request.Msg.GetOrganizationId(), metadataQueries, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (s *Server) ListOrganizationDomains(ctx context.Context, req *connect.Reque
 	}
 	queries.Queries = append(queries.Queries, orgIDQuery)
 
-	domains, err := s.query.SearchOrgDomains(ctx, queries, false)
+	domains, err := s.query.SearchOrgDomains(ctx, queries, false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/ui/login/custom_action.go
+++ b/internal/api/ui/login/custom_action.go
@@ -131,6 +131,7 @@ func (l *Login) runPostExternalAuthenticationActions(
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
 								false,
+								false,
 							)
 							if err != nil {
 								logging.WithError(err).Info("unable to get org metadata in action")
@@ -325,6 +326,7 @@ func (l *Login) runPreCreationActions(
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
 								false,
+								false,
 							)
 							if err != nil {
 								logging.WithError(err).Info("unable to get org metadata in action")
@@ -400,6 +402,7 @@ func (l *Login) runPostCreationActions(
 								false,
 								resourceOwner,
 								&query.OrgMetadataSearchQueries{},
+								false,
 								false,
 							)
 							if err != nil {

--- a/internal/api/ui/login/register_option_handler.go
+++ b/internal/api/ui/login/register_option_handler.go
@@ -105,7 +105,7 @@ func (l *Login) passLoginHintToRegistration(r *http.Request, authReq *domain.Aut
 		logging.WithFields("authRequest", authReq.ID, "org", authReq.RequestedOrgID).Error("unable to search query for registration loginHint")
 		return data
 	}
-	domains, err := l.query.SearchOrgDomains(r.Context(), &query.OrgDomainSearchQueries{Queries: []query.SearchQuery{searchQuery}}, false)
+	domains, err := l.query.SearchOrgDomains(r.Context(), &query.OrgDomainSearchQueries{Queries: []query.SearchQuery{searchQuery}}, false, false)
 	if err != nil {
 		logging.WithFields("authRequest", authReq.ID, "org", authReq.RequestedOrgID).Error("unable to load domains for registration loginHint")
 		return data


### PR DESCRIPTION
# Which Problems Are Solved

The latest fix to the organization v2beta service unintentionally prevented actions v1 to retrieve organization metadata because of an additional permission check.

# How the Problems Are Solved

- Implicitly allow the actions v1 org metadata query.
- V1 endpoints doing the same query also no longer require the additional permission check as they already do the corresponding check in the API. (same for organization domains).

# Additional Changes

None

# Additional Context

Reported by customers after the deployment of v4.6.3