### PR TITLE
fix(docs): remove obsolete buf token

### DIFF
--- a/apps/docs/scripts/generate-proto-docs.mjs
+++ b/apps/docs/scripts/generate-proto-docs.mjs
@@ -161,10 +161,7 @@ async function run() {
             const child = spawn('npx', args, {
               cwd: taskTempDir, 
               stdio: 'inherit',
-              env: {
-                  ...process.env,
-                  BUF_TOKEN: '851d3e2519b882d9e6da46eadec5e3ccc6a966dae0ce5e78dd285d9f912e35fd'
-              }
+              env: process.env
             });
 
             child.on('close', (code) => {


### PR DESCRIPTION
This pull request makes a small change to the environment variables used when spawning a child process in the `generate-proto-docs.mjs` script. The hardcoded `BUF_TOKEN` environment variable has been removed, and now only the existing environment variables from `process.env` are passed to the child process.

- Removed the hardcoded `BUF_TOKEN` from the environment variables when spawning the child process in `generate-proto-docs.mjs`.