### PR TITLE
docs: update MockSAML IDP documentation

### DIFF
--- a/docs/docs/guides/integrate/identity-providers/mocksaml.mdx
+++ b/docs/docs/guides/integrate/identity-providers/mocksaml.mdx
@@ -61,14 +61,14 @@ They are available under `https://${CUSTOMDOMAIN}/idps/\{ID of the provider in Z
 ### Required for Login V2
 The creation of users in ZITADEL will fail if the required fields to create a user are not set.
 
-This can be achieved by using **Actions V2** to map the SAML attributes returned by the IDP to the required fields in ZITADEL.
+**Actions V2** can be used to map the SAML attributes returned by the IDP to the required fields in ZITADEL.
 See the [Actions V2 Response Manipulation](/guides/integrate/actions/testing-response-manipulation.md)
 guide for more information on setting up a Target and an Execution. In short,
 * Create an Actions V2 Target of type `REST Call`
 * Create an Execution of type `Response` on the method `/zitadel.user.v2.UserService/RetrieveIdentityProviderIntent`
 
 The following minimal example modifies the response of `/zitadel.user.v2.UserService/RetrieveIdentityProviderIntent` to set the required fields
-for user creation. This example is specific to MockSAML, please adjust the attributes according to your IDP configuration.
+for user creation. This example is specific to MockSAML, please adjust the attributes according to your IDP.
 
 ``` go
 package main


### PR DESCRIPTION
# Which Problems Are Solved

The current documentation on setting up a MockSAML IDP is unclear/incomplete, and doesn't work with Login V2.

# How the Problems Are Solved

- Add a new section that explains mapping of MockSAML attributes to Zitadel user fields (using Actions V2) in case of Login V2
- Update the Actions V1 script used to prefill user data in case of Login V1

# Additional Changes

N/A

# Additional Context
- Related to https://github.com/zitadel/zitadel/issues/11078
