### PR TITLE
docs: fix fallback branch

### DIFF
--- a/apps/docs/scripts/fetch-remote-content.mjs
+++ b/apps/docs/scripts/fetch-remote-content.mjs
@@ -6,7 +6,7 @@ import semver from 'semver';
 import { Readable } from 'stream';
 
 const FALLBACK_VERSION = 'v4.10.0'; // Temporary fallback until > 4.10.0 exists
-const FALLBACK_BRANCH = 'fuma-docs'; // Primary branch to check for 4.10.0 content
+const FALLBACK_BRANCH = 'main'; // Primary branch to check for 4.10.0 content
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -99,7 +99,7 @@ function getFallbackSource() {
 
 // sourceRef: Can be a tag (v1.2.3) or a branch (main, fuma-docs)
 async function downloadVersion(tag, sourceRef) {
-  const isBranch = sourceRef === 'main' || sourceRef === 'fuma-docs' || !sourceRef.startsWith('v');
+  const isBranch = sourceRef === 'main' || sourceRef === 'master' || !sourceRef.startsWith('v');
   const typeSegment = isBranch ? 'heads' : 'tags';
   const url = `https://github.com/${REPO}/archive/refs/${typeSegment}/${sourceRef}.tar.gz`;
   
@@ -452,8 +452,12 @@ function getLocalVersion() {
         } catch (e) {}
     }
 
-    if (branch && branch !== 'main') {
+    if (branch && branch !== 'main' && branch !== 'master') {
         return { label: branch, isUnreleased: true };
+    }
+
+    if (branch === 'main' || branch === 'master') {
+        return { label: 'ZITADEL Docs', isUnreleased: false };
     }
 
     try {


### PR DESCRIPTION
This pull request updates the fallback branch logic and improves handling of branch names in the `fetch-remote-content.mjs` script. The changes ensure better compatibility with both `main` and `master` branches, and clarify how documentation versions are labeled.

Branch handling improvements:

* Changed the fallback branch from `fuma-docs` to `main` for fetching content when a newer version does not exist.
* Updated branch detection logic to recognize both `main` and `master` as valid primary branches, instead of just `main` and `fuma-docs`.
* Improved local version labeling: if the current branch is `main` or `master`, it now returns a standardized label (`ZITADEL Docs`) and marks it as not unreleased; other branches are handled accordingly.