### PR TITLE
fix: use grpc-web http 1.1 for @zitadel/client/node transport

### DIFF
--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -12,7 +12,7 @@ import {
 import { NewAuthorizationBearerInterceptor } from "./interceptors.js";
 
 /**
- * Create a server transport using grpc with the given token and configuration options.
+ * Create a server transport using grpc web with the given token and configuration options.
  * @param token
  * @param opts
  */


### PR DESCRIPTION
# Which Problems Are Solved
All http 2 based connect-es clients caused memory leaks in our testing using the login v2 application as the host.

# How the Problems Are Solved
Switch to grpc-web based http 1.1 transport for the @zitadel/client/node package which is also used by the login v2.

# Additional Context
After publishing this change to NPM we will update the login v2 to use the http 1.1 based grpc web for it's API calls to the backend.

- Discussion: #10562
