### PR TITLE
chore(deps): bump protoc-gen-connect-openapi to v0.25.5

### DIFF
--- a/apps/docs/scripts/install-proto-plugins.sh
+++ b/apps/docs/scripts/install-proto-plugins.sh
@@ -18,12 +18,12 @@ set -euo pipefail
 # Note: macOS ships a universal binary, so darwin_amd64 and darwin_arm64 share
 #       the same tarball and checksum.
 
-CONNECT_OPENAPI_VERSION="0.25.2"
+CONNECT_OPENAPI_VERSION="0.25.5"
 # checksums from upstream checksums.txt
-CONNECT_OPENAPI_SHA256_linux_amd64="90821ab96f16747dc5a4ab93900a6bc6b968d63f47553a08274dc594301bced3"
-CONNECT_OPENAPI_SHA256_linux_arm64="9726418d7af55f87e3bbb2a4fa6233016b200caf5a285ce1c6e6428ef225536d"
-CONNECT_OPENAPI_SHA256_darwin_amd64="a6bc3d87b4caaa7048d22fe0f45e3b5e778b4b209f84a836b3335fb2fd14b588"
-CONNECT_OPENAPI_SHA256_darwin_arm64="a6bc3d87b4caaa7048d22fe0f45e3b5e778b4b209f84a836b3335fb2fd14b588"
+CONNECT_OPENAPI_SHA256_linux_amd64="a9cbf821d42bc12a91b853d1fc8c3ffbea19bd8a6096d8db8b39263f1f67da74"
+CONNECT_OPENAPI_SHA256_linux_arm64="287575b705cdd4a037baef75adcd8813566c4fda2eba5399483a9cbad8be7422"
+CONNECT_OPENAPI_SHA256_darwin_amd64="07af8e3adbac202a0d09b97d281dcdb24949d642e43c101ea2a1a0d09aff7bd0"
+CONNECT_OPENAPI_SHA256_darwin_arm64="07af8e3adbac202a0d09b97d281dcdb24949d642e43c101ea2a1a0d09aff7bd0"
 
 # ── HELPERS ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Which Problems Are Solved

1. `oneOf` variant sub-schemas generated from proto `oneof` fields missing `type: "object"`. This causes fumadocs to skip rendering the properties within each variant. Example: https://zitadel.com/docs/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.CreateAdministrator

[Before](https://zitadel.com/docs/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.CreateAdministrator):
<img width="977" height="823" alt="Screenshot 2026-03-06 at 09 56 38" src="https://github.com/user-attachments/assets/54ddbbbb-f36b-4a2a-96af-13b3da41de3b" />

[After](https://docs-git-bump-protoc-gen-connect-openapi-version-zitadel.vercel.app/docs/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.CreateAdministrator):
<img width="964" height="1021" alt="Screenshot 2026-03-06 at 09 56 47" src="https://github.com/user-attachments/assets/a461c4b5-44fe-487b-b4d2-8af47d407d3e" />


2. missing requestBody for messages with oneOf and path params. Example: https://zitadel.com/docs/reference/api/user/zitadel.user.v2.UserService.UpdateUser

[Before](https://zitadel.com/docs/reference/api/user/zitadel.user.v2.UserService.UpdateUser):
<img width="994" height="883" alt="Screenshot 2026-03-06 at 09 59 03" src="https://github.com/user-attachments/assets/824f4154-3270-45d7-9af7-a28c7bdc7c44" />


[After](https://docs-git-bump-protoc-gen-connect-openapi-version-zitadel.vercel.app/docs/reference/api/user/zitadel.user.v2.UserService.UpdateUser):

<img width="978" height="1293" alt="Screenshot 2026-03-06 at 09 59 25" src="https://github.com/user-attachments/assets/330c1204-ccce-402c-bccb-b27076198dcd" />

(https://github.com/fuma-nama/fumadocs/issues/3063 will also be updated with improved `oneOf` visualization in this case.)

# How the Problems Are Solved

By fixing `protoc-gen-connect-openapi` to correctly generate the OpenAPI docs.

# Additional Changes

n/a

# Additional Context

https://github.com/sudorandom/protoc-gen-connect-openapi/pull/233
https://github.com/sudorandom/protoc-gen-connect-openapi/pull/234

