### PR TITLE
fix(grpc): increase MaxSendMsgSize

### DIFF
--- a/internal/api/grpc/server/gateway.go
+++ b/internal/api/grpc/server/gateway.go
@@ -132,7 +132,7 @@ func CreateGatewayWithPrefix(
 			client_middleware.UnaryActivityClientInterceptor(),
 		),
 		grpc.WithStatsHandler(client_middleware.DefaultTracingClient()),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10 * 1024 * 1024)), // Increase to 10MB for exports
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxSendMsgSize)),
 	}
 	connection, err := dial(ctx, port, opts)
 	if err != nil {
@@ -160,7 +160,7 @@ func CreateGateway(
 				client_middleware.UnaryActivityClientInterceptor(),
 			),
 			grpc.WithStatsHandler(client_middleware.DefaultTracingClient()),
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10 * 1024 * 1024)), // Increase to 10MB for exports
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxSendMsgSize)),
 		})
 	if err != nil {
 		return nil, err

--- a/internal/api/grpc/server/gateway.go
+++ b/internal/api/grpc/server/gateway.go
@@ -132,6 +132,7 @@ func CreateGatewayWithPrefix(
 			client_middleware.UnaryActivityClientInterceptor(),
 		),
 		grpc.WithStatsHandler(client_middleware.DefaultTracingClient()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10 * 1024 * 1024)), // Increase to 10MB for exports
 	}
 	connection, err := dial(ctx, port, opts)
 	if err != nil {
@@ -159,6 +160,7 @@ func CreateGateway(
 				client_middleware.UnaryActivityClientInterceptor(),
 			),
 			grpc.WithStatsHandler(client_middleware.DefaultTracingClient()),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10 * 1024 * 1024)), // Increase to 10MB for exports
 		})
 	if err != nil {
 		return nil, err

--- a/internal/api/grpc/server/server.go
+++ b/internal/api/grpc/server/server.go
@@ -90,6 +90,7 @@ func CreateServer(
 			),
 		),
 		grpc.StatsHandler(middleware.DefaultTracingServer()),
+		grpc.MaxSendMsgSize(10 * 1024 * 1024), // Increase to 10MB for exports
 	}
 	if tlsConfig != nil {
 		serverOptions = append(serverOptions, grpc.Creds(credentials.NewTLS(tlsConfig)))

--- a/internal/api/grpc/server/server.go
+++ b/internal/api/grpc/server/server.go
@@ -24,6 +24,10 @@ import (
 	system_pb "github.com/zitadel/zitadel/pkg/grpc/system"
 )
 
+const (
+	MaxSendMsgSize = 10 * 1024 * 1024 // 10MiB, global value required for exports.
+)
+
 type Server interface {
 	AppName() string
 	MethodPrefix() string
@@ -90,7 +94,7 @@ func CreateServer(
 			),
 		),
 		grpc.StatsHandler(middleware.DefaultTracingServer()),
-		grpc.MaxSendMsgSize(10 * 1024 * 1024), // Increase to 10MB for exports
+		grpc.MaxSendMsgSize(MaxSendMsgSize),
 	}
 	if tlsConfig != nil {
 		serverOptions = append(serverOptions, grpc.Creds(credentials.NewTLS(tlsConfig)))


### PR DESCRIPTION
# Which Problems Are Solved

Users exporting larger orgsanizations were facing grpc message size limits of 4 MiB, while trying to export 6.3 MiB of data. Other export methods like S3 aren't implemented.

# How the Problems Are Solved

Set MaxSendMsgSize to 10 MiB (allow some overhead). This is not a long-term solution and we should investigate better ways of export.

# Additional Changes

- none

# Additional Context

- Support ticket
