### PR TITLE
docs: fix empty page for instance API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,9 @@ Start a docs server
 # Start development server with live-reloading
 pnpm nx run @zitadel/docs:dev
 
+# To tell Nx to ignore cached outputs
+pnpm nx run @zitadel/docs:dev --skip-nx-cache
+
 # Or serve a production build
 pnpm nx run @zitadel/docs:prod
 ```

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,12 +4,20 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
-    commit: 6607b10f00ed4a3d98f906807131c44a
+    commit: daf171c6cdb54629b5f51e345a79e4dd
+    digest: shake256:4ae167d7eed10da5f83a3f5df8c670d249170f11b1f2fd19afda06be2cff4d47dcc95e9e4a15151ecc8ce2d3d3614caf9a04d3ad82fb768a3870dedfa9455f36
+  - remote: buf.build
+    owner: gnostic
+    repository: gnostic
+    commit: 087bc8072ce44e339f213209e4d57bf0
+    digest: shake256:4689c26f0460fea84c4c277c1b9c7e7d657388c5b4116d1065f907a92100ffbea87de05bbd138a0166411361e1f6ce063b4c0c6002358d39710f3c4a8de788d5
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 75b4300737fb4efca0831636be94e517
+    commit: 004180b77378443887d3b55cabc00384
+    digest: shake256:d26c7c2fd95f0873761af33ca4a0c0d92c8577122b6feb74eb3b0a57ebe47a98ab24a209a0e91945ac4c77204e9da0c2de0020b2cedc27bdbcdea6c431eec69b
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: a1ecdc58eccd49aa8bea2a7a9022dc27
+    commit: 4c5ba75caaf84e928b7137ae5c18c26a
+    digest: shake256:e174ad9408f3e608f6157907153ffec8d310783ee354f821f57178ffbeeb8faa6bb70b41b61099c1783c82fe16210ebd1279bc9c9ee6da5cffba9f0e675b8b99

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -4,6 +4,7 @@ deps:
   - buf.build/grpc-ecosystem/grpc-gateway
   - buf.build/envoyproxy/protoc-gen-validate
   - buf.build/googleapis/googleapis
+  - buf.build/gnostic/gnostic
 breaking:
   use:
     - FILE

--- a/proto/zitadel/instance/v2/instance_service.proto
+++ b/proto/zitadel/instance/v2/instance_service.proto
@@ -12,8 +12,171 @@ import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 import "zitadel/protoc_gen_zitadel/v2/options.proto";
+import "gnostic/openapi/v3/annotations.proto";
 
 option go_package = "github.com/zitadel/zitadel/pkg/grpc/instance/v2;instance";
+
+option (gnostic.openapi.v3.document) = {
+  info: {
+    title: "Instance Service";
+    version: "2.0";
+    description: "This API is intended to manage instances in ZITADEL.";
+    contact: {
+      name: "ZITADEL";
+      url: "https://zitadel.com";
+      email: "hi@zitadel.com";
+    }
+    license: {
+      name: "AGPL-3.0-only";
+      url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
+    }
+  }
+
+  servers: {
+    url: "https://$CUSTOM-DOMAIN";
+    description: "Default Instance";
+  }
+
+  external_docs: {
+    description: "Detailed information about ZITADEL";
+    url: "https://zitadel.com/docs";
+  }
+
+  components: {
+    // 1. SCHEMAS
+    schemas: {
+      additional_properties: {
+        name: "rpcStatus";
+        value: {
+          schema: {
+            type: "object";
+            description: "The `Status` type defines a logical error model.";
+            properties: {
+              additional_properties: {
+                name: "code";
+                value: {
+                  schema: {
+                    type: "integer";
+                    format: "int32";
+                    description: "The status code.";
+                  }
+                }
+              }
+              additional_properties: {
+                name: "message";
+                value: {
+                  schema: {
+                    type: "string";
+                    description: "A developer-facing error message.";
+                  }
+                }
+              }
+              additional_properties: {
+                name: "details";
+                value: {
+                  schema: {
+                    type: "array";
+                    items: {
+                      schema_or_reference: {
+                        schema: {
+                          type: "object";
+                        }
+                      }
+                    }
+                    description: "A list of messages that carry the error details.";
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // 2. SECURITY SCHEMES
+    security_schemes: {
+      additional_properties: {
+        name: "OAuth2";
+        value: {
+          security_scheme: {
+            type: "oauth2";
+            description: "OAuth2 Authorization Code Flow";
+            flows: {
+              authorization_code: {
+                authorization_url: "$CUSTOM-DOMAIN/oauth/v2/authorize";
+                token_url: "$CUSTOM-DOMAIN/oauth/v2/token";
+                scopes: {
+                  additional_properties: {
+                    name: "openid";
+                    value: "openid";
+                  }
+                  additional_properties: {
+                    name: "urn:zitadel:iam:org:project:id:zitadel:aud";
+                    value: "urn:zitadel:iam:org:project:id:zitadel:aud";
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // 3. RESPONSES
+    responses: {
+      additional_properties: {
+        name: "403";
+        value: {
+          response: {
+            description: "Returned when the user does not have permission to access the resource.";
+            content: {
+              additional_properties: {
+                name: "application/json";
+                value: {
+                  schema: {
+                    reference: {
+                      _ref: "#/components/schemas/rpcStatus";
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      additional_properties: {
+        name: "404";
+        value: {
+          response: {
+            description: "Returned when the resource does not exist.";
+            content: {
+              additional_properties: {
+                name: "application/json";
+                value: {
+                  schema: {
+                    reference: {
+                      _ref: "#/components/schemas/rpcStatus";
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 4. GLOBAL SECURITY
+  security: {
+    additional_properties: {
+      name: "OAuth2";
+      value: {
+        value: ["openid", "urn:zitadel:iam:org:project:id:zitadel:aud"];
+      }
+    }
+  }
+};
 
 // Service to manage instances and their domains.
 // The service provides methods to create, update, delete and list instances and their domains.
@@ -35,6 +198,26 @@ service InstanceService {
         permission: "system.instance.delete"
       }
     };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
+      }
+    };
   }
 
   // Get Instance
@@ -52,6 +235,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }
@@ -73,6 +276,26 @@ service InstanceService {
         permission: "authenticated"
       }
     };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
+      }
+    };
   }
 
   // List Instances
@@ -88,6 +311,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "system.instance.read"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }
@@ -107,6 +350,26 @@ service InstanceService {
         permission: "system.domain.write"
       }
     };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
+      }
+    };
   }
 
   // Remove Custom Domain
@@ -122,6 +385,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "system.domain.write"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }
@@ -142,6 +425,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }
@@ -171,6 +474,26 @@ service InstanceService {
         permission: "authenticated"
       }
     };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
+      }
+    };
   }
 
   // Remove Trusted Domain
@@ -188,6 +511,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }
@@ -208,6 +551,26 @@ service InstanceService {
     option (zitadel.protoc_gen_zitadel.v2.options) = {
       auth_option: {
         permission: "authenticated"
+      }
+    };
+    option (gnostic.openapi.v3.operation) = {
+      responses: {
+        response_or_reference: {
+          name: "403";
+          value: {
+            reference: {
+              _ref: "#/components/responses/403"
+            }
+          }
+        }
+        response_or_reference: {
+          name: "404";
+          value: {
+            reference: {
+              _ref: "#/components/responses/404"
+            }
+          }
+        }
       }
     };
   }

--- a/proto/zitadel/instance/v2/instance_service.proto
+++ b/proto/zitadel/instance/v2/instance_service.proto
@@ -32,11 +32,6 @@ option (gnostic.openapi.v3.document) = {
     }
   }
 
-  servers: {
-    url: "https://$CUSTOM-DOMAIN";
-    description: "Default Instance";
-  }
-
   external_docs: {
     description: "Detailed information about ZITADEL";
     url: "https://zitadel.com/docs";

--- a/proto/zitadel/instance/v2/instance_service.proto
+++ b/proto/zitadel/instance/v2/instance_service.proto
@@ -43,7 +43,6 @@ option (gnostic.openapi.v3.document) = {
   }
 
   components: {
-    // 1. SCHEMAS
     schemas: {
       additional_properties: {
         name: "rpcStatus";
@@ -93,7 +92,6 @@ option (gnostic.openapi.v3.document) = {
       }
     }
 
-    // 2. SECURITY SCHEMES
     security_schemes: {
       additional_properties: {
         name: "OAuth2";
@@ -123,7 +121,6 @@ option (gnostic.openapi.v3.document) = {
     }
   }
 
-  // 4. GLOBAL SECURITY
   security: {
     additional_properties: {
       name: "OAuth2";

--- a/proto/zitadel/instance/v2/instance_service.proto
+++ b/proto/zitadel/instance/v2/instance_service.proto
@@ -121,50 +121,6 @@ option (gnostic.openapi.v3.document) = {
         }
       }
     }
-
-    // 3. RESPONSES
-    responses: {
-      additional_properties: {
-        name: "403";
-        value: {
-          response: {
-            description: "Returned when the user does not have permission to access the resource.";
-            content: {
-              additional_properties: {
-                name: "application/json";
-                value: {
-                  schema: {
-                    reference: {
-                      _ref: "#/components/schemas/rpcStatus";
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      additional_properties: {
-        name: "404";
-        value: {
-          response: {
-            description: "Returned when the resource does not exist.";
-            content: {
-              additional_properties: {
-                name: "application/json";
-                value: {
-                  schema: {
-                    reference: {
-                      _ref: "#/components/schemas/rpcStatus";
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   // 4. GLOBAL SECURITY
@@ -203,16 +159,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -242,16 +222,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -281,16 +285,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -318,16 +346,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -355,16 +407,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -392,16 +468,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -432,16 +532,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -479,16 +603,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -518,16 +666,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -558,16 +730,40 @@ service InstanceService {
         response_or_reference: {
           name: "403";
           value: {
-            reference: {
-              _ref: "#/components/responses/403"
+            response: {
+              description: "Returned when the user does not have permission to access the resource.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
         response_or_reference: {
           name: "404";
           value: {
-            reference: {
-              _ref: "#/components/responses/404"
+            response: {
+              description: "Returned when the resource does not exist.";
+              content: {
+                additional_properties: {
+                  name: "application/json";
+                  value: {
+                    schema: {
+                      reference: {
+                        _ref: "#/components/schemas/rpcStatus";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Updated the instance proto file to generate the content needed to render the missing information in the instance page API such as description, authorization and response codes.

Fixes: #11022 