### PR TITLE
feat: OIDC IDP button alignment and IDP options (iconUrl, backgroundC…

### DIFF
--- a/apps/login/constants/csp.js
+++ b/apps/login/constants/csp.js
@@ -1,6 +1,3 @@
-const ZITADEL_DOMAIN = process.env.ZITADEL_API_URL
-  ? new URL(process.env.ZITADEL_API_URL).hostname
-  : '*.zitadel.cloud';
-
+// img-src includes https: so OIDC/IdP provider icon URLs (e.g. from CDNs) can load
 export const DEFAULT_CSP =
-  `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' https://${ZITADEL_DOMAIN};`;
+  "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; child-src; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; img-src 'self' https:;";

--- a/apps/login/src/components/idps/base-button.tsx
+++ b/apps/login/src/components/idps/base-button.tsx
@@ -12,6 +12,10 @@ export type SignInWithIdentityProviderProps = DetailedHTMLProps<
 > & {
   name?: string;
   e2e?: string;
+  /** Optional icon URL for the provider (e.g. OIDC custom icon). */
+  iconUrl?: string;
+  /** Optional background color for the button (e.g. hex "#1976d2"). */
+  backgroundColor?: string;
 };
 
 // Helper function to get default IDP button appearance from centralized theme system
@@ -26,9 +30,12 @@ export const BaseButton = forwardRef<HTMLButtonElement, SignInWithIdentityProvid
   const buttonRoundness = getComponentRoundness("button");
   const idpButtonAppearance = getDefaultIdpButtonAppearance();
 
+  const { iconUrl, backgroundColor, className, style, ...restProps } = props;
+  const hasCustomStyle = Boolean(backgroundColor);
+
   return (
     <button
-      {...props}
+      {...restProps}
       type="submit"
       ref={ref}
       disabled={formStatus.pending}
@@ -36,12 +43,29 @@ export const BaseButton = forwardRef<HTMLButtonElement, SignInWithIdentityProvid
         `flex flex-1 cursor-pointer flex-row items-center px-4 text-sm text-text-light-500 outline-none transition-all hover:border-black focus:border-primary-light-500 dark:text-text-dark-500 hover:dark:border-white focus:dark:border-primary-dark-500`,
         buttonRoundness,
         idpButtonAppearance,
-        `bg-background-light-400 dark:bg-background-dark-500`, // Keep background as fallback for non-glass themes
-        props.className,
+        !hasCustomStyle && `bg-background-light-400 dark:bg-background-dark-500`,
+        className,
       )}
+      style={
+        hasCustomStyle
+          ? { ...style, backgroundColor }
+          : style
+      }
     >
       <div className="flex flex-1 items-center justify-between gap-4">
-        <div className="flex flex-1 flex-row items-center">{props.children}</div>
+        <div className="flex min-w-0 flex-1 flex-row items-center gap-4">
+          {iconUrl && (
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center">
+              <img
+                src={iconUrl}
+                alt=""
+                className="h-5 w-5 object-contain"
+                referrerPolicy="no-referrer"
+              />
+            </div>
+          )}
+          {iconUrl ? <span className="ml-4 shrink-0">{props.children}</span> : props.children}
+        </div>
         {formStatus.pending && <Loader2Icon className="h-4 w-4 animate-spin" />}
       </div>
     </button>

--- a/apps/login/src/components/idps/sign-in-with-generic.tsx
+++ b/apps/login/src/components/idps/sign-in-with-generic.tsx
@@ -10,7 +10,7 @@ export const SignInWithGeneric = forwardRef<
   const {
     children,
     name = "",
-    className = "h-[50px] pl-20",
+    className = "h-[50px]",
     ...restProps
   } = props;
   return (

--- a/apps/login/src/components/sign-in-with-idp.tsx
+++ b/apps/login/src/components/sign-in-with-idp.tsx
@@ -36,7 +36,9 @@ export function SignInWithIdp({
   const [state, action, _isPending] = useActionState(redirectToIdp, {});
 
   const renderIDPButton = (idp: IdentityProvider, index: number) => {
-    const { id, name, type } = idp;
+    const { id, name, type, options } = idp;
+    const iconUrl = options?.iconUrl ?? "";
+    const backgroundColor = options?.backgroundColor ?? "";
 
     const components: Partial<Record<IdentityProviderType, (props: SignInWithIdentityProviderProps) => ReactNode>> = {
       [IdentityProviderType.APPLE]: SignInWithApple,
@@ -62,7 +64,12 @@ export function SignInWithIdp({
         <input type="hidden" name="organization" value={organization} />
         {sessionId && <input type="hidden" name="sessionId" value={sessionId} />}
         {postErrorRedirectUrl && <input type="hidden" name="postErrorRedirectUrl" value={postErrorRedirectUrl} />}
-        <Component key={id} name={name} />
+        <Component
+          key={id}
+          name={name}
+          iconUrl={iconUrl || undefined}
+          backgroundColor={backgroundColor || undefined}
+        />
       </form>
     ) : null;
   };

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -1,0 +1,27 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 70.sql
+	idpTemplate6OIDCBranding string
+)
+
+type IDPTemplate6OIDCBranding struct {
+	dbClient *database.DB
+}
+
+func (mig *IDPTemplate6OIDCBranding) Execute(ctx context.Context, _ eventstore.Event) error {
+	_, err := mig.dbClient.ExecContext(ctx, idpTemplate6OIDCBranding)
+	return err
+}
+
+func (mig *IDPTemplate6OIDCBranding) String() string {
+	return "70_idp_templates6_oidc_add_icon_and_background_color"
+}

--- a/cmd/setup/70.sql
+++ b/cmd/setup/70.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS projections.idp_templates6_oidc ADD COLUMN IF NOT EXISTS icon_url TEXT;
+ALTER TABLE IF EXISTS projections.idp_templates6_oidc ADD COLUMN IF NOT EXISTS background_color TEXT;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -182,6 +182,7 @@ type Steps struct {
 	s67SyncMemberRoleFields                 *SyncMemberRoleFields
 	s68TargetAddPayloadTypeColumn           *TargetAddPayloadTypeColumn
 	s69CacheTablesLogged                    *CacheTablesLogged
+	s70IDPTemplate6OIDCBranding             *IDPTemplate6OIDCBranding
 }
 
 func NewSteps(ctx context.Context, v *viper.Viper) (*Steps, error) {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -247,6 +247,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s67SyncMemberRoleFields = &SyncMemberRoleFields{dbClient: dbClient}
 	steps.s68TargetAddPayloadTypeColumn = &TargetAddPayloadTypeColumn{dbClient: dbClient}
 	steps.s69CacheTablesLogged = &CacheTablesLogged{dbClient: dbClient}
+	steps.s70IDPTemplate6OIDCBranding = &IDPTemplate6OIDCBranding{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -304,6 +305,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s65FixUserMetadata5Index,
 		steps.s67SyncMemberRoleFields,
 		steps.s69CacheTablesLogged,
+		steps.s70IDPTemplate6OIDCBranding,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {

--- a/console/src/app/modules/providers/provider-oidc/provider-oidc.component.html
+++ b/console/src/app/modules/providers/provider-oidc/provider-oidc.component.html
@@ -107,6 +107,15 @@
             </cnsl-info-section>
           </div>
 
+          <cnsl-form-field class="formfield">
+            <cnsl-label>{{ 'IDP.ICONURL' | translate }}</cnsl-label>
+            <input cnslInput formControlName="iconUrl" type="url" placeholder="https://example.com/icon.png" />
+          </cnsl-form-field>
+          <cnsl-form-field class="formfield">
+            <cnsl-label>{{ 'IDP.BACKGROUNDCOLOR' | translate }}</cnsl-label>
+            <input cnslInput formControlName="backgroundColor" type="text" placeholder="#1976d2" />
+          </cnsl-form-field>
+
           <cnsl-provider-options
             [initialOptions]="provider?.config?.options"
             (optionsChanged)="options = $event"

--- a/console/src/app/modules/providers/provider-oidc/provider-oidc.component.ts
+++ b/console/src/app/modules/providers/provider-oidc/provider-oidc.component.ts
@@ -87,6 +87,8 @@ export class ProviderOIDCComponent {
       scopesList: new UntypedFormControl(['openid', 'profile', 'email'], []),
       isIdTokenMapping: new UntypedFormControl(),
       usePkce: new UntypedFormControl(false),
+      iconUrl: new UntypedFormControl(''),
+      backgroundColor: new UntypedFormControl(''),
     });
 
     this.route.data.pipe(take(1)).subscribe((data) => {
@@ -168,6 +170,12 @@ export class ProviderOIDCComponent {
     req.setProviderOptions(this.options);
     req.setIsIdTokenMapping(this.isIdTokenMapping?.value);
     req.setUsePkce(this.usePkce?.value);
+    if (this.iconUrl?.value) {
+      req.setIconUrl(this.iconUrl.value);
+    }
+    if (this.backgroundColor?.value) {
+      req.setBackgroundColor(this.backgroundColor.value);
+    }
 
     this.loading = true;
     this.service
@@ -197,6 +205,12 @@ export class ProviderOIDCComponent {
       req.setProviderOptions(this.options);
       req.setIsIdTokenMapping(this.isIdTokenMapping?.value);
       req.setUsePkce(this.usePkce?.value);
+      if (this.iconUrl?.value !== undefined) {
+        req.setIconUrl(this.iconUrl.value);
+      }
+      if (this.backgroundColor?.value !== undefined) {
+        req.setBackgroundColor(this.backgroundColor.value);
+      }
 
       this.loading = true;
       this.service
@@ -268,5 +282,13 @@ export class ProviderOIDCComponent {
 
   public get usePkce(): AbstractControl | null {
     return this.form.get('usePkce');
+  }
+
+  public get iconUrl(): AbstractControl | null {
+    return this.form.get('iconUrl');
+  }
+
+  public get backgroundColor(): AbstractControl | null {
+    return this.form.get('backgroundColor');
   }
 }

--- a/console/src/assets/i18n/de.json
+++ b/console/src/assets/i18n/de.json
@@ -2377,7 +2377,9 @@
     "ISIDTOKENMAPPING": "Zuordnung vom ID-Token",
     "ISIDTOKENMAPPING_DESC": "Legt fest, ob für das Mapping der Provider Informationen das ID-Token verwendet werden soll, anstatt des Userinfo-Endpoints.",
     "USEPKCE": "Verwenden Sie PKCE",
-    "USEPKCE_DESC": "Bestimmt, ob die Parameter code_challenge und code_challenge_method in der Authentifizierungsanforderung enthalten sind"
+    "USEPKCE_DESC": "Bestimmt, ob die Parameter code_challenge und code_challenge_method in der Authentifizierungsanforderung enthalten sind",
+    "ICONURL": "Icon-URL",
+    "BACKGROUNDCOLOR": "Hintergrundfarbe"
   },
   "MFA": {
     "LIST": {

--- a/console/src/assets/i18n/en.json
+++ b/console/src/assets/i18n/en.json
@@ -2403,7 +2403,9 @@
     "ISIDTOKENMAPPING": "Map from the ID token",
     "ISIDTOKENMAPPING_DESC": "If selected, provider information gets mapped from the ID token, not from the userinfo endpoint.",
     "USEPKCE": "Use PKCE",
-    "USEPKCE_DESC": "Determines whether the code_challenge and code_challenge_method params are included in the auth request"
+    "USEPKCE_DESC": "Determines whether the code_challenge and code_challenge_method params are included in the auth request",
+    "ICONURL": "Icon URL",
+    "BACKGROUNDCOLOR": "Background Color"
   },
   "MFA": {
     "LIST": {

--- a/internal/api/grpc/admin/idp_converter.go
+++ b/internal/api/grpc/admin/idp_converter.go
@@ -245,6 +245,8 @@ func addGenericOIDCProviderToCommand(req *admin_pb.AddGenericOIDCProviderRequest
 		Scopes:           req.Scopes,
 		IsIDTokenMapping: req.IsIdTokenMapping,
 		UsePKCE:          req.UsePkce,
+		IconURL:          req.IconUrl,
+		BackgroundColor:  req.BackgroundColor,
 		IDPOptions:       idp_grpc.OptionsToCommand(req.ProviderOptions),
 	}
 }
@@ -258,6 +260,8 @@ func updateGenericOIDCProviderToCommand(req *admin_pb.UpdateGenericOIDCProviderR
 		Scopes:           req.Scopes,
 		IsIDTokenMapping: req.IsIdTokenMapping,
 		UsePKCE:          req.UsePkce,
+		IconURL:          req.IconUrl,
+		BackgroundColor:  req.BackgroundColor,
 		IDPOptions:       idp_grpc.OptionsToCommand(req.ProviderOptions),
 	}
 }

--- a/internal/api/grpc/idp/converter.go
+++ b/internal/api/grpc/idp/converter.go
@@ -518,6 +518,8 @@ func oidcConfigToPb(providerConfig *idp_pb.ProviderConfig, template *query.OIDCI
 			Scopes:           template.Scopes,
 			IsIdTokenMapping: template.IsIDTokenMapping,
 			UsePkce:          template.UsePKCE,
+			IconUrl:          template.IconURL,
+			BackgroundColor:  template.BackgroundColor,
 		},
 	}
 }

--- a/internal/api/grpc/idp/v2/query.go
+++ b/internal/api/grpc/idp/v2/query.go
@@ -186,6 +186,8 @@ func oidcConfigToPb(idpConfig *idp_pb.IDPConfig, template *query.OIDCIDPTemplate
 			Issuer:           template.Issuer,
 			Scopes:           template.Scopes,
 			IsIdTokenMapping: template.IsIDTokenMapping,
+			IconUrl:          template.IconURL,
+			BackgroundColor:  template.BackgroundColor,
 		},
 	}
 }

--- a/internal/api/grpc/management/idp_converter.go
+++ b/internal/api/grpc/management/idp_converter.go
@@ -238,6 +238,8 @@ func addGenericOIDCProviderToCommand(req *mgmt_pb.AddGenericOIDCProviderRequest)
 		Scopes:           req.Scopes,
 		IsIDTokenMapping: req.IsIdTokenMapping,
 		UsePKCE:          req.UsePkce,
+		IconURL:          req.IconUrl,
+		BackgroundColor:  req.BackgroundColor,
 		IDPOptions:       idp_grpc.OptionsToCommand(req.ProviderOptions),
 	}
 }
@@ -251,6 +253,8 @@ func updateGenericOIDCProviderToCommand(req *mgmt_pb.UpdateGenericOIDCProviderRe
 		Scopes:           req.Scopes,
 		IsIDTokenMapping: req.IsIdTokenMapping,
 		UsePKCE:          req.UsePkce,
+		IconURL:          req.IconUrl,
+		BackgroundColor:  req.BackgroundColor,
 		IDPOptions:       idp_grpc.OptionsToCommand(req.ProviderOptions),
 	}
 }

--- a/internal/api/grpc/settings/v2/settings_converter.go
+++ b/internal/api/grpc/settings/v2/settings_converter.go
@@ -190,17 +190,24 @@ func identityProvidersToPb(idps []*query.IDPLoginPolicyLink) []*settings.Identit
 }
 
 func identityProviderToPb(idp *query.IDPLoginPolicyLink) *settings.IdentityProvider {
+	opts := &idp_pb.Options{
+		IsLinkingAllowed:  idp.IsLinkingAllowed,
+		IsCreationAllowed: idp.IsCreationAllowed,
+		IsAutoCreation:    idp.IsAutoCreation,
+		IsAutoUpdate:      idp.IsAutoUpdate,
+		AutoLinking:       idp_api.AutoLinkingOptionToPb(idp.AutoLinking),
+	}
+	if idp.IconURL != "" {
+		opts.IconUrl = idp.IconURL
+	}
+	if idp.BackgroundColor != "" {
+		opts.BackgroundColor = idp.BackgroundColor
+	}
 	return &settings.IdentityProvider{
-		Id:   idp.IDPID,
-		Name: domain.IDPName(idp.IDPName, idp.IDPType),
-		Type: idpTypeToPb(idp.IDPType),
-		Options: &idp_pb.Options{
-			IsLinkingAllowed:  idp.IsLinkingAllowed,
-			IsCreationAllowed: idp.IsCreationAllowed,
-			IsAutoCreation:    idp.IsAutoCreation,
-			IsAutoUpdate:      idp.IsAutoUpdate,
-			AutoLinking:       idp_api.AutoLinkingOptionToPb(idp.AutoLinking),
-		},
+		Id:      idp.IDPID,
+		Name:    domain.IDPName(idp.IDPName, idp.IDPType),
+		Type:    idpTypeToPb(idp.IDPType),
+		Options: opts,
 	}
 }
 

--- a/internal/command/idp.go
+++ b/internal/command/idp.go
@@ -32,6 +32,8 @@ type GenericOIDCProvider struct {
 	Scopes           []string
 	IsIDTokenMapping bool
 	UsePKCE          bool
+	IconURL          string
+	BackgroundColor  string
 	IDPOptions       idp.Options
 }
 

--- a/internal/command/idp_model.go
+++ b/internal/command/idp_model.go
@@ -218,6 +218,8 @@ type OIDCIDPWriteModel struct {
 	Scopes           []string
 	IsIDTokenMapping bool
 	UsePKCE          bool
+	IconURL          string
+	BackgroundColor  string
 	idp.Options
 
 	State domain.IDPState
@@ -259,6 +261,8 @@ func (wm *OIDCIDPWriteModel) reduceAddedEvent(e *idp.OIDCIDPAddedEvent) {
 	wm.Scopes = e.Scopes
 	wm.IsIDTokenMapping = e.IsIDTokenMapping
 	wm.UsePKCE = e.UsePKCE
+	wm.IconURL = e.IconURL
+	wm.BackgroundColor = e.BackgroundColor
 	wm.Options = e.Options
 	wm.State = domain.IDPStateActive
 }
@@ -285,6 +289,12 @@ func (wm *OIDCIDPWriteModel) reduceChangedEvent(e *idp.OIDCIDPChangedEvent) {
 	if e.UsePKCE != nil {
 		wm.UsePKCE = *e.UsePKCE
 	}
+	if e.IconURL != nil {
+		wm.IconURL = *e.IconURL
+	}
+	if e.BackgroundColor != nil {
+		wm.BackgroundColor = *e.BackgroundColor
+	}
 	wm.Options.ReduceChanges(e.OptionChanges)
 }
 
@@ -296,6 +306,7 @@ func (wm *OIDCIDPWriteModel) NewChanges(
 	secretCrypto crypto.EncryptionAlgorithm,
 	scopes []string,
 	idTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options idp.Options,
 ) ([]idp.OIDCIDPChanges, error) {
 	changes := make([]idp.OIDCIDPChanges, 0)
@@ -325,6 +336,12 @@ func (wm *OIDCIDPWriteModel) NewChanges(
 	}
 	if wm.UsePKCE != usePKCE {
 		changes = append(changes, idp.ChangeOIDCUsePKCE(usePKCE))
+	}
+	if wm.IconURL != iconURL {
+		changes = append(changes, idp.ChangeOIDCIconURL(iconURL))
+	}
+	if wm.BackgroundColor != backgroundColor {
+		changes = append(changes, idp.ChangeOIDCBackgroundColor(backgroundColor))
 	}
 	opts := wm.Options.Changes(options)
 	if !opts.IsZero() {

--- a/internal/command/instance_idp.go
+++ b/internal/command/instance_idp.go
@@ -763,6 +763,8 @@ func (c *Commands) prepareAddInstanceOIDCProvider(a *instance.Aggregate, writeMo
 					provider.Scopes,
 					provider.IsIDTokenMapping,
 					provider.UsePKCE,
+					provider.IconURL,
+					provider.BackgroundColor,
 					provider.IDPOptions,
 				),
 			}, nil
@@ -808,6 +810,8 @@ func (c *Commands) prepareUpdateInstanceOIDCProvider(a *instance.Aggregate, writ
 				provider.Scopes,
 				provider.IsIDTokenMapping,
 				provider.UsePKCE,
+				provider.IconURL,
+				provider.BackgroundColor,
 				provider.IDPOptions,
 			)
 			if err != nil || event == nil {

--- a/internal/command/instance_idp_model.go
+++ b/internal/command/instance_idp_model.go
@@ -177,6 +177,7 @@ func (wm *InstanceOIDCIDPWriteModel) NewChangedEvent(
 	secretCrypto crypto.EncryptionAlgorithm,
 	scopes []string,
 	idTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options idp.Options,
 ) (*instance.OIDCIDPChangedEvent, error) {
 
@@ -189,6 +190,8 @@ func (wm *InstanceOIDCIDPWriteModel) NewChangedEvent(
 		scopes,
 		idTokenMapping,
 		usePKCE,
+		iconURL,
+		backgroundColor,
 		options,
 	)
 	if err != nil || len(changes) == 0 {

--- a/internal/command/org_idp.go
+++ b/internal/command/org_idp.go
@@ -734,6 +734,8 @@ func (c *Commands) prepareAddOrgOIDCProvider(a *org.Aggregate, writeModel *OrgOI
 					provider.Scopes,
 					provider.IsIDTokenMapping,
 					provider.UsePKCE,
+					provider.IconURL,
+					provider.BackgroundColor,
 					provider.IDPOptions,
 				),
 			}, nil
@@ -779,6 +781,8 @@ func (c *Commands) prepareUpdateOrgOIDCProvider(a *org.Aggregate, writeModel *Or
 				provider.Scopes,
 				provider.IsIDTokenMapping,
 				provider.UsePKCE,
+				provider.IconURL,
+				provider.BackgroundColor,
 				provider.IDPOptions,
 			)
 			if err != nil || event == nil {

--- a/internal/command/org_idp_model.go
+++ b/internal/command/org_idp_model.go
@@ -179,6 +179,7 @@ func (wm *OrgOIDCIDPWriteModel) NewChangedEvent(
 	secretCrypto crypto.EncryptionAlgorithm,
 	scopes []string,
 	idTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options idp.Options,
 ) (*org.OIDCIDPChangedEvent, error) {
 
@@ -191,6 +192,8 @@ func (wm *OrgOIDCIDPWriteModel) NewChangedEvent(
 		scopes,
 		idTokenMapping,
 		usePKCE,
+		iconURL,
+		backgroundColor,
 		options,
 	)
 	if err != nil || len(changes) == 0 {

--- a/internal/query/idp_login_policy_link_test.go
+++ b/internal/query/idp_login_policy_link_test.go
@@ -25,9 +25,12 @@ var (
 		` projections.idp_templates6.is_auto_creation,` +
 		` projections.idp_templates6.is_auto_update,` +
 		` projections.idp_templates6.auto_linking,` +
+		` projections.idp_templates6_oidc.icon_url,` +
+		` projections.idp_templates6_oidc.background_color,` +
 		` COUNT(*) OVER ()` +
 		` FROM projections.idp_login_policy_links5` +
 		` LEFT JOIN projections.idp_templates6 ON projections.idp_login_policy_links5.idp_id = projections.idp_templates6.id AND projections.idp_login_policy_links5.instance_id = projections.idp_templates6.instance_id` +
+		` LEFT JOIN projections.idp_templates6_oidc ON projections.idp_templates6.id = projections.idp_templates6_oidc.idp_id AND projections.idp_templates6.instance_id = projections.idp_templates6_oidc.instance_id` +
 		` RIGHT JOIN (SELECT login_policy_owner.aggregate_id, login_policy_owner.instance_id, login_policy_owner.owner_removed FROM projections.login_policies5 AS login_policy_owner` +
 		` WHERE (login_policy_owner.instance_id = $1 AND (login_policy_owner.aggregate_id = $2 OR login_policy_owner.aggregate_id = $3)) ORDER BY login_policy_owner.is_default LIMIT 1) AS login_policy_owner` +
 		` ON login_policy_owner.aggregate_id = projections.idp_login_policy_links5.resource_owner AND login_policy_owner.instance_id = projections.idp_login_policy_links5.instance_id`)
@@ -41,6 +44,8 @@ var (
 		"is_auto_creation",
 		"is_auto_update",
 		"auto_linking",
+		"icon_url",
+		"background_color",
 		"count",
 	}
 )
@@ -76,6 +81,9 @@ func Test_IDPLoginPolicyLinkPrepares(t *testing.T) {
 							true,
 							true,
 							domain.AutoLinkingOptionUsername,
+							nil,
+							nil,
+							uint64(1),
 						},
 					},
 				),
@@ -118,7 +126,10 @@ func Test_IDPLoginPolicyLinkPrepares(t *testing.T) {
 							false,
 							false,
 							false,
-							0,
+							nil,
+							nil,
+							nil,
+							1,
 						},
 					},
 				),

--- a/internal/query/idp_template.go
+++ b/internal/query/idp_template.go
@@ -74,6 +74,8 @@ type OIDCIDPTemplate struct {
 	Scopes           database.TextArray[string]
 	IsIDTokenMapping bool
 	UsePKCE          bool
+	IconURL          string
+	BackgroundColor  string
 }
 
 type JWTIDPTemplate struct {
@@ -322,6 +324,14 @@ var (
 	}
 	OIDCUsePKCECol = Column{
 		name:  projection.OIDCUsePKCECol,
+		table: oidcIdpTemplateTable,
+	}
+	OIDCIconURLCol = Column{
+		name:  projection.OIDCIconURLCol,
+		table: oidcIdpTemplateTable,
+	}
+	OIDCBackgroundColorCol = Column{
+		name:  projection.OIDCBackgroundColorCol,
 		table: oidcIdpTemplateTable,
 	}
 )
@@ -907,6 +917,8 @@ func prepareIDPTemplateByIDQuery() (sq.SelectBuilder, func(*sql.Row) (*IDPTempla
 			OIDCScopesCol.identifier(),
 			OIDCIDTokenMappingCol.identifier(),
 			OIDCUsePKCECol.identifier(),
+			OIDCIconURLCol.identifier(),
+			OIDCBackgroundColorCol.identifier(),
 			// jwt
 			JWTIDCol.identifier(),
 			JWTIssuerCol.identifier(),
@@ -1028,6 +1040,8 @@ func prepareIDPTemplateByIDQuery() (sq.SelectBuilder, func(*sql.Row) (*IDPTempla
 			oidcScopes := database.TextArray[string]{}
 			oidcIDTokenMapping := sql.NullBool{}
 			oidcUserPKCE := sql.NullBool{}
+			oidcIconURL := sql.NullString{}
+			oidcBackgroundColor := sql.NullString{}
 
 			jwtID := sql.NullString{}
 			jwtIssuer := sql.NullString{}
@@ -1147,6 +1161,8 @@ func prepareIDPTemplateByIDQuery() (sq.SelectBuilder, func(*sql.Row) (*IDPTempla
 				&oidcScopes,
 				&oidcIDTokenMapping,
 				&oidcUserPKCE,
+				&oidcIconURL,
+				&oidcBackgroundColor,
 				// jwt
 				&jwtID,
 				&jwtIssuer,
@@ -1264,6 +1280,8 @@ func prepareIDPTemplateByIDQuery() (sq.SelectBuilder, func(*sql.Row) (*IDPTempla
 					Scopes:           oidcScopes,
 					IsIDTokenMapping: oidcIDTokenMapping.Bool,
 					UsePKCE:          oidcUserPKCE.Bool,
+					IconURL:          oidcIconURL.String,
+					BackgroundColor:  oidcBackgroundColor.String,
 				}
 			}
 			if jwtID.Valid {
@@ -1423,6 +1441,8 @@ func prepareIDPTemplatesQuery() (sq.SelectBuilder, func(*sql.Rows) (*IDPTemplate
 			OIDCScopesCol.identifier(),
 			OIDCIDTokenMappingCol.identifier(),
 			OIDCUsePKCECol.identifier(),
+			OIDCIconURLCol.identifier(),
+			OIDCBackgroundColorCol.identifier(),
 			// jwt
 			JWTIDCol.identifier(),
 			JWTIssuerCol.identifier(),
@@ -1549,6 +1569,8 @@ func prepareIDPTemplatesQuery() (sq.SelectBuilder, func(*sql.Rows) (*IDPTemplate
 				oidcScopes := database.TextArray[string]{}
 				oidcIDTokenMapping := sql.NullBool{}
 				oidcUserPKCE := sql.NullBool{}
+				oidcIconURL := sql.NullString{}
+				oidcBackgroundColor := sql.NullString{}
 
 				jwtID := sql.NullString{}
 				jwtIssuer := sql.NullString{}
@@ -1668,6 +1690,8 @@ func prepareIDPTemplatesQuery() (sq.SelectBuilder, func(*sql.Rows) (*IDPTemplate
 					&oidcScopes,
 					&oidcIDTokenMapping,
 					&oidcUserPKCE,
+					&oidcIconURL,
+					&oidcBackgroundColor,
 					// jwt
 					&jwtID,
 					&jwtIssuer,
@@ -1784,6 +1808,8 @@ func prepareIDPTemplatesQuery() (sq.SelectBuilder, func(*sql.Rows) (*IDPTemplate
 						Scopes:           oidcScopes,
 						IsIDTokenMapping: oidcIDTokenMapping.Bool,
 						UsePKCE:          oidcUserPKCE.Bool,
+						IconURL:          oidcIconURL.String,
+						BackgroundColor:  oidcBackgroundColor.String,
 					}
 				}
 				if jwtID.Valid {

--- a/internal/query/projection/idp_template.go
+++ b/internal/query/projection/idp_template.go
@@ -80,6 +80,8 @@ const (
 	OIDCScopesCol         = "scopes"
 	OIDCIDTokenMappingCol = "id_token_mapping"
 	OIDCUsePKCECol        = "use_pkce"
+	OIDCIconURLCol        = "icon_url"
+	OIDCBackgroundColorCol = "background_color"
 
 	JWTIDCol           = "idp_id"
 	JWTInstanceIDCol   = "instance_id"
@@ -236,6 +238,8 @@ func (*idpTemplateProjection) Init() *old_handler.Check {
 			handler.NewColumn(OIDCScopesCol, handler.ColumnTypeTextArray, handler.Nullable()),
 			handler.NewColumn(OIDCIDTokenMappingCol, handler.ColumnTypeBool, handler.Default(false)),
 			handler.NewColumn(OIDCUsePKCECol, handler.ColumnTypeBool, handler.Default(false)),
+			handler.NewColumn(OIDCIconURLCol, handler.ColumnTypeText, handler.Nullable()),
+			handler.NewColumn(OIDCBackgroundColorCol, handler.ColumnTypeText, handler.Nullable()),
 		},
 			handler.NewPrimaryKey(OIDCInstanceIDCol, OIDCIDCol),
 			IDPTemplateOIDCSuffix,
@@ -823,6 +827,8 @@ func (p *idpTemplateProjection) reduceOIDCIDPAdded(event eventstore.Event) (*han
 				handler.NewCol(OIDCScopesCol, database.TextArray[string](idpEvent.Scopes)),
 				handler.NewCol(OIDCIDTokenMappingCol, idpEvent.IsIDTokenMapping),
 				handler.NewCol(OIDCUsePKCECol, idpEvent.UsePKCE),
+				handler.NewCol(OIDCIconURLCol, idpEvent.IconURL),
+				handler.NewCol(OIDCBackgroundColorCol, idpEvent.BackgroundColor),
 			},
 			handler.WithTableSuffix(IDPTemplateOIDCSuffix),
 		),
@@ -2291,6 +2297,12 @@ func reduceOIDCIDPChangedColumns(idpEvent idp.OIDCIDPChangedEvent) []handler.Col
 	}
 	if idpEvent.UsePKCE != nil {
 		oidcCols = append(oidcCols, handler.NewCol(OIDCUsePKCECol, *idpEvent.UsePKCE))
+	}
+	if idpEvent.IconURL != nil {
+		oidcCols = append(oidcCols, handler.NewCol(OIDCIconURLCol, *idpEvent.IconURL))
+	}
+	if idpEvent.BackgroundColor != nil {
+		oidcCols = append(oidcCols, handler.NewCol(OIDCBackgroundColorCol, *idpEvent.BackgroundColor))
 	}
 	return oidcCols
 }

--- a/internal/repository/idp/oidc.go
+++ b/internal/repository/idp/oidc.go
@@ -17,6 +17,8 @@ type OIDCIDPAddedEvent struct {
 	Scopes           []string            `json:"scopes,omitempty"`
 	IsIDTokenMapping bool                `json:"idTokenMapping,omitempty"`
 	UsePKCE          bool                `json:"usePKCE,omitempty"`
+	IconURL          string              `json:"iconUrl,omitempty"`
+	BackgroundColor  string              `json:"backgroundColor,omitempty"`
 	Options
 }
 
@@ -29,6 +31,7 @@ func NewOIDCIDPAddedEvent(
 	clientSecret *crypto.CryptoValue,
 	scopes []string,
 	isIDTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options Options,
 ) *OIDCIDPAddedEvent {
 	return &OIDCIDPAddedEvent{
@@ -41,6 +44,8 @@ func NewOIDCIDPAddedEvent(
 		Scopes:           scopes,
 		IsIDTokenMapping: isIDTokenMapping,
 		UsePKCE:          usePKCE,
+		IconURL:          iconURL,
+		BackgroundColor:  backgroundColor,
 		Options:          options,
 	}
 }
@@ -77,6 +82,8 @@ type OIDCIDPChangedEvent struct {
 	Scopes           []string            `json:"scopes,omitempty"`
 	IsIDTokenMapping *bool               `json:"idTokenMapping,omitempty"`
 	UsePKCE          *bool               `json:"usePKCE,omitempty"`
+	IconURL          *string             `json:"iconUrl,omitempty"`
+	BackgroundColor  *string             `json:"backgroundColor,omitempty"`
 	OptionChanges
 }
 
@@ -145,6 +152,18 @@ func ChangeOIDCIsIDTokenMapping(idTokenMapping bool) func(*OIDCIDPChangedEvent) 
 func ChangeOIDCUsePKCE(usePKCE bool) func(*OIDCIDPChangedEvent) {
 	return func(e *OIDCIDPChangedEvent) {
 		e.UsePKCE = &usePKCE
+	}
+}
+
+func ChangeOIDCIconURL(iconURL string) func(*OIDCIDPChangedEvent) {
+	return func(e *OIDCIDPChangedEvent) {
+		e.IconURL = &iconURL
+	}
+}
+
+func ChangeOIDCBackgroundColor(backgroundColor string) func(*OIDCIDPChangedEvent) {
+	return func(e *OIDCIDPChangedEvent) {
+		e.BackgroundColor = &backgroundColor
 	}
 }
 

--- a/internal/repository/instance/idp.go
+++ b/internal/repository/instance/idp.go
@@ -140,6 +140,7 @@ func NewOIDCIDPAddedEvent(
 	clientSecret *crypto.CryptoValue,
 	scopes []string,
 	isIDTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options idp.Options,
 ) *OIDCIDPAddedEvent {
 
@@ -158,6 +159,8 @@ func NewOIDCIDPAddedEvent(
 			scopes,
 			isIDTokenMapping,
 			usePKCE,
+			iconURL,
+			backgroundColor,
 			options,
 		),
 	}

--- a/internal/repository/org/idp.go
+++ b/internal/repository/org/idp.go
@@ -140,6 +140,7 @@ func NewOIDCIDPAddedEvent(
 	clientSecret *crypto.CryptoValue,
 	scopes []string,
 	isIDTokenMapping, usePKCE bool,
+	iconURL, backgroundColor string,
 	options idp.Options,
 ) *OIDCIDPAddedEvent {
 
@@ -158,6 +159,8 @@ func NewOIDCIDPAddedEvent(
 			scopes,
 			isIDTokenMapping,
 			usePKCE,
+			iconURL,
+			backgroundColor,
 			options,
 		),
 	}

--- a/proto/zitadel/admin.proto
+++ b/proto/zitadel/admin.proto
@@ -6436,6 +6436,10 @@ message AddGenericOIDCProviderRequest {
     bool is_id_token_mapping = 7;
     // Enable the use of Proof Key for Code Exchange (PKCE) for the OIDC flow.
     bool use_pkce = 8;
+    // Optional URL to an icon for the provider button on the login screen.
+    string icon_url = 9;
+    // Optional background color for the provider button (e.g. hex color \"#1976d2\").
+    string background_color = 10;
 }
 
 message AddGenericOIDCProviderResponse {
@@ -6489,6 +6493,10 @@ message UpdateGenericOIDCProviderRequest {
     bool is_id_token_mapping = 8;
     // Enable the use of Proof Key for Code Exchange (PKCE) for the OIDC flow.
     bool use_pkce = 9;
+    // Optional URL to an icon for the provider button on the login screen.
+    string icon_url = 10;
+    // Optional background color for the provider button (e.g. hex color \"#1976d2\").
+    string background_color = 11;
 }
 
 message UpdateGenericOIDCProviderResponse {

--- a/proto/zitadel/idp.proto
+++ b/proto/zitadel/idp.proto
@@ -380,6 +380,20 @@ message GenericOIDCConfig {
             example: "true";
         }
     ];
+    // Optional URL to an icon for the provider button on the login screen.
+    string icon_url = 6 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"https://example.com/icon.png\"";
+            description: "URL to an icon image for the identity provider button";
+        }
+    ];
+    // Optional background color for the provider button (e.g. hex color \"#1976d2\").
+    string background_color = 7 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"#1976d2\"";
+            description: "Background color for the identity provider button";
+        }
+    ];
 }
 
 message GitHubConfig {

--- a/proto/zitadel/idp/v2/idp.proto
+++ b/proto/zitadel/idp/v2/idp.proto
@@ -203,6 +203,10 @@ message GenericOIDCConfig {
         example:
           "true";
       } ];
+  // Optional URL to an icon for the provider button on the login screen.
+  string icon_url = 5;
+  // Optional background color for the provider button (e.g. hex color).
+  string background_color = 6;
 }
 
 message GitHubConfig {
@@ -356,6 +360,10 @@ message Options {
   // Enable if users should get prompted to link an existing Zitadel user to an
   // external account if the selected attribute matches.
   AutoLinkingOption auto_linking = 5;
+  // Optional URL to an icon for the provider button on the login screen.
+  string icon_url = 6;
+  // Optional background color for the provider button (e.g. hex color).
+  string background_color = 7;
 }
 
 enum AutoLinkingOption {

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -13161,6 +13161,10 @@ message AddGenericOIDCProviderRequest {
     bool is_id_token_mapping = 7;
     // Enable the use of Proof Key for Code Exchange (PKCE) for the OIDC flow.
     bool use_pkce = 8;
+    // Optional URL to an icon for the provider button on the login screen.
+    string icon_url = 9;
+    // Optional background color for the provider button (e.g. hex color \"#1976d2\").
+    string background_color = 10;
 }
 
 message AddGenericOIDCProviderResponse {
@@ -13214,6 +13218,10 @@ message UpdateGenericOIDCProviderRequest {
     bool is_id_token_mapping = 8;
     // Enable the use of Proof Key for Code Exchange (PKCE) for the OIDC flow.
     bool use_pkce = 9;
+    // Optional URL to an icon for the provider button on the login screen.
+    string icon_url = 10;
+    // Optional background color for the provider button (e.g. hex color \"#1976d2\").
+    string background_color = 11;
 }
 
 message UpdateGenericOIDCProviderResponse {


### PR DESCRIPTION
…olor)

<img width="2386" height="1566" alt="image" src="https://github.com/user-attachments/assets/d7f1ddc7-33a7-49c6-a18f-f8f88be5c95f" />


- Align custom OIDC IDP buttons (e.g. Klaviyo) with known providers (Google):
  - Remove extra left padding from generic IDP button
  - Use same icon container (h-12 w-12) and ml-4 text spacing as Google
- Add iconUrl and backgroundColor support for OIDC IDPs (proto, API, console, login)
- Add setup migration 70 for IDP template options

<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- If the property XY is not given, the system crashes with a nil pointer exception.

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
