### PR TITLE
docs: correct "complement" flow names

### DIFF
--- a/docs/docs/apis/actions/introduction.md
+++ b/docs/docs/apis/actions/introduction.md
@@ -49,7 +49,7 @@ Currently ZITADEL provides the following flows:
 - [Internal Authentication](./internal-authentication)
 - [External Authentication](./external-authentication)
 - [Complement Token](./complement-token)
-- [Customize SAML Response](./customize-samlresponse)
+- [Complement SAML Response](./customize-samlresponse)
 
 ## Available Modules inside Javascript
 

--- a/docs/docs/guides/integrate/actions/migrate-from-v1.md
+++ b/docs/docs/guides/integrate/actions/migrate-from-v1.md
@@ -97,7 +97,7 @@ Some use-cases:
 - Add metadata to user through function on `preaccesstoken`, [Action Function Example](./testing-function)
 - Add logs to the log claim through function on `preaccesstoken`, [Action Function Example](./testing-function)
 
-## Customize SAML Response
+## Complement SAML Response
 
 These are executed before the return of the SAML Response.
 


### PR DESCRIPTION
# Which Problems Are Solved

As part of the naming inconsistencies  (#5888) we want to ensure action v1 flow name are always correct and mapping to enum values line up: #11309

# How the Problems Are Solved

Rename last "Customize SAML Response" occurrences to "Complement SAML Response" where it's referring to the flow type. There are some titles left with "customize SAML / OIDC response", which refer to the intent of customizing the outcome and not directly to the flow type.

# Additional Changes

None

# Additional Context

The duiscord thread linked in the epic seems outdated (2023): https://discord.com/channels/927474939156643850/1019895518383583323/threads/1146705723657568316

- closes #11309