### PR TITLE
docs: add Actions V1 to V2 migration guide

### DIFF
--- a/docs/docs/guides/integrate/actions/actions-v1-to-v2-migration.md
+++ b/docs/docs/guides/integrate/actions/actions-v1-to-v2-migration.md
@@ -1,0 +1,132 @@
+---
+title: Migrate from Actions V1 to V2
+sidebar_label: Migrate from V1 to V2
+---
+
+This guide helps existing users understand the shift from Actions V1 (Embedded) to V2 (Webhook), and provides guidance for new users on how to work with Actions V2.
+
+:::caution Deprecation Notice
+Actions V1 APIs are planned to be sunsetted in ZITADEL V5. While a definitive V5 release date is not yet available, this is the final timeline for V1 API removal. Actions V1 will receive no new features, and all new implementations must use V2.
+:::
+
+## Why Actions Changed from V1 to V2
+
+ZITADEL Actions evolved from V1 to V2 to address fundamental architectural limitations. While Actions V1 executed JavaScript code directly within ZITADEL's runtime, Actions V2 uses external HTTP endpoints.
+
+This shift enables:
+
+- **Better Scalability:** Distributed, serverless execution
+- **Greater Flexibility:** Support for any technology stack (not just JavaScript)
+- **Improved Resilience:** Isolating custom logic from core ZITADEL services
+- **Cost Optimization:** Pay-per-execution models with serverless providers
+- **Enhanced Monitoring:** Better debugging and observability of custom extensions
+
+The transition represents a move from "embedded extensions" to "true webhooks," aligning ZITADEL with industry patterns (GitHub Actions, Zapier, etc.).
+
+## Architecture Deep Dive: V1 vs V2
+
+### Actions V1: The Embedded Model
+
+Custom JavaScript code executed directly inside ZITADEL's process.
+
+- **Context:** Embedded goja JavaScript engine
+- **Risks:** Shared memory space; errors could affect core functionality
+- **Constraints:** Bound to ZITADEL process resources; limited timeout configuration
+- **V1 Triggers:** Pre-event hooks (fire before operation) and Post-event hooks (fire after success)
+
+### Actions V2: The Webhook Model
+
+Custom logic lives in external HTTP endpoints called via webhooks.
+
+- **Context:** Runs on your infrastructure (Cloudflare Workers, AWS Lambda, etc.)
+- **Isolation:** Completely isolated memory; failures do not crash ZITADEL
+- **Scaling:** Endpoints scale independently of ZITADEL
+
+**V2 Execution Types:**
+
+| Type | Description |
+|------|-------------|
+| **Request** | Triggers when a specific API request occurs |
+| **Response** | Triggers when a specific API response occurs |
+| **Function** | Triggers when specific functionality is used (useful for adding custom claims to tokens or executing external code during OIDC/SAML flows) |
+| **Event** | Triggers reactively when ZITADEL events occur |
+
+### Key Architectural Differences
+
+| Aspect | Actions V1 | Actions V2 |
+|--------|-----------|-----------|
+| Execution Environment | Embedded in ZITADEL (sandboxed JavaScript) | External webhooks (Cloudflare Workers, AWS Lambda, etc.) |
+| Code Location | Inline in ZITADEL Console | Hosted on your infrastructure |
+| Language | JavaScript (limited runtime) | Any language |
+| API Access | `ctx` and `api` objects provided by ZITADEL | ZITADEL REST/gRPC APIs via HTTP calls |
+| Triggers | Flow + Trigger (e.g., "Pre Access Token Creation") | Specific API methods or webhook events |
+| Dependencies | Limited (`zitadel/http`, `zitadel/log`) | Any framework |
+| Security | Managed by ZITADEL | HMAC signature verification required (to validate incoming webhook requests from ZITADEL) |
+| Scalability | Limited by ZITADEL instance | Independent scaling |
+
+### Business Benefits
+
+- **Technology Flexibility:** Use your preferred language instead of being locked into JavaScript
+- **Operational Resilience:** Isolates failures to prevent cascading outages
+- **Cost Optimization:** Leverage serverless "scale to zero" pricing for custom logic
+- **Observability:** Integrate with tools such as Datadog and Sentry
+
+## When to Use Each V2 Execution Type
+
+We provide a collection of [ready-to-deploy Cloudflare Worker examples](https://github.com/zitadel/actions/tree/main/actions-v2-cloudflare-workers) that integrate with ZITADEL Actions V2. Each script demonstrates how to handle ZITADEL events, signatures, and responses directly from a serverless Cloudflare Worker environment. While the examples are designed for Cloudflare Workers, the code can be adapted to deploy on the platform of your choice (AWS Lambda, Azure Functions, etc.).
+
+| If You Need To... | Use This V2 Type | When It Fires | Example |
+|-------------------|------------------|---------------|---------|
+| Add custom token claims | Function (`preaccesstoken`) | Before access token generated | [custom-claims](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/CUSTOM-CLAIMS.md) |
+| Map roles to permissions | Function (`preaccesstoken`) | Before access token generated | [authorization](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/AUTHORIZATION.md) |
+| Add "groups" claim from roles | Function (`preaccesstoken`/`preuserinfo`) | Before token/userinfo generated | [groups-claim](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/GROUPS-CLAIM.md) |
+| Block login | Function (`preuserinfo`) + `interruptOnError: true` | Before userinfo generated | [block-login](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/BLOCK-LOGIN.md) |
+| Track last login time | Function (`preuserinfo`) | Before userinfo generated | [set-user-metadata](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/SET-USER-METADATA.md) |
+| Add custom SAML attributes | Function (`presamlresponse`) | Before SAML response sent | [saml-attributes](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/SAML-ATTRIBUTES.md) |
+| Migrate users on first login | Request + Response (API methods) | Before/after user lookup & session | [jit-users-migration](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/JIT-USERS-MIGRATION.md) |
+| Map IDP attributes | Response (`/RetrieveIdentityProviderIntent`) | After IDP authentication | [idp-mapping](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/IDP-MAPPING.md) |
+| Auto-assign roles to new users | Event (`user.human.added`) | When user created | [set-role](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/SET-ROLE.md) |
+| Forward events to monitoring | Event (any event) | When event occurs | [datadog-forwarder](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/DATADOG-FORWARDER.md) |
+
+## Detailed Flow Explanations
+
+### Flow 1: Internal Authentication
+
+Maps user registration and login triggers to Request (Pre-operation) and Response (Post-operation) execution types.
+
+**Example Scripts:**
+
+- Block/validate requests: [block-login-flow.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/BLOCK-LOGIN.md)
+- Add metadata post-creation: [metadata.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/SET-USER-METADATA.md)
+
+### Flow 2: External Authentication
+
+Handles IDP logins and JIT (Just-in-Time) provisioning via Response (Intent retrieval) and standard User Creation hooks.
+
+**Example Scripts:**
+
+- Map IDP attributes: [idp-mapping.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/IDP-MAPPING.md)
+- JIT user migration: [jit-user-migration.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/JIT-USERS-MIGRATION.md)
+
+### Flow 3: Complement Token
+
+Moves from implicit hooks to specific V2 functions, primarily Function (`preaccesstoken`).
+
+**Example Scripts:**
+
+- Add custom claims: [custom-claims.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/CUSTOM-CLAIMS.md)
+- Add permissions claim: [authorization.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/AUTHORIZATION.md)
+
+### Flow 4: Customize SAML Response
+
+Moves to the Function (`presamlresponse`).
+
+**Example Scripts:**
+
+- Add SAML attributes: [saml-attributes.js](https://github.com/zitadel/actions/blob/main/actions-v2-cloudflare-workers/SAML-ATTRIBUTES.md)
+
+## Additional Resources
+
+- [ZITADEL Actions V2 Documentation](/concepts/features/actions_v2)
+- [Using Actions Guide](./usage)
+- [Actions V2 Examples Repository](https://github.com/zitadel/actions/tree/main/actions-v2-cloudflare-workers)


### PR DESCRIPTION
# Which Problems Are Solved

- Users migrating from Actions V1 to V2 lack comprehensive documentation explaining the architectural differences and migration patterns
- The existing migration guide doesn't provide enough context on why Actions changed and how to map V1 concepts to V2
- No clear reference table mapping common use cases to the appropriate V2 execution types

# How the Problems Are Solved

- Added a new comprehensive migration guide (`actions-v1-to-v2-migration.md`) covering:
  - Deprecation notice for Actions V1 (sunsetting in ZITADEL V5)
  - Architecture deep dive comparing V1 (embedded JavaScript) vs V2 (webhook model)
  - Key architectural differences table
  - Business benefits of migrating to V2
  - Use case mapping table with links to ready-to-deploy Cloudflare Worker examples
  - Detailed flow explanations for Internal Authentication, External Authentication, Complement Token, and SAML Response customization