### PR TITLE
fix: use correct autocomplete attribute on password fields

### DIFF
--- a/apps/login/src/components/ldap-username-password-form.tsx
+++ b/apps/login/src/components/ldap-username-password-form.tsx
@@ -77,7 +77,7 @@ export function LDAPUsernamePasswordForm({ idpId, link }: Props) {
       <div className={`${error && "transform-gpu animate-shake"}`}>
         <TextInput
           type="password"
-          autoComplete="password"
+          autoComplete="current-password"
           {...register("password", { required: t("required.password") })}
           label={t("labels.password")}
           data-testid="password-text-input"

--- a/apps/login/src/components/password-form.tsx
+++ b/apps/login/src/components/password-form.tsx
@@ -115,7 +115,7 @@ export function PasswordForm({ loginSettings, loginName, organization, defaultOr
         <div className={`${error && "transform-gpu animate-shake"}`}>
           <TextInput
             type="password"
-            autoComplete="password"
+            autoComplete="current-password"
             autoFocus
             {...register("password", { required: t("verify.required.password") })}
             label={t("verify.labels.password")}


### PR DESCRIPTION
# Which Problems Are Solved

The proton password manager is not suggesting passwords on the login page.

# How the Problems Are Solved

Replace the incorrect `autocomplete="password"` attributes with `autocomplete="current-password"` attributes.

# Additional Context

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#current-password
