### PR TITLE
Fix csp for images and therefore for branding

### DIFF
--- a/apps/login/.env
+++ b/apps/login/.env
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_BASE_PATH=/ui/v2/login
 EMAIL_VERIFICATION=false
-ZITADEL_API_URL=https://some-test:8080
+ZITADEL_API_URL=http://localhost:8080
 ZITADEL_SERVICE_USER_TOKEN_FILE=../../login-client.pat

--- a/apps/login/constants/csp.js
+++ b/apps/login/constants/csp.js
@@ -1,14 +1,2 @@
-const ZITADEL_DOMAIN = process.env.ZITADEL_API_URL
-  ? new URL(process.env.ZITADEL_API_URL).hostname
-  : '*.zitadel.cloud';
-
-const ZITADEL_PROTOCOL = process.env.ZITADEL_API_URL
-  ? new URL(process.env.ZITADEL_API_URL).protocol.replace(':', '')
-  : 'https';
-
-console.log('Environment ZITADEL_API_URL:', process.env.ZITADEL_API_URL);
-console.log('Using ZITADEL_DOMAIN for CSP:', ZITADEL_DOMAIN);
-console.log('Using ZITADEL_PROTOCOL for CSP:', ZITADEL_PROTOCOL);
-
 export const DEFAULT_CSP =
-  `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' https://${ZITADEL_DOMAIN};`;
+  `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none';`;

--- a/apps/login/next.config.mjs
+++ b/apps/login/next.config.mjs
@@ -24,10 +24,6 @@ const secureHeaders = [
     key: "X-XSS-Protection",
     value: "1; mode=block",
   },
-  {
-    key: "Content-Security-Policy",
-    value: `${DEFAULT_CSP} frame-ancestors 'none'`,
-  },
   { key: "X-Frame-Options", value: "deny" },
 ];
 

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -227,11 +227,14 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
 
       const noSessionResponse = NextResponse.json({ error: "No active session found" }, { status: 400 });
 
+      const cspImages = `${DEFAULT_CSP} img-src 'self' ${serviceUrl};`;
+      noSessionResponse.headers.set("Content-Security-Policy", cspImages);
+
       if (securitySettings?.embeddedIframe?.enabled) {
         securitySettings.embeddedIframe.allowedOrigins;
         noSessionResponse.headers.set(
           "Content-Security-Policy",
-          `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,
+          `${cspImages} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,
         );
         noSessionResponse.headers.delete("X-Frame-Options");
       }
@@ -264,11 +267,13 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
 
       const callbackResponse = NextResponse.redirect(callbackUrl);
 
+      callbackResponse.headers.set("Content-Security-Policy", cspImages);
+
       if (securitySettings?.embeddedIframe?.enabled) {
         securitySettings.embeddedIframe.allowedOrigins;
         callbackResponse.headers.set(
           "Content-Security-Policy",
-          `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,
+          `${cspImages} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`,
         );
         callbackResponse.headers.delete("X-Frame-Options");
       }


### PR DESCRIPTION
# Which Problems Are Solved

On self-hosted zitadel the content-security-policy for images was not defined by the env variable `ZITADEL_API_URL`.

The CSP was resolved during build-time because I think it got imported in the next.config.msj.

<img width="2931" height="1649" alt="image" src="https://github.com/user-attachments/assets/f88a3d56-f6cf-4fa4-9a2c-3faa5e51f585" />
<img width="2931" height="1649" alt="image" src="https://github.com/user-attachments/assets/cc2896ef-6963-469f-854f-e40b986a43b2" />

# How the Problems Are Solved

- removed the CSP from the next.config.mjs header configuration
- added the image part of the csp dynamically in the middleware

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/1c971568-6d41-4940-8799-263d2f848a2e" />

No error because of wrong csp, but csp still set.

# Additional Changes

- removed the "dynamic" default csp generation since it is not dynamic

# Additional Context

- https://discord.com/channels/927474939156643850/1437384945466216478
