### PR TITLE
fix(login): add LDAP success page and pass requestId/organization

### DIFF
--- a/apps/docs/content/guides/integrate/identity-providers/openldap.mdx
+++ b/apps/docs/content/guides/integrate/identity-providers/openldap.mdx
@@ -45,22 +45,24 @@ networks:
     driver: bridge
 services:
   openldap:
-    image: bitnami/openldap:latest
+    image: osixia/openldap:1.5.0
     ports:
-      - '389:1389'
+      - '389:389'
+      - '636:636'
     environment:
-      - LDAP_ADMIN_USERNAME=admin
+      - LDAP_ORGANISATION=Example Inc.
+      - LDAP_DOMAIN=example.com
       - LDAP_ADMIN_PASSWORD=Password1!
-      - LDAP_USERS=test
-      - LDAP_PASSWORDS=Password1!
-      - LDAP_ROOT=dc=example,dc=com
-      - LDAP_ADMIN_DN=cn=admin,dc=example,dc=com
+      - LDAP_TLS=false
     networks:
       - my-network
     volumes:
-      - 'openldap_data:/bitnami/openldap'
+      - 'openldap_data:/var/lib/ldap'
+      - 'openldap_config:/etc/ldap/slapd.d'
 volumes:
   openldap_data:
+    driver: local
+  openldap_config:
     driver: local
 ````
 


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- LDAP login using Login v2 redirects to /ui/v2/login/idp/ldap/success?... but the route was missing, resulting in a 404 and preventing the login flow from completing.
- requestId and organization context were not preserved through the LDAP username/password form submission, which can break downstream session/flow handling.

# How the Problems Are Solved

- Adds a dedicated LDAP success callback page that processes the id + token (and optional linking/context parameters) via the existing IdpProcessHandler.
- Extends the LDAP username/password form and server action plumbing to pass through requestId and organization, and includes them in the redirect to the success page.

# Additional Changes

- None (scoped to Login v2 LDAP flow only).

# Additional Context

- Closes #11096
- Repro details and sample config are in the issue; the symptom was a 404 on the LDAP success redirect URL.
- I dont have a lot of experience on go but this fixes the issue for me, using already with a published image for a qa test instance.
