### PR TITLE
feat(eventstore): add safe events2 cleanup command

### DIFF
--- a/cmd/eventstore/cleanup.go
+++ b/cmd/eventstore/cleanup.go
@@ -1,0 +1,205 @@
+package eventstore
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/zitadel/zitadel/internal/database"
+)
+
+//go:embed sql/cleanup_events2_count.sql
+var cleanupEvents2CountSQL string
+
+//go:embed sql/cleanup_events2_delete.sql
+var cleanupEvents2DeleteSQL string
+
+type cleanupEvents2Config struct {
+	Database database.Config
+}
+
+type cleanupSummary struct {
+	EventType      string
+	RowCount       int64
+	AggregateCount int64
+}
+
+func cleanupEvents2Cmd() *cobra.Command {
+	var (
+		execute    bool
+		olderThan  time.Duration
+		batchSize  int
+		maxBatches int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "purge terminal auth-flow history from eventstore.events2",
+		Long: `Purges terminal auth-flow aggregates from eventstore.events2 once their live state has
+already been materialized elsewhere and the configured retention period has elapsed.
+
+This only purges oidc_session aggregates after their current access token and current
+refresh token are no longer usable. It intentionally excludes session and session_logout
+aggregates because their events still participate in live token or logout validation.
+
+Without --execute, the command performs a dry run and only prints what would be deleted.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if olderThan <= 0 {
+				return fmt.Errorf("--older-than must be greater than 0")
+			}
+			if batchSize <= 0 {
+				return fmt.Errorf("--batch-size must be greater than 0")
+			}
+			if maxBatches < 0 {
+				return fmt.Errorf("--max-batches must be 0 or greater")
+			}
+
+			cfg, err := readCleanupEvents2Config(viper.GetViper())
+			if err != nil {
+				return fmt.Errorf("read config: %w", err)
+			}
+
+			db, err := database.Connect(cfg.Database, false)
+			if err != nil {
+				return fmt.Errorf("connect database: %w", err)
+			}
+			defer db.Close()
+
+			cutoff := time.Now().UTC().Add(-olderThan)
+			fmt.Fprintf(cmd.OutOrStdout(), "cutoff=%s execute=%t batch_size=%d max_batches=%d\n", cutoff.Format(time.RFC3339), execute, batchSize, maxBatches)
+
+			if !execute {
+				summaries, err := queryCleanupSummaries(cmd.Context(), db, cleanupEvents2CountSQL, cutoff)
+				if err != nil {
+					return err
+				}
+				printCleanupSummaries(cmd, "dry-run", summaries)
+				return nil
+			}
+
+			var (
+				allSummaries []cleanupSummary
+				batchesRun   int
+			)
+
+			for maxBatches == 0 || batchesRun < maxBatches {
+				summaries, err := queryCleanupSummaries(cmd.Context(), db, cleanupEvents2DeleteSQL, cutoff, batchSize)
+				if err != nil {
+					return err
+				}
+				if totalRows(summaries) == 0 {
+					break
+				}
+				allSummaries = append(allSummaries, summaries...)
+				batchesRun++
+				printCleanupSummaries(cmd, fmt.Sprintf("batch=%d", batchesRun), summaries)
+			}
+
+			if batchesRun == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no eligible rows found")
+				return nil
+			}
+
+			printCleanupSummaries(cmd, "deleted", mergeCleanupSummaries(allSummaries))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&execute, "execute", false, "delete eligible rows instead of performing a dry run")
+	cmd.Flags().DurationVar(&olderThan, "older-than", 0, "only delete aggregates whose terminal event is older than this duration")
+	cmd.Flags().IntVar(&batchSize, "batch-size", 1000, "maximum number of aggregates to delete per batch")
+	cmd.Flags().IntVar(&maxBatches, "max-batches", 0, "maximum number of delete batches to run; 0 means until no eligible rows remain")
+
+	return cmd
+}
+
+func readCleanupEvents2Config(v *viper.Viper) (*cleanupEvents2Config, error) {
+	cfg := new(cleanupEvents2Config)
+	if err := v.Unmarshal(cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		database.DecodeHook(false),
+	))); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func queryCleanupSummaries(ctx context.Context, db *database.DB, query string, args ...any) ([]cleanupSummary, error) {
+	summaries := make([]cleanupSummary, 0)
+	err := db.QueryContext(ctx, func(rows *sql.Rows) error {
+		for rows.Next() {
+			var summary cleanupSummary
+			if err := rows.Scan(&summary.EventType, &summary.RowCount, &summary.AggregateCount); err != nil {
+				return err
+			}
+			summaries = append(summaries, summary)
+		}
+		return rows.Err()
+	}, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return summaries, nil
+}
+
+func printCleanupSummaries(cmd *cobra.Command, label string, summaries []cleanupSummary) {
+	summaries = mergeCleanupSummaries(summaries)
+	if len(summaries) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s rows=0 aggregates=0\n", label)
+		return
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s rows=%d aggregates=%d\n", label, totalRows(summaries), totalAggregates(summaries))
+	for _, summary := range summaries {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s rows=%d aggregates=%d\n", summary.EventType, summary.RowCount, summary.AggregateCount)
+	}
+}
+
+func mergeCleanupSummaries(summaries []cleanupSummary) []cleanupSummary {
+	merged := make(map[string]cleanupSummary, len(summaries))
+	for _, summary := range summaries {
+		current := merged[summary.EventType]
+		current.EventType = summary.EventType
+		current.RowCount += summary.RowCount
+		current.AggregateCount += summary.AggregateCount
+		merged[summary.EventType] = current
+	}
+
+	result := make([]cleanupSummary, 0, len(merged))
+	for _, summary := range merged {
+		result = append(result, summary)
+	}
+	slices.SortFunc(result, func(a, b cleanupSummary) int {
+		switch {
+		case a.EventType < b.EventType:
+			return -1
+		case a.EventType > b.EventType:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return result
+}
+
+func totalRows(summaries []cleanupSummary) int64 {
+	var total int64
+	for _, summary := range summaries {
+		total += summary.RowCount
+	}
+	return total
+}
+
+func totalAggregates(summaries []cleanupSummary) int64 {
+	var total int64
+	for _, summary := range summaries {
+		total += summary.AggregateCount
+	}
+	return total
+}

--- a/cmd/eventstore/cleanup_test.go
+++ b/cmd/eventstore/cleanup_test.go
@@ -1,0 +1,40 @@
+package eventstore
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanupSQLTargetsOnlySafeTerminalAggregates(t *testing.T) {
+	for _, sqlText := range []string{cleanupEvents2CountSQL, cleanupEvents2DeleteSQL} {
+		for _, forbidden := range []string{
+			"'session'",
+			"'session_logout'",
+			"'auth_request.code.exchanged'",
+		} {
+			if strings.Contains(sqlText, forbidden) {
+				t.Fatalf("cleanup SQL must not target %s", forbidden)
+			}
+		}
+
+		for _, required := range []string{
+			"'auth_request.failed'",
+			"'auth_request.succeeded'",
+			"'device.authorization.canceled'",
+			"'device.authorization.done'",
+			"'idpintent.consumed'",
+			"'idpintent.failed'",
+			"'oidc_session'",
+			"'oidc_session.access_token.added'",
+			"'oidc_session.refresh_token.added'",
+			"'oidc_session.refresh_token.renewed'",
+			"'oidc_session.refresh_token.revoked'",
+			"'saml_request.failed'",
+			"'saml_request.succeeded'",
+		} {
+			if !strings.Contains(sqlText, required) {
+				t.Fatalf("cleanup SQL must include %s", required)
+			}
+		}
+	}
+}

--- a/cmd/eventstore/eventstore.go
+++ b/cmd/eventstore/eventstore.go
@@ -1,0 +1,24 @@
+package eventstore
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	eventstoreCMD := &cobra.Command{
+		Use:   "eventstore",
+		Short: "eventstore maintenance commands",
+		Long:  `eventstore maintenance commands`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("no additional command provided")
+		},
+	}
+
+	eventstoreCMD.AddCommand(
+		cleanupEvents2Cmd(),
+	)
+
+	return eventstoreCMD
+}

--- a/cmd/eventstore/sql/cleanup_events2_count.sql
+++ b/cmd/eventstore/sql/cleanup_events2_count.sql
@@ -1,0 +1,195 @@
+WITH current_state_floor AS (
+    SELECT
+        instance_id,
+        MIN(position) AS floor_position
+    FROM projections.current_states
+    WHERE instance_id <> ''
+      AND position IS NOT NULL
+    GROUP BY instance_id
+),
+latest_events AS (
+    SELECT DISTINCT ON (instance_id, aggregate_type, aggregate_id)
+        instance_id,
+        aggregate_type,
+        aggregate_id,
+        event_type AS last_event_type,
+        created_at AS last_created_at,
+        position AS last_position
+    FROM eventstore.events2
+    WHERE aggregate_type IN (
+        'auth_request',
+        'device_auth',
+        'idpintent',
+        'oidc_session',
+        'saml_request'
+    )
+    ORDER BY instance_id, aggregate_type, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_access_added AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'lifetime')::bigint, 0) AS lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.access_token.added'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_access_revoked AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.access_token.revoked'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_added AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'lifetime')::bigint, 0) AS lifetime_ns,
+        COALESCE((payload->>'idleLifetime')::bigint, 0) AS idle_lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.added'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_renewed AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'idleLifetime')::bigint, 0) AS idle_lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.renewed'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_revoked AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.revoked'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+terminal_candidates AS (
+    SELECT
+        le.instance_id,
+        le.aggregate_type,
+        le.aggregate_id
+    FROM latest_events le
+    JOIN current_state_floor cs
+        ON cs.instance_id = le.instance_id
+    WHERE le.aggregate_type <> 'oidc_session'
+      AND le.last_created_at < $1
+      AND le.last_position <= cs.floor_position
+      AND (
+          (le.aggregate_type = 'auth_request' AND le.last_event_type IN (
+              'auth_request.failed',
+              'auth_request.succeeded'
+          ))
+          OR (le.aggregate_type = 'saml_request' AND le.last_event_type IN (
+              'saml_request.failed',
+              'saml_request.succeeded'
+          ))
+          OR (le.aggregate_type = 'device_auth' AND le.last_event_type IN (
+              'device.authorization.canceled',
+              'device.authorization.done'
+          ))
+          OR (le.aggregate_type = 'idpintent' AND le.last_event_type IN (
+              'idpintent.consumed',
+              'idpintent.failed'
+          ))
+      )
+),
+oidc_session_candidates AS (
+    SELECT
+        le.instance_id,
+        le.aggregate_type,
+        le.aggregate_id
+    FROM latest_events le
+    JOIN current_state_floor cs
+        ON cs.instance_id = le.instance_id
+    LEFT JOIN latest_oidc_access_added aaa
+        ON aaa.instance_id = le.instance_id
+       AND aaa.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_access_revoked aar
+        ON aar.instance_id = le.instance_id
+       AND aar.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_added rta
+        ON rta.instance_id = le.instance_id
+       AND rta.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_renewed rtr
+        ON rtr.instance_id = le.instance_id
+       AND rtr.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_revoked rrv
+        ON rrv.instance_id = le.instance_id
+       AND rrv.aggregate_id = le.aggregate_id
+    CROSS JOIN LATERAL (
+        SELECT
+            CASE
+                WHEN aaa.created_at IS NULL
+                    AND aar.created_at IS NULL
+                    AND rta.created_at IS NULL
+                    AND rtr.created_at IS NULL
+                    AND rrv.created_at IS NULL THEN le.last_created_at
+                ELSE GREATEST(
+                    COALESCE(
+                        GREATEST(
+                            COALESCE(aaa.created_at + ((aaa.lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz),
+                            COALESCE(aar.created_at, '-infinity'::timestamptz),
+                            COALESCE(rrv.created_at, '-infinity'::timestamptz)
+                        ),
+                        '-infinity'::timestamptz
+                    ),
+                    COALESCE(
+                        GREATEST(
+                            LEAST(
+                                COALESCE(rta.created_at + ((rta.lifetime_ns / 1000.0) * interval '1 microsecond'), 'infinity'::timestamptz),
+                                GREATEST(
+                                    COALESCE(rta.created_at + ((rta.idle_lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz),
+                                    COALESCE(rtr.created_at + ((rtr.idle_lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz)
+                                )
+                            ),
+                            COALESCE(rrv.created_at, '-infinity'::timestamptz)
+                        ),
+                        '-infinity'::timestamptz
+                    )
+                )
+            END AS invalid_after
+    ) AS oidc_state
+    WHERE le.aggregate_type = 'oidc_session'
+      AND le.last_position <= cs.floor_position
+      AND oidc_state.invalid_after < $1
+),
+candidates AS (
+    SELECT * FROM terminal_candidates
+    UNION ALL
+    SELECT * FROM oidc_session_candidates
+),
+candidate_rows AS (
+    SELECT
+        e.event_type,
+        e.instance_id,
+        e.aggregate_type,
+        e.aggregate_id
+    FROM eventstore.events2 e
+    JOIN candidates c
+        ON c.instance_id = e.instance_id
+       AND c.aggregate_type = e.aggregate_type
+       AND c.aggregate_id = e.aggregate_id
+)
+SELECT
+    event_type,
+    COUNT(*) AS row_count,
+    COUNT(DISTINCT (instance_id, aggregate_type, aggregate_id)) AS aggregate_count
+FROM candidate_rows
+GROUP BY event_type
+ORDER BY event_type;

--- a/cmd/eventstore/sql/cleanup_events2_delete.sql
+++ b/cmd/eventstore/sql/cleanup_events2_delete.sql
@@ -1,0 +1,198 @@
+WITH current_state_floor AS (
+    SELECT
+        instance_id,
+        MIN(position) AS floor_position
+    FROM projections.current_states
+    WHERE instance_id <> ''
+      AND position IS NOT NULL
+    GROUP BY instance_id
+),
+latest_events AS (
+    SELECT DISTINCT ON (instance_id, aggregate_type, aggregate_id)
+        instance_id,
+        aggregate_type,
+        aggregate_id,
+        event_type AS last_event_type,
+        created_at AS last_created_at,
+        position AS last_position
+    FROM eventstore.events2
+    WHERE aggregate_type IN (
+        'auth_request',
+        'device_auth',
+        'idpintent',
+        'oidc_session',
+        'saml_request'
+    )
+    ORDER BY instance_id, aggregate_type, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_access_added AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'lifetime')::bigint, 0) AS lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.access_token.added'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_access_revoked AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.access_token.revoked'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_added AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'lifetime')::bigint, 0) AS lifetime_ns,
+        COALESCE((payload->>'idleLifetime')::bigint, 0) AS idle_lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.added'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_renewed AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at,
+        COALESCE((payload->>'idleLifetime')::bigint, 0) AS idle_lifetime_ns
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.renewed'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+latest_oidc_refresh_revoked AS (
+    SELECT DISTINCT ON (instance_id, aggregate_id)
+        instance_id,
+        aggregate_id,
+        created_at
+    FROM eventstore.events2
+    WHERE aggregate_type = 'oidc_session'
+      AND event_type = 'oidc_session.refresh_token.revoked'
+    ORDER BY instance_id, aggregate_id, sequence DESC, in_tx_order DESC
+),
+terminal_candidates AS (
+    SELECT
+        le.instance_id,
+        le.aggregate_type,
+        le.aggregate_id,
+        le.last_created_at AS sort_time
+    FROM latest_events le
+    JOIN current_state_floor cs
+        ON cs.instance_id = le.instance_id
+    WHERE le.aggregate_type <> 'oidc_session'
+      AND le.last_created_at < $1
+      AND le.last_position <= cs.floor_position
+      AND (
+          (le.aggregate_type = 'auth_request' AND le.last_event_type IN (
+              'auth_request.failed',
+              'auth_request.succeeded'
+          ))
+          OR (le.aggregate_type = 'saml_request' AND le.last_event_type IN (
+              'saml_request.failed',
+              'saml_request.succeeded'
+          ))
+          OR (le.aggregate_type = 'device_auth' AND le.last_event_type IN (
+              'device.authorization.canceled',
+              'device.authorization.done'
+          ))
+          OR (le.aggregate_type = 'idpintent' AND le.last_event_type IN (
+              'idpintent.consumed',
+              'idpintent.failed'
+          ))
+      )
+),
+oidc_session_candidates AS (
+    SELECT
+        le.instance_id,
+        le.aggregate_type,
+        le.aggregate_id,
+        oidc_state.invalid_after AS sort_time
+    FROM latest_events le
+    JOIN current_state_floor cs
+        ON cs.instance_id = le.instance_id
+    LEFT JOIN latest_oidc_access_added aaa
+        ON aaa.instance_id = le.instance_id
+       AND aaa.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_access_revoked aar
+        ON aar.instance_id = le.instance_id
+       AND aar.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_added rta
+        ON rta.instance_id = le.instance_id
+       AND rta.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_renewed rtr
+        ON rtr.instance_id = le.instance_id
+       AND rtr.aggregate_id = le.aggregate_id
+    LEFT JOIN latest_oidc_refresh_revoked rrv
+        ON rrv.instance_id = le.instance_id
+       AND rrv.aggregate_id = le.aggregate_id
+    CROSS JOIN LATERAL (
+        SELECT
+            CASE
+                WHEN aaa.created_at IS NULL
+                    AND aar.created_at IS NULL
+                    AND rta.created_at IS NULL
+                    AND rtr.created_at IS NULL
+                    AND rrv.created_at IS NULL THEN le.last_created_at
+                ELSE GREATEST(
+                    COALESCE(
+                        GREATEST(
+                            COALESCE(aaa.created_at + ((aaa.lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz),
+                            COALESCE(aar.created_at, '-infinity'::timestamptz),
+                            COALESCE(rrv.created_at, '-infinity'::timestamptz)
+                        ),
+                        '-infinity'::timestamptz
+                    ),
+                    COALESCE(
+                        GREATEST(
+                            LEAST(
+                                COALESCE(rta.created_at + ((rta.lifetime_ns / 1000.0) * interval '1 microsecond'), 'infinity'::timestamptz),
+                                GREATEST(
+                                    COALESCE(rta.created_at + ((rta.idle_lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz),
+                                    COALESCE(rtr.created_at + ((rtr.idle_lifetime_ns / 1000.0) * interval '1 microsecond'), '-infinity'::timestamptz)
+                                )
+                            ),
+                            COALESCE(rrv.created_at, '-infinity'::timestamptz)
+                        ),
+                        '-infinity'::timestamptz
+                    )
+                )
+            END AS invalid_after
+    ) AS oidc_state
+    WHERE le.aggregate_type = 'oidc_session'
+      AND le.last_position <= cs.floor_position
+      AND oidc_state.invalid_after < $1
+),
+candidates AS (
+    SELECT instance_id, aggregate_type, aggregate_id
+    FROM (
+        SELECT * FROM terminal_candidates
+        UNION ALL
+        SELECT * FROM oidc_session_candidates
+    ) AS all_candidates
+    ORDER BY sort_time
+    LIMIT $2
+),
+deleted AS (
+    DELETE FROM eventstore.events2 e
+    USING candidates c
+    WHERE c.instance_id = e.instance_id
+      AND c.aggregate_type = e.aggregate_type
+      AND c.aggregate_id = e.aggregate_id
+    RETURNING e.event_type, e.instance_id, e.aggregate_type, e.aggregate_id
+)
+SELECT
+    event_type,
+    COUNT(*) AS row_count,
+    COUNT(DISTINCT (instance_id, aggregate_type, aggregate_id)) AS aggregate_count
+FROM deleted
+GROUP BY event_type
+ORDER BY event_type;

--- a/cmd/zitadel.go
+++ b/cmd/zitadel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
 	"github.com/zitadel/zitadel/cmd/admin"
 	"github.com/zitadel/zitadel/cmd/build"
+	"github.com/zitadel/zitadel/cmd/eventstore"
 	"github.com/zitadel/zitadel/cmd/initialise"
 	"github.com/zitadel/zitadel/cmd/key"
 	"github.com/zitadel/zitadel/cmd/mirror"
@@ -53,6 +54,7 @@ func New(out io.Writer, in io.Reader, args []string, server chan<- *start.Server
 
 	cmd.AddCommand(
 		admin.New(), //is now deprecated, remove later on
+		eventstore.New(),
 		initialise.New(),
 		setup.New(),
 		start.New(server),

--- a/internal/command/oidc_session.go
+++ b/internal/command/oidc_session.go
@@ -274,6 +274,12 @@ func (c *Commands) RevokeOIDCSessionToken(ctx context.Context, token, clientID s
 	if err != nil {
 		return zerrors.ThrowInternal(err, "OIDCS-NB3t2", "Errors.Internal")
 	}
+	if writeModel.State == domain.OIDCSessionStateUnspecified {
+		// Revocation must stay a no-op for dead tokens even after cleanup has removed
+		// the backing oidc_session aggregate from events2.
+		logging.WithFields("oidcSessionID", oidcSessionID).Info("token revocation for unknown oidc session")
+		return nil
+	}
 	if err = writeModel.CheckClient(clientID); err != nil {
 		return err
 	}

--- a/internal/command/oidc_session_test.go
+++ b/internal/command/oidc_session_test.go
@@ -2159,6 +2159,21 @@ func TestCommands_RevokeOIDCSessionToken(t *testing.T) {
 			},
 		},
 		{
+			"unknown oidc_session",
+			fields{
+				eventstore:   expectEventstore(expectFilter()),
+				keyAlgorithm: crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+			},
+			args{
+				ctx:      authz.WithInstanceID(context.Background(), "instanceID"),
+				token:    "V2_missingSession-at_accessTokenID",
+				clientID: "clientID",
+			},
+			res{
+				err: nil,
+			},
+		},
+		{
 			"refresh_token inactive",
 			fields{
 				eventstore: expectEventstore(


### PR DESCRIPTION
**Disclosure**: This is largely AI coded and an early attempt at mitigating the perpetually growing events2 table (see https://github.com/zitadel/zitadel/discussions/11972). Additional guidance welcome.



# Which Problems Are Solved

ZITADEL keeps a large amount of historical data in `eventstore.events2`,
especially from short-lived authentication flows and OIDC session
activity. That creates storage pressure, but deleting rows by age alone
is unsafe because some parts of the system still reconstruct live state
directly from raw event history.

This change adds a supported cleanup path for historical `events2` data
that can be run regularly, including from cron, without risking active
authentication, token validation, refresh-token exchange, or logout
behavior.

It also solves the main practical limitation of the first cleanup
version: without handling `oidc_session`, the command would remove some
auth-flow history but leave behind the high-volume
`oidc_session.added` and `oidc_session.access_token.added` rows that
make up a large share of the table.

# How the Problems Are Solved

dd a new `zitadel eventstore cleanup` command that connects with the
normal ZITADEL database configuration and operates in dry-run mode by
default. The command requires an explicit `--older-than` retention
window and supports bounded batch execution through `--batch-size` and
`--max-batches`, so it can be used safely in daily automation.

The cleanup logic is intentionally based on current code behavior, not
just event age. For aggregate types that are clearly terminal and whose
live state is already materialized elsewhere, the SQL deletes whole
aggregates only after their latest event is older than the retention
cutoff and their latest position is already behind the slowest
projection recorded in `projections.current_states`.

That makes cleanup safe for:
- `auth_request` after `failed` or `succeeded`
- `saml_request` after `failed` or `succeeded`
- `device_auth` after `device.authorization.canceled` or
  `device.authorization.done`
- `idpintent` after `failed` or `consumed`

`oidc_session` requires a stricter rule because the current code still
reads those events directly for:
- access-token validation
- refresh-token exchange
- token revocation

To handle that safely, the cleanup SQL derives whether an OIDC session
is still live from the latest access-token and refresh-token events in
the aggregate. An `oidc_session` is only eligible for deletion once the
current access token and the current refresh token are both no longer
usable, or when the aggregate never issued token events at all. This is
what allows old `oidc_session.added` and
`oidc_session.access_token.added` rows to be removed without affecting
active tokens.

The implementation keeps `session`, `session_logout`, and
`auth_request.code.exchanged` out of scope on purpose. Those event
streams still participate in live token or logout behavior, or were not
proven terminal enough to delete safely.

Because deleted `oidc_session` aggregates no longer exist in `events2`,
revocation also needs one compatibility safeguard: when
`RevokeOIDCSessionToken` cannot reconstruct an OIDC session aggregate,
it now treats that case as a no-op instead of allowing the request to
fall through into client validation on an empty write model. Without
that guard, revoking an already-dead token after cleanup could return
`invalid_client`, which would make revocation behavior depend on whether
cleanup had already run.

Add tests that lock in the cleanup scope and the revocation behavior so
future changes do not silently widen deletion criteria or reintroduce
cleanup-dependent token semantics.

