### PR TITLE
fix(api): use appId in CreateApplicationRequest when set

### DIFF
--- a/internal/api/grpc/application/v2/application.go
+++ b/internal/api/grpc/application/v2/application.go
@@ -34,7 +34,7 @@ func (s *Server) CreateApplication(ctx context.Context, req *connect.Request[app
 		}), nil
 
 	case *application.CreateApplicationRequest_OidcConfiguration:
-		oidcAppRequest, err := convert.CreateOIDCAppRequestToDomain(req.Msg.GetName(), req.Msg.GetProjectId(), req.Msg.GetOidcConfiguration())
+		oidcAppRequest, err := convert.CreateOIDCAppRequestToDomain(req.Msg.GetName(), req.Msg.GetApplicationId(), req.Msg.GetProjectId(), req.Msg.GetOidcConfiguration())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/grpc/application/v2/convert/oidc_app.go
+++ b/internal/api/grpc/application/v2/convert/oidc_app.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zitadel/zitadel/pkg/grpc/application/v2"
 )
 
-func CreateOIDCAppRequestToDomain(name, projectID string, req *application.CreateOIDCApplicationRequest) (*domain.OIDCApp, error) {
+func CreateOIDCAppRequestToDomain(name, appID, projectID string, req *application.CreateOIDCApplicationRequest) (*domain.OIDCApp, error) {
 	loginVersion, loginBaseURI, err := loginVersionToDomain(req.GetLoginVersion())
 	if err != nil {
 		return nil, err
@@ -19,6 +19,7 @@ func CreateOIDCAppRequestToDomain(name, projectID string, req *application.Creat
 		ObjectRoot: models.ObjectRoot{
 			AggregateID: projectID,
 		},
+		AppID:                    appID,
 		AppName:                  name,
 		OIDCVersion:              gu.Ptr(domain.OIDCVersionV1),
 		RedirectUris:             req.GetRedirectUris(),

--- a/internal/command/project_application_oidc.go
+++ b/internal/command/project_application_oidc.go
@@ -158,9 +158,12 @@ func (c *Commands) AddOIDCApplication(ctx context.Context, oidcApp *domain.OIDCA
 		return nil, zerrors.ThrowInvalidArgument(nil, "PROJECT-1n8df", "Errors.Project.App.Invalid")
 	}
 
-	appID, err := c.idGenerator.Next()
-	if err != nil {
-		return nil, err
+	appID := oidcApp.AppID
+	if appID == "" {
+		appID, err = c.idGenerator.Next()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return c.addOIDCApplicationWithID(ctx, oidcApp, resourceOwner, appID)


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

In the proto-api definition the `CreateApplicationRequest` offers the field `application_id`. This field doesn't get set on oidc.
See here the definition:
https://github.com/zitadel/zitadel/blob/3903355d18a7e72fa4c4e33779220b8450def56e/proto/zitadel/application/v2/application_service.proto#L185-L221

# How the Problems Are Solved

- read `appId` from req
- `appId` gets correctly propagated -> fallback to generator
