### PR TITLE
fix(container): Volume definition for rootless setup

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,9 @@ RUN useradd -s "" --home / zitadel && \
     chown zitadel /app/zitadel && \
     chmod +x /app/zitadel && \
     chown zitadel /app/entrypoint.sh && \
-    chmod +x /app/entrypoint.sh
+    chmod +x /app/entrypoint.sh && \
+    mkdir -p /current-dir && \
+    chown zitadel /current-dir
 
 WORKDIR /app
 ENV PATH="/app:${PATH}"
@@ -29,9 +31,11 @@ FROM scratch AS final
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /app/zitadel /app/zitadel
+COPY --from=builder /current-dir /current-dir
 
 HEALTHCHECK NONE
 EXPOSE 8080
 
 USER zitadel
+VOLUME [ "/current-dir" ]
 ENTRYPOINT ["/app/zitadel"]

--- a/apps/login/Dockerfile
+++ b/apps/login/Dockerfile
@@ -3,11 +3,12 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 # If /.env-file/.env is mounted into the container, its variables are made available to the server before it starts up.
-RUN mkdir -p /.env-file && touch /.env-file/.env && chown -R nextjs:nodejs /.env-file
+RUN mkdir -p /.env-file /current-dir && touch /.env-file/.env && chown -R nextjs:nodejs /.env-file /current-dir
 
 COPY --chown=nextjs:nodejs .next/standalone ./
 
 USER nextjs
+VOLUME [ "/current-dir" ]
 ENV HOSTNAME="::" \
     PORT="3000" \
     NODE_ENV="production" \


### PR DESCRIPTION
Currently it's not possible to install Zitadel on rootless environments (e.g. podman rootless) without changing ownership of `/current-dir` folder (for login-client cert generation).

My current compose looks like this:
```yaml
services:
  app:
    volumes:
      - data:/current-dir:z
```

Following fix solves the issue (volumes got generated by docker/podman depend on user defined before in `Containerfile/Dockerfile`).