### PR TITLE
fix(setup): add missing user: 0 to prodlike compose

### DIFF
--- a/deploy/compose/docker-compose.prodlike.yml
+++ b/deploy/compose/docker-compose.prodlike.yml
@@ -17,6 +17,7 @@ services:
   zitadel-setup:
     image: ghcr.io/zitadel/zitadel:${ZITADEL_VERSION}
     restart: "no"
+    user: "0"
     command: setup --masterkey "${ZITADEL_MASTERKEY}"
     environment:
       <<: *zitadel-db-env


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

The zitadel-setup service in `docker-compose.prodlike.yml` runs as the default zitadel user from the Docker image. This non-root user cannot write to the freshly-created zitadel-bootstrap Docker volume, whose mount point /zitadel/bootstrap is owned by root. The result is, that the `zitadel-setup` step fails migrating the DB on startup.

# How the Problems Are Solved

Add `user: 0` like it is done for the actual api.
