### PR TITLE
docs(api): remove incorrect note on CreateInviteCode endpoint

### DIFF
--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -1784,7 +1784,7 @@ service UserService {
   // Create an invite code for a user
   //
   // Create an invite code for a user to initialize their first authentication method (password, passkeys, IdP) depending on the organization's available methods.
-  // If an invite code has been created previously, it's url template and application name will be used as defaults for the new code.
+  // If an invite code has been created previously, its URL template and application name will be used as defaults for the new code.
   // The new code will overwrite the previous one and make it invalid.
   rpc CreateInviteCode (CreateInviteCodeRequest) returns (CreateInviteCodeResponse) {
     option (google.api.http) = {

--- a/proto/zitadel/user/v2/user_service.proto
+++ b/proto/zitadel/user/v2/user_service.proto
@@ -1786,7 +1786,6 @@ service UserService {
   // Create an invite code for a user to initialize their first authentication method (password, passkeys, IdP) depending on the organization's available methods.
   // If an invite code has been created previously, it's url template and application name will be used as defaults for the new code.
   // The new code will overwrite the previous one and make it invalid.
-  // Note: It is possible to reissue a new code only when the previous code has expired, or when the user provides a wrong code three or more times during verification.
   rpc CreateInviteCode (CreateInviteCodeRequest) returns (CreateInviteCodeResponse) {
     option (google.api.http) = {
       post: "/v2/users/{user_id}/invite_code"


### PR DESCRIPTION
# Which Problems Are Solved

The CreateInviteCode endpoint wrongly stated that a new code can only be issued if the old had expired or was invalidated due to too many attempts, which is not true.

# How the Problems Are Solved

Removed the note from the proto / API documentation.

# Additional Changes

None

# Additional Context

- noticed by a customer
- requires backport to v4.x