### PR TITLE
fix(login v1): update password verification handling

### DIFF
--- a/internal/auth/repository/eventsourcing/handler/user_session.go
+++ b/internal/auth/repository/eventsourcing/handler/user_session.go
@@ -264,6 +264,8 @@ func (u *UserSession) Reduce(event eventstore.Event) (_ *handler.Statement, err 
 		return handler.NewUpdateStatement(event,
 			[]handler.Column{
 				handler.NewCol(view_model.UserSessionKeyPasswordVerification, time.Time{}),
+				handler.NewCol(view_model.UserSessionKeyChangeDate, event.CreatedAt()),
+				handler.NewCol(view_model.UserSessionKeySequence, event.Sequence()),
 			},
 			[]handler.Condition{
 				handler.NewCond(view_model.UserSessionKeyUserAgentID, userAgent),


### PR DESCRIPTION
# Which Problems Are Solved

Failed password attempts in login V1 potentially created new session entries.

# How the Problems Are Solved

Correct handling to only update existing sessions.

# Additional Changes

None

# Additional Context

- reported through support
- requires backport to v4.x