### PR TITLE
fix(console): generic oidc help button opens Google config page

### DIFF
--- a/console/src/app/modules/providers/provider-oidc/provider-oidc.component.html
+++ b/console/src/app/modules/providers/provider-oidc/provider-oidc.component.html
@@ -21,7 +21,7 @@
       [configureProvider]="(justCreated$ | async) === ''"
       [configureTitle]="'DESCRIPTIONS.SETTINGS.IDPS.CALLBACK.TITLE' | translate: { provider: 'OIDC' }"
       [configureDescription]="'DESCRIPTIONS.SETTINGS.IDPS.CALLBACK.DESCRIPTION' | translate: { provider: 'OIDC' }"
-      configureLink="https://zitadel.com/docs/guides/integrate/identity-providers/generic-oidc
+      configureLink="https://zitadel.com/docs/guides/integrate/identity-providers/generic-oidc"
       [autofillLink]="autofillLink$ | async"
       [activateLink]="activateLink$ | async"
       [copyUrls]="copyUrls$ | async"


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- Generic OIDC Identity Provider - help button opens Google Configuration page

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- made the URL update in `provider-oidc.component.html`


# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #11505
