### PR TITLE
chore(go): make sure  we use go 1.25 instead of 1.2.5x

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.25.3"
+			"version": "1.25"
 		},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker": {},
 		"ghcr.io/schlich/devcontainer-features/cypress:1": {


### PR DESCRIPTION
This pull request makes a minor update to the Go feature version in the dev container configuration, ensuring compatibility with the latest patch releases in the 1.25 series.

* Updated the Go feature version from `1.25.3` to `1.25` in `.devcontainer/devcontainer.json` to allow for the latest patch version to be used.