### PR TITLE
fix: return 404 for unknown paths and fix gRPC routing on h2c/Cloud Run

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -153,9 +153,14 @@ func New(
 	api.registerHealthServer()
 
 	api.RegisterHandlerOnPrefix("/debug", api.healthHandler())
-	api.router.Handle("/", http.RedirectHandler(login.HandlerPrefix, http.StatusFound))
+	registerDefaultRoutes(api.router)
 
 	return api, nil
+}
+
+func registerDefaultRoutes(router *mux.Router) {
+	router.Handle("/favicon.ico", http.NotFoundHandler())
+	router.Handle("/", http.RedirectHandler(login.HandlerPrefix, http.StatusFound))
 }
 
 func (a *API) serverReflection() {
@@ -271,21 +276,35 @@ func (a *API) RouteGRPC() {
 	// since all services are now registered, we can build the grpc server reflection and register the handler
 	a.serverReflection()
 
-	http2Route := a.router.
+	a.router.
+		NewRoute().
 		MatcherFunc(func(r *http.Request, _ *mux.RouteMatch) bool {
-			return r.ProtoMajor == 2
+			return isGRPCRequest(r)
 		}).
-		Subrouter().
+		Handler(a.grpcServer).
 		Name("grpc")
-	http2Route.
-		Methods(http.MethodPost).
-		HeadersRegexp(http_util.ContentType, `^application\/grpc(\+proto|\+json)?$`).
-		Handler(a.grpcServer)
 
 	a.routeGRPCWeb()
 	a.router.NewRoute().
 		Handler(a.grpcGateway.Handler()).
 		Name("grpc-gateway")
+}
+
+func isGRPCRequest(r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		return false
+	}
+	return isGRPCContentType(r.Header.Get(http_util.ContentType))
+}
+
+func isGRPCContentType(contentType string) bool {
+	mediaType, _, _ := strings.Cut(contentType, ";")
+	switch strings.TrimSpace(strings.ToLower(mediaType)) {
+	case "application/grpc", "application/grpc+proto", "application/grpc+json":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *API) routeGRPCWeb() {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/api/ui/login"
+)
+
+func TestRegisterDefaultRoutes(t *testing.T) {
+	t.Parallel()
+
+	router := mux.NewRouter()
+	registerDefaultRoutes(router)
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		wantStatus   int
+		wantLocation string
+	}{
+		{
+			name:       "favicon returns not found",
+			method:     http.MethodGet,
+			path:       "/favicon.ico",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:         "root redirects to login",
+			method:       http.MethodGet,
+			path:         "/",
+			wantStatus:   http.StatusFound,
+			wantLocation: login.HandlerPrefix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			res := httptest.NewRecorder()
+
+			router.ServeHTTP(res, req)
+			assert.Equal(t, tt.wantStatus, res.Code)
+			if tt.wantLocation != "" {
+				assert.Equal(t, tt.wantLocation, res.Header().Get("Location"))
+			}
+		})
+	}
+}
+
+func TestIsGRPCRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		method      string
+		contentType string
+		want        bool
+	}{
+		{
+			name:        "grpc content type",
+			method:      http.MethodPost,
+			contentType: "application/grpc",
+			want:        true,
+		},
+		{
+			name:        "grpc proto content type",
+			method:      http.MethodPost,
+			contentType: "application/grpc+proto",
+			want:        true,
+		},
+		{
+			name:        "grpc json content type with charset",
+			method:      http.MethodPost,
+			contentType: "application/grpc+json; charset=utf-8",
+			want:        true,
+		},
+		{
+			name:        "non grpc content type",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			want:        false,
+		},
+		{
+			name:        "non post grpc request",
+			method:      http.MethodGet,
+			contentType: "application/grpc",
+			want:        false,
+		},
+		{
+			name:        "missing content type",
+			method:      http.MethodPost,
+			contentType: "",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/zitadel.org.v2.OrganizationService/ListOrganizations", nil)
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+
+			assert.Equal(t, tt.want, isGRPCRequest(req))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Do not remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

On Google Cloud Run (and likely other h2c/h2-terminating proxies), two classes of requests returned a delayed HTTP 500 (~6.5 s) instead of a fast, meaningful response:

1. **Unknown static paths** (e.g. `GET /favicon.ico`): ZITADEL does not serve a favicon, so these should immediately return 404. Instead they fell through to the catch-all grpc-gateway handler, which forwarded them to the internal gRPC server, timed out, and returned 500.
2. **Native gRPC requests via HTTP/1.1 framing** (e.g. a `grpc-go` client posting to `/zitadel.org.v2.OrganizationService/ListOrganizations` when Cloud Run terminates TLS and forwards h2c as HTTP/1.1): The previous gRPC route matcher required `r.ProtoMajor == 2`, which was never true when an h2c-terminating proxy unwraps the framing. Requests therefore bypassed the gRPC server, hit the gateway, and failed with 500.

# How the Problems Are Solved

- **Explicit `/favicon.ico` 404 route** (`registerDefaultRoutes`): A dedicated route is registered for `/favicon.ico` that immediately returns `404 Not Found`, short-circuiting the gateway fall-through.
- **Content-type–based gRPC routing** (`isGRPCRequest` / `isGRPCContentType`): The gRPC route matcher no longer checks `ProtoMajor == 2`. It now routes a request to the gRPC server when:
  - The HTTP method is `POST`, **and**
  - The `Content-Type` header matches `application/grpc`, `application/grpc+proto`, or `application/grpc+json` (with optional parameters such as `; charset=utf-8`).

  This makes native gRPC routing work regardless of whether the transport is raw HTTP/2 or h2c unwrapped to HTTP/1.1 by a proxy.

# Additional Changes

- Added `TestRegisterDefaultRoutes` and `TestIsGRPCRequest` unit tests in `internal/api/api_test.go` to prevent regressions.

# Additional Context

Observed on Google Cloud Run deployments:
- `GET /favicon.ico` → `500` after ~6.8 s (should be `404` immediately)
- `POST /zitadel.org.v2.OrganizationService/ListOrganizations` (grpc-go 1.78.0 via Cloud Run h2c proxy) → `500` after ~6.7 s (should reach the gRPC server)

Cloud Run terminates HTTPS and forwards to the container as plain HTTP/1.1 (even for gRPC traffic), so relying on `ProtoMajor == 2` to identify gRPC is not safe in that environment.
