### PR TITLE
docs: added link to sidebar title for benchmarks

### DIFF
--- a/apps/docs/lib/sidebar-data.ts
+++ b/apps/docs/lib/sidebar-data.ts
@@ -1009,7 +1009,7 @@ export const apisSidebar: readonly SidebarItem[] = [
     label: "Benchmarks",
     link: {
       type: "doc",
-      id: "apis/benchmarks/index", 
+      id: "apis/benchmarks/index",
     },
     items: [
       {


### PR DESCRIPTION
This PR adds a link to the benchmarks title on the sidebar