### PR TITLE
fix: don't append select_account in prompt parameter when already specified in auth request

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -1431,8 +1431,13 @@ func mapExternalNotFoundOptionFormDataToLoginUser(formData *externalNotFoundOpti
 }
 
 func (l *Login) sessionParamsFromAuthRequest(ctx context.Context, authReq *domain.AuthRequest, identityProviderID string) []idp.Parameter {
-	params := make([]idp.Parameter, 1, 2)
+	params := make([]idp.Parameter, 1, 3)
 	params[0] = idp.UserAgentID(authReq.AgentID)
+
+	// Indicate if the auth request already has a prompt parameter
+	if len(authReq.Prompt) > 0 {
+		params = append(params, idp.HasPromptParam(true))
+	}
 
 	if authReq.UserID != "" && identityProviderID != "" {
 		links, err := l.getUserLinks(ctx, authReq.UserID, identityProviderID)

--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -169,7 +169,7 @@ func (l *Login) handleIDP(w http.ResponseWriter, r *http.Request, authReq *domai
 	case domain.IDPTypeOAuth:
 		provider, err = l.oauthProvider(r.Context(), identityProvider)
 	case domain.IDPTypeOIDC:
-		provider, err = l.oidcProvider(r.Context(), identityProvider)
+		provider, err = l.oidcProvider(r.Context(), identityProvider, authReq)
 	case domain.IDPTypeJWT:
 		provider, err = l.jwtProvider(identityProvider)
 	case domain.IDPTypeAzureAD:
@@ -302,7 +302,7 @@ func (l *Login) handleExternalLoginCallback(w http.ResponseWriter, r *http.Reque
 		}
 		session = oauth.NewSession(provider, data.Code, authReq.SelectedIDPConfigArgs)
 	case domain.IDPTypeOIDC:
-		provider, err := l.oidcProvider(r.Context(), identityProvider)
+		provider, err := l.oidcProvider(r.Context(), identityProvider, authReq)
 		if err != nil {
 			l.externalAuthCallbackFailed(w, r, authReq, nil, nil, err)
 			return
@@ -1056,13 +1056,23 @@ func (l *Login) googleProvider(ctx context.Context, identityProvider *query.IDPT
 	)
 }
 
-func (l *Login) oidcProvider(ctx context.Context, identityProvider *query.IDPTemplate) (*openid.Provider, error) {
+func (l *Login) oidcProvider(ctx context.Context, identityProvider *query.IDPTemplate, authReq *domain.AuthRequest) (*openid.Provider, error) {
 	secret, err := crypto.DecryptString(identityProvider.OIDCIDPTemplate.ClientSecret, l.idpConfigAlg)
 	if err != nil {
 		return nil, err
 	}
-	opts := make([]openid.ProviderOpts, 1, 3)
-	opts[0] = openid.WithSelectAccount()
+
+	opts := make([]openid.ProviderOpts, 0, 3)
+
+	// Only add WithSelectAccount if the auth request doesn't already have a prompt parameter
+	if !domain.IsPrompt(authReq.Prompt, domain.PromptSelectAccount) && len(authReq.Prompt) == 0 {
+		opts = append(opts, openid.WithSelectAccount())
+	}
+
+	if !domain.IsPrompt(authReq.Prompt, domain.PromptSelectAccount) && len(authReq.Prompt) == 0 {
+	  opts = append(opts, openid.WithSelectAccount())
+	}
+	
 	if identityProvider.OIDCIDPTemplate.IsIDTokenMapping {
 		opts = append(opts, openid.WithIDTokenMapping())
 	}

--- a/internal/idp/provider.go
+++ b/internal/idp/provider.go
@@ -49,3 +49,8 @@ func (p UserAgentID) setValue() {}
 type LoginHintParam string
 
 func (p LoginHintParam) setValue() {}
+
+// HasPromptParam indicates that the auth request already has a prompt parameter
+type HasPromptParam bool
+
+func (p HasPromptParam) setValue() {}

--- a/internal/idp/providers/oauth/oauth2.go
+++ b/internal/idp/providers/oauth/oauth2.go
@@ -91,14 +91,22 @@ func (p *Provider) Name() string {
 // It will create a [Session] with an OAuth2.0 authorization request as AuthURL.
 func (p *Provider) BeginAuth(ctx context.Context, state string, params ...idp.Parameter) (idp.Session, error) {
 	opts := make([]rp.AuthURLOpt, 0)
+	
 	var loginHintSet bool
+	var hasPrompt bool
+
 	for _, param := range params {
 		if username, ok := param.(idp.LoginHintParam); ok {
 			loginHintSet = true
 			opts = append(opts, loginHint(string(username)))
 		}
+
+		if hasP, ok := param.(idp.HasPromptParam); ok && hasP {
+			hasPrompt = true
+		}
 	}
-	if !loginHintSet {
+	
+	if !loginHintSet && !hasPrompt {
 		opts = append(opts, rp.WithPrompt(oidc.PromptSelectAccount))
 	}
 


### PR DESCRIPTION
## Which Problems Are Solved

- When initiating external IDP login (OAuth/OIDC), ZITADEL automatically appends `prompt=select_account` to the authorization URL, even when the original auth request already contains a `prompt` parameter
- This results in duplicate or conflicting prompt parameters in the redirect URL (e.g., `prompt=login&prompt=select_account`)
- External identity providers that don't support multiple prompt values or have strict validation reject these requests with errors like "Prompt parameter select_account is invalid or unsupported"

## How the Problems Are Solved

- Added a new `HasPromptParam` type to the `idp.Parameter` interface to signal when an auth request already contains prompt parameters
- Updated the OIDC provider's `oidcProvider` function to conditionally add `WithSelectAccount()` only when the auth request doesn't already have any prompt parameters
- Updated the OAuth provider's `BeginAuth` method to check for `HasPromptParam` before automatically adding `prompt=select_account`
- Modified `sessionParamsFromAuthRequest` to pass `HasPromptParam(true)` when the auth request contains prompt values, preventing automatic prompt injection

## Additional Changes

- Updated `oidcProvider` function signature to accept `authReq *domain.AuthRequest` parameter for prompt checking
- Updated both call sites of `oidcProvider` to pass the auth request parameter

## Additional Context

This fix ensures that user-specified prompt parameters in OIDC/OAuth authorization requests are respected and not duplicated by ZITADEL's automatic `select_account` injection for external identity providers.