### PR TITLE
docs: remove user-schema page reference from the docs

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -215,7 +215,6 @@ module.exports = {
             "guides/manage/customize/branding",
             "guides/manage/customize/texts",
             "guides/manage/customize/restrictions",
-            "guides/manage/customize/user-schema",
             "guides/manage/customize/user-metadata",
             "guides/manage/customize/notification-providers",
             "concepts/features/custom-domain",


### PR DESCRIPTION
This PR removes the user-schema page from the sidebar menu