### PR TITLE
docs: update database configuration page

### DIFF
--- a/docs/docs/self-hosting/manage/database/database.mdx
+++ b/docs/docs/self-hosting/manage/database/database.mdx
@@ -25,11 +25,24 @@ import Postgres from './_postgres.mdx'
     </TabItem>
 </Tabs>
 
-## Zitadel credentials
-The [init phase](/docs/self-hosting/manage/updating_scaling#separating-init-and-setup-from-the-runtime) of Zitadel creates a the zitadel user (`Database.*.User.Username` & `Database.*.User.Password`) with their password if it does not exist (and Admin credentials are passed). It is though to note that it does **neither** update **nor** deprecate them. In case you provisioned a Zitadel setup with insecure or _easy-to-guess_ values you should first of all rotate them but also manually ensure, that the old role/user gets deprecated.
+## Zitadel Credentials
 
-If you rotate the credentials you either must opt for a new username or deprecate the old user first (might lead to interruptions) since the init phase will fail if the user already exists but only the password changes. To deprecate the old user you need admin access to your database server and remove the user with commands matching your database provider.
+The [init phase](/docs/self-hosting/manage/updating_scaling#separating-init-and-setup-from-the-runtime) of ZITADEL creates the ZITADEL database user (`Database.*.User.Username` & `Database.*.User.Password`) if it does not exist and admin credentials are provided. **Init does not update or deprecate existing users or passwords.** If you need to change the ZITADEL database user or rotate its password, you must do this manually.
 
 :::caution
-Recreating a database will not necessarily remove the user, make sure to check for the user and remove it if necessary.
+The `init` command is designed to be run **only once**, during the initial setup of ZITADEL. Running `init` again after changing the database user or credentials does **not** migrate database object ownerships, nor does it reassign permissions on schemas, tables, or other objects to a new user. You must update these permissions manually if you switch users.
+:::
+
+### Rotating Database Credentials
+
+If you must rotate the credentials:
+
+- You can change the password for the existing ZITADEL user, but you must manually update the password wherever ZITADEL needs it.
+- Creating a new database user requires manual reassignment of ownership and privileges for all required database objects (schemas, tables, etc.) to the new user. 
+- After migration, remove or deprecate the old user using admin access and commands appropriate for your database provider.
+
+Attempting to run `init` a second time with new credentials will fail if the user already exists, and will not change existing permissions or migrate data.
+
+:::caution
+Dropping and recreating the database does **not** automatically remove existing users. Always verify and clean up old users if necessary.
 :::


### PR DESCRIPTION
Fixes #11216 

This update makes it more clear that init is only supposed to be run once and is not intended to migrate the zitadel user.