### PR TITLE
chore: update js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@^4: '>=4.1.1'
+
 importers:
 
   .:
@@ -9614,10 +9617,6 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -25019,10 +25018,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -27261,7 +27256,7 @@ snapshots:
       async: 3.2.4
       commander: 2.20.3
       graphlib: 2.1.8
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json-pointer: 0.6.2
       json-schema-merge-allof: 0.8.1
       lodash: 4.17.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,5 @@ packages:
 exclude:
   - benchmark # because of the node 18 or 20 dependency
 
+overrides:
+  "js-yaml@^4": ">=4.1.1"


### PR DESCRIPTION
# Which Problems Are Solved
Fixes [Dependency Security Alert](https://github.com/zitadel/zitadel/security/dependabot/379)

# How the Problems Are Solved
This PR adds a pnpm override to force `js-yaml@^4` to resolve to `>=4.1.1`, which contains the fix for the prototype pollution vulnerability. The override only affects the 4.x line, leaving 3.x versions unchanged.

# Additional Context
- Closes https://github.com/zitadel/zitadel/security/dependabot/379