### PR TITLE
fix(eventstore): allow resource owner reset on aggregate recreation (#10799)

### DIFF
--- a/cmd/initialise/sql/08_events_table.sql
+++ b/cmd/initialise/sql/08_events_table.sql
@@ -32,12 +32,28 @@ DO $$ BEGIN
         , payload JSONB
         , creator TEXT
         , owner TEXT
+        , enforce_owner BOOLEAN
     );
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;
 
 CREATE OR REPLACE FUNCTION eventstore.commands_to_events(commands eventstore.command[]) RETURNS SETOF eventstore.events2 VOLATILE AS $$
+WITH c AS (
+    SELECT
+        c.instance_id
+        , c.aggregate_type
+        , c.aggregate_id
+        , c.command_type
+        , c.revision
+        , c.payload
+        , c.creator
+        , c.owner
+        , c.enforce_owner
+        , ROW_NUMBER() OVER () AS in_tx_order
+    FROM
+        UNNEST(commands) AS c
+)
 SELECT
     c.instance_id
     , c.aggregate_type
@@ -48,64 +64,80 @@ SELECT
     , NOW() AS created_at
     , c.payload
     , c.creator
-    , cs.owner
+    , COALESCE(cs.enforced_owner, cs.current_owner, cs.command_owner) AS owner
     , EXTRACT(EPOCH FROM NOW()) AS position
     , c.in_tx_order
-FROM (
-    SELECT
-        c.instance_id
-        , c.aggregate_type
-        , c.aggregate_id
-        , c.command_type
-        , c.revision
-        , c.payload
-        , c.creator
-        , c.owner
-        , ROW_NUMBER() OVER () AS in_tx_order
-    FROM
-        UNNEST(commands) AS c
-) AS c
+FROM c
 JOIN (
     SELECT
         cmds.instance_id
         , cmds.aggregate_type
         , cmds.aggregate_id
-        , CASE WHEN (e.owner IS NOT NULL OR e.owner <> '') THEN e.owner ELSE command_owners.owner END AS owner
-        , COALESCE(MAX(e.sequence), 0) AS sequence
+        , current_owners.owner AS current_owner
+        , command_owners.owner AS command_owner
+        , enforced_owners.owner AS enforced_owner
+        , COALESCE(current_owners.sequence, 0) AS sequence
     FROM (
         SELECT DISTINCT
             instance_id
             , aggregate_type
             , aggregate_id
-            , owner
-        FROM UNNEST(commands)
+        FROM c
     ) AS cmds
-    LEFT JOIN eventstore.events2 AS e
-        ON cmds.instance_id = e.instance_id
-        AND cmds.aggregate_type = e.aggregate_type
-        AND cmds.aggregate_id = e.aggregate_id
-    JOIN (
+    LEFT JOIN LATERAL (
         SELECT
-            DISTINCT ON (
-                instance_id
-                , aggregate_type
-                , aggregate_id
-            )
+            e.owner
+            , e.sequence
+        FROM eventstore.events2 AS e
+        WHERE
+            cmds.instance_id = e.instance_id
+            AND cmds.aggregate_type = e.aggregate_type
+            AND cmds.aggregate_id = e.aggregate_id
+        ORDER BY
+            e.sequence DESC
+        LIMIT 1
+    ) AS current_owners ON true
+    JOIN (
+        SELECT DISTINCT ON (
+            instance_id
+            , aggregate_type
+            , aggregate_id
+        )
             instance_id
             , aggregate_type
             , aggregate_id
             , owner
-        FROM
-            UNNEST(commands)
-    ) AS command_owners ON
-        cmds.instance_id = command_owners.instance_id
+        FROM c
+        ORDER BY
+            instance_id
+            , aggregate_type
+            , aggregate_id
+            , in_tx_order
+    ) AS command_owners
+        ON cmds.instance_id = command_owners.instance_id
         AND cmds.aggregate_type = command_owners.aggregate_type
         AND cmds.aggregate_id = command_owners.aggregate_id
-    GROUP BY
-        cmds.instance_id
-        , cmds.aggregate_type
-        , cmds.aggregate_id
-        , 4 -- owner
+    LEFT JOIN (
+        SELECT DISTINCT ON (
+            instance_id
+            , aggregate_type
+            , aggregate_id
+        )
+            instance_id
+            , aggregate_type
+            , aggregate_id
+            , owner
+        FROM c
+        WHERE enforce_owner
+        ORDER BY
+            instance_id
+            , aggregate_type
+            , aggregate_id
+            , in_tx_order
+    ) AS enforced_owners
+        ON cmds.instance_id = enforced_owners.instance_id
+        AND cmds.aggregate_type = enforced_owners.aggregate_type
+        AND cmds.aggregate_id = enforced_owners.aggregate_id
 ) AS cs
     ON c.instance_id = cs.instance_id
     AND c.aggregate_type = cs.aggregate_type
@@ -117,5 +149,6 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION eventstore.push(commands eventstore.command[]) RETURNS SETOF eventstore.events2 VOLATILE AS $$
 INSERT INTO eventstore.events2
 SELECT * FROM eventstore.commands_to_events(commands)
+ORDER BY in_tx_order
 RETURNING *
 $$ LANGUAGE SQL;

--- a/cmd/setup/40/01_type.sql
+++ b/cmd/setup/40/01_type.sql
@@ -9,6 +9,7 @@ DO $$ BEGIN
         , payload JSONB
         , creator TEXT
         , owner TEXT
+        , enforce_owner BOOLEAN
     );
 EXCEPTION
     WHEN duplicate_object THEN null;

--- a/cmd/setup/64.sql
+++ b/cmd/setup/64.sql
@@ -8,6 +8,8 @@ DECLARE
     "aggregate" RECORD;
     current_sequence BIGINT;
     current_owner TEXT;
+    command_owner TEXT;
+    enforced_owner TEXT;
     created_at TIMESTAMPTZ;
 BEGIN
     created_at := statement_timestamp();
@@ -29,26 +31,57 @@ BEGIN
             , "aggregate".aggregate_id
         );
 
+        SELECT
+            c.owner
+        INTO
+            command_owner
+        FROM
+            UNNEST(commands) WITH ORDINALITY AS c
+        WHERE
+            c.instance_id = "aggregate".instance_id
+            AND c.aggregate_type = "aggregate".aggregate_type
+            AND c.aggregate_id = "aggregate".aggregate_id
+        ORDER BY
+            c.ordinality
+        LIMIT 1;
+
+        SELECT
+            c.owner
+        INTO
+            enforced_owner
+        FROM
+            UNNEST(commands) WITH ORDINALITY AS c
+        WHERE
+            c.instance_id = "aggregate".instance_id
+            AND c.aggregate_type = "aggregate".aggregate_type
+            AND c.aggregate_id = "aggregate".aggregate_id
+            AND c.enforce_owner
+        ORDER BY
+            c.ordinality
+        LIMIT 1;
+
         RETURN QUERY
         SELECT
             c.instance_id
             , c.aggregate_type
             , c.aggregate_id
             , c.command_type -- AS event_type
-            , COALESCE(current_sequence, 0) + ROW_NUMBER() OVER () -- AS sequence
+            , COALESCE(current_sequence, 0) + ROW_NUMBER() OVER (ORDER BY c.ordinality) -- AS sequence
             , c.revision
             , created_at
             , c.payload
             , c.creator
-            , COALESCE(current_owner, c.owner) -- AS owner
+            , COALESCE(enforced_owner, current_owner, command_owner) -- AS owner
             , EXTRACT(EPOCH FROM created_at) -- AS position
             , c.ordinality::%s -- AS in_tx_order
         FROM
             UNNEST(commands) WITH ORDINALITY AS c
         WHERE
-            c.instance_id = aggregate.instance_id
-            AND c.aggregate_type = aggregate.aggregate_type
-            AND c.aggregate_id = aggregate.aggregate_id;
+            c.instance_id = "aggregate".instance_id
+            AND c.aggregate_type = "aggregate".aggregate_type
+            AND c.aggregate_id = "aggregate".aggregate_id
+        ORDER BY
+            c.ordinality;
     END LOOP;
     RETURN;
 END;

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -1,0 +1,45 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 70.sql
+	addEventStoreCommandEnforceOwnerColumn string
+)
+
+type AddEventStoreCommandEnforceOwnerColumn struct {
+	dbClient *database.DB
+}
+
+func (mig *AddEventStoreCommandEnforceOwnerColumn) Execute(ctx context.Context, _ eventstore.Event) error {
+	conn, err := mig.dbClient.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := conn.Close()
+		logging.OnError(ctx, closeErr).Debug("failed to release connection")
+		mig.dbClient.Pool.Reset()
+	}()
+
+	inTxOrderType, err := (&ChangePushPosition{dbClient: mig.dbClient}).inTxOrderType(ctx)
+	if err != nil {
+		return err
+	}
+
+	stmt := fmt.Sprintf(addEventStoreCommandEnforceOwnerColumn, inTxOrderType)
+	_, err = conn.ExecContext(ctx, stmt)
+	return err
+}
+
+func (mig *AddEventStoreCommandEnforceOwnerColumn) String() string {
+	return "70_add_eventstore_command_type_enforce_owner_column"
+}

--- a/cmd/setup/70.sql
+++ b/cmd/setup/70.sql
@@ -1,37 +1,11 @@
-CREATE OR REPLACE FUNCTION eventstore.latest_aggregate_state(
-    instance_id TEXT
-    , aggregate_type TEXT
-    , aggregate_id TEXT
-    
-    , sequence OUT BIGINT
-    , owner OUT TEXT
-)
-    LANGUAGE 'plpgsql'
-    STABLE PARALLEL SAFE
-AS $$
-    BEGIN
-        SELECT
-            COALESCE(e.sequence, 0) AS sequence
-            , e.owner
-        INTO
-            sequence
-            , owner
-        FROM
-            eventstore.events2 e
-        WHERE
-            e.instance_id = $1
-            AND e.aggregate_type = $2
-            AND e.aggregate_id = $3
-        ORDER BY 
-            e.sequence DESC
-        LIMIT 1;
-
-        RETURN;
-    END;
-$$;
+DO $$ BEGIN
+    ALTER TYPE eventstore.command ADD ATTRIBUTE enforce_owner BOOLEAN;
+EXCEPTION
+    WHEN duplicate_column THEN null;
+END $$;
 
 CREATE OR REPLACE FUNCTION eventstore.commands_to_events(commands eventstore.command[])
-    RETURNS SETOF eventstore.events2 
+    RETURNS SETOF eventstore.events2
     LANGUAGE 'plpgsql'
     STABLE PARALLEL SAFE
     ROWS 10
@@ -45,18 +19,18 @@ DECLARE
     created_at TIMESTAMPTZ;
 BEGIN
     created_at := statement_timestamp();
-    FOR "aggregate" IN 
+    FOR "aggregate" IN
         SELECT DISTINCT
             instance_id
             , aggregate_type
             , aggregate_id
         FROM UNNEST(commands)
     LOOP
-        SELECT 
-            * 
+        SELECT
+            *
         INTO
             current_sequence
-            , current_owner 
+            , current_owner
         FROM eventstore.latest_aggregate_state(
             "aggregate".instance_id
             , "aggregate".aggregate_type
@@ -97,15 +71,15 @@ BEGIN
             c.instance_id
             , c.aggregate_type
             , c.aggregate_id
-            , c.command_type -- AS event_type
-            , COALESCE(current_sequence, 0) + ROW_NUMBER() OVER (ORDER BY c.ordinality) -- AS sequence
+            , c.command_type
+            , COALESCE(current_sequence, 0) + ROW_NUMBER() OVER (ORDER BY c.ordinality)
             , c.revision
             , created_at
             , c.payload
             , c.creator
-            , COALESCE(enforced_owner, current_owner, command_owner) -- AS owner
-            , EXTRACT(EPOCH FROM created_at) -- AS position
-            , c.ordinality::{{ .InTxOrderType }} -- AS in_tx_order
+            , COALESCE(enforced_owner, current_owner, command_owner)
+            , EXTRACT(EPOCH FROM created_at)
+            , c.ordinality::%s
         FROM
             UNNEST(commands) WITH ORDINALITY AS c
         WHERE
@@ -118,10 +92,3 @@ BEGIN
     RETURN;
 END;
 $$;
-
-CREATE OR REPLACE FUNCTION eventstore.push(commands eventstore.command[]) RETURNS SETOF eventstore.events2 VOLATILE AS $$
-INSERT INTO eventstore.events2
-SELECT * FROM eventstore.commands_to_events(commands)
-ORDER BY in_tx_order
-RETURNING *
-$$ LANGUAGE SQL;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -185,6 +185,7 @@ type Steps struct {
 	s67SyncMemberRoleFields                 *SyncMemberRoleFields
 	s68TargetAddPayloadTypeColumn           *TargetAddPayloadTypeColumn
 	s69CacheTablesLogged                    *CacheTablesLogged
+	s70AddEventStoreCommandEnforceOwner     *AddEventStoreCommandEnforceOwnerColumn
 	RelationalTables                        *TransactionalTables
 }
 

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -248,6 +248,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s67SyncMemberRoleFields = &SyncMemberRoleFields{dbClient: dbClient}
 	steps.s68TargetAddPayloadTypeColumn = &TargetAddPayloadTypeColumn{dbClient: dbClient}
 	steps.s69CacheTablesLogged = &CacheTablesLogged{dbClient: dbClient}
+	steps.s70AddEventStoreCommandEnforceOwner = &AddEventStoreCommandEnforceOwnerColumn{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -257,6 +258,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	for _, step := range []migration.Migration{
 		steps.s14NewEventsTable,
 		steps.s40InitPushFunc,
+		steps.s70AddEventStoreCommandEnforceOwner,
 		steps.s1ProjectionTable,
 		steps.s2AssetsTable,
 		steps.s28AddFieldTable,

--- a/internal/eventstore/event.go
+++ b/internal/eventstore/event.go
@@ -40,6 +40,16 @@ type Command interface {
 	Fields() []*FieldOperation
 }
 
+type EnforceResourceOwnerCommand interface {
+	Command
+	EnforceResourceOwner()
+}
+
+func ShouldEnforceResourceOwner(cmd Command) bool {
+	_, ok := cmd.(EnforceResourceOwnerCommand)
+	return ok
+}
+
 // Event is a stored activity
 type Event interface {
 	action

--- a/internal/eventstore/eventstore_pusher_test.go
+++ b/internal/eventstore/eventstore_pusher_test.go
@@ -607,6 +607,70 @@ func TestEventstore_Push_ResourceOwner(t *testing.T) {
 	}
 }
 
+func TestEventstore_Push_ResourceOwner_ReusedAggregateID(t *testing.T) {
+	aggregateType := eventstore.AggregateType(t.Name())
+	aggregateID := "510"
+
+	for pusherName, pusher := range pushers {
+		t.Run(pusherName, func(t *testing.T) {
+			t.Cleanup(cleanupEventstore(clients[pusherName]))
+
+			db := eventstore.NewEventstore(
+				&eventstore.Config{
+					Querier: queriers["v2(inmemory)"],
+					Pusher:  pusher,
+				},
+			)
+
+			initialEvents, err := db.Push(context.Background(),
+				generateCommand(
+					aggregateType,
+					aggregateID,
+					func(e *testEvent) { e.BaseEvent.Agg.ResourceOwner = "old" },
+					withEventType("test.initial"),
+				),
+			)
+			if err != nil {
+				t.Fatalf("initial eventstore.Push() error = %v", err)
+			}
+			if len(initialEvents) != 1 {
+				t.Fatalf("initial events length = %d, want 1", len(initialEvents))
+			}
+			if initialEvents[0].Aggregate().ResourceOwner != "old" {
+				t.Fatalf("initial resource owner = %q, want %q", initialEvents[0].Aggregate().ResourceOwner, "old")
+			}
+
+			reusedEvents, err := db.Push(context.Background(),
+				generateEnforcedCommand(
+					aggregateType,
+					aggregateID,
+					func(e *testEvent) { e.BaseEvent.Agg.ResourceOwner = "new" },
+					withEventType("test.recreated"),
+				),
+				generateCommand(
+					aggregateType,
+					aggregateID,
+					func(e *testEvent) { e.BaseEvent.Agg.ResourceOwner = "ignored" },
+					withEventType("test.followup"),
+				),
+			)
+			if err != nil {
+				t.Fatalf("reused eventstore.Push() error = %v", err)
+			}
+			if len(reusedEvents) != 2 {
+				t.Fatalf("reused events length = %d, want 2", len(reusedEvents))
+			}
+			for i, event := range reusedEvents {
+				if event.Aggregate().ResourceOwner != "new" {
+					t.Fatalf("reused event %d resource owner = %q, want %q", i, event.Aggregate().ResourceOwner, "new")
+				}
+			}
+
+			assertResourceOwnersBySequence(t, clients[pusherName], []string{"old", "new", "new"}, string(aggregateType), aggregateID)
+		})
+	}
+}
+
 func pushAggregates(es *eventstore.Eventstore, aggregateCommands [][]eventstore.Command) []error {
 	wg := sync.WaitGroup{}
 	errs := make([]error, 0)
@@ -656,6 +720,33 @@ func assertResourceOwners(t *testing.T, db *database.DB, resourceOwners, aggrega
 		}
 		return nil
 	}, "SELECT owner FROM eventstore.events2 WHERE aggregate_type = $1 AND aggregate_id = ANY($2) ORDER BY position, in_tx_order", aggregateType, aggregateIDs)
+	if err != nil {
+		t.Error("query failed: ", err)
+		return
+	}
+
+	if eventCount != len(resourceOwners) {
+		t.Errorf("wrong queried event count: want %d, got %d", len(resourceOwners), eventCount)
+	}
+}
+
+func assertResourceOwnersBySequence(t *testing.T, db *database.DB, resourceOwners []string, aggregateType, aggregateID string) {
+	t.Helper()
+
+	eventCount := 0
+	err := db.Query(func(rows *sql.Rows) error {
+		for i := 0; rows.Next(); i++ {
+			var resourceOwner string
+			if err := rows.Scan(&resourceOwner); err != nil {
+				return err
+			}
+			if resourceOwner != resourceOwners[i] {
+				t.Errorf("unexpected resource owner in queried event. want %q, got: %q", resourceOwners[i], resourceOwner)
+			}
+			eventCount++
+		}
+		return nil
+	}, `SELECT owner FROM eventstore.events2 WHERE aggregate_type = $1 AND aggregate_id = $2 ORDER BY "sequence"`, aggregateType, aggregateID)
 	if err != nil {
 		t.Error("query failed: ", err)
 		return

--- a/internal/eventstore/local_postgres_test.go
+++ b/internal/eventstore/local_postgres_test.go
@@ -2,7 +2,6 @@ package eventstore_test
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -239,16 +238,6 @@ func generateRemoveUniqueConstraint(table, uniqueField string) func(e *testEvent
 func withEventType(eventType eventstore.EventType) func(e *testEvent) {
 	return func(e *testEvent) {
 		e.BaseEvent.EventType = eventType
-	}
-}
-
-func withTestData(data any) func(e *testEvent) {
-	return func(e *testEvent) {
-		d, err := json.Marshal(data)
-		if err != nil {
-			panic("marshal data failed")
-		}
-		e.BaseEvent.Data = d
 	}
 }
 

--- a/internal/eventstore/local_postgres_test.go
+++ b/internal/eventstore/local_postgres_test.go
@@ -159,10 +159,39 @@ func generateCommand(aggregateType eventstore.AggregateType, aggregateID string,
 	return e
 }
 
+func generateEnforcedCommand(aggregateType eventstore.AggregateType, aggregateID string, opts ...func(*testEvent)) eventstore.Command {
+	e := &enforcedTestEvent{
+		testEvent: testEvent{
+			BaseEvent: eventstore.BaseEvent{
+				Agg: &eventstore.Aggregate{
+					ID:            aggregateID,
+					Type:          aggregateType,
+					ResourceOwner: "ro",
+					Version:       "v1",
+				},
+				Service:   "svc",
+				EventType: "test.created",
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&e.testEvent)
+	}
+
+	return e
+}
+
 type testEvent struct {
 	eventstore.BaseEvent
 	uniqueConstraints []*eventstore.UniqueConstraint
 }
+
+type enforcedTestEvent struct {
+	testEvent
+}
+
+func (*enforcedTestEvent) EnforceResourceOwner() {}
 
 func (e *testEvent) Payload() any {
 	return e.BaseEvent.Data
@@ -204,6 +233,12 @@ func generateRemoveUniqueConstraint(table, uniqueField string) func(e *testEvent
 				Action:      eventstore.UniqueConstraintRemove,
 			},
 		)
+	}
+}
+
+func withEventType(eventType eventstore.EventType) func(e *testEvent) {
+	return func(e *testEvent) {
+		e.BaseEvent.EventType = eventType
 	}
 }
 

--- a/internal/eventstore/v3/event.go
+++ b/internal/eventstore/v3/event.go
@@ -27,6 +27,7 @@ type command struct {
 	Payload       Payload
 	Creator       string
 	Owner         string
+	EnforceOwner  bool
 }
 
 func (c *command) Aggregate() *eventstore.Aggregate {
@@ -106,6 +107,7 @@ func commandToEvent(cmd eventstore.Command) (_ eventstore.Event, err error) {
 		Payload:       payload,
 		Creator:       cmd.Creator(),
 		Owner:         cmd.Aggregate().ResourceOwner,
+		EnforceOwner:  eventstore.ShouldEnforceResourceOwner(cmd),
 	}
 
 	return &event{

--- a/internal/eventstore/v3/event_test.go
+++ b/internal/eventstore/v3/event_test.go
@@ -96,6 +96,32 @@ func Test_commandToEvent(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "enforced resource owner",
+			args: args{
+				command: &enforcedMockCommand{
+					mockCommand: &mockCommand{
+						aggregate: mockAggregate("V3-Red9I"),
+						payload:   nil,
+					},
+				},
+			},
+			want: want{
+				event: &event{
+					command: &command{
+						InstanceID:    "instance",
+						AggregateType: "type",
+						AggregateID:   "V3-Red9I",
+						Owner:         "ro",
+						Creator:       "creator",
+						Revision:      1,
+						CommandType:   "event.type",
+						Payload:       nil,
+						EnforceOwner:  true,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		if tt.want.err == nil {
@@ -454,6 +480,53 @@ func Test_commandsToEvents(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single enforced command",
+			args: args{
+				ctx: ctx,
+				cmds: []eventstore.Command{
+					&enforcedMockCommand{
+						mockCommand: &mockCommand{
+							aggregate: mockAggregate("V3-Red9I"),
+							payload:   nil,
+						},
+					},
+				},
+			},
+			want: want{
+				events: []eventstore.Event{
+					&event{
+						command: &command{
+							InstanceID:    "instance",
+							AggregateType: "type",
+							AggregateID:   "V3-Red9I",
+							Owner:         "ro",
+							Creator:       "creator",
+							Revision:      1,
+							CommandType:   "event.type",
+							Payload:       nil,
+							EnforceOwner:  true,
+						},
+					},
+				},
+				commands: []*command{
+					{
+						InstanceID:    "instance",
+						AggregateType: "type",
+						AggregateID:   "V3-Red9I",
+						Owner:         "ro",
+						CommandType:   "event.type",
+						Revision:      1,
+						Payload:       nil,
+						Creator:       "creator",
+						EnforceOwner:  true,
+					},
+				},
+				err: func(t *testing.T, err error) {
+					require.NoError(t, err)
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -479,4 +552,5 @@ func assertCommand(t *testing.T, want, got *command) {
 	assert.Equal(t, want.AggregateType, got.AggregateType)
 	assert.Equal(t, want.InstanceID, got.InstanceID)
 	assert.Equal(t, want.Revision, got.Revision)
+	assert.Equal(t, want.EnforceOwner, got.EnforceOwner)
 }

--- a/internal/eventstore/v3/eventstore.go
+++ b/internal/eventstore/v3/eventstore.go
@@ -90,6 +90,14 @@ var (
 					Name: "owner",
 					Type: textType,
 				},
+				{
+					Name: "enforce_owner",
+					Type: &pgtype.Type{
+						Name:  "bool",
+						OID:   pgtype.BoolOID,
+						Codec: pgtype.BoolCodec{},
+					},
+				},
 			},
 		},
 	}

--- a/internal/eventstore/v3/mock_test.go
+++ b/internal/eventstore/v3/mock_test.go
@@ -5,12 +5,19 @@ import (
 )
 
 var _ eventstore.Command = (*mockCommand)(nil)
+var _ eventstore.EnforceResourceOwnerCommand = (*enforcedMockCommand)(nil)
 
 type mockCommand struct {
 	aggregate   *eventstore.Aggregate
 	payload     any
 	constraints []*eventstore.UniqueConstraint
 }
+
+type enforcedMockCommand struct {
+	*mockCommand
+}
+
+func (*enforcedMockCommand) EnforceResourceOwner() {}
 
 // Aggregate implements [eventstore.Command]
 func (m *mockCommand) Aggregate() *eventstore.Aggregate {

--- a/internal/eventstore/v3/sequence.go
+++ b/internal/eventstore/v3/sequence.go
@@ -15,8 +15,9 @@ import (
 )
 
 type latestSequence struct {
-	aggregate *eventstore.Aggregate
-	sequence  uint64
+	aggregate    *eventstore.Aggregate
+	sequence     uint64
+	enforceOwner bool
 }
 
 //go:embed sequences_query.sql
@@ -70,7 +71,11 @@ func commandsToSequences(ctx context.Context, commands []eventstore.Command) []*
 	sequences := make([]*latestSequence, 0, len(commands))
 
 	for _, command := range commands {
-		if searchSequenceByCommand(sequences, command) != nil {
+		if existing := searchSequenceByCommand(sequences, command); existing != nil {
+			if eventstore.ShouldEnforceResourceOwner(command) {
+				existing.enforceOwner = true
+				existing.aggregate.ResourceOwner = command.Aggregate().ResourceOwner
+			}
 			continue
 		}
 
@@ -78,7 +83,8 @@ func commandsToSequences(ctx context.Context, commands []eventstore.Command) []*
 			command.Aggregate().InstanceID = authz.GetInstance(ctx).InstanceID()
 		}
 		sequences = append(sequences, &latestSequence{
-			aggregate: command.Aggregate(),
+			aggregate:    command.Aggregate(),
+			enforceOwner: eventstore.ShouldEnforceResourceOwner(command),
 		})
 	}
 
@@ -134,8 +140,9 @@ func scanToSequence(rows database.Rows, sequences []*latestSequence) error {
 			"provided_owner", sequence.aggregate.ResourceOwner,
 		).Info("would have set wrong resource owner")
 	}
+
 	// set resource owner from previous events
-	if resourceOwner != "" {
+	if resourceOwner != "" && !sequence.enforceOwner {
 		sequence.aggregate.ResourceOwner = resourceOwner
 	}
 

--- a/internal/eventstore/v3/sequence_test.go
+++ b/internal/eventstore/v3/sequence_test.go
@@ -217,6 +217,86 @@ func Test_commandsToSequences(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "duplicate aggregate with enforcing command updates owner",
+			args: args{
+				ctx: context.Background(),
+				commands: []eventstore.Command{
+					&mockCommand{
+						aggregate: &eventstore.Aggregate{
+							ID:            "V3-bF0Sa",
+							Type:          "type",
+							ResourceOwner: "old",
+							InstanceID:    "instance",
+							Version:       "v1",
+						},
+					},
+					&enforcedMockCommand{
+						mockCommand: &mockCommand{
+							aggregate: &eventstore.Aggregate{
+								ID:            "V3-bF0Sa",
+								Type:          "type",
+								ResourceOwner: "new",
+								InstanceID:    "instance",
+								Version:       "v1",
+							},
+						},
+					},
+				},
+			},
+			want: []*latestSequence{
+				{
+					aggregate: &eventstore.Aggregate{
+						ID:            "V3-bF0Sa",
+						Type:          "type",
+						ResourceOwner: "new",
+						InstanceID:    "instance",
+						Version:       "v1",
+					},
+					enforceOwner: true,
+				},
+			},
+		},
+		{
+			name: "first command enforcing keeps owner for aggregate",
+			args: args{
+				ctx: context.Background(),
+				commands: []eventstore.Command{
+					&enforcedMockCommand{
+						mockCommand: &mockCommand{
+							aggregate: &eventstore.Aggregate{
+								ID:            "V3-3oEV1",
+								Type:          "type",
+								ResourceOwner: "new",
+								InstanceID:    "instance",
+								Version:       "v1",
+							},
+						},
+					},
+					&mockCommand{
+						aggregate: &eventstore.Aggregate{
+							ID:            "V3-3oEV1",
+							Type:          "type",
+							ResourceOwner: "ignored",
+							InstanceID:    "instance",
+							Version:       "v1",
+						},
+					},
+				},
+			},
+			want: []*latestSequence{
+				{
+					aggregate: &eventstore.Aggregate{
+						ID:            "V3-3oEV1",
+						Type:          "type",
+						ResourceOwner: "new",
+						InstanceID:    "instance",
+						Version:       "v1",
+					},
+					enforceOwner: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/repository/action/action.go
+++ b/internal/repository/action/action.go
@@ -40,6 +40,8 @@ type AddedEvent struct {
 	AllowedToFail bool          `json:"allowedToFail"`
 }
 
+func (*AddedEvent) EnforceResourceOwner() {}
+
 func (e *AddedEvent) Payload() interface{} {
 	return e
 }

--- a/internal/repository/group/group.go
+++ b/internal/repository/group/group.go
@@ -20,6 +20,8 @@ type GroupAddedEvent struct {
 	Description string `json:"description,omitempty"`
 }
 
+func (*GroupAddedEvent) EnforceResourceOwner() {}
+
 func NewGroupAddedEvent(
 	ctx context.Context,
 	aggregate *eventstore.Aggregate,

--- a/internal/repository/idpintent/intent.go
+++ b/internal/repository/idpintent/intent.go
@@ -53,6 +53,8 @@ func NewStartedEvent(
 	}
 }
 
+func (*StartedEvent) EnforceResourceOwner() {}
+
 func (e *StartedEvent) Payload() any {
 	return e
 }

--- a/internal/repository/project/project.go
+++ b/internal/repository/project/project.go
@@ -47,6 +47,8 @@ type ProjectAddedEvent struct {
 	PrivateLabelingSetting domain.PrivateLabelingSetting `json:"privateLabelingSetting,omitempty"`
 }
 
+func (*ProjectAddedEvent) EnforceResourceOwner() {}
+
 func (e *ProjectAddedEvent) Payload() interface{} {
 	return e
 }

--- a/internal/repository/user/human.go
+++ b/internal/repository/user/human.go
@@ -58,6 +58,8 @@ type HumanAddedEvent struct {
 	ChangeRequired bool                `json:"changeRequired,omitempty"`
 }
 
+func (*HumanAddedEvent) EnforceResourceOwner() {}
+
 func (e *HumanAddedEvent) Payload() interface{} {
 	return e
 }
@@ -166,6 +168,8 @@ type HumanRegisteredEvent struct {
 
 	UserAgentID string `json:"userAgentID,omitempty"`
 }
+
+func (*HumanRegisteredEvent) EnforceResourceOwner() {}
 
 func (e *HumanRegisteredEvent) Payload() interface{} {
 	return e

--- a/internal/repository/user/machine.go
+++ b/internal/repository/user/machine.go
@@ -25,6 +25,8 @@ type MachineAddedEvent struct {
 	AccessTokenType domain.OIDCTokenType `json:"accessTokenType,omitempty"`
 }
 
+func (*MachineAddedEvent) EnforceResourceOwner() {}
+
 func (e *MachineAddedEvent) Payload() interface{} {
 	return e
 }

--- a/internal/repository/user/schemauser/user.go
+++ b/internal/repository/user/schemauser/user.go
@@ -26,6 +26,8 @@ type CreatedEvent struct {
 	Data                  json.RawMessage `json:"user,omitempty"`
 }
 
+func (*CreatedEvent) EnforceResourceOwner() {}
+
 func (e *CreatedEvent) SetBaseEvent(event *eventstore.BaseEvent) {
 	e.BaseEvent = event
 }


### PR DESCRIPTION
# Which Problems Are Solved
Recreating an aggregate with a reused API-provided aggregate ID can inherit the previous aggregate's resource_owner from the eventstore.

This made valid recreate flows unsafe, as the new create event could be written under the old owner even if the object now belongs to a different entity.

# How the Problems Are Solved
Allow create commands for reusable aggregate IDs to explicitly reset the resource owner when an aggregate is recreated after deletion.
    
Add EnforceResourceOwnerCommand marker interface to allow repository objects to implicitly enforce a resource owner. Extend the v3 command payload with enforce_owner field.

How to identify the events that needs to implement the EnforceResourceOwnerCommand interface?

Only mark events that have the condition where the same aggregate ID can later be reused under a different owner:
like It must be have aggregate creation flow, reusable and can have different owners on recreate.

In command layer, looked for requests that accepts aggregate id, have event pushed with eventstore.Push(...) and this event must be the first event of a aggregate.
Child event objects can be ignored as they use the parent event decided aggregate id.


SQL changes:

set owner as:
    enforced_owner if any command in the batch is marked
    else current_owner from previous stored events
    else command_owner from the first command in that aggregate batch

- Closes #10799 
