### PR TITLE
docs: fix docker-compose.yaml link in self-hosting docs page

### DIFF
--- a/apps/docs/content/self-hosting/deploy/compose.mdx
+++ b/apps/docs/content/self-hosting/deploy/compose.mdx
@@ -30,7 +30,7 @@ The following commands set up services for a PostgreSQL database, a Zitadel API 
 
 1. Download the `docker-compose.yaml` file from the Zitadel repository:
    ```shell
-   curl -L https://raw.githubusercontent.com/zitadel/zitadel/main/docs/self-hosting/deploy/docker-compose.yaml -o docker-compose.yaml
+   curl -L https://raw.githubusercontent.com/zitadel/zitadel/main/apps/docs/content/self-hosting/deploy/docker-compose.yaml -o docker-compose.yaml
    ```
 2. Make sure the containers use the latest image versions.
     ```shell


### PR DESCRIPTION
# Which Problems Are Solved

The 'self-hosting with Docker Compose' documentation page features a link to a `docker-compose.yaml` file in the repo. It looks like this link was not updated when #11166 migrated the docs to be under the `apps/docs` folder structure, so currently it results in a 404.

# How the Problems Are Solved

Replaces the old link with the correct one featuring the new folder structure.