### PR TITLE
docs: clarify container tagging

### DIFF
--- a/docs/docs/self-hosting/deploy/overview.mdx
+++ b/docs/docs/self-hosting/deploy/overview.mdx
@@ -17,11 +17,8 @@ Choose your platform and run ZITADEL with the most minimal configuration possibl
 
 ## Releases
 
-The easiest way to use ZITADEL is to run one of our container releases
-
-- ZITADEL does provide latest and stable [container images](https://github.com/zitadel/zitadel/pkgs/container/zitadel)
-- **stable** is the current **production** release of ZITADEL.
-- **latest** is the **last created** release from our pipelines that gets updated in a high frequency.
+The easiest way to use ZITADEL is to run our container images from the [GitHub Container Registry](https://github.com/zitadel/zitadel/pkgs/container/zitadel).  
+The **`latest`** tag always points to the current **production** release of ZITADEL.
 
 # Production Setup
 


### PR DESCRIPTION
# Which Problems Are Solved

- Removes outdated information about container tagging and clarifies that `latest` is the only stable, production-ready container tag.