### PR TITLE
fix(query): merge instance translations at org-level hosted login lookup

### DIFF
--- a/internal/api/grpc/settings/v2/integration_test/query_test.go
+++ b/internal/api/grpc/settings/v2/integration_test/query_test.go
@@ -429,6 +429,58 @@ func TestServer_GetHostedLoginTranslation(t *testing.T) {
 	}
 }
 
+// TestServer_GetHostedLoginTranslation_InheritsInstanceLevel verifies that a
+// translation set at instance level is returned when querying at organization
+// level with inheritance enabled. Regression test for the bug where the SQL
+// WHERE clause filtered strictly to the requested level, making the
+// instance→org merge branch unreachable.
+func TestServer_GetHostedLoginTranslation_InheritsInstanceLevel(t *testing.T) {
+	// Use a dedicated instance so other tests that write instance-level
+	// translations don't interfere with the assertions below.
+	instance := integration.NewInstance(CTX)
+	adminCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)
+
+	instanceTranslation := map[string]any{"loginTitle": "Login with Instance Branding"}
+	protoInstanceTranslation, err := structpb.NewStruct(instanceTranslation)
+	require.NoError(t, err)
+
+	_, err = instance.Client.SettingsV2.SetHostedLoginTranslation(adminCtx, &settings.SetHostedLoginTranslationRequest{
+		Level:        &settings.SetHostedLoginTranslationRequest_Instance{Instance: true},
+		Translations: protoInstanceTranslation,
+		Locale:       "en-US",
+	})
+	require.NoError(t, err)
+
+	// Reading at org level with inheritance enabled (the default) must
+	// return the instance-level override merged into the response. Before
+	// the fix this returned only the embedded system defaults.
+	res, err := instance.Client.SettingsV2.GetHostedLoginTranslation(adminCtx, &settings.GetHostedLoginTranslationRequest{
+		Level: &settings.GetHostedLoginTranslationRequest_OrganizationId{
+			OrganizationId: instance.DefaultOrg.GetId(),
+		},
+		Locale: "en-US",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.GetTranslations())
+	assert.Equal(t, "Login with Instance Branding", res.GetTranslations().GetFields()["loginTitle"].GetStringValue(),
+		"org-level lookup with inheritance must surface instance-level overrides")
+
+	// Reading at org level with ignore_inheritance=true must NOT return the
+	// instance-level override because nothing was set at org level.
+	resNoInherit, err := instance.Client.SettingsV2.GetHostedLoginTranslation(adminCtx, &settings.GetHostedLoginTranslationRequest{
+		Level: &settings.GetHostedLoginTranslationRequest_OrganizationId{
+			OrganizationId: instance.DefaultOrg.GetId(),
+		},
+		Locale:            "en-US",
+		IgnoreInheritance: true,
+	})
+	require.NoError(t, err)
+	if resNoInherit.GetTranslations() != nil {
+		_, hasKey := resNoInherit.GetTranslations().GetFields()["loginTitle"]
+		assert.False(t, hasKey, "ignore_inheritance=true must not leak instance-level translations")
+	}
+}
+
 func TestServer_ListOrganizationSettings(t *testing.T) {
 	instance := integration.NewInstance(CTX)
 	iamOwnerCtx := instance.WithAuthorizationToken(CTX, integration.UserTypeIAMOwner)

--- a/internal/query/hosted_login_translation.go
+++ b/internal/query/hosted_login_translation.go
@@ -128,13 +128,30 @@ func (q *Queries) GetHostedLoginTranslation(ctx context.Context, req *settings.G
 		sq.Eq{hostedLoginTranslationColLocale.identifier(): lang.String()},
 		sq.Eq{hostedLoginTranslationColLocale.identifier(): parentLang.String()},
 	}
-	eq := sq.Eq{
+	requestedLevelEq := sq.Eq{
 		hostedLoginTranslationColInstanceID.identifier():        inst.InstanceID(),
 		hostedLoginTranslationColResourceOwner.identifier():     levelID,
 		hostedLoginTranslationColResourceOwnerType.identifier(): resourceOwner,
 	}
 
-	query, args, err := stmt.Where(eq).Where(langORBaseLang).ToSql()
+	// When querying at organization level with inheritance enabled, also
+	// fetch the instance-level row so it can be merged into the organization
+	// translations further down. Without this, the downstream merge branch
+	// for the instance parent is dead code because the WHERE clause would
+	// only ever return rows for the organization.
+	var levelFilter sq.Sqlizer = requestedLevelEq
+	if resourceOwner == org.AggregateType && !req.GetIgnoreInheritance() {
+		levelFilter = sq.Or{
+			requestedLevelEq,
+			sq.Eq{
+				hostedLoginTranslationColInstanceID.identifier():        inst.InstanceID(),
+				hostedLoginTranslationColResourceOwner.identifier():     inst.InstanceID(),
+				hostedLoginTranslationColResourceOwnerType.identifier(): instance.AggregateType,
+			},
+		}
+	}
+
+	query, args, err := stmt.Where(levelFilter).Where(langORBaseLang).ToSql()
 	if err != nil {
 		logging.WithError(err).Error("unable to generate sql statement")
 		return nil, zerrors.ThrowInternal(err, "QUERY-ZgCMux", "Errors.Query.SQLStatement")
@@ -207,15 +224,17 @@ func getSystemTranslation(lang, instanceDefaultLang language.Tag) (map[string]an
 }
 
 func prepareHostedLoginTranslationQuery() (sq.SelectBuilder, func(*sql.Rows) ([]*HostedLoginTranslation, error)) {
+	// Up to 4 rows can legitimately match: 2 levels (requested + parent
+	// instance) × 2 locales (requested lang + its parent lang).
 	return sq.Select(
 			hostedLoginTranslationColFile.identifier(),
 			hostedLoginTranslationColResourceOwnerType.identifier(),
 			hostedLoginTranslationColEtag.identifier(),
 		).From(hostedLoginTranslationTable.identifier()).
-			Limit(2).
+			Limit(4).
 			PlaceholderFormat(sq.Dollar),
 		func(r *sql.Rows) ([]*HostedLoginTranslation, error) {
-			translations := make([]*HostedLoginTranslation, 0, 2)
+			translations := make([]*HostedLoginTranslation, 0, 4)
 			for r.Next() {
 				var rawTranslation json.RawMessage
 				translation := &HostedLoginTranslation{}

--- a/internal/query/hosted_login_translation_test.go
+++ b/internal/query/hosted_login_translation_test.go
@@ -132,13 +132,29 @@ func TestGetTranslationOutput(t *testing.T) {
 }
 
 func TestGetHostedLoginTranslation(t *testing.T) {
-	query := `SELECT projections.hosted_login_translations.file, projections.hosted_login_translations.aggregate_type, projections.hosted_login_translations.etag
+	// Query used when requesting at organization level with inheritance
+	// enabled: the WHERE clause matches either the org row or the instance
+	// row so that the instance-level translations can be merged in.
+	orgWithInheritanceQuery := `SELECT projections.hosted_login_translations.file, projections.hosted_login_translations.aggregate_type, projections.hosted_login_translations.etag
+	FROM projections.hosted_login_translations
+	WHERE (projections.hosted_login_translations.aggregate_id = $1
+		AND projections.hosted_login_translations.aggregate_type = $2
+		AND projections.hosted_login_translations.instance_id = $3
+		OR projections.hosted_login_translations.aggregate_id = $4
+		AND projections.hosted_login_translations.aggregate_type = $5
+		AND projections.hosted_login_translations.instance_id = $6)
+	AND (projections.hosted_login_translations.locale = $7 OR projections.hosted_login_translations.locale = $8)
+	LIMIT 4`
+
+	// Query used when inheritance is disabled or when requesting at
+	// instance level (no parent level exists to merge).
+	singleLevelQuery := `SELECT projections.hosted_login_translations.file, projections.hosted_login_translations.aggregate_type, projections.hosted_login_translations.etag
 	FROM projections.hosted_login_translations
 	WHERE projections.hosted_login_translations.aggregate_id = $1
 	AND projections.hosted_login_translations.aggregate_type = $2
 	AND projections.hosted_login_translations.instance_id = $3
 	AND (projections.hosted_login_translations.locale = $4 OR projections.hosted_login_translations.locale = $5)
-	LIMIT 2`
+	LIMIT 4`
 	okTranslation := defaultLoginTranslations
 
 	parsedOKTranslation := map[string]map[string]any{}
@@ -216,8 +232,8 @@ func TestGetHostedLoginTranslation(t *testing.T) {
 			defaultInstanceLanguage: language.English,
 			sqlExpectations: []mock.Expectation{
 				mock.ExpectQuery(
-					query,
-					mock.WithQueryArgs("123", "org", "instance-id", "en-US", "en"),
+					orgWithInheritanceQuery,
+					mock.WithQueryArgs("123", "org", "instance-id", "instance-id", "instance", "instance-id", "en-US", "en"),
 					mock.WithQueryErr(sql.ErrConnDone),
 				),
 			},
@@ -236,8 +252,8 @@ func TestGetHostedLoginTranslation(t *testing.T) {
 			defaultInstanceLanguage: language.English,
 			sqlExpectations: []mock.Expectation{
 				mock.ExpectQuery(
-					query,
-					mock.WithQueryArgs("123", "org", "instance-id", "en-US", "en"),
+					orgWithInheritanceQuery,
+					mock.WithQueryArgs("123", "org", "instance-id", "instance-id", "instance", "instance-id", "en-US", "en"),
 					mock.WithQueryResult(
 						[]string{"file", "aggregate_type", "etag"},
 						[][]driver.Value{},
@@ -262,7 +278,7 @@ func TestGetHostedLoginTranslation(t *testing.T) {
 			defaultInstanceLanguage: language.English,
 			sqlExpectations: []mock.Expectation{
 				mock.ExpectQuery(
-					query,
+					singleLevelQuery,
 					mock.WithQueryArgs("123", "org", "instance-id", "en-US", "en"),
 					mock.WithQueryResult(
 						[]string{"file", "aggregate_type", "etag"},
@@ -289,8 +305,8 @@ func TestGetHostedLoginTranslation(t *testing.T) {
 			defaultInstanceLanguage: language.English,
 			sqlExpectations: []mock.Expectation{
 				mock.ExpectQuery(
-					query,
-					mock.WithQueryArgs("123", "org", "instance-id", "en-US", "en"),
+					orgWithInheritanceQuery,
+					mock.WithQueryArgs("123", "org", "instance-id", "instance-id", "instance", "instance-id", "en-US", "en"),
 					mock.WithQueryResult(
 						[]string{"file", "aggregate_type", "etag"},
 						[][]driver.Value{
@@ -311,6 +327,72 @@ func TestGetHostedLoginTranslation(t *testing.T) {
 				Etag:         "etag-org",
 				Translations: protoDefaultWithDBTranslation,
 			},
+		},
+		{
+			testName: "when only instance row exists should merge it into empty org result",
+
+			defaultInstanceLanguage: language.English,
+			sqlExpectations: []mock.Expectation{
+				mock.ExpectQuery(
+					orgWithInheritanceQuery,
+					mock.WithQueryArgs("123", "org", "instance-id", "instance-id", "instance", "instance-id", "en-US", "en"),
+					mock.WithQueryResult(
+						[]string{"file", "aggregate_type", "etag"},
+						[][]driver.Value{
+							{[]byte(`{"test2": "translation2"}`), "instance", "etag-instance"},
+						},
+					),
+				),
+			},
+			inputRequest: &settings.GetHostedLoginTranslationRequest{
+				Locale: "en-US",
+				Level: &settings.GetHostedLoginTranslationRequest_OrganizationId{
+					OrganizationId: "123",
+				},
+			},
+
+			expectedResult: func() *settings.GetHostedLoginTranslationResponse {
+				merged := maps.Clone(parsedOKTranslation["en"])
+				merged["test2"] = "translation2"
+				proto, err := structpb.NewStruct(merged)
+				require.NoError(t, err)
+				return &settings.GetHostedLoginTranslationResponse{
+					Etag:         "etag-instance",
+					Translations: proto,
+				}
+			}(),
+		},
+		{
+			testName: "when instance level requested should use single-level query",
+
+			defaultInstanceLanguage: language.English,
+			sqlExpectations: []mock.Expectation{
+				mock.ExpectQuery(
+					singleLevelQuery,
+					mock.WithQueryArgs("instance-id", "instance", "instance-id", "en-US", "en"),
+					mock.WithQueryResult(
+						[]string{"file", "aggregate_type", "etag"},
+						[][]driver.Value{
+							{[]byte(`{"test2": "translation2"}`), "instance", "etag-instance"},
+						},
+					),
+				),
+			},
+			inputRequest: &settings.GetHostedLoginTranslationRequest{
+				Locale: "en-US",
+				Level:  &settings.GetHostedLoginTranslationRequest_Instance{Instance: true},
+			},
+
+			expectedResult: func() *settings.GetHostedLoginTranslationResponse {
+				merged := maps.Clone(parsedOKTranslation["en"])
+				merged["test2"] = "translation2"
+				proto, err := structpb.NewStruct(merged)
+				require.NoError(t, err)
+				return &settings.GetHostedLoginTranslationResponse{
+					Etag:         "etag-instance",
+					Translations: proto,
+				}
+			}(),
 		},
 	}
 


### PR DESCRIPTION
# Which Problems Are Solved

`GetHostedLoginTranslation` does not apply instance-level translations when called at organization level with inheritance enabled (the default). As a result, customization set via `SetHostedLoginTranslation` at instance level silently has no effect on any login flow whose URL carries an `organization=<id>` query parameter — e.g. email verification links produced by `send_invite_code`, or any OIDC authorization request that pins the organization.

Reproduction (against any ZITADEL instance):

1. `PUT /v2/settings/hosted_login_translation` at instance level with `{"common":{"title":"Login with Acme"}, "register":{"description":"Create your Acme account."}}`.
2. `GET /v2/settings/hosted_login_translation?instance=true&locale=en` → returns the Acme strings. ✅
3. `GET /v2/settings/hosted_login_translation?organizationId=<default-org>&locale=en` → returns the embedded `v2-default.json` "Zitadel" strings, **not** the instance-level overrides. ❌
4. The login v2 Next.js app forwards the URL `organization` query param as the `x-zitadel-i18n-organization` header (`apps/login/src/proxy.ts:37-40`), so `i18n/request.ts` fetches translations at org level and the user sees the default ZITADEL branding instead of the configured override.

# How the Problems Are Solved

Root cause is in `internal/query/hosted_login_translation.go`. The WHERE clause of the translation lookup filtered strictly to the requested level:

```go
eq := sq.Eq{
    hostedLoginTranslationColInstanceID.identifier():        inst.InstanceID(),
    hostedLoginTranslationColResourceOwner.identifier():     levelID,
    hostedLoginTranslationColResourceOwnerType.identifier(): resourceOwner,
}
```

When `resourceOwner = "org"`, the query can only ever return org-level rows. The code then loops over the rows looking for one to assign to `parentTranslation`, and further down attempts to merge it in:

```go
if parentTranslation != nil && parentTranslation.LevelType == instance.AggregateType {
    mergo.Merge(&requestedTranslation.File, parentTranslation.File)
}
```

But this branch is unreachable in production — `parentTranslation` is always the zero value because the WHERE filter excluded the instance row. The `.Limit(2)` on the prepared statement and the loop's two-slot design (`requestedTranslation` + `parentTranslation`) reveal the original intent: fetch one row per level and merge them.

This PR rewrites the WHERE clause so that, **when requesting at organization level with inheritance enabled**, it also matches the instance-level row:

```go
levelFilter := sq.Sqlizer(requestedLevelEq)
if resourceOwner == org.AggregateType && !req.GetIgnoreInheritance() {
    levelFilter = sq.Or{
        requestedLevelEq,
        sq.Eq{
            ...: inst.InstanceID(),
            ...: inst.InstanceID(),
            ...: instance.AggregateType,
        },
    }
}
```

Instance-level requests and `ignore_inheritance=true` requests are unchanged — they keep the original single-level filter. The existing downstream merge code now receives the instance row it was always expecting and does the right thing.

The query `Limit` is bumped from `2` to `4` so it has headroom for up to two levels × two locales (requested lang + parent lang), matching the existing locale fallback in the WHERE clause.

# Additional Changes

- Updated `internal/query/hosted_login_translation_test.go` to reflect the new SQL shape. The existing tests' `WithQueryResult` mocks already returned both an org and an instance row, so they pass the inheritance merge without any behavioural change — only the expected SQL string and arg order needed updating.
- Added two new unit test cases:
  - `when only instance row exists should merge it into empty org result` — exercises the previously-dead merge branch with a realistic "admin set at instance, nothing at org" setup.
  - `when instance level requested should use single-level query` — guards against accidentally forcing instance-level lookups through the OR-form filter.
- Added an integration test `TestServer_GetHostedLoginTranslation_InheritsInstanceLevel` in `internal/api/grpc/settings/v2/integration_test/query_test.go` that exercises the full end-to-end path: `SetHostedLoginTranslation` at instance level on a dedicated instance, then `GetHostedLoginTranslation` at org level and assert the key is present; and one assertion that `ignore_inheritance=true` does not leak the instance-level key into the org-level response.

# Additional Context

- The bug was observed in production on v4.12.0 while customizing the Login v2 branding via Settings v2 API. Users following the documented flow (PR #11849 / [text customization docs](https://zitadel.com/docs/guides/integrate/login-ui/text-customization)) would see their overrides applied on `/ui/v2/login/register` but ignored on any URL that includes an `organization` parameter — e.g. email verification links and most OIDC redirects to `/login`.
- The existing unit test at `internal/query/hosted_login_translation_test.go:286-314` masked the bug because it fed the `sqlmock` both an org row and an instance row regardless of the WHERE clause. The test passed while the production query could never return the instance row.
- No upstream issue existed at time of filing — searched `hosted_login_translation`, `hosted login translation`, `login v2 translation`, `SetHostedLoginTranslation`, and inheritance-related terms. Happy to open a tracking issue if preferred.
- This fixes only the instance→org inheritance path. Customizations set at `SetCustomLoginText` (the v1 API) are a separate path and are not addressed here — see #11772 for that.
