### PR TITLE
chore: fix db to volume mapping

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     env_file:
       - ./.env.db
     volumes:
-      - db-data-dev:/var/lib/postgresql/data
+      - db-data-dev:/var/lib/postgresql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready", "-U", "postgres" ]
       interval: "10s"


### PR DESCRIPTION
# Which Problems Are Solved

The upgrade to PG 18 changed the way named volumes and bind mounts need to be mapped on the docker image.

The old way of mapping (`db-data-dev:/var/lib/postgresql/data`) is not supported anymore and leads to the following error:

```
db-1  | ********************************************************************************
db-1  | Error: in 18+, these Docker images are configured to store database data in a
db-1  |        format which is compatible with "pg_ctlcluster" (specifically, using
db-1  |        major-version-specific directory names).  This better reflects how
db-1  |        PostgreSQL itself works, and how upgrades are to be performed.
db-1  | 
db-1  |        See also https://github.com/docker-library/postgres/pull/1259
db-1  | 
db-1  |        Counter to that, there appears to be PostgreSQL data in:
db-1  |          /var/lib/postgresql/data (unused mount/volume)
db-1  | 
db-1  |        This is usually the result of upgrading the Docker image without
db-1  |        upgrading the underlying database using "pg_upgrade" (which requires both
db-1  |        versions).
db-1  | 
db-1  |        The suggested container configuration for 18+ is to place a single mount
db-1  |        at /var/lib/postgresql which will then place PostgreSQL data in a
db-1  |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
db-1  |        boundary issues.
db-1  | 
db-1  |        See https://github.com/docker-library/postgres/issues/37 for a (long)
db-1  |        discussion around this process, and suggestions for how to do so.
db-1 exited with code 1 (restarting)
```

See also: https://github.com/docker-library/postgres/pull/1259

# How the Problems Are Solved

Fix PG18 volume mapping
