### PR TITLE
docs: postgresql 18 warning

### DIFF
--- a/apps/docs/content/self-hosting/deploy/kubernetes/index.mdx
+++ b/apps/docs/content/self-hosting/deploy/kubernetes/index.mdx
@@ -92,7 +92,7 @@ For production you need:
 - Helm 3.x+
 
 <Callout type="warn">
-**PostgreSQL Compatibility Notice:** While ZITADEL requires PostgreSQL 14 or higher, **PostgreSQL 18** is currently not supported. Please ensure you deploy using a supported version (e.g., PostgreSQL 14 through 17) to avoid compatibility issues.
+**PostgreSQL compatibility:** ZITADEL supports PostgreSQL **14–18**. When using **PostgreSQL 18**, ensure you run **ZITADEL v4.11.0 or newer**. For the most up-to-date compatibility matrix and configuration details, see [Database requirements](/self-hosting/manage/database).
 </Callout>
 
 <Callout type="warn">


### PR DESCRIPTION
Added a callout to the Kubernetes deployment guide (`Deploy ZITADEL on Kubernetes`) explicitly stating that PostgreSQL 18 is not currently supported, ensuring users deploy with a compatible version (14-17).