### PR TITLE
fix(login): delete custom request headers when their value is empty

### DIFF
--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -1282,7 +1282,13 @@ export function createServerTransport(token: string, serviceConfig: ServiceConfi
                   process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
                     const kv = header.indexOf(":");
                     if (kv > 0) {
-                      req.header.set(header.slice(0, kv).trim(), header.slice(kv + 1).trim());
+                      const key = header.slice(0, kv).trim();
+                      const value = header.slice(kv + 1).trim();
+                      if (value) {
+                        req.header.set(key, value);
+                      } else {
+                        req.header.delete(key);
+                      }
                     } else {
                       console.warn(`Skipping malformed header: ${header}`);
                     }


### PR DESCRIPTION
# Which Problems Are Solved

The application automatically appends the x-zitadel-public-host header when a public host is configured. In some deployment scenarios where the host is determined by default or via other means, sending this header allows for improper routing or is simply redundant. The existing CUSTOM_REQUEST_HEADERS configuration only supported adding or overwriting headers, offering no way to remove headers that were set by default logic.

# How the Problems Are Solved

Extended the `CUSTOM_REQUEST_HEADERS` handling in `src/lib/zitadel.ts`. The logic now checks for empty header values. If a header is defined in `CUSTOM_REQUEST_HEADERS` with an empty value (e.g., x-zitadel-public-host:), the interceptor will delete that header from the request instead of setting it to an empty string. This allows users to opt-out of default headers via configuration.