### PR TITLE
chore(docs): fix cutoff handling to address missing docs in release 4.11.x

### DIFF
--- a/apps/docs/scripts/fetch-remote-content.mjs
+++ b/apps/docs/scripts/fetch-remote-content.mjs
@@ -493,10 +493,10 @@ async function run() {
   await Promise.all(others.map(async (tag) => {
     let sourceRef = tag;
 
-    // Explicit logic for version 4.10.x to use active branch (Faking 4.10.x)
-    // This prevents fetching incompatible legacy docs for 4.10.1 etc.
-    if (tag === FALLBACK_VERSION || (semver.major(tag) === 4 && semver.minor(tag) === 10)) {
-      console.log(`[fake-override] Version ${tag} matches 4.10.x. Using fallback source (main/current) instead of tag.`);
+    // Explicit logic for version 4.10.x and 4.11.x to use active branch (Faking legacy versions)
+    // This prevents fetching incompatible legacy docs for 4.10.1, 4.11.0 etc.
+    if (tag === FALLBACK_VERSION || (semver.major(tag) === 4 && semver.minor(tag) <= 11)) {
+      console.log(`[fake-override] Version ${tag} matches legacy (<= 4.11). Using fallback source (main/current) instead of tag.`);
       sourceRef = getCurrentRef();
     }
 


### PR DESCRIPTION
Fixes failing pipelines, because in release 4.11 the app/docs folder is missing due to a potential cherry pick issue from the next branch