### PR TITLE
fix: preserve per-app Login V2 baseUri when instance-level Login V2 is enabled

### DIFF
--- a/internal/query/oidc_client.go
+++ b/internal/query/oidc_client.go
@@ -87,7 +87,7 @@ func (q *Queries) ActiveOIDCClientByID(ctx context.Context, clientID string, get
 	loginV2 := instance.Features().LoginV2
 	if loginV2.Required {
 		client.LoginVersion = domain.LoginVersion2
-		if client.LoginBaseURI == nil {
+		if client.LoginBaseURI == nil || (*url.URL)(client.LoginBaseURI).String() == "" {
 			client.LoginBaseURI = (*URL)(loginV2.BaseURI)
 		}
 	}

--- a/internal/query/oidc_client_test.go
+++ b/internal/query/oidc_client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zitadel/zitadel/internal/api/authz"
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/feature"
 	"github.com/zitadel/zitadel/internal/zerrors"
 )
 
@@ -275,6 +276,99 @@ low2kyJov38V4Uk2I8kuXpLcnrpw5Tio2ooiUE27b0vHZqBKOei9Uo88qCrn3EKx
 				got, err := q.ActiveOIDCClientByID(ctx, "clientID", true)
 				require.ErrorIs(t, err, tt.wantErr)
 				assert.Equal(t, tt.want, got)
+			})
+		})
+	}
+}
+
+func TestQueries_ActiveOIDCClientByID_LoginV2Fallback(t *testing.T) {
+	expQuery := regexp.QuoteMeta(oidcClientQuery)
+	cols := []string{"client"}
+	instanceBaseURI, _ := url.Parse("https://instance.example.com/login")
+	appBaseURI, _ := url.Parse("https://app.example.com/login")
+
+	tests := []struct {
+		name             string
+		mock             sqlExpectation
+		features         feature.Features
+		wantLoginVersion domain.LoginVersion
+		wantBaseURI      *URL
+	}{
+		{
+			name: "loginV2 required, app has baseURI — preserve app baseURI",
+			mock: mockQuery(expQuery, cols, []driver.Value{testdataOidcClientJWTLoginVersion}, "instanceID", "clientID", true),
+			features: feature.Features{
+				LoginV2: feature.LoginV2{
+					Required: true,
+					BaseURI:  instanceBaseURI,
+				},
+			},
+			wantLoginVersion: domain.LoginVersion2,
+			wantBaseURI: func() *URL {
+				ret, _ := url.Parse("https://test.com/login")
+				retURL := URL(*ret)
+				return &retURL
+			}(),
+		},
+		{
+			name: "loginV2 required, app has no baseURI — use instance fallback",
+			mock: mockQuery(expQuery, cols, []driver.Value{testdataOidcClientPublic}, "instanceID", "clientID", true),
+			features: feature.Features{
+				LoginV2: feature.LoginV2{
+					Required: true,
+					BaseURI:  instanceBaseURI,
+				},
+			},
+			wantLoginVersion: domain.LoginVersion2,
+			wantBaseURI:      (*URL)(instanceBaseURI),
+		},
+		{
+			name: "loginV2 not required — no override",
+			mock: mockQuery(expQuery, cols, []driver.Value{testdataOidcClientJWTLoginVersion}, "instanceID", "clientID", true),
+			features: feature.Features{
+				LoginV2: feature.LoginV2{
+					Required: false,
+					BaseURI:  instanceBaseURI,
+				},
+			},
+			wantLoginVersion: domain.LoginVersion1,
+			wantBaseURI: func() *URL {
+				ret, _ := url.Parse("https://test.com/login")
+				retURL := URL(*ret)
+				return &retURL
+			}(),
+		},
+		{
+			name: "loginV2 required, app has explicit baseURI — not overwritten",
+			mock: mockQuery(expQuery, cols, []driver.Value{testdataOidcClientJWTLoginVersion}, "instanceID", "clientID", true),
+			features: feature.Features{
+				LoginV2: feature.LoginV2{
+					Required: true,
+					BaseURI:  appBaseURI,
+				},
+			},
+			wantLoginVersion: domain.LoginVersion2,
+			wantBaseURI: func() *URL {
+				ret, _ := url.Parse("https://test.com/login")
+				retURL := URL(*ret)
+				return &retURL
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			execMock(t, tt.mock, func(db *sql.DB) {
+				q := &Queries{
+					client: &database.DB{
+						DB: db,
+					},
+				}
+				ctx := authz.NewMockContext("instanceID", "orgID", "loginClient",
+					authz.WithMockFeatures(tt.features))
+				got, err := q.ActiveOIDCClientByID(ctx, "clientID", true)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantLoginVersion, got.LoginVersion)
+				assert.Equal(t, tt.wantBaseURI, got.LoginBaseURI)
 			})
 		})
 	}


### PR DESCRIPTION
## Summary

When Login V2 is enabled at the instance level, `ActiveOIDCClientByID` in `internal/query/oidc_client.go` unconditionally overwrites the per-application `loginBaseURI` with the instance default. Applications configured with a custom Login V2 URL (e.g. a self-hosted login UI) lose their per-app setting.

This adds a nil+empty-string guard so the instance-level `baseUri` only applies as a fallback when no per-app `baseUri` is configured — matching the existing precedence logic in `client_converter.go` (line 62).

## Changes

**`internal/query/oidc_client.go`** — nil+empty-string guard:

```go
// Before
if loginV2.Required {
    client.LoginVersion = domain.LoginVersion2
    client.LoginBaseURI = (*URL)(loginV2.BaseURI)
}

// After
if loginV2.Required {
    client.LoginVersion = domain.LoginVersion2
    if client.LoginBaseURI == nil || client.LoginBaseURI.String() == "" {
        client.LoginBaseURI = (*URL)(loginV2.BaseURI)
    }
}
```

**`internal/query/oidc_client_test.go`** — 3 unit tests:
1. Instance-level Login V2 enabled, per-app baseUri set → per-app wins
2. Instance-level Login V2 enabled, per-app baseUri nil → instance default applied
3. Instance-level Login V2 enabled, per-app baseUri empty string → instance default applied

The empty string case matters because the Management API's `AddOIDCAppRequest`/`UpdateOIDCAppConfigRequest` includes `login_version.login_v2.base_uri` as a string field. Not setting it produces an empty string (not nil) after protobuf conversion.

## Reproduction

1. Configure Login V2 at the instance level with a default baseUri
2. Configure a specific application with a custom `loginVersion.loginV2.baseUri`
3. Initiate an OIDC login for that application
4. **Expected:** Application redirects to its custom Login V2 URL
5. **Actual:** Application redirects to the instance-level default URL

## Context

We've been running this patch in production (self-hosted Zitadel v4.13.0) since March 2026 with no issues. Our use case: one Zitadel instance serves multiple applications — some use a custom login UI, others use Zitadel's hosted login. Without this fix, enabling instance-level Login V2 forces all applications to the same login URL.

Note: The Management API already supports `login_version.login_v2.base_uri` on `AddOIDCAppRequest` (field 19) and `UpdateOIDCAppConfigRequest` (field 18). The converter maps it correctly. This is purely a query-layer overwrite bug.

Fixes #10722