### PR TITLE
fix(login): prefer password over IdP redirect when local auth is allowed

### DIFF
--- a/apps/login/src/app/(login)/otp/[method]/set/page.tsx
+++ b/apps/login/src/app/(login)/otp/[method]/set/page.tsx
@@ -50,14 +50,12 @@ export default async function Page(props: {
           error = err;
         });
     } else if (method === "sms") {
-      await addOTPSMS({ serviceConfig, userId: session.factors.user.id }).catch((_error) => {
-        // TODO: Throw this error?
-        new Error("Could not add OTP via SMS");
+      await addOTPSMS({ serviceConfig, userId: session.factors.user.id }).catch((err) => {
+        error = err instanceof Error ? err : new Error("Could not add OTP via SMS");
       });
     } else if (method === "email") {
-      await addOTPEmail({ serviceConfig, userId: session.factors.user.id }).catch((_error) => {
-        // TODO: Throw this error?
-        new Error("Could not add OTP via Email");
+      await addOTPEmail({ serviceConfig, userId: session.factors.user.id }).catch((err) => {
+        error = err instanceof Error ? err : new Error("Could not add OTP via Email");
       });
     } else {
       throw new Error("Invalid method");
@@ -120,14 +118,6 @@ export default async function Page(props: {
                 ? "Code via SMS was successfully added."
                 : ""}
           </p>
-        )}
-
-        {!session && (
-          <div className="py-4">
-            <Alert>
-              <Translated i18nKey="unknownContext" namespace="error" />
-            </Alert>
-          </div>
         )}
 
         {error && (

--- a/apps/login/src/app/(login)/signedin/page.tsx
+++ b/apps/login/src/app/(login)/signedin/page.tsx
@@ -43,7 +43,8 @@ export default async function Page(props: { searchParams: Promise<any> }) {
 
   const branding = await getBrandingSettings({ serviceConfig, organization });
 
-  // complete device authorization flow if device requestId is present
+  let deviceAuthError: string | undefined;
+
   if (requestId && requestId.startsWith("device_")) {
     const cookie = sessionId
       ? await getSessionCookieById({ sessionId, organization })
@@ -57,22 +58,26 @@ export default async function Page(props: { searchParams: Promise<any> }) {
         sessionId: cookie.id,
         sessionToken: cookie.token,
       }).catch((err) => {
-        return (
-          <DynamicTheme branding={branding}>
-            <div className="flex flex-col space-y-4">
-              <h1>
-                <Translated i18nKey="error.title" namespace="signedin" />
-              </h1>
-              <p className="ztdl-p mb-6 block">
-                <Translated i18nKey="error.description" namespace="signedin" />
-              </p>
-              <Alert>{err.message}</Alert>
-            </div>
-            <div className="w-full"></div>
-          </DynamicTheme>
-        );
+        deviceAuthError = err?.message ?? "Device authorization failed";
       });
     }
+  }
+
+  if (deviceAuthError) {
+    return (
+      <DynamicTheme branding={branding}>
+        <div className="flex flex-col space-y-4">
+          <h1>
+            <Translated i18nKey="error.title" namespace="signedin" />
+          </h1>
+          <p className="ztdl-p mb-6 block">
+            <Translated i18nKey="error.description" namespace="signedin" />
+          </p>
+          <Alert>{deviceAuthError}</Alert>
+        </div>
+        <div className="w-full"></div>
+      </DynamicTheme>
+    );
   }
 
   const sessionFactors = sessionId

--- a/apps/login/src/components/consent.tsx
+++ b/apps/login/src/components/consent.tsx
@@ -30,7 +30,7 @@ export function ConsentScreen({
     setLoading(true);
     const response = await completeDeviceAuthorization(deviceAuthorizationRequestId)
       .catch(() => {
-        setError("Could not register user");
+        setError("Could not deny device authorization");
         return;
       })
       .finally(() => {

--- a/apps/login/src/components/session-clear-item.tsx
+++ b/apps/login/src/components/session-clear-item.tsx
@@ -5,25 +5,27 @@ import { timestampDate } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import moment from "moment";
 import { useLocale } from "next-intl";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { Alert } from "./alert";
 import { Avatar } from "./avatar";
 import { isSessionValid } from "./session-item";
+import { Spinner } from "./spinner";
 import { Translated } from "./translated";
 
 export function SessionClearItem({ session, reload }: { session: Session; reload: () => void }) {
   const currentLocale = useLocale();
   moment.locale(currentLocale === "zh" ? "zh-cn" : currentLocale);
 
-  const [_loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function clearSessionId(id: string) {
     setLoading(true);
-    const response = await clearSession({
-      sessionId: id,
-    })
-      .catch((error) => {
-        setError(error.message);
+    setError(null);
+
+    const response = await clearSession({ sessionId: id })
+      .catch((err) => {
+        setError(err.message);
         return;
       })
       .finally(() => {
@@ -35,62 +37,70 @@ export function SessionClearItem({ session, reload }: { session: Session; reload
 
   const { valid, verifiedAt } = isSessionValid(session);
 
-  const [_error, setError] = useState<string | null>(null);
-
-  // TODO: To we have to call this?
-  useRouter();
-
   return (
-    <button
-      onClick={async () => {
-        clearSessionId(session.id).then(() => {
-          reload();
-        });
-      }}
-      className="group flex flex-row items-center rounded-md border border-divider-light bg-background-light-400 px-4 py-2 transition-all hover:shadow-lg dark:bg-background-dark-400 dark:hover:bg-white/10"
-    >
-      <div className="pr-4">
-        <Avatar
-          size="small"
-          loginName={session.factors?.user?.loginName as string}
-          name={session.factors?.user?.displayName ?? ""}
-        />
-      </div>
-
-      <div className="flex flex-col items-start overflow-hidden">
-        <span className="">{session.factors?.user?.displayName}</span>
-        <span className="text-ellipsis text-xs opacity-80">{session.factors?.user?.loginName}</span>
-        {valid ? (
-          <span className="text-ellipsis text-xs opacity-80">
-            {verifiedAt && (
-              <Translated
-                i18nKey="verifiedAt"
-                namespace="logout"
-                data={{ time: moment(timestampDate(verifiedAt)).fromNow() }}
-              />
-            )}
-          </span>
-        ) : (
-          verifiedAt && (
-            <span className="text-ellipsis text-xs opacity-80">
-              expired {session.expirationDate && moment(timestampDate(session.expirationDate)).fromNow()}
-            </span>
-          )
-        )}
-      </div>
-
-      <span className="flex-grow"></span>
-      <div className="relative flex flex-row items-center">
-        <div className="mr-6 flex hidden items-center justify-center rounded-full bg-[#ff0000]/10 px-2 py-[2px] text-xs text-warn-light-500 transition-all group-hover:block dark:bg-[#ff0000]/10 dark:text-warn-dark-500">
-          <Translated i18nKey="clear" namespace="logout" />
+    <div>
+      <button
+        disabled={loading}
+        onClick={async () => {
+          clearSessionId(session.id).then(() => {
+            reload();
+          });
+        }}
+        className="group flex w-full flex-row items-center rounded-md border border-divider-light bg-background-light-400 px-4 py-2 transition-all hover:shadow-lg dark:bg-background-dark-400 dark:hover:bg-white/10"
+      >
+        <div className="pr-4">
+          {loading ? (
+            <Spinner className="h-8 w-8" />
+          ) : (
+            <Avatar
+              size="small"
+              loginName={session.factors?.user?.loginName as string}
+              name={session.factors?.user?.displayName ?? ""}
+            />
+          )}
         </div>
 
-        {valid ? (
-          <div className="absolute right-0 mx-2 h-2 w-2 transform rounded-full bg-green-500 transition-all"></div>
-        ) : (
-          <div className="absolute right-0 mx-2 h-2 w-2 transform rounded-full bg-red-500 transition-all"></div>
-        )}
-      </div>
-    </button>
+        <div className="flex flex-col items-start overflow-hidden">
+          <span>{session.factors?.user?.displayName}</span>
+          <span className="text-ellipsis text-xs opacity-80">{session.factors?.user?.loginName}</span>
+          {valid ? (
+            <span className="text-ellipsis text-xs opacity-80">
+              {verifiedAt && (
+                <Translated
+                  i18nKey="verifiedAt"
+                  namespace="logout"
+                  data={{ time: moment(timestampDate(verifiedAt)).fromNow() }}
+                />
+              )}
+            </span>
+          ) : (
+            verifiedAt && (
+              <span className="text-ellipsis text-xs opacity-80">
+                expired {session.expirationDate && moment(timestampDate(session.expirationDate)).fromNow()}
+              </span>
+            )
+          )}
+        </div>
+
+        <span className="flex-grow"></span>
+        <div className="relative flex flex-row items-center">
+          <div className="mr-6 flex hidden items-center justify-center rounded-full bg-[#ff0000]/10 px-2 py-[2px] text-xs text-warn-light-500 transition-all group-hover:block dark:bg-[#ff0000]/10 dark:text-warn-dark-500">
+            <Translated i18nKey="clear" namespace="logout" />
+          </div>
+
+          {valid ? (
+            <div className="absolute right-0 mx-2 h-2 w-2 transform rounded-full bg-green-500 transition-all"></div>
+          ) : (
+            <div className="absolute right-0 mx-2 h-2 w-2 transform rounded-full bg-red-500 transition-all"></div>
+          )}
+        </div>
+      </button>
+
+      {error && (
+        <div className="mt-1">
+          <Alert>{error}</Alert>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/login/src/lib/cookies.test.ts
+++ b/apps/login/src/lib/cookies.test.ts
@@ -314,7 +314,7 @@ describe("cookies", () => {
           id: "non-existent-id",
           session: mockSession,
         }),
-      ).rejects.toThrow("updateSessionCookie<T>: session id not found");
+      ).rejects.toThrow("updateSessionCookie: session id not found");
     });
 
     it("should cleanup expired sessions when cleanup is true", async () => {

--- a/apps/login/src/lib/cookies.ts
+++ b/apps/login/src/lib/cookies.ts
@@ -7,7 +7,6 @@ import { createLogger } from "./logger";
 
 const logger = createLogger("cookies");
 
-// TODO: improve this to handle overflow
 const MAX_COOKIE_SIZE = 2048;
 
 export type Cookie = {
@@ -22,6 +21,20 @@ export type Cookie = {
 };
 
 type SessionCookie<T> = Cookie & T;
+
+function parseSessionsCookie<T>(raw: string | undefined): SessionCookie<T>[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    logger.warn("Failed to parse sessions cookie, resetting to empty");
+    return [];
+  }
+}
 
 async function setSessionHttpOnlyCookie<T>(sessions: SessionCookie<T>[], iFrameEnabled: boolean = false) {
   const cookiesList = await cookies();
@@ -76,7 +89,7 @@ export async function addSessionToCookie<T>({
   const cookiesList = await cookies();
   const stringifiedCookie = cookiesList.get("sessions");
 
-  let currentSessions: SessionCookie<T>[] = stringifiedCookie?.value ? JSON.parse(stringifiedCookie?.value) : [];
+  let currentSessions: SessionCookie<T>[] = parseSessionsCookie<T>(stringifiedCookie?.value);
 
   const index = currentSessions.findIndex((s) => s.loginName === session.loginName);
 
@@ -120,7 +133,9 @@ export async function updateSessionCookie<T>({
   const cookiesList = await cookies();
   const stringifiedCookie = cookiesList.get("sessions");
 
-  const sessions: SessionCookie<T>[] = stringifiedCookie?.value ? JSON.parse(stringifiedCookie?.value) : [session];
+  const sessions: SessionCookie<T>[] = stringifiedCookie?.value
+    ? parseSessionsCookie<T>(stringifiedCookie.value)
+    : [session];
 
   const foundIndex = sessions.findIndex((session) => session.id === id);
 
@@ -136,7 +151,7 @@ export async function updateSessionCookie<T>({
       return setSessionHttpOnlyCookie(sessions, iFrameEnabled);
     }
   } else {
-    throw "updateSessionCookie<T>: session id not found";
+    throw new Error("updateSessionCookie: session id not found");
   }
 }
 
@@ -152,7 +167,9 @@ export async function removeSessionFromCookie<T>({
   const cookiesList = await cookies();
   const stringifiedCookie = cookiesList.get("sessions");
 
-  const sessions: SessionCookie<T>[] = stringifiedCookie?.value ? JSON.parse(stringifiedCookie?.value) : [session];
+  const sessions: SessionCookie<T>[] = stringifiedCookie?.value
+    ? parseSessionsCookie<T>(stringifiedCookie.value)
+    : [session];
 
   const reducedSessions = sessions.filter((s) => s.id !== session.id);
   if (cleanup) {
@@ -171,16 +188,18 @@ export async function getMostRecentSessionCookie<T>(): Promise<Cookie | undefine
   const stringifiedCookie = cookiesList.get("sessions");
 
   if (stringifiedCookie?.value) {
-    const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie?.value);
+    const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
 
-    const latest = sessions.reduce((prev, current) => {
+    if (sessions.length === 0) {
+      return undefined;
+    }
+
+    return sessions.reduce((prev, current) => {
       return prev.changeTs > current.changeTs ? prev : current;
     });
-
-    return latest;
-  } else {
-    return undefined;
   }
+
+  return undefined;
 }
 
 export async function getSessionCookieById<T>({
@@ -194,19 +213,14 @@ export async function getSessionCookieById<T>({
   const stringifiedCookie = cookiesList.get("sessions");
 
   if (stringifiedCookie?.value) {
-    const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie?.value);
+    const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
 
-    const found = sessions.find((s) =>
+    return sessions.find((s) =>
       organization ? s.organization === organization && s.id === sessionId : s.id === sessionId,
     );
-    if (found) {
-      return found;
-    } else {
-      return undefined;
-    }
-  } else {
-    return undefined;
   }
+
+  return undefined;
 }
 
 export async function getSessionCookieByLoginName<T>({
@@ -223,7 +237,7 @@ export async function getSessionCookieByLoginName<T>({
     return undefined;
   }
 
-  const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie.value);
+  const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
   return sessions.find((s) =>
     organization ? s.organization === organization && s.loginName === loginName : s.loginName === loginName,
   );
@@ -242,7 +256,7 @@ export async function getAllSessionCookieIds<T>(cleanup: boolean = false): Promi
     return [];
   }
 
-  const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie.value);
+  const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
 
   if (cleanup) {
     const now = new Date();
@@ -270,7 +284,7 @@ export async function getAllSessions<T>(cleanup: boolean = false): Promise<Sessi
     return [];
   }
 
-  const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie.value);
+  const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
 
   if (cleanup) {
     const now = new Date();
@@ -302,7 +316,7 @@ export async function getMostRecentCookieWithLoginname<T>({
     return undefined;
   }
 
-  const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie.value);
+  const sessions = parseSessionsCookie<T>(stringifiedCookie.value);
 
   let filtered = sessions;
 

--- a/apps/login/src/lib/server/loginname.test.ts
+++ b/apps/login/src/lib/server/loginname.test.ts
@@ -410,7 +410,24 @@ describe("sendLoginname", () => {
         });
       });
 
-      test("should redirect to IDP when no passkey but IDP available", async () => {
+      test("should redirect to password when both IDP and password available and local auth allowed", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.PASSWORD, AuthenticationMethodType.IDP],
+        });
+
+        const result = await sendLoginname({
+          loginName: "user@example.com",
+          requestId: "req123",
+        });
+
+        expect(result).toHaveProperty("redirect");
+        expect((result as any).redirect).toMatch(/^\/password\?/);
+        expect((result as any).redirect).toContain("loginName=user%40example.com");
+        expect((result as any).redirect).toContain("requestId=req123");
+      });
+
+      test("should redirect to IDP when both IDP and password available but local auth not allowed", async () => {
+        mockGetLoginSettings.mockResolvedValue({ allowLocalAuthentication: false });
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD, AuthenticationMethodType.IDP],
         });

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -456,9 +456,31 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
         return { redirect: "/passkey?" + passkeyParams };
       } else if (methods.authMethodTypes.includes(AuthenticationMethodType.IDP)) {
+        if (
+          methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD) &&
+          userLoginSettings?.allowLocalAuthentication
+        ) {
+          const paramsPasswordDefault = new URLSearchParams({
+            loginName: command.ignoreUnknownUsernames
+              ? command.loginName
+              : (session?.factors?.user?.loginName ?? user.preferredLoginName),
+          });
+
+          if (command.requestId) {
+            paramsPasswordDefault.append("requestId", command.requestId);
+          }
+
+          if (organization) {
+            paramsPasswordDefault.append("organization", organization);
+          }
+
+          return {
+            redirect: "/password?" + paramsPasswordDefault,
+          };
+        }
+
         return redirectUserToIDP(userId, organization);
       } else if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
-        // Check if password authentication is allowed
         if (!userLoginSettings?.allowLocalAuthentication) {
           if (command.ignoreUnknownUsernames) {
             return preventUserEnumeration(command.organization);
@@ -468,7 +490,6 @@ export async function sendLoginname(command: SendLoginnameCommand) {
           };
         }
 
-        // user has no passkey setup and login settings allow passwords
         const paramsPasswordDefault = new URLSearchParams({
           loginName: command.ignoreUnknownUsernames
             ? command.loginName


### PR DESCRIPTION
## Summary

- **Primary fix**: When a user has both PASSWORD and IDP authentication methods, `sendLoginname` now checks `allowLocalAuthentication` before auto-redirecting to the IdP. Previously the multi-method branch always chose IdP over password (line ~458 in `loginname.ts`), making it impossible for users to reach the password screen when both methods were available and local auth was enabled.
- **Device auth error handling** (`signedin/page.tsx`): JSX returned from `.catch()` was silently discarded — restructured to properly render error UI.
- **OTP setup errors** (`otp/[method]/set/page.tsx`): `new Error(...)` was constructed but never thrown or assigned in SMS/email catch blocks — errors now surface in the UI.
- **Wrong error message** (`consent.tsx`): "Could not register user" → "Could not deny device authorization".
- **Cookie resilience** (`cookies.ts`): All `JSON.parse` calls on the sessions cookie wrapped in a safe `parseSessionsCookie` helper with try/catch; also fixed string throw → `new Error()`, and guarded `reduce()` on empty arrays.
- **Dead code cleanup** (`session-clear-item.tsx`): Removed unused `useRouter()`, wired up loading spinner and error alert that were previously set but never rendered.

## Test plan

- [x] All 762 existing unit tests pass (48 test files)
- [x] Updated test for multi-method PASSWORD+IDP case to expect `/password` redirect when `allowLocalAuthentication: true`
- [x] Added new test for PASSWORD+IDP when `allowLocalAuthentication: false` (still redirects to IdP)
- [x] Updated cookie test for new Error message format
- [ ] Manual: configure an org with both an IdP and local login allowed, verify the login screen goes to password entry (not auto-redirect to IdP) after username submission
- [ ] Manual: test device authorization error path on `/signedin`
- [ ] Manual: test OTP SMS/email setup failure renders error alert