### PR TITLE
docs: update proto files with correct license

### DIFF
--- a/proto/zitadel/action/v2/action_service.proto
+++ b/proto/zitadel/action/v2/action_service.proto
@@ -30,7 +30,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/action/v2beta/action_service.proto
+++ b/proto/zitadel/action/v2beta/action_service.proto
@@ -30,7 +30,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -40,7 +40,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
             email: "hi@zitadel.com"
         }
         license: {
-            name: "Apache 2.0",
+            name: "AGPL-3.0-only",
             url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
         };
     };

--- a/proto/zitadel/app/v2beta/app_service.proto
+++ b/proto/zitadel/app/v2beta/app_service.proto
@@ -29,7 +29,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/feature/v2/feature_service.proto
+++ b/proto/zitadel/feature/v2/feature_service.proto
@@ -24,7 +24,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/feature/v2beta/feature_service.proto
+++ b/proto/zitadel/feature/v2beta/feature_service.proto
@@ -24,7 +24,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/group/v2/group_service.proto
+++ b/proto/zitadel/group/v2/group_service.proto
@@ -27,7 +27,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/idp/v2/idp_service.proto
+++ b/proto/zitadel/idp/v2/idp_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
+++ b/proto/zitadel/internal_permission/v2beta/internal_permission_service.proto
@@ -28,7 +28,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/oidc/v2/oidc_service.proto
+++ b/proto/zitadel/oidc/v2/oidc_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/oidc/v2beta/oidc_service.proto
+++ b/proto/zitadel/oidc/v2beta/oidc_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/org/v2/org_service.proto
+++ b/proto/zitadel/org/v2/org_service.proto
@@ -33,7 +33,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/org/v2beta/org_service.proto
+++ b/proto/zitadel/org/v2beta/org_service.proto
@@ -30,7 +30,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/project/v2beta/project_service.proto
+++ b/proto/zitadel/project/v2beta/project_service.proto
@@ -28,7 +28,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/resources/debug_events/v3alpha/debug_events_service.proto
+++ b/proto/zitadel/resources/debug_events/v3alpha/debug_events_service.proto
@@ -26,7 +26,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/resources/user/v3alpha/user_service.proto
+++ b/proto/zitadel/resources/user/v3alpha/user_service.proto
@@ -29,7 +29,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/resources/userschema/v3alpha/user_schema_service.proto
+++ b/proto/zitadel/resources/userschema/v3alpha/user_schema_service.proto
@@ -26,7 +26,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/saml/v2/saml_service.proto
+++ b/proto/zitadel/saml/v2/saml_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/session/v2/session_service.proto
+++ b/proto/zitadel/session/v2/session_service.proto
@@ -27,7 +27,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/session/v2beta/session_service.proto
+++ b/proto/zitadel/session/v2beta/session_service.proto
@@ -27,7 +27,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/settings/v2/settings_service.proto
+++ b/proto/zitadel/settings/v2/settings_service.proto
@@ -34,7 +34,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/settings/v2beta/settings_service.proto
+++ b/proto/zitadel/settings/v2beta/settings_service.proto
@@ -32,7 +32,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/system.proto
+++ b/proto/zitadel/system.proto
@@ -29,7 +29,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -37,7 +37,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/user/v2beta/user_service.proto
+++ b/proto/zitadel/user/v2beta/user_service.proto
@@ -31,7 +31,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/webkey/v2/webkey_service.proto
+++ b/proto/zitadel/webkey/v2/webkey_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };

--- a/proto/zitadel/webkey/v2beta/webkey_service.proto
+++ b/proto/zitadel/webkey/v2beta/webkey_service.proto
@@ -23,7 +23,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       email: "hi@zitadel.com"
     }
     license: {
-      name: "Apache 2.0",
+      name: "AGPL-3.0-only",
       url: "https://github.com/zitadel/zitadel/blob/main/LICENSING.md";
     };
   };


### PR DESCRIPTION
Some proto files still mention the "Apache 2.0" license - this PR changes that to "AGPL-3.0-only"

This fix reflect the right license when viewing the API introduction page in the documentation, for example, here:

- https://zitadel.com/docs/apis/resources/action_service_v2/action-service

Fixes #11253 
