### PR TITLE
feat(login): add password visibility toggle to input

### DIFF
--- a/apps/login/locales/ar.json
+++ b/apps/login/locales/ar.json
@@ -62,6 +62,8 @@
     }
   },
   "password": {
+    "showPassword": "إظهار كلمة المرور",
+    "hidePassword": "إخفاء كلمة المرور",
     "verify": {
       "title": "كلمة المرور",
       "description": "أدخل كلمة المرور الخاصة بك.",

--- a/apps/login/locales/de.json
+++ b/apps/login/locales/de.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort ausblenden",
     "verify": {
       "title": "Passwort",
       "description": "Geben Sie Ihr Passwort ein.",

--- a/apps/login/locales/en.json
+++ b/apps/login/locales/en.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "verify": {
       "title": "Password",
       "description": "Enter your password.",

--- a/apps/login/locales/es.json
+++ b/apps/login/locales/es.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña",
     "verify": {
       "title": "Contraseña",
       "description": "Introduce tu contraseña.",

--- a/apps/login/locales/fr.json
+++ b/apps/login/locales/fr.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe",
     "verify": {
       "title": "Mot de passe",
       "description": "Entrez votre mot de passe.",

--- a/apps/login/locales/it.json
+++ b/apps/login/locales/it.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Mostra password",
+    "hidePassword": "Nascondi password",
     "verify": {
       "title": "Password",
       "description": "Inserisci la tua password.",

--- a/apps/login/locales/ja.json
+++ b/apps/login/locales/ja.json
@@ -54,6 +54,8 @@
     }
   },
   "password": {
+    "showPassword": "パスワードを表示",
+    "hidePassword": "パスワードを非表示",
     "verify": {
       "title": "パスワード",
       "description": "パスワードを入力してください。",

--- a/apps/login/locales/nl.json
+++ b/apps/login/locales/nl.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Wachtwoord tonen",
+    "hidePassword": "Wachtwoord verbergen",
     "verify": {
       "title": "Wachtwoord",
       "description": "Voer jouw wachtwoord in.",

--- a/apps/login/locales/pl.json
+++ b/apps/login/locales/pl.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Pokaż hasło",
+    "hidePassword": "Ukryj hasło",
     "verify": {
       "title": "Hasło",
       "description": "Wprowadź swoje hasło.",

--- a/apps/login/locales/ru.json
+++ b/apps/login/locales/ru.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Показать пароль",
+    "hidePassword": "Скрыть пароль",
     "verify": {
       "title": "Пароль",
       "description": "Введите ваш пароль.",

--- a/apps/login/locales/tr.json
+++ b/apps/login/locales/tr.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Parolayı göster",
+    "hidePassword": "Parolayı gizle",
     "verify": {
       "title": "Şifre",
       "description": "Şifrenizi girin.",

--- a/apps/login/locales/uk.json
+++ b/apps/login/locales/uk.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "Показати пароль",
+    "hidePassword": "Приховати пароль",
     "verify": {
       "title": "Пароль",
       "description": "Введіть свій пароль.",

--- a/apps/login/locales/zh.json
+++ b/apps/login/locales/zh.json
@@ -61,6 +61,8 @@
     }
   },
   "password": {
+    "showPassword": "显示密码",
+    "hidePassword": "隐藏密码",
     "verify": {
       "title": "密码",
       "description": "请输入您的密码。",

--- a/apps/login/src/components/input.test.tsx
+++ b/apps/login/src/components/input.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TextInput } from "./input";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
 
 describe("TextInput Component", () => {
   const originalEnv = process.env;
@@ -11,6 +15,7 @@ describe("TextInput Component", () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    cleanup();
   });
 
   describe("Component Rendering", () => {
@@ -130,6 +135,25 @@ describe("TextInput Component", () => {
       const { container } = render(<TextInput label="Test" autoFocus />);
       const input = container.querySelector("input");
       expect(input).toHaveFocus();
+    });
+
+    it("should render a toggle for password inputs", () => {
+      render(<TextInput label="Password" type="password" data-testid="password-input" />);
+      expect(screen.getByRole("button", { name: "showPassword" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "showPassword" })).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("should toggle password visibility", () => {
+      render(<TextInput label="Password" type="password" data-testid="password-input" />);
+      const input = screen.getByTestId("password-input");
+      const toggle = screen.getByRole("button", { name: "showPassword" });
+
+      expect(input).toHaveAttribute("type", "password");
+
+      fireEvent.click(toggle);
+
+      expect(input).toHaveAttribute("type", "text");
+      expect(screen.getByRole("button", { name: "hidePassword" })).toHaveAttribute("aria-pressed", "true");
     });
   });
 

--- a/apps/login/src/components/input.tsx
+++ b/apps/login/src/components/input.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { getComponentRoundness } from "@/lib/theme";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon } from "@heroicons/react/24/solid";
 import { clsx } from "clsx";
-import { ChangeEvent, DetailedHTMLProps, forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { ChangeEvent, DetailedHTMLProps, forwardRef, InputHTMLAttributes, ReactNode, useState } from "react";
 
 export type TextInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
   label: string;
@@ -18,12 +20,13 @@ export type TextInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElem
   roundness?: string; // Allow override via props
 };
 
-const styles = (error: boolean, disabled: boolean, roundnessClasses: string = "rounded-md") =>
+const styles = (error: boolean, disabled: boolean, hasPasswordToggle: boolean, roundnessClasses: string = "rounded-md") =>
   clsx(
     {
       "h-[40px] mb-[2px] p-[7px] bg-input-light-background dark:bg-input-dark-background transition-colors duration-300 grow": true,
       "border border-input-light-border dark:border-input-dark-border hover:border-black hover:dark:border-white focus:border-primary-light-500 focus:dark:border-primary-dark-500": true,
       "focus:outline-none focus:ring-0 text-base text-black dark:text-white placeholder:italic placeholder-gray-700 dark:placeholder-gray-700": true,
+      "pr-10": hasPasswordToggle,
       "border border-warn-light-500 dark:border-warn-dark-500 hover:border-warn-light-500 hover:dark:border-warn-dark-500 focus:border-warn-light-500 focus:dark:border-warn-dark-500":
         error,
       "pointer-events-none text-gray-500 dark:text-gray-800 border border-input-light-border dark:border-input-dark-border hover:border-light-hoverborder hover:dark:border-hoverborder cursor-default":
@@ -58,36 +61,62 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     // Use theme-based roundness if not explicitly provided
     const actualRoundness = roundness || getDefaultInputRoundness();
 
+    const t = useTranslations("password");
+    const isPasswordInput = props.type === "password";
+    const [showPassword, setShowPassword] = useState(false);
+    const toggleLabel = showPassword ? t("hidePassword") : t("showPassword");
+
     return (
       <label className="relative flex flex-col text-12px text-input-light-label dark:text-input-dark-label">
         <span className={`mb-1 leading-3 ${error ? "text-warn-light-500 dark:text-warn-dark-500" : ""}`}>
           {label} {required && "*"}
         </span>
-        <input
-          suppressHydrationWarning
-          ref={ref}
-          className={styles(!!error, !!disabled, actualRoundness)}
-          defaultValue={defaultValue}
-          required={required}
-          disabled={disabled}
-          placeholder={placeholder}
-          autoComplete={props.autoComplete ?? "off"}
-          onChange={(e) => onChange && onChange(e)}
-          onBlur={(e) => onBlur && onBlur(e)}
-          {...props}
-        />
+        <div className="relative flex items-center">
+          <input
+            suppressHydrationWarning
+            ref={ref}
+            className={styles(!!error, !!disabled, isPasswordInput, actualRoundness)}
+            defaultValue={defaultValue}
+            required={required}
+            disabled={disabled}
+            placeholder={placeholder}
+            autoComplete={props.autoComplete ?? "off"}
+            onChange={(e) => onChange && onChange(e)}
+            onBlur={(e) => onBlur && onBlur(e)}
+            {...props}
+            type={isPasswordInput && showPassword ? "text" : props.type}
+          />
 
-        {suffix && (
-          <span
-            className={clsx(
-              "absolute bottom-[22px] right-[3px] z-30 translate-y-1/2 transform bg-background-light-500 p-2 dark:bg-background-dark-500",
-              // Extract just the roundness part for the suffix (no padding)
-              actualRoundness.split(" ")[0], // Take only the first part (rounded-full, rounded-md, etc.)
-            )}
-          >
-            @{suffix}
-          </span>
-        )}
+          {suffix && (
+            <span
+              className={clsx(
+                "absolute bottom-[22px] right-[3px] z-30 translate-y-1/2 transform bg-background-light-500 p-2 dark:bg-background-dark-500",
+                // Extract just the roundness part for the suffix (no padding)
+                actualRoundness.split(" ")[0], // Take only the first part (rounded-full, rounded-md, etc.)
+              )}
+            >
+              @{suffix}
+            </span>
+          )}
+
+          {isPasswordInput && (
+            <button
+              type="button"
+              aria-label={toggleLabel}
+              aria-pressed={showPassword}
+              title={toggleLabel}
+              disabled={disabled}
+              className={clsx(
+                "absolute bottom-[22px] right-[5px] z-30 flex h-[30px] w-[30px] translate-y-1/2 transform flex-row items-center justify-center border-none bg-transparent text-gray-400 transition-colors hover:text-gray-900 disabled:cursor-default disabled:text-gray-500 dark:text-gray-400 dark:hover:text-white dark:disabled:text-gray-700",
+                // Extract just the roundness part for the toggle button (no padding)
+                actualRoundness.split(" ")[0], // Take only the first part (rounded-full, rounded-md, etc.)
+              )}
+              onClick={() => setShowPassword((value) => !value)}
+            >
+              {showPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+            </button>
+          )}
+        </div>
 
         <div className="leading-14.5px h-14.5px flex flex-row items-center text-12px text-warn-light-500 dark:text-warn-dark-500">
           <span>{error ? error : " "}</span>


### PR DESCRIPTION
# Which Problems Are Solved

- Implements https://github.com/zitadel/zitadel/issues/11951
- Adds password visibility toggle

# How the Problems Are Solved

- Adds password visibility toggle




<table>
<tr>
 <td>Password hidden</td>
 <td>Password visible, and toggle button is in focus</td>
<tr>
 <td><img width="425" height="584" alt="image" src="https://github.com/user-attachments/assets/cc8a6f29-6c1d-4692-a979-37e219786124" /></td>
 <td><img width="417" height="579" alt="image" src="https://github.com/user-attachments/assets/51d74203-7fde-4310-8df3-40aef2ba5d5b" /></td>
</table>




# Additional Changes

N.A

# Additional Context

Closes #11951
