### PR TITLE
fix(console): pass data to user delete dialog

### DIFF
--- a/console/src/app/pages/users/user-detail/auth-user-detail/auth-user-detail.component.ts
+++ b/console/src/app/pages/users/user-detail/auth-user-detail/auth-user-detail.component.ts
@@ -406,6 +406,7 @@ export class AuthUserDetailComponent implements OnInit {
     };
 
     const dialogRef = this.dialog.open<WarnDialogComponent, typeof data, boolean>(WarnDialogComponent, {
+      data,
       width: '400px',
     });
 


### PR DESCRIPTION
# Which Problems Are Solved

The account deletion modal for users with the user.self.delete permission was previously broken (displayed no text) because the properties were not passed to it:

<img width="1920" height="951" alt="grafik" src="https://github.com/user-attachments/assets/3bfc6126-1777-4f1a-9fa9-c151a8275cea" />


# How the Problems Are Solved

The data is correctly passed to the modal.

