### PR TITLE
docs: saas use-case - update project settings description for clarity

### DIFF
--- a/apps/docs/content/guides/solution-scenarios/saas.mdx
+++ b/apps/docs/content/guides/solution-scenarios/saas.mdx
@@ -34,7 +34,7 @@ In the project you will configure all your roles and applications (clients and A
 
 ### Project Settings
 
-Enable the `Only authorized users can authenticate` setting on the project, if you want to restrict access to users that have the correct access for the project.
+Enable the `Only authorized users can authenticate` setting on the project to restrict authentication to users with at least one role assigned to this project.
 
 ### Project Grant
 


### PR DESCRIPTION
# Which Problems Are Solved

The Project Settings section of the [/docs/guides/solution-scenarios/saas](https://zitadel.com/docs/guides/solution-scenarios/saas#project-settings) page refers to a setting `PROJECT.ROLE.CHECK` that got renamed  ([1](https://github.com/zitadel/zitadel/blob/00f7dbe875606486a183f88c77497db9576e7cf5/console/src/assets/i18n/en.json#L1209), [2](https://github.com/zitadel/zitadel/blob/0f2a349ec145fc3efe0ec45db52d1f974fa180d2/console/src/assets/i18n/en.json#L2138), [3](https://github.com/zitadel/zitadel/blob/7e11f7a03279655366ab47909fd8b20151abc215/console/src/assets/i18n/en.json#L2138)). Also, the meaning of the setting was inverted on [93a4ed8
](https://github.com/zitadel/zitadel/commit/93a4ed8857a63b24db56d17626827c662beb7579#diff-c44c61daf06a171a97f8897c96f831a54e677759198a7f2bb65ec52473a20063R36)

before: "if you want to restrict access to users that have the correct authorization for the project"
after: "if you want to restrict access to users that **do not** have the correct access for the project"

<img width="669" height="168" alt="Screenshot 2026-02-23 at 10 59 54" src="https://github.com/user-attachments/assets/91454f6d-cefb-4db0-b064-391779ea3bae" />

<img width="692" height="660" alt="Screenshot 2026-02-23 at 10 59 46" src="https://github.com/user-attachments/assets/bba11870-c579-4fea-986b-0d960500cd77" />


# How the Problems Are Solved

Update documentation.

# Additional Changes

n/a

# Additional Context

n/a
