### PR TITLE
[POC] (feat): Download config env as file

### DIFF
--- a/console/src/app/pages/projects/apps/app-detail/app-detail.component.html
+++ b/console/src/app/pages/projects/apps/app-detail/app-detail.component.html
@@ -76,16 +76,23 @@
   <div class="app-main-content">
     <cnsl-meta-layout>
       <cnsl-sidenav [(setting)]="currentSetting" [settingsList]="settingsList">
+        <button mat-raised-button (click)="downloadEnv()">Download .env</button>
         <ng-container *ngIf="currentSetting.id === 'configuration'">
-          <cnsl-card *ngIf="oidcForm && app?.oidcConfig" title=" {{ 'APP.OIDC.TITLE' | translate }}">
-            <div
+          <cnsl-card
+            *ngIf="oidcForm && app?.oidcConfig"
+            title=" {{ 'APP.OIDC.TITLE' | translate }}"
+          >
+
+          <div
               class="current-auth-method"
               *ngIf="currentRadioItemAuthType"
               [ngStyle]="{ background: currentRadioItemAuthType.background }"
             >
               <h3>{{ currentRadioItemAuthType.titleI18nKey | translate }}</h3>
               <p>{{ currentRadioItemAuthType.descI18nKey | translate }}</p>
+
               <span class="fill-space"></span>
+
               <button mat-icon-button (click)="changeAuthMethod()"><i class="las la-pen"></i></button>
             </div>
 

--- a/console/src/app/pages/projects/apps/app-detail/app-detail.component.ts
+++ b/console/src/app/pages/projects/apps/app-detail/app-detail.component.ts
@@ -83,6 +83,50 @@ export class AppDetailComponent implements OnInit, OnDestroy {
   public appId: string = '';
   public app?: App.AsObject;
 
+
+  public downloadEnv = () => {
+    this.issuer$.pipe(take(1)).subscribe((issuer) => {
+      const content = `# Port number where your React development server will listen for incoming HTTP requests.
+# Change this if port 3000 is already in use on your system.
+VITE_PORT=3000
+
+
+
+
+# Your ZITADEL instance domain URL. Found in your ZITADEL console under
+# instance settings. Include the full https:// URL.
+# Example: https://my-company-abc123.zitadel.cloud
+VITE_ZITADEL_DOMAIN="${issuer}"
+
+# Application Client ID from your ZITADEL application settings. This unique
+# identifier tells ZITADEL which application is making the authentication
+# request.
+VITE_ZITADEL_CLIENT_ID="${this.app?.oidcConfig?.clientId ?? 'your-client-id'}"
+
+# OAuth callback URL where ZITADEL redirects after user authentication. This
+# MUST exactly match a Redirect URI configured in your ZITADEL application.
+VITE_ZITADEL_CALLBACK_URL="http://localhost:3000/auth/callback"
+
+
+# URL where users are redirected after logout. This should match a Post Logout
+# Redirect URI configured in your ZITADEL application settings.
+VITE_ZITADEL_POST_LOGOUT_URL="http://localhost:3000/"
+
+# URL where users are redirected after successful login. This is typically
+# your profile or dashboard page.
+VITE_POST_LOGIN_URL="/profile"`;
+
+      const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = '.env';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  };
+
+
   public apiURLs$ = this.envSvc.env.pipe(
     mergeMap((env) =>
       this.wellknownURLs$.pipe(


### PR DESCRIPTION
# Which Problems Are Solved

It is mildly tedious and potentially confusing to get the configuration variables for a given app from different parts of the Zitadel UI when setting up the auth examples.

# How the Problems Are Solved

Download the config as a single env file that can be used with e.g. https://github.com/zitadel/example-auth-react



# Additional Changes

None

# Additional Context

Part of a broader attempt to make integration easier.

# Notes
This is a draft PR to illustrate the idea. The current implemention is specific to https://github.com/zitadel/example-auth-react. Also, the file is downloaded as "env" and must be renamed to ".env", which should be addressed (possibly by altering the example repo)