### PR TITLE
fix(idp): pass PKCE option in OAuth/OIDC ToProvider for Login V2

### DIFF
--- a/internal/command/idp_model.go
+++ b/internal/command/idp_model.go
@@ -192,6 +192,9 @@ func (wm *OAuthIDPWriteModel) ToProvider(callbackURL string, idpAlg crypto.Encry
 	if wm.IsAutoUpdate {
 		opts = append(opts, oauth.WithAutoUpdate())
 	}
+	if wm.UsePKCE {
+		opts = append(opts, oauth.WithRelyingPartyOption(rp.WithPKCE(nil)))
+	}
 	return oauth.New(
 		config,
 		wm.Name,
@@ -398,6 +401,9 @@ func (wm *OIDCIDPWriteModel) ToProvider(callbackURL string, idpAlg crypto.Encryp
 	}
 	if wm.IsAutoUpdate {
 		opts = append(opts, oidc.WithAutoUpdate())
+	}
+	if wm.UsePKCE {
+		opts = append(opts, oidc.WithRelyingPartyOption(rp.WithPKCE(nil)))
 	}
 	return oidc.New(
 		wm.Name,


### PR DESCRIPTION
## Summary

When a Generic OIDC or OAuth IdP is configured with **Use PKCE** enabled, the Login V2 (intent-based) flow does not send `code_challenge` in the authorize request. This causes `code_challenge is required (PKCE)` errors from IdPs that enforce PKCE.

## Root Cause

The Login V1 handler in `external_provider_handler.go` explicitly checks `UsePKCE` and passes `rp.WithPKCE(nil)` when constructing the provider:

https://github.com/zitadel/zitadel/blob/bb3b52dda/internal/api/ui/login/external_provider_handler.go#L1071-L1074

https://github.com/zitadel/zitadel/blob/bb3b52dda/internal/api/ui/login/external_provider_handler.go#L1115-L1118

The `ToProvider()` methods on `OAuthIDPWriteModel` and `OIDCIDPWriteModel` (used by the V2 API / intent flow via `Commands.GetProvider()`) never include this option, so PKCE is silently skipped regardless of the `UsePKCE` flag.

## Fix

Add the missing `rp.WithPKCE(nil)` option in both `OAuthIDPWriteModel.ToProvider()` and `OIDCIDPWriteModel.ToProvider()` when `wm.UsePKCE` is true, matching the existing Login V1 behaviour.

## Changes

- `internal/command/idp_model.go`: +3 lines in each of the two `ToProvider()` methods (6 lines total)

## Testing

Verified against a custom OIDC IdP that unconditionally requires PKCE. Before the fix, clicking the IdP button returned `code_challenge is required (PKCE)`. After the fix, the authorize request includes `code_challenge` and the flow completes.