### PR TITLE
fix(console): update email validator to use a custom regex for utf8

### DIFF
--- a/console/angular.json
+++ b/console/angular.json
@@ -37,10 +37,7 @@
               "sass": {
                 "silenceDeprecations": ["import", "mixed-decls"]
               },
-              "includePaths": [
-                "node_modules",
-                "."
-              ]
+              "includePaths": ["node_modules", "."]
             },
             "allowedCommonJsDependencies": [
               "opentype.js",
@@ -148,6 +145,12 @@
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
+            "stylePreprocessorOptions": {
+              "sass": {
+                "silenceDeprecations": ["import", "mixed-decls"]
+              },
+              "includePaths": ["node_modules", "."]
+            },
             "scripts": []
           }
         },

--- a/console/src/app/modules/form-field/validators/validators.spec.ts
+++ b/console/src/app/modules/form-field/validators/validators.spec.ts
@@ -1,0 +1,24 @@
+import { FormControl } from '@angular/forms';
+import { emailValidator } from './validators';
+
+describe('emailValidator', () => {
+  it('should validate standard ascii email', () => {
+    const control = new FormControl('test@example.com');
+    expect(emailValidator(control)).toBeNull();
+  });
+
+  it('should validate email with utf8 characters', () => {
+    const control = new FormControl('müller@test.com');
+    expect(emailValidator(control)).toBeNull();
+  });
+
+  it('should validate email with utf8 domain', () => {
+    const control = new FormControl('test@ü.com');
+    expect(emailValidator(control)).toBeNull();
+  });
+
+  it('should fail for invalid email', () => {
+    const control = new FormControl('invalid-email');
+    expect(emailValidator(control)).not.toBeNull();
+  });
+});

--- a/console/src/app/modules/form-field/validators/validators.ts
+++ b/console/src/app/modules/form-field/validators/validators.ts
@@ -42,7 +42,8 @@ export function minArrayLengthValidator(minArrLength: number): ValidatorFn {
 }
 
 export function emailValidator(c: AbstractControl): ValidationErrors | null {
-  return i18nErr(Validators.email(c), 'ERRORS.NOTANEMAIL');
+  const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return regexpValidator(c, EMAIL_REGEXP, 'ERRORS.NOTANEMAIL');
 }
 
 export function minLengthValidator(minLength: number): ValidatorFn {


### PR DESCRIPTION
# Which Problems Are Solved

Updates the email validator in the Console to support Internationalized Email Addresses (RFC 6531). The previous Angular Validators.email implementation was too restrictive and rejected valid UTF-8 email addresses (e.g., `müller@example.com` or `user@例子.cn`).

This change replaces the default validator with a more permissive regex that allows UTF-8 characters in both the local and domain parts of the address.

# How the Problems Are Solved

Replaced Validators.email with a custom regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`.
