### PR TITLE
fix(login): make OpenTelemetry opt-in

### DIFF
--- a/apps/login/dockerized/otel/otel.integration.test.ts
+++ b/apps/login/dockerized/otel/otel.integration.test.ts
@@ -146,6 +146,7 @@ describe("OpenTelemetry Integration", () => {
       .withEnvironment({
         ZITADEL_API_URL: "http://mock-zitadel:8080",
         ZITADEL_SERVICE_USER_TOKEN: "test-token-for-otel-integration-tests",
+        OTEL_ENABLED: "true",
         OTEL_SERVICE_NAME: "zitadel-login-test",
         OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318",
         OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
@@ -1297,7 +1298,6 @@ describe("OpenTelemetry Disabled", () => {
       .withEnvironment({
         ZITADEL_API_URL: "http://mock-zitadel:8080",
         ZITADEL_SERVICE_USER_TOKEN: "test-token",
-        OTEL_SDK_DISABLED: "true",
       })
       .withStartupTimeout(120000)
       .withWaitStrategy(Wait.forHttp("/ui/v2/login/healthy", 3000))
@@ -1315,7 +1315,7 @@ describe("OpenTelemetry Disabled", () => {
 
   describe("Application Health", () => {
     it(
-      "starts successfully with OTEL_SDK_DISABLED=true",
+      "starts successfully with OTEL_ENABLED unset (disabled by default)",
       async () => {
         const response = await fetch(`${appUrl}/ui/v2/login/healthy`);
         expect(response.ok).toBe(true);
@@ -1402,7 +1402,6 @@ describe("Log Level Configuration", () => {
           .withEnvironment({
             ZITADEL_API_URL: "http://mock-zitadel:8080",
             ZITADEL_SERVICE_USER_TOKEN: "test-token",
-            OTEL_SDK_DISABLED: "true",
             LOG_LEVEL: "debug",
           })
           .withStartupTimeout(120000)
@@ -1469,7 +1468,6 @@ describe("Log Level Configuration", () => {
           .withEnvironment({
             ZITADEL_API_URL: "http://mock-zitadel:8080",
             ZITADEL_SERVICE_USER_TOKEN: "test-token",
-            OTEL_SDK_DISABLED: "true",
             LOG_LEVEL: "warn",
           })
           .withStartupTimeout(120000)
@@ -1570,6 +1568,7 @@ describe("Log Level Configuration", () => {
           .withEnvironment({
             ZITADEL_API_URL: "http://mock-zitadel:8080",
             ZITADEL_SERVICE_USER_TOKEN: "test-token",
+            OTEL_ENABLED: "true",
             OTEL_SERVICE_NAME: "zitadel-login-loglevel-debug",
             OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318",
             OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
@@ -1684,6 +1683,7 @@ describe("Log Level Configuration", () => {
           .withEnvironment({
             ZITADEL_API_URL: "http://mock-zitadel:8080",
             ZITADEL_SERVICE_USER_TOKEN: "test-token",
+            OTEL_ENABLED: "true",
             OTEL_SERVICE_NAME: "zitadel-login-loglevel-warn",
             OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318",
             OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",

--- a/apps/login/next-env-vars.d.ts
+++ b/apps/login/next-env-vars.d.ts
@@ -102,10 +102,10 @@ declare namespace NodeJS {
     API_CACHE_CONFIG?: string;
 
     /**
-     * Optional: Disable OpenTelemetry instrumentation.
-     * Set to "true" to bypass OTEL initialization.
-     * In local development (NODE_ENV=development), it is disabled by default unless explicitly set to "false".
+     * Optional: Enable OpenTelemetry instrumentation.
+     * Set to "true" to enable OTEL initialization.
+     * OTel is disabled by default in all environments.
      */
-    OTEL_SDK_DISABLED?: string;
+    OTEL_ENABLED?: string;
   }
 }

--- a/apps/login/next-env.d.ts
+++ b/apps/login/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/login/next.config.mjs
+++ b/apps/login/next.config.mjs
@@ -63,6 +63,15 @@ const nextConfig = {
     '@opentelemetry/resource-detector-container',
     '@opentelemetry/resource-detector-gcp',
   ],
+  // Exclude OpenTelemetry packages from output file tracing when OTel is not
+  // enabled. This prevents lstat ENOENT errors during Vercel builds where
+  // OTel packages are not needed. When OTEL_ENABLED=true, packages are traced
+  // normally so they are available in the deployment output.
+  ...(process.env.OTEL_ENABLED !== "true" && {
+    outputFileTracingExcludes: {
+      '*': ['node_modules/@opentelemetry/**'],
+    },
+  }),
   // Improve SSR stability - not actually needed for React 19 SSR issues
   // onDemandEntries: {
   //   maxInactiveAge: 25 * 1000,

--- a/apps/login/package.json
+++ b/apps/login/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "NEXT_OUTPUT_MODE=standalone next build && cp -r public scripts/* .next/standalone/ && mv .next/standalone/apps/login/server.js .next/standalone/apps/login/next-server.js && cp .next/standalone/server.mjs .next/standalone/apps/login/server.js && cp -r .next/static .next/standalone/apps/login/.next/ && rm .next/standalone/apps/login/.env",
+    "build": "NEXT_OUTPUT_MODE=standalone OTEL_ENABLED=true next build && cp -r public scripts/* .next/standalone/ && mv .next/standalone/apps/login/server.js .next/standalone/apps/login/next-server.js && cp .next/standalone/server.mjs .next/standalone/apps/login/server.js && cp -r .next/static .next/standalone/apps/login/.next/ && rm .next/standalone/apps/login/.env",
     "build-vercel": "next build",
     "dev": "HOSTNAME=127.0.0.1 ./scripts/entrypoint.sh next dev",
     "prod": "cd ./.next/standalone && HOSTNAME=127.0.0.1 ./entrypoint.sh node apps/login/server.js",

--- a/apps/login/src/instrumentation.ts
+++ b/apps/login/src/instrumentation.ts
@@ -29,16 +29,11 @@ import type { LoggerProvider } from "@opentelemetry/api-logs";
 let _loggerProvider: LoggerProvider | null = null;
 
 export async function register(): Promise<void> {
-  // Only run OpenTelemetry in the Node.js environment
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    // Disable by default in local development to avoid unnecessary overhead
-    if (process.env.NODE_ENV === "development" && process.env.OTEL_SDK_DISABLED !== "false") {
-      return;
-    }
-
-    // Explicit check for disabled env variable
-    if (process.env.OTEL_SDK_DISABLED === "true") return;
-
+  // Only run OpenTelemetry in the Node.js environment.
+  // OTel is opt-in: set OTEL_ENABLED=true to enable it.
+  // This prevents unnecessary initialization (and build tracing issues) in
+  // environments like Vercel where OTel is not configured.
+  if (process.env.NEXT_RUNTIME === "nodejs" && process.env.OTEL_ENABLED === "true") {
     const { registerNode } = await import("./instrumentation.node");
     _loggerProvider = await registerNode();
   }

--- a/apps/login/tsconfig.json
+++ b/apps/login/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,22 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
-  "exclude": ["node_modules", "acceptance", "dockerized", "vitest.config*.ts"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "acceptance",
+    "dockerized",
+    "vitest.config*.ts"
+  ]
 }


### PR DESCRIPTION
# Which Problems Are Solved

fix(login): make OpenTelemetry opt-in and fix vercel build

The Vercel build was failing with an ENOENT: lstat error because Next.js's output file tracer tried to copy @opentelemetry/resource-detector-gcp into .next/node_modules but produced a broken path.

# How the Problems Are Solved

- Replaced OTEL_SDK_DISABLED type with OTEL_ENABLED
- Exclude all @opentelemetry/** packages from output file tracing unless OTEL_ENABLED=true is set at build time, preventing the lstat error on Vercel
- OTel is now opt-in — only initializes when OTEL_ENABLED=true is set at runtime (previously on by default in production)
-  Added OTEL_ENABLED=true to the build (standalone/Docker) script so OTel packages are correctly traced into the output for self-hosted deployments


