### PR TITLE
fix(api): add dummy implementation of new LinksSettings APIs to satisfy SettingsServiceHandler interface

### DIFF
--- a/internal/api/grpc/settings/v2/settings.go
+++ b/internal/api/grpc/settings/v2/settings.go
@@ -56,3 +56,23 @@ func (s *Server) DeleteOrganizationSettings(ctx context.Context, req *connect.Re
 		DeletionDate: deletionDate,
 	}), nil
 }
+
+func (s *Server) GetLinkSettings(ctx context.Context, req *connect.Request[settings.GetLinkSettingsRequest]) (*connect.Response[settings.GetLinkSettingsResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *Server) SetLinkSettings(ctx context.Context, req *connect.Request[settings.SetLinkSettingsRequest]) (*connect.Response[settings.SetLinkSettingsResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *Server) ResetLinkSettings(ctx context.Context, req *connect.Request[settings.ResetLinkSettingsRequest]) (*connect.Response[settings.ResetLinkSettingsResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *Server) GetEffectiveSettings(ctx context.Context, req *connect.Request[settings.GetEffectiveSettingsRequest]) (*connect.Response[settings.GetEffectiveSettingsResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/internal/api/grpc/settings/v2/settings.go
+++ b/internal/api/grpc/settings/v2/settings.go
@@ -58,21 +58,17 @@ func (s *Server) DeleteOrganizationSettings(ctx context.Context, req *connect.Re
 }
 
 func (s *Server) GetLinkSettings(ctx context.Context, req *connect.Request[settings.GetLinkSettingsRequest]) (*connect.Response[settings.GetLinkSettingsResponse], error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (s *Server) SetLinkSettings(ctx context.Context, req *connect.Request[settings.SetLinkSettingsRequest]) (*connect.Response[settings.SetLinkSettingsResponse], error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (s *Server) ResetLinkSettings(ctx context.Context, req *connect.Request[settings.ResetLinkSettingsRequest]) (*connect.Response[settings.ResetLinkSettingsResponse], error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (s *Server) GetEffectiveSettings(ctx context.Context, req *connect.Request[settings.GetEffectiveSettingsRequest]) (*connect.Response[settings.GetEffectiveSettingsResponse], error) {
-	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
# Which Problems Are Solved

#11975 introduces new APIs to `SettingsService`, however, `settingsconnect.SettingsServiceHandler` wasn't updated to satisfy the interface containing the new APIs.

# How the Problems Are Solved

By adding a dummy implementation of new RPC methods to the SettingsService Server.

# Additional Changes

n/a 

# Additional Context

n/a