### PR TITLE
chore: upgrade oidc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/veqryn/slog-context/otel v0.9.0
 	github.com/zitadel/exifremove v0.1.0
 	github.com/zitadel/logging v0.7.0
-	github.com/zitadel/oidc/v3 v3.47.0
+	github.com/zitadel/oidc/v3 v3.47.3
 	github.com/zitadel/passwap v0.11.0
 	github.com/zitadel/saml v0.4.1
 	github.com/zitadel/schema v1.3.2
@@ -133,7 +133,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
-	golang.org/x/text v0.35.0
+	golang.org/x/text v0.36.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -839,6 +839,8 @@ github.com/zitadel/logging v0.7.0 h1:eugftwMM95Wgqwftsvj81isL0JK/hoScVqp/7iA2adQ
 github.com/zitadel/logging v0.7.0/go.mod h1:9A6h9feBF/3u0IhA4uffdzSDY7mBaf7RE78H5sFMINQ=
 github.com/zitadel/oidc/v3 v3.47.0 h1:ryH8tWkBZ+WHFYi//uoeW2mjg/PsV8YVcMn/GQyqhZI=
 github.com/zitadel/oidc/v3 v3.47.0/go.mod h1:xhsEkuRmwxuU7elQ1isxIou983rEJAJdM7fCQnJq2lQ=
+github.com/zitadel/oidc/v3 v3.47.3 h1:Dz7XzjTf+SJLg8BjjeABCmYZOqXOReLJdWbWGVHOZQo=
+github.com/zitadel/oidc/v3 v3.47.3/go.mod h1:XxFh0666HRXycyrKmono+3gY0RACpYJLgy4r/+kliKY=
 github.com/zitadel/passwap v0.11.0 h1:EL1A8dWz83xiJYru2326i+chkVKVR7YZq5Wep1GKQ3k=
 github.com/zitadel/passwap v0.11.0/go.mod h1:Jn7sqawaxrwRL24byEJ1CVIAmznR6LsMsKcCfO/dIsg=
 github.com/zitadel/saml v0.4.1 h1:4PPOAvnUFcfwOFIAFZ3oGTMD+tKVeF96ySfGBf5j3IU=
@@ -1096,6 +1098,8 @@ golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=

--- a/internal/api/oidc/integration_test/auth_request_test.go
+++ b/internal/api/oidc/integration_test/auth_request_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	armPasskey  = []string{oidc_api.UserPresence, oidc_api.MFA}
+	armPasskey  = oidc.AuthenticationMethodsReferences{oidc_api.UserPresence, oidc_api.MFA}
 	armPassword = []string{oidc_api.PWD}
 )
 
@@ -697,7 +697,7 @@ func assertTokens(t *testing.T, tokens *oidc.Tokens[*oidc.IDTokenClaims], requir
 	assert.Empty(t, tokens.Extra("state"))
 }
 
-func assertIDTokenClaims(t *testing.T, claims *oidc.IDTokenClaims, userID string, arm []string, sessionStart, sessionChange time.Time, sessionID string) {
+func assertIDTokenClaims(t *testing.T, claims *oidc.IDTokenClaims, userID string, arm oidc.AuthenticationMethodsReferences, sessionStart, sessionChange time.Time, sessionID string) {
 	assert.Equal(t, userID, claims.Subject)
 	assert.Equal(t, arm, claims.AuthenticationMethodsReferences)
 	assertOIDCTimeRange(t, claims.AuthTime, sessionStart, sessionChange)


### PR DESCRIPTION
# Which Problems Are Solved

Upgrade OIDC library to its latest version.

# How the Problems Are Solved
Upgraded oidc to [v3.47.3](https://github.com/zitadel/oidc/releases/tag/v3.47.3)

# Additional Changes
Upgraded golang.org/x/text to v0.36.0

# Additional Context

