### PR TITLE
fix: make auth not required for testing smtp

### DIFF
--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -5300,7 +5300,6 @@ message TestEmailProviderSMTPRequest {
         }
     ];
     oneof Auth {
-        option (validate.required) = true;
         SMTPNoAuth none = 9;
         SMTPPlainAuth plain = 10;
         SMTPXOAuth2Auth xoauth2 = 11;


### PR DESCRIPTION
# Which Problems Are Solved

With the xoath introduction an `auth` oneof was added to the proto. This was made because one of the authentication methods should always be selected. This however, created a backwards compatibility issue.

# How the Problems Are Solved

Don't make `auth` required.

# Additional Changes


# Additional Context

