### PR TITLE
fix(login): show correct error when user enters wrong password

### DIFF
--- a/apps/login/src/lib/server/password.test.ts
+++ b/apps/login/src/lib/server/password.test.ts
@@ -79,8 +79,9 @@ describe("checkSessionAndSetPassword", () => {
     const { headers } = await import("next/headers");
     const { getServiceConfig } = await import("../service-url");
     const { getSessionCookieById } = await import("../cookies");
-    const { getSession, listAuthenticationMethodTypes, getLoginSettings, getLockoutSettings, setPassword } =
-      await import("../zitadel");
+    const { getSession, listAuthenticationMethodTypes, getLoginSettings, getLockoutSettings, setPassword } = await import(
+      "../zitadel"
+    );
     const { setSessionAndUpdateCookie } = await import("./cookie");
 
     mockHeaders = vi.mocked(headers);
@@ -402,6 +403,56 @@ describe("sendPassword", () => {
     expect(result).toEqual({
       error: "errors.failedToAuthenticate",
     });
+  });
+
+  test("should return invalid password error without recreating session when existing session verification fails", async () => {
+    mockGetSessionCookieByLoginName.mockResolvedValue({
+      id: "session123",
+      token: "token123",
+      organization: "org123",
+    });
+    mockGetLoginSettings.mockResolvedValue({
+      ignoreUnknownUsernames: false,
+      allowLocalAuthentication: true,
+      passwordCheckLifetime: { seconds: BigInt(60 * 60 * 24), nanos: 0 },
+    });
+    mockSetSessionAndUpdateCookie.mockRejectedValue({ failedAttempts: 3 });
+    mockGetLockoutSettings.mockResolvedValue({ maxPasswordAttempts: BigInt(5) });
+
+    const result = await sendPassword({
+      loginName: "user@example.com",
+      organization: "org123",
+      checks: { password: { password: "wrong" } } as any,
+    });
+
+    expect(result).toEqual({ error: "errors.failedToAuthenticate" });
+    expect(mockCreateSessionAndUpdateCookie).not.toHaveBeenCalled();
+    expect(mockSearchUsers).not.toHaveBeenCalled();
+  });
+
+  test("should return no-limit invalid password error without recreating session when no password limit is configured", async () => {
+    mockGetSessionCookieByLoginName.mockResolvedValue({
+      id: "session123",
+      token: "token123",
+      organization: "org123",
+    });
+    mockGetLoginSettings.mockResolvedValue({
+      ignoreUnknownUsernames: false,
+      allowLocalAuthentication: true,
+      passwordCheckLifetime: { seconds: BigInt(60 * 60 * 24), nanos: 0 },
+    });
+    mockSetSessionAndUpdateCookie.mockRejectedValue({ failedAttempts: 3 });
+    mockGetLockoutSettings.mockResolvedValue({ maxPasswordAttempts: BigInt(0) });
+
+    const result = await sendPassword({
+      loginName: "user@example.com",
+      organization: "org123",
+      checks: { password: { password: "wrong" } } as any,
+    });
+
+    expect(result).toEqual({ error: "errors.failedToAuthenticateNoLimit" });
+    expect(mockCreateSessionAndUpdateCookie).not.toHaveBeenCalled();
+    expect(mockSearchUsers).not.toHaveBeenCalled();
   });
 
   test("should recreate session when session verification fails with keys/session terminated error and ignoreUnknownUsernames is true", async () => {

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -193,7 +193,30 @@ export async function sendPassword(
         // Force fallback if settings can't be loaded
         throw new Error("Could not load login settings");
       }
-    } catch {
+    } catch (error: any) {
+      if ("failedAttempts" in error && error.failedAttempts) {
+        recordAuthFailure("password", "invalid_password", command.organization);
+        if (loginSettingsByUser?.ignoreUnknownUsernames) {
+          return { error: t("errors.failedToAuthenticateNoLimit") };
+        }
+        const lockoutSettings = await getLockoutSettings({
+          serviceConfig,
+          orgId: command.organization ?? sessionCookie.organization,
+        });
+
+        const hasLimit =
+          lockoutSettings?.maxPasswordAttempts !== undefined && lockoutSettings?.maxPasswordAttempts > BigInt(0);
+        const locked = hasLimit && error.failedAttempts >= lockoutSettings?.maxPasswordAttempts;
+        const messageKey = hasLimit ? "errors.failedToAuthenticate" : "errors.failedToAuthenticateNoLimit";
+
+        return {
+          error: t(messageKey, {
+            failedAttempts: error.failedAttempts,
+            maxPasswordAttempts: hasLimit ? String(lockoutSettings?.maxPasswordAttempts ?? 0) : "?",
+            lockoutMessage: locked ? t("errors.accountLockedContactAdmin") : "",
+          }),
+        };
+      }
       logger.warn("[Password] Could not update session");
       // If the session was terminated or any other error occurred during update,
       // we fall back to creating a new session.


### PR DESCRIPTION
# Which Problems Are Solved

- Fixes: https://github.com/zitadel/zitadel/issues/11953

# How the Problems Are Solved

- restore logic for catching error when user enters wrong password

# Additional Changes

- Adds tests to prevent regression in future

# Additional Context

Closes #11953 
