### PR TITLE
feat: support PKCS#1 private keys in newSystemToken

### DIFF
--- a/apps/login/src/lib/api.test.ts
+++ b/apps/login/src/lib/api.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, expect, test } from "vitest";
+import { newSystemToken } from "@zitadel/client/node";
+import { execSync } from "child_process";
+
+// Generate an RSA 2048 key pair in both formats using openssl
+const pkcs1Key = execSync(
+  "openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 2>/dev/null | openssl rsa -traditional 2>/dev/null",
+  { encoding: "utf-8" },
+);
+
+const pkcs8Key = execSync(
+  "openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 2>/dev/null",
+  { encoding: "utf-8" },
+);
+
+describe("newSystemToken key format support", () => {
+  test("should sign a JWT with a PKCS#8 key (BEGIN PRIVATE KEY)", async () => {
+    expect(pkcs8Key).toContain("BEGIN PRIVATE KEY");
+
+    const token = await newSystemToken({
+      audience: "https://example.com",
+      subject: "login-client",
+      key: pkcs8Key,
+    });
+
+    expect(token).toBeDefined();
+    expect(typeof token).toBe("string");
+    expect(token.split(".")).toHaveLength(3); // valid JWT
+  });
+
+  test("should sign a JWT with a PKCS#1 key (BEGIN RSA PRIVATE KEY)", async () => {
+    expect(pkcs1Key).toContain("BEGIN RSA PRIVATE KEY");
+
+    const token = await newSystemToken({
+      audience: "https://example.com",
+      subject: "login-client",
+      key: pkcs1Key,
+    });
+
+    expect(token).toBeDefined();
+    expect(typeof token).toBe("string");
+    expect(token.split(".")).toHaveLength(3); // valid JWT
+  });
+});

--- a/packages/zitadel-client/src/node.ts
+++ b/packages/zitadel-client/src/node.ts
@@ -1,3 +1,4 @@
+import { createPrivateKey } from "crypto";
 import {
   createGrpcTransport,
   GrpcTransportOptions,
@@ -29,6 +30,18 @@ export function createServerTransport(
   });
 }
 
+/**
+ * Normalize a PEM private key to PKCS#8 format. Accepts both PKCS#1
+ * (BEGIN RSA PRIVATE KEY) and PKCS#8 (BEGIN PRIVATE KEY) inputs.
+ * Returns the key as a PKCS#8 PEM string.
+ */
+function toPKCS8(pem: string): string {
+  if (pem.includes("BEGIN PRIVATE KEY")) {
+    return pem;
+  }
+  return createPrivateKey(pem).export({ type: "pkcs8", format: "pem" }) as string;
+}
+
 export async function newSystemToken({
   audience,
   subject,
@@ -47,7 +60,7 @@ export async function newSystemToken({
     .setIssuer(subject)
     .setSubject(subject)
     .setAudience(audience)
-    .sign(await importPKCS8(key, "RS256"));
+    .sign(await importPKCS8(toPKCS8(key), "RS256"));
 }
 
 /**


### PR DESCRIPTION
# Which Problems Are Solved

The `newSystemToken` function in `@zitadel/client` uses `importPKCS8` from the `jose` library, which only accepts PKCS#8 formatted keys (`BEGIN PRIVATE KEY`). Helm's `genSelfSignedCert` outputs PKCS#1 (`BEGIN RSA PRIVATE KEY`), so JWT signing fails in Kubernetes deployments that use Helm-generated self-signed certificates.

# How the Problems Are Solved

A `toPKCS8` helper normalizes PKCS#1 keys to PKCS#8 using Node's `crypto.createPrivateKey` before passing them to `importPKCS8`. Keys already in PKCS#8 format are returned unchanged, preserving full backwards compatibility.

# Additional Changes

Integration tests in `apps/login/src/lib/api.test.ts` verify that both PKCS#1 and PKCS#8 key formats work with `newSystemToken`.

# Additional Context

This is a prerequisite for Helm chart changes to use `genSelfSignedCert` for login-client auth. Related to #11876 and #11572.