### PR TITLE
docs: improve og metadata handling

### DIFF
--- a/apps/docs/app/[[...slug]]/page.tsx
+++ b/apps/docs/app/[[...slug]]/page.tsx
@@ -68,15 +68,36 @@ export async function generateMetadata(
   if (!description) {
     description = `Explore ZITADEL documentation for ${page.data.title}. Learn how to integrate, manage, and secure your applications with our comprehensive identity and access management solutions.`;
   }
+  const metadataDescription =
+    description.length > 200 ? description.substring(0, 197) + '...' : description;
+  const image = getPageImage(page).url;
 
   return {
     title: page.data.title,
-    description: description.length > 200 ? description.substring(0, 197) + '...' : description,
+    description: metadataDescription,
     alternates: {
       canonical: canonicalUrl,
     },
     openGraph: {
-      images: getPageImage(page).url,
+      type: 'article',
+      url: canonicalUrl,
+      title: page.data.title,
+      description: metadataDescription,
+      siteName: 'ZITADEL Docs',
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: page.data.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.data.title,
+      description: metadataDescription,
+      images: [image],
     },
   };
 }

--- a/apps/docs/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/app/og/docs/[...slug]/route.tsx
@@ -1,20 +1,20 @@
 import { ImageResponse } from 'next/og';
 import { notFound } from 'next/navigation';
-import { source } from '@/lib/source';
+import { getPage, getPageImage, source, versionSource } from '@/lib/source';
 import { generate as DefaultImage } from 'fumadocs-ui/og';
 
 export const revalidate = false;
 
-export async function GET(request: Request, context: any) {
-  const { slug } = context.params;
-  const page = source.getPage(slug.slice(0, -1));
+export async function GET(_request: Request, context: any) {
+  const { slug } = await context.params;
+  const { page } = getPage(slug.slice(0, -1));
   if (!page) notFound();
 
   return new ImageResponse(
     <DefaultImage
       title={page.data.title}
       description={page.data.description}
-      site="My App"
+      site="ZITADEL Docs"
     />,
     {
       width: 1200,
@@ -24,5 +24,7 @@ export async function GET(request: Request, context: any) {
 }
 
 export function generateStaticParams() {
-  return [];
+  return [...source.getPages(), ...versionSource.getPages()].map((page) => ({
+    slug: getPageImage(page).segments,
+  }));
 }

--- a/apps/docs/content/guides/solution-scenarios/introduction/index.mdx
+++ b/apps/docs/content/guides/solution-scenarios/introduction/index.mdx
@@ -16,4 +16,5 @@ import { FileText, Folder, Link as LinkIcon } from 'lucide-react';
     <Card title="Saas" href="/guides/solution-scenarios/saas" icon={<FileText />} />
     <Card title="B2c" href="/guides/solution-scenarios/b2c" icon={<FileText />} />
     <Card title="Frontend Calling Backend API" href="/guides/solution-scenarios/frontend-calling-backend-API" icon={<FileText />} />
+    <Card title="Guest Auth" href="/guides/solution-scenarios/guest-auth" icon={<FileText />} />
 </Cards>

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -27,12 +27,14 @@ export function getPage(slugs: string[] | undefined) {
   return { page: source.getPage(safeSlugs), source: source };
 }
 
-export function getPageImage(page: InferPageType<typeof source>) {
+type DocsPage = InferPageType<typeof source> | InferPageType<typeof versionSource>;
+
+export function getPageImage(page: DocsPage) {
   const segments = [...page.slugs, 'image.png'];
 
   return {
     segments,
-    url: `/og/docs/${segments.join('/')}`,
+    url: `/docs/og/docs/${segments.join('/')}`,
   };
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

- OG image lookup in docs was not version-aware, so versioned pages could miss generated OG images.
- The OG route did not emit static params, reducing build-time crawler coverage.
- Docs page metadata only set a minimal OG image field and did not expose full OG/Twitter metadata alignment for crawlers.

# How the Problems Are Solved

- Updated the OG route handler to use the shared version-aware `getPage` lookup.
- Implemented `generateStaticParams()` for the OG route from both latest and versioned page sources.
- Updated docs metadata generation to emit explicit Open Graph and Twitter fields (title, description, URL, site name, image), aligned with canonical URLs.
- Adjusted `getPageImage()` output to include the docs base path (`/docs`) so generated OG image URLs resolve correctly for the docs deployment.

# Additional Changes

- Updated OG image generator site label to `ZITADEL Docs`.
- Preserved existing description fallback/truncation behavior while reusing it consistently for OG and Twitter metadata.
- Verified with `pnpm nx run @zitadel/docs:check-types` and `pnpm nx run @zitadel/docs:build`, plus local spot checks of OG meta tags and OG image endpoints for latest and versioned docs URLs.

# Additional Context

- Addresses Copilot PR review feedback in this PR about incomplete PR description/template placeholders.
