### PR TITLE
docs: fix deprecated label for actions v2

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -339,7 +339,7 @@ module.exports = {
           },
           action_v2: {
             specPath:
-              ".artifacts/openapi/zitadel/action/v2beta/action_service.swagger.json",
+              ".artifacts/openapi/zitadel/action/v2/action_service.swagger.json",
             outputDir: "docs/apis/resources/action_service_v2",
             sidebarOptions: {
               groupPathsBy: "tag",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -822,15 +822,13 @@ module.exports = {
             },
             {
               type: "category",
-              label: "Action (Beta)",
+              label: "Action",
               link: {
                 type: "generated-index",
-                title: "Action Service API (Beta)",
+                title: "Action Service API",
                 slug: "/apis/resources/action_service_v2",
                 description:
                   "This API is intended to manage custom executions and targets (previously known as actions) in a ZITADEL instance.\n" +
-                  "\n" +
-                  "This service is in beta state. It can AND will continue breaking until a stable version is released.\n" +
                   "\n" +
                   "The version 2 of actions provide much more options to customize ZITADELs behaviour than previous action versions.\n" +
                   "Also, v2 actions are available instance-wide, whereas previous actions had to be managed for each organization individually\n" +


### PR DESCRIPTION
Removed deprecated label for Action V2 endpoints and removed Beta label also. Fixed actions V2 domain endpoint (v2 instead of v2beta)