### PR TITLE
feat(actions): add pre-OTP-code hooks for SMS and email

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -396,6 +396,7 @@ func startZitadel(ctx context.Context, config *Config, masterKey string, server 
 	}
 	commands.GrpcMethodExisting = checkExisting(api.ListGrpcMethods())
 	commands.GrpcServiceExisting = checkExisting(api.ListGrpcServices())
+	commands.GetActiveSigningWebKey = queries.GetActiveSigningWebKey
 
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)

--- a/internal/api/action/otp/hook.go
+++ b/internal/api/action/otp/hook.go
@@ -1,0 +1,157 @@
+package otp
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/zitadel/zitadel/internal/query"
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+// Duration wraps time.Duration so JSON bodies can specify values as either
+// duration strings ("5m", "30s") or integer nanoseconds.
+type Duration time.Duration
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		parsed, perr := time.ParseDuration(s)
+		if perr != nil {
+			return perr
+		}
+		*d = Duration(parsed)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*d = Duration(n)
+	return nil
+}
+
+// PreOTPSMSCodeContext is the JSON payload delivered to a preotpsmscode action target
+// before an OTP SMS code is generated.
+type PreOTPSMSCodeContext struct {
+	FunctionName         string                 `json:"function,omitempty"`
+	User                 *query.User            `json:"user,omitempty"`
+	Org                  *query.UserInfoOrg     `json:"org,omitempty"`
+	RecipientPhoneNumber string                 `json:"recipient_phone_number,omitempty"`
+	GeneratorConfig      *PublicGeneratorConfig `json:"generator_config,omitempty"`
+	Response             *PreOTPSMSCodeResponse `json:"response,omitempty"`
+}
+
+// PreOTPEmailCodeContext is the JSON payload delivered to a preotpemailcode action target
+// before an OTP Email code is generated.
+type PreOTPEmailCodeContext struct {
+	FunctionName          string                   `json:"function,omitempty"`
+	User                  *query.User              `json:"user,omitempty"`
+	Org                   *query.UserInfoOrg       `json:"org,omitempty"`
+	RecipientEmailAddress string                   `json:"recipient_email_address,omitempty"`
+	GeneratorConfig       *PublicGeneratorConfig   `json:"generator_config,omitempty"`
+	Response              *PreOTPEmailCodeResponse `json:"response,omitempty"`
+}
+
+// PublicGeneratorConfig is a JSON-safe snapshot of the effective OTP secret generator
+// configuration passed to the action target for context.
+type PublicGeneratorConfig struct {
+	Length              uint32   `json:"length,omitempty"`
+	Expiry              Duration `json:"expiry,omitempty"`
+	IncludeLowerLetters bool     `json:"include_lower_letters,omitempty"`
+	IncludeUpperLetters bool     `json:"include_upper_letters,omitempty"`
+	IncludeDigits       bool     `json:"include_digits,omitempty"`
+	IncludeSymbols      bool     `json:"include_symbols,omitempty"`
+}
+
+// GenerationOverrides lets an action target override individual OTP generator
+// parameters for a single request. A nil field means "inherit from the instance
+// default". Expiry is intentionally not part of this struct; it is controlled
+// by PreOTP*CodeResponse.Expiry because it applies whether the code is generated
+// or supplied by the action.
+type GenerationOverrides struct {
+	Length              *uint32 `json:"length,omitempty"`
+	IncludeLowerLetters *bool   `json:"include_lower_letters,omitempty"`
+	IncludeUpperLetters *bool   `json:"include_upper_letters,omitempty"`
+	IncludeDigits       *bool   `json:"include_digits,omitempty"`
+	IncludeSymbols      *bool   `json:"include_symbols,omitempty"`
+}
+
+// PreOTPSMSCodeResponse is the JSON body returned by a preotpsmscode action target.
+// Code and Generate are mutually exclusive: setting both is rejected. If neither
+// is set the instance defaults are used.
+type PreOTPSMSCodeResponse struct {
+	Expiry   *Duration            `json:"expiry,omitempty"`
+	Code     *string              `json:"code,omitempty"`
+	Generate *GenerationOverrides `json:"generate,omitempty"`
+}
+
+// PreOTPEmailCodeResponse mirrors PreOTPSMSCodeResponse for the OTP Email channel.
+type PreOTPEmailCodeResponse struct {
+	Expiry   *Duration            `json:"expiry,omitempty"`
+	Code     *string              `json:"code,omitempty"`
+	Generate *GenerationOverrides `json:"generate,omitempty"`
+}
+
+func (c *PreOTPSMSCodeContext) GetHTTPRequestBody() []byte {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func (c *PreOTPSMSCodeContext) SetHTTPResponseBody(resp []byte) error {
+	if !json.Valid(resp) {
+		return zerrors.ThrowPreconditionFailed(nil, "ACTION-p7q2w", "Errors.Execution.ResponseIsNotValidJSON")
+	}
+	if c.Response == nil {
+		c.Response = &PreOTPSMSCodeResponse{}
+	}
+	if err := json.Unmarshal(resp, c.Response); err != nil {
+		return err
+	}
+	// Code and Generate describe different things (a finished value vs generation parameters);
+	// accepting both would require an unspecified precedence rule — reject instead.
+	if c.Response.Code != nil && c.Response.Generate != nil {
+		c.Response = &PreOTPSMSCodeResponse{}
+		return zerrors.ThrowPreconditionFailed(nil, "ACTION-k3j9z", "Errors.Execution.Invalid")
+	}
+	return nil
+}
+
+func (c *PreOTPSMSCodeContext) GetContent() any {
+	return c.Response
+}
+
+func (c *PreOTPEmailCodeContext) GetHTTPRequestBody() []byte {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func (c *PreOTPEmailCodeContext) SetHTTPResponseBody(resp []byte) error {
+	if !json.Valid(resp) {
+		return zerrors.ThrowPreconditionFailed(nil, "ACTION-m8x4n", "Errors.Execution.ResponseIsNotValidJSON")
+	}
+	if c.Response == nil {
+		c.Response = &PreOTPEmailCodeResponse{}
+	}
+	if err := json.Unmarshal(resp, c.Response); err != nil {
+		return err
+	}
+	if c.Response.Code != nil && c.Response.Generate != nil {
+		c.Response = &PreOTPEmailCodeResponse{}
+		return zerrors.ThrowPreconditionFailed(nil, "ACTION-r5t8b", "Errors.Execution.Invalid")
+	}
+	return nil
+}
+
+func (c *PreOTPEmailCodeContext) GetContent() any {
+	return c.Response
+}

--- a/internal/api/action/otp/hook_test.go
+++ b/internal/api/action/otp/hook_test.go
@@ -1,0 +1,136 @@
+package otp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/muhlemmer/gu"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+func TestPreOTPSMSCodeContext_GetHTTPRequestBody(t *testing.T) {
+	ctx := &PreOTPSMSCodeContext{
+		FunctionName:         "preotpsmscode",
+		RecipientPhoneNumber: "+15555551234",
+		GeneratorConfig: &PublicGeneratorConfig{
+			Length:        6,
+			Expiry:        Duration(5 * time.Minute),
+			IncludeDigits: true,
+		},
+	}
+	body := ctx.GetHTTPRequestBody()
+	assert.True(t, json.Valid(body))
+
+	var decoded map[string]any
+	assert.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "preotpsmscode", decoded["function"])
+	assert.Equal(t, "+15555551234", decoded["recipient_phone_number"])
+}
+
+func TestPreOTPSMSCodeContext_SetHTTPResponseBody(t *testing.T) {
+	tests := []struct {
+		name         string
+		resp         string
+		wantErr      error
+		wantCode     *string
+		wantGenerate *GenerationOverrides
+		wantExpiry   *Duration
+	}{
+		{
+			name:       "code only",
+			resp:       `{"code":"A7F2B9","expiry":"5m0s"}`,
+			wantCode:   gu.Ptr("A7F2B9"),
+			wantExpiry: gu.Ptr(Duration(5 * time.Minute)),
+		},
+		{
+			name: "generate only",
+			resp: `{"generate":{"length":4,"include_digits":true}}`,
+			wantGenerate: &GenerationOverrides{
+				Length:        gu.Ptr(uint32(4)),
+				IncludeDigits: gu.Ptr(true),
+			},
+		},
+		{
+			name:    "code and generate both set rejected",
+			resp:    `{"code":"123","generate":{"length":4}}`,
+			wantErr: zerrors.ThrowPreconditionFailed(nil, "ACTION-k3j9z", "Errors.Execution.Invalid"),
+		},
+		{
+			name:    "invalid json rejected",
+			resp:    `not-json`,
+			wantErr: zerrors.ThrowPreconditionFailed(nil, "ACTION-p7q2w", "Errors.Execution.ResponseIsNotValidJSON"),
+		},
+		{
+			name: "empty response uses defaults",
+			resp: `{}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &PreOTPSMSCodeContext{}
+			err := ctx.SetHTTPResponseBody([]byte(tt.resp))
+			assert.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				return
+			}
+			assert.Equal(t, tt.wantCode, ctx.Response.Code)
+			assert.Equal(t, tt.wantGenerate, ctx.Response.Generate)
+			assert.Equal(t, tt.wantExpiry, ctx.Response.Expiry)
+		})
+	}
+}
+
+func TestPreOTPSMSCodeContext_GetContent(t *testing.T) {
+	ctx := &PreOTPSMSCodeContext{
+		Response: &PreOTPSMSCodeResponse{Code: gu.Ptr("abc")},
+	}
+	got, ok := ctx.GetContent().(*PreOTPSMSCodeResponse)
+	assert.True(t, ok)
+	assert.Equal(t, "abc", *got.Code)
+}
+
+func TestPreOTPEmailCodeContext_GetHTTPRequestBody(t *testing.T) {
+	ctx := &PreOTPEmailCodeContext{
+		FunctionName:          "preotpemailcode",
+		RecipientEmailAddress: "alice@example.com",
+	}
+	body := ctx.GetHTTPRequestBody()
+	assert.True(t, json.Valid(body))
+
+	var decoded map[string]any
+	assert.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "preotpemailcode", decoded["function"])
+	assert.Equal(t, "alice@example.com", decoded["recipient_email_address"])
+}
+
+func TestPreOTPEmailCodeContext_SetHTTPResponseBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    string
+		wantErr error
+	}{
+		{"code only", `{"code":"123456"}`, nil},
+		{"generate only", `{"generate":{"length":8}}`, nil},
+		{"empty", `{}`, nil},
+		{
+			"both set rejected",
+			`{"code":"123","generate":{"length":8}}`,
+			zerrors.ThrowPreconditionFailed(nil, "ACTION-r5t8b", "Errors.Execution.Invalid"),
+		},
+		{
+			"invalid json rejected",
+			`{`,
+			zerrors.ThrowPreconditionFailed(nil, "ACTION-m8x4n", "Errors.Execution.ResponseIsNotValidJSON"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &PreOTPEmailCodeContext{}
+			err := ctx.SetHTTPResponseBody([]byte(tt.resp))
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/api/grpc/feature/v2/converter.go
+++ b/internal/api/grpc/feature/v2/converter.go
@@ -25,6 +25,7 @@ func systemFeaturesToCommand(req *feature_pb.SetSystemFeaturesRequest) (*command
 		LoginV2:                        loginV2,
 		PermissionCheckV2:              req.PermissionCheckV2,
 		EnableRelationalTables:         req.EnableRelationalTables,
+		AllowOTPCodeOverride:           req.AllowOtpCodeOverride,
 	}, nil
 }
 
@@ -46,6 +47,7 @@ func systemFeaturesToPb(f *query.SystemFeatures) *feature_pb.GetSystemFeaturesRe
 		LoginV2:                loginV2ToLoginV2FlagPb(f.LoginV2),
 		PermissionCheckV2:      featureSourceToFlagPb(&f.PermissionCheckV2),
 		EnableRelationalTables: featureSourceToFlagPb(&f.EnableRelationalTables),
+		AllowOtpCodeOverride:   featureSourceToFlagPb(&f.AllowOTPCodeOverride),
 	}
 }
 
@@ -64,6 +66,7 @@ func instanceFeaturesToCommand(req *feature_pb.SetInstanceFeaturesRequest) (*com
 		PermissionCheckV2:              req.PermissionCheckV2,
 		ManagementConsoleUseV2UserApi:  req.ConsoleUseV2UserApi,
 		EnableRelationalTables:         req.EnableRelationalTables,
+		AllowOTPCodeOverride:           req.AllowOtpCodeOverride,
 	}, nil
 }
 
@@ -87,6 +90,7 @@ func instanceFeaturesToPb(f *query.InstanceFeatures) *feature_pb.GetInstanceFeat
 		PermissionCheckV2:      featureSourceToFlagPb(&f.PermissionCheckV2),
 		ConsoleUseV2UserApi:    featureSourceToFlagPb(&f.ManagementConsoleUseV2UserApi),
 		EnableRelationalTables: featureSourceToFlagPb(&f.EnableRelationalTables),
+		AllowOtpCodeOverride:   featureSourceToFlagPb(&f.AllowOTPCodeOverride),
 	}
 }
 

--- a/internal/api/grpc/feature/v2/converter_test.go
+++ b/internal/api/grpc/feature/v2/converter_test.go
@@ -31,6 +31,7 @@ func Test_systemFeaturesToCommand(t *testing.T) {
 		},
 		EnableRelationalTables: gu.Ptr(true),
 		PermissionCheckV2:      gu.Ptr(true),
+		AllowOtpCodeOverride:   gu.Ptr(true),
 	}
 	want := &command.SystemFeatures{
 		LoginDefaultOrg:                gu.Ptr(true),
@@ -43,6 +44,7 @@ func Test_systemFeaturesToCommand(t *testing.T) {
 		},
 		EnableRelationalTables: gu.Ptr(true),
 		PermissionCheckV2:      gu.Ptr(true),
+		AllowOTPCodeOverride:   gu.Ptr(true),
 	}
 
 	// Test
@@ -94,6 +96,10 @@ func Test_systemFeaturesToPb(t *testing.T) {
 			Level: feature.LevelSystem,
 			Value: true,
 		},
+		AllowOTPCodeOverride: query.FeatureSource[bool]{
+			Level: feature.LevelSystem,
+			Value: true,
+		},
 	}
 	want := &feature_pb.GetSystemFeaturesResponse{
 		Details: &object.Details{
@@ -138,6 +144,10 @@ func Test_systemFeaturesToPb(t *testing.T) {
 			Enabled: true,
 			Source:  feature_pb.Source_SOURCE_SYSTEM,
 		},
+		AllowOtpCodeOverride: &feature_pb.FeatureFlag{
+			Enabled: true,
+			Source:  feature_pb.Source_SOURCE_SYSTEM,
+		},
 	}
 
 	// Test
@@ -163,6 +173,7 @@ func Test_instanceFeaturesToCommand(t *testing.T) {
 		ConsoleUseV2UserApi:    gu.Ptr(true),
 		PermissionCheckV2:      gu.Ptr(false),
 		EnableRelationalTables: gu.Ptr(true),
+		AllowOtpCodeOverride:   gu.Ptr(true),
 	}
 	want := &command.InstanceFeatures{
 		LoginDefaultOrg:                gu.Ptr(true),
@@ -177,6 +188,7 @@ func Test_instanceFeaturesToCommand(t *testing.T) {
 		ManagementConsoleUseV2UserApi: gu.Ptr(true),
 		PermissionCheckV2:             gu.Ptr(false),
 		EnableRelationalTables:        gu.Ptr(true),
+		AllowOTPCodeOverride:          gu.Ptr(true),
 	}
 
 	// Test
@@ -231,6 +243,10 @@ func Test_instanceFeaturesToPb(t *testing.T) {
 			Level: feature.LevelInstance,
 			Value: true,
 		},
+		AllowOTPCodeOverride: query.FeatureSource[bool]{
+			Level: feature.LevelInstance,
+			Value: true,
+		},
 	}
 	want := &feature_pb.GetInstanceFeaturesResponse{
 		Details: &object.Details{
@@ -280,6 +296,10 @@ func Test_instanceFeaturesToPb(t *testing.T) {
 			Source:  feature_pb.Source_SOURCE_INSTANCE,
 		},
 		EnableRelationalTables: &feature_pb.FeatureFlag{
+			Enabled: true,
+			Source:  feature_pb.Source_SOURCE_INSTANCE,
+		},
+		AllowOtpCodeOverride: &feature_pb.FeatureFlag{
 			Enabled: true,
 			Source:  feature_pb.Source_SOURCE_INSTANCE,
 		},

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zitadel/logging"
 
 	new_domain "github.com/zitadel/zitadel/backend/v3/domain"
+	"github.com/zitadel/zitadel/internal/api/action/otp"
 	"github.com/zitadel/zitadel/internal/api/authz"
 	api_http "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/cache/connector"
@@ -98,6 +99,10 @@ type Commands struct {
 	ActionFunctionExisting func(function string) bool
 	EventExisting          func(event string) bool
 	EventGroupExisting     func(group string) bool
+
+	GetActiveSigningWebKey func(ctx context.Context) (*jose.JSONWebKey, error)
+
+	preOTPSMSCodeHook func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error)
 
 	GenerateDomain func(instanceName, domain string) (string, error)
 
@@ -241,6 +246,7 @@ func StartCommands(
 	}
 	repo.phoneCodeVerifier = repo.phoneCodeVerifierFromConfig
 	repo.emailCodeVerifier = repo.emailCodeVerifierFromConfig
+	repo.preOTPSMSCodeHook = repo.preOTPSMSCodeHookFromTargets
 	repo.tarpit = defaults.Tarpit.Tarpit()
 	return repo, nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -102,7 +102,8 @@ type Commands struct {
 
 	GetActiveSigningWebKey func(ctx context.Context) (*jose.JSONWebKey, error)
 
-	preOTPSMSCodeHook func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error)
+	preOTPSMSCodeHook   func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error)
+	preOTPEmailCodeHook func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPEmailCodeResponse, error)
 
 	GenerateDomain func(instanceName, domain string) (string, error)
 
@@ -247,6 +248,7 @@ func StartCommands(
 	repo.phoneCodeVerifier = repo.phoneCodeVerifierFromConfig
 	repo.emailCodeVerifier = repo.emailCodeVerifierFromConfig
 	repo.preOTPSMSCodeHook = repo.preOTPSMSCodeHookFromTargets
+	repo.preOTPEmailCodeHook = repo.preOTPEmailCodeHookFromTargets
 	repo.tarpit = defaults.Tarpit.Tarpit()
 	return repo, nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -74,6 +74,7 @@ type Commands struct {
 	defaultRefreshTokenLifetime     time.Duration
 	defaultRefreshTokenIdleLifetime time.Duration
 	phoneCodeVerifier               func(ctx context.Context, id string) (senders.CodeGenerator, error)
+	emailCodeVerifier               func(ctx context.Context, id string) (senders.CodeGenerator, error)
 	tarpit                          func(failedAttempts uint64)
 
 	multifactors            domain.MultifactorConfigs
@@ -239,6 +240,7 @@ func StartCommands(
 		repo.newHashedSecret = newHashedSecretWithDefault(secretHasher, defaultSecretGenerators.ClientSecret)
 	}
 	repo.phoneCodeVerifier = repo.phoneCodeVerifierFromConfig
+	repo.emailCodeVerifier = repo.emailCodeVerifierFromConfig
 	repo.tarpit = defaults.Tarpit.Tarpit()
 	return repo, nil
 }

--- a/internal/command/instance_features.go
+++ b/internal/command/instance_features.go
@@ -22,6 +22,7 @@ type InstanceFeatures struct {
 	PermissionCheckV2              *bool
 	ManagementConsoleUseV2UserApi  *bool `mapstructure:"ConsoleUseV2UserApi"` // for backwards compatibility we need to change this back to the old config name
 	EnableRelationalTables         *bool
+	AllowOTPCodeOverride           *bool
 }
 
 func (m *InstanceFeatures) isEmpty() bool {
@@ -34,7 +35,8 @@ func (m *InstanceFeatures) isEmpty() bool {
 		m.LoginV2 == nil &&
 		m.PermissionCheckV2 == nil &&
 		m.ManagementConsoleUseV2UserApi == nil &&
-		m.EnableRelationalTables == nil)
+		m.EnableRelationalTables == nil &&
+		m.AllowOTPCodeOverride == nil)
 }
 
 func (c *Commands) SetInstanceFeatures(ctx context.Context, f *InstanceFeatures) (*domain.ObjectDetails, error) {

--- a/internal/command/instance_features_model.go
+++ b/internal/command/instance_features_model.go
@@ -75,6 +75,7 @@ func (m *InstanceFeaturesWriteModel) Query() *eventstore.SearchQueryBuilder {
 			feature_v2.InstancePermissionCheckV2,
 			feature_v2.InstanceManagementConsoleUseV2UserApi,
 			feature_v2.InstanceEnableRelationalTables,
+			feature_v2.InstanceAllowOTPCodeOverride,
 		).
 		Builder().ResourceOwner(m.ResourceOwner)
 }
@@ -113,6 +114,9 @@ func reduceInstanceFeature(features *InstanceFeatures, key feature.Key, value an
 	case feature.KeyEnableRelationalTables:
 		v := value.(bool)
 		features.EnableRelationalTables = &v
+	case feature.KeyAllowOTPCodeOverride:
+		v := value.(bool)
+		features.AllowOTPCodeOverride = &v
 	}
 }
 
@@ -128,5 +132,6 @@ func (wm *InstanceFeaturesWriteModel) setCommands(ctx context.Context, f *Instan
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.PermissionCheckV2, f.PermissionCheckV2, feature_v2.InstancePermissionCheckV2)
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.ManagementConsoleUseV2UserApi, f.ManagementConsoleUseV2UserApi, feature_v2.InstanceManagementConsoleUseV2UserApi)
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.EnableRelationalTables, f.EnableRelationalTables, feature_v2.InstanceEnableRelationalTables)
+	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.AllowOTPCodeOverride, f.AllowOTPCodeOverride, feature_v2.InstanceAllowOTPCodeOverride)
 	return cmds
 }

--- a/internal/command/system_features.go
+++ b/internal/command/system_features.go
@@ -17,6 +17,7 @@ type SystemFeatures struct {
 	LoginV2                        *feature.LoginV2
 	PermissionCheckV2              *bool
 	EnableRelationalTables         *bool
+	AllowOTPCodeOverride           *bool
 }
 
 func (m *SystemFeatures) isEmpty() bool {
@@ -27,7 +28,8 @@ func (m *SystemFeatures) isEmpty() bool {
 		m.OIDCSingleV1SessionTermination == nil &&
 		m.LoginV2 == nil &&
 		m.PermissionCheckV2 == nil &&
-		m.EnableRelationalTables == nil)
+		m.EnableRelationalTables == nil &&
+		m.AllowOTPCodeOverride == nil)
 }
 
 func (c *Commands) SetSystemFeatures(ctx context.Context, f *SystemFeatures) (*domain.ObjectDetails, error) {

--- a/internal/command/system_features_model.go
+++ b/internal/command/system_features_model.go
@@ -66,6 +66,7 @@ func (m *SystemFeaturesWriteModel) Query() *eventstore.SearchQueryBuilder {
 			feature_v2.SystemLoginVersion,
 			feature_v2.SystemPermissionCheckV2,
 			feature_v2.SystemEnableRelationalTables,
+			feature_v2.SystemAllowOTPCodeOverride,
 		).
 		Builder().ResourceOwner(m.ResourceOwner)
 }
@@ -97,6 +98,9 @@ func reduceSystemFeature(features *SystemFeatures, key feature.Key, value any) {
 	case feature.KeyEnableRelationalTables:
 		v := value.(bool)
 		features.EnableRelationalTables = &v
+	case feature.KeyAllowOTPCodeOverride:
+		v := value.(bool)
+		features.AllowOTPCodeOverride = &v
 	}
 }
 
@@ -110,6 +114,7 @@ func (wm *SystemFeaturesWriteModel) setCommands(ctx context.Context, f *SystemFe
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.LoginV2, f.LoginV2, feature_v2.SystemLoginVersion)
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.PermissionCheckV2, f.PermissionCheckV2, feature_v2.SystemPermissionCheckV2)
 	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.EnableRelationalTables, f.EnableRelationalTables, feature_v2.SystemEnableRelationalTables)
+	cmds = appendFeatureUpdate(ctx, cmds, aggregate, wm.AllowOTPCodeOverride, f.AllowOTPCodeOverride, feature_v2.SystemAllowOTPCodeOverride)
 	return cmds
 }
 

--- a/internal/command/system_features_test.go
+++ b/internal/command/system_features_test.go
@@ -294,6 +294,7 @@ func TestSystemFeatures_isEmpty(t *testing.T) {
 		{name: "LoginV2 set", sysFeatures: &SystemFeatures{LoginV2: &feature.LoginV2{}}, want: false},
 		{name: "PermissionCheckV2 set", sysFeatures: &SystemFeatures{PermissionCheckV2: gu.Ptr(true)}, want: false},
 		{name: "EnableRelationalTables set", sysFeatures: &SystemFeatures{EnableRelationalTables: gu.Ptr(true)}, want: false},
+		{name: "AllowOTPCodeOverride set", sysFeatures: &SystemFeatures{AllowOTPCodeOverride: gu.Ptr(true)}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/user_human_email.go
+++ b/internal/command/user_human_email.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zitadel/zitadel/internal/crypto"
 	"github.com/zitadel/zitadel/internal/domain"
 	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/notification/senders"
 	"github.com/zitadel/zitadel/internal/repository/user"
 	"github.com/zitadel/zitadel/internal/telemetry/tracing"
 	"github.com/zitadel/zitadel/internal/zerrors"
@@ -171,4 +172,8 @@ func (c *Commands) emailWriteModel(ctx context.Context, userID, resourceOwner st
 		return nil, err
 	}
 	return writeModel, nil
+}
+
+func (c *Commands) emailCodeVerifierFromConfig(_ context.Context, _ string) (senders.CodeGenerator, error) {
+	return nil, nil
 }

--- a/internal/command/user_human_email.go
+++ b/internal/command/user_human_email.go
@@ -174,6 +174,11 @@ func (c *Commands) emailWriteModel(ctx context.Context, userID, resourceOwner st
 	return writeModel, nil
 }
 
+// emailCodeVerifierFromConfig mirrors phoneCodeVerifierFromConfig for the email
+// channel. Returns (nil, nil) today — no email provider supports external code
+// verification — so the verify path falls back to the local-crypto check.
+// Present as a parity stub so future external email verifiers can be resolved
+// by GeneratorID without changing HumanCheckOTPEmail.
 func (c *Commands) emailCodeVerifierFromConfig(_ context.Context, _ string) (senders.CodeGenerator, error) {
 	return nil, nil
 }

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -460,8 +460,8 @@ func (c *Commands) HumanSendOTPEmail(ctx context.Context, userID, resourceOwner 
 	smsWriteModel := func(ctx context.Context, userID string, resourceOwner string) (OTPWriteModel, error) {
 		return c.otpEmailWriteModelByID(ctx, userID, resourceOwner)
 	}
-	codeAddedEvent := func(ctx context.Context, aggregate *eventstore.Aggregate, code *crypto.CryptoValue, expiry time.Duration, info *user.AuthRequestInfo, _ string) eventstore.Command {
-		return user.NewHumanOTPEmailCodeAddedEvent(ctx, aggregate, code, expiry, info)
+	codeAddedEvent := func(ctx context.Context, aggregate *eventstore.Aggregate, code *crypto.CryptoValue, expiry time.Duration, info *user.AuthRequestInfo, generatorID string) eventstore.Command {
+		return user.NewHumanOTPEmailCodeAddedEvent(ctx, aggregate, code, expiry, info, generatorID)
 	}
 	generateCode := func(ctx context.Context, filter preparation.FilterToQueryReducer, typ domain.SecretGeneratorType, alg crypto.EncryptionAlgorithm, defaultConfig *crypto.GeneratorConfig) (*EncryptedCode, string, error) {
 		code, err := c.newEncryptedCodeWithDefault(ctx, filter, typ, alg, defaultConfig)
@@ -509,7 +509,7 @@ func (c *Commands) HumanCheckOTPEmail(ctx context.Context, userID, code, resourc
 		writeModel,
 		c.eventstore.FilterToQueryReducer,
 		c.userEncryption,
-		nil, // email currently always uses local code checks
+		c.emailCodeVerifier,
 		succeededEvent,
 		failedEvent,
 		c.tarpit,

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -341,7 +341,7 @@ func (c *Commands) HumanSendOTPSMS(ctx context.Context, userID, resourceOwner st
 		domain.SecretGeneratorTypeOTPSMS,
 		c.defaultSecretGenerators.OTPSMS,
 		codeAddedEvent,
-		c.newPhoneCode,
+		c.newPhoneCodeWithHook(userID, resourceOwner),
 	)
 }
 

--- a/internal/command/user_human_otp.go
+++ b/internal/command/user_human_otp.go
@@ -463,10 +463,6 @@ func (c *Commands) HumanSendOTPEmail(ctx context.Context, userID, resourceOwner 
 	codeAddedEvent := func(ctx context.Context, aggregate *eventstore.Aggregate, code *crypto.CryptoValue, expiry time.Duration, info *user.AuthRequestInfo, generatorID string) eventstore.Command {
 		return user.NewHumanOTPEmailCodeAddedEvent(ctx, aggregate, code, expiry, info, generatorID)
 	}
-	generateCode := func(ctx context.Context, filter preparation.FilterToQueryReducer, typ domain.SecretGeneratorType, alg crypto.EncryptionAlgorithm, defaultConfig *crypto.GeneratorConfig) (*EncryptedCode, string, error) {
-		code, err := c.newEncryptedCodeWithDefault(ctx, filter, typ, alg, defaultConfig)
-		return code, "", err
-	}
 	return c.sendHumanOTP(
 		ctx,
 		userID,
@@ -476,7 +472,7 @@ func (c *Commands) HumanSendOTPEmail(ctx context.Context, userID, resourceOwner 
 		domain.SecretGeneratorTypeOTPEmail,
 		c.defaultSecretGenerators.OTPEmail,
 		codeAddedEvent,
-		generateCode,
+		c.newEmailCodeWithHook(userID, resourceOwner),
 	)
 }
 

--- a/internal/command/user_human_otp_hook.go
+++ b/internal/command/user_human_otp_hook.go
@@ -1,0 +1,176 @@
+package command
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/zitadel/zitadel/internal/api/action/otp"
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/command/preparation"
+	"github.com/zitadel/zitadel/internal/crypto"
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/execution"
+	exec_repo "github.com/zitadel/zitadel/internal/repository/execution"
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+// preOTPSMSCodeHookFromTargets is the default implementation of the preotpsmscode
+// hook invocation. It queries registered execution targets and calls them with a
+// context snapshot. Returns (nil, nil) when no targets are registered or the
+// response is unusable, letting the caller fall back to the standard generation path.
+func (c *Commands) preOTPSMSCodeHookFromTargets(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error) {
+	fnID := exec_repo.ID(domain.ExecutionTypeFunction, domain.ActionFunctionPreOTPSMSCode.LocalizationKey())
+	targets := execution.QueryExecutionTargetsForFunction(ctx, fnID)
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	phoneWM, err := c.phoneWriteModelByID(ctx, userID, resourceOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	// OTP SMS enrollment requires a verified phone (AddHumanOTPSMS precondition),
+	// so phoneWM.Phone is the verified number at this point.
+	ctxInfo := &otp.PreOTPSMSCodeContext{
+		FunctionName:         domain.ActionFunctionPreOTPSMSCode.LocalizationKey(),
+		RecipientPhoneNumber: string(phoneWM.Phone),
+		GeneratorConfig:      publicGeneratorConfigFrom(effectiveConfig),
+	}
+
+	resp, err := execution.CallTargets(ctx, targets, ctxInfo, c.targetEncryption, c.GetActiveSigningWebKey, c.ActionsV2DenyList)
+	if err != nil {
+		return nil, err
+	}
+	response, ok := resp.(*otp.PreOTPSMSCodeResponse)
+	if !ok {
+		return nil, nil
+	}
+	return response, nil
+}
+
+// newPhoneCodeWithHook wraps newPhoneCode so that, when AllowOTPCodeOverride is
+// enabled and no Twilio Verify provider owns the code lifecycle, the
+// preotpsmscode hook can supply an override code or adjust generator parameters
+// before local code generation.
+func (c *Commands) newPhoneCodeWithHook(userID, resourceOwner string) encryptedCodeGeneratorWithDefaultFunc {
+	return func(ctx context.Context, filter preparation.FilterToQueryReducer, secretGeneratorType domain.SecretGeneratorType, alg crypto.EncryptionAlgorithm, defaultConfig *crypto.GeneratorConfig) (*EncryptedCode, string, error) {
+		if !authz.GetFeatures(ctx).AllowOTPCodeOverride {
+			slog.DebugContext(ctx, "preotpsmscode hook skipped: AllowOTPCodeOverride disabled", "userID", userID)
+			return c.newPhoneCode(ctx, filter, secretGeneratorType, alg, defaultConfig)
+		}
+		if c.preOTPSMSCodeHook == nil {
+			slog.DebugContext(ctx, "preotpsmscode hook skipped: no hook implementation", "userID", userID)
+			return c.newPhoneCode(ctx, filter, secretGeneratorType, alg, defaultConfig)
+		}
+
+		externalID, err := c.activeSMSProvider(ctx)
+		if err != nil {
+			return nil, "", err
+		}
+		if externalID != "" {
+			// Twilio Verify owns the code lifecycle when configured; skip the hook.
+			slog.DebugContext(ctx, "preotpsmscode hook skipped: external SMS provider owns code", "userID", userID, "provider", externalID)
+			return nil, externalID, nil
+		}
+
+		effectiveConfig, err := cryptoGeneratorConfigWithDefault(ctx, filter, secretGeneratorType, defaultConfig)
+		if err != nil {
+			return nil, "", err
+		}
+
+		hookResp, err := c.preOTPSMSCodeHook(ctx, userID, resourceOwner, effectiveConfig)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if hookResp != nil && hookResp.Code != nil {
+			code, err := encryptOverriddenOTPCode(*hookResp.Code, alg, overrideExpiry(effectiveConfig.Expiry, hookResp.Expiry))
+			if err != nil {
+				return nil, "", err
+			}
+			return code, "", nil
+		}
+
+		codeConfig := effectiveConfig
+		if hookResp != nil && (hookResp.Generate != nil || hookResp.Expiry != nil) {
+			codeConfig = applyGenerationOverrides(effectiveConfig, hookResp.Generate, hookResp.Expiry)
+			if err := validateGenerationConfig(codeConfig); err != nil {
+				return nil, "", err
+			}
+		}
+		crypted, plain, err := crypto.NewCode(crypto.NewEncryptionGenerator(*codeConfig, alg))
+		if err != nil {
+			return nil, "", err
+		}
+		return &EncryptedCode{Crypted: crypted, Plain: plain, Expiry: codeConfig.Expiry}, "", nil
+	}
+}
+
+// validateGenerationConfig rejects configs that would cause crypto.NewCode to
+// produce an empty code or panic: non-zero length with no character class set.
+// This guards the new override path — pre-existing instance configs are trusted.
+func validateGenerationConfig(cfg *crypto.GeneratorConfig) error {
+	if cfg.Length == 0 {
+		return nil
+	}
+	if !cfg.IncludeLowerLetters && !cfg.IncludeUpperLetters && !cfg.IncludeDigits && !cfg.IncludeSymbols {
+		return zerrors.ThrowPreconditionFailed(nil, "ACTION-w4n9p", "Errors.Execution.Invalid")
+	}
+	return nil
+}
+
+func publicGeneratorConfigFrom(cfg *crypto.GeneratorConfig) *otp.PublicGeneratorConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &otp.PublicGeneratorConfig{
+		Length:              uint32(cfg.Length),
+		Expiry:              otp.Duration(cfg.Expiry),
+		IncludeLowerLetters: cfg.IncludeLowerLetters,
+		IncludeUpperLetters: cfg.IncludeUpperLetters,
+		IncludeDigits:       cfg.IncludeDigits,
+		IncludeSymbols:      cfg.IncludeSymbols,
+	}
+}
+
+func applyGenerationOverrides(base *crypto.GeneratorConfig, gen *otp.GenerationOverrides, expiry *otp.Duration) *crypto.GeneratorConfig {
+	out := *base
+	if gen != nil {
+		if gen.Length != nil {
+			out.Length = uint(*gen.Length)
+		}
+		if gen.IncludeLowerLetters != nil {
+			out.IncludeLowerLetters = *gen.IncludeLowerLetters
+		}
+		if gen.IncludeUpperLetters != nil {
+			out.IncludeUpperLetters = *gen.IncludeUpperLetters
+		}
+		if gen.IncludeDigits != nil {
+			out.IncludeDigits = *gen.IncludeDigits
+		}
+		if gen.IncludeSymbols != nil {
+			out.IncludeSymbols = *gen.IncludeSymbols
+		}
+	}
+	if expiry != nil {
+		out.Expiry = time.Duration(*expiry)
+	}
+	return &out
+}
+
+func overrideExpiry(base time.Duration, override *otp.Duration) time.Duration {
+	if override == nil {
+		return base
+	}
+	return time.Duration(*override)
+}
+
+func encryptOverriddenOTPCode(plain string, alg crypto.EncryptionAlgorithm, expiry time.Duration) (*EncryptedCode, error) {
+	crypted, err := crypto.Encrypt([]byte(plain), alg)
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptedCode{Crypted: crypted, Plain: plain, Expiry: expiry}, nil
+}

--- a/internal/command/user_human_otp_hook.go
+++ b/internal/command/user_human_otp_hook.go
@@ -121,6 +121,92 @@ func validateGenerationConfig(cfg *crypto.GeneratorConfig) error {
 	return nil
 }
 
+// preOTPEmailCodeHookFromTargets is the default implementation of the preotpemailcode
+// hook invocation. Mirrors preOTPSMSCodeHookFromTargets for the email channel.
+func (c *Commands) preOTPEmailCodeHookFromTargets(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPEmailCodeResponse, error) {
+	fnID := exec_repo.ID(domain.ExecutionTypeFunction, domain.ActionFunctionPreOTPEmailCode.LocalizationKey())
+	targets := execution.QueryExecutionTargetsForFunction(ctx, fnID)
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	emailWM, err := c.emailWriteModel(ctx, userID, resourceOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	// OTP Email enrollment requires a verified email (AddHumanOTPEmail precondition),
+	// so emailWM.Email is the verified address at this point.
+	ctxInfo := &otp.PreOTPEmailCodeContext{
+		FunctionName:          domain.ActionFunctionPreOTPEmailCode.LocalizationKey(),
+		RecipientEmailAddress: string(emailWM.Email),
+		GeneratorConfig:       publicGeneratorConfigFrom(effectiveConfig),
+	}
+
+	resp, err := execution.CallTargets(ctx, targets, ctxInfo, c.targetEncryption, c.GetActiveSigningWebKey, c.ActionsV2DenyList)
+	if err != nil {
+		return nil, err
+	}
+	response, ok := resp.(*otp.PreOTPEmailCodeResponse)
+	if !ok {
+		return nil, nil
+	}
+	return response, nil
+}
+
+// newEmailCodeWithHook wraps the default email code generator so that, when
+// AllowOTPCodeOverride is enabled, the preotpemailcode hook can supply an
+// override code or adjust generator parameters before local code generation.
+// Unlike the SMS wrapper there is no external-provider bypass — email has no
+// provider-level CodeGenerator equivalent to Twilio Verify.
+func (c *Commands) newEmailCodeWithHook(userID, resourceOwner string) encryptedCodeGeneratorWithDefaultFunc {
+	base := func(ctx context.Context, filter preparation.FilterToQueryReducer, secretGeneratorType domain.SecretGeneratorType, alg crypto.EncryptionAlgorithm, defaultConfig *crypto.GeneratorConfig) (*EncryptedCode, string, error) {
+		code, err := c.newEncryptedCodeWithDefault(ctx, filter, secretGeneratorType, alg, defaultConfig)
+		return code, "", err
+	}
+	return func(ctx context.Context, filter preparation.FilterToQueryReducer, secretGeneratorType domain.SecretGeneratorType, alg crypto.EncryptionAlgorithm, defaultConfig *crypto.GeneratorConfig) (*EncryptedCode, string, error) {
+		if !authz.GetFeatures(ctx).AllowOTPCodeOverride {
+			slog.DebugContext(ctx, "preotpemailcode hook skipped: AllowOTPCodeOverride disabled", "userID", userID)
+			return base(ctx, filter, secretGeneratorType, alg, defaultConfig)
+		}
+		if c.preOTPEmailCodeHook == nil {
+			slog.DebugContext(ctx, "preotpemailcode hook skipped: no hook implementation", "userID", userID)
+			return base(ctx, filter, secretGeneratorType, alg, defaultConfig)
+		}
+
+		effectiveConfig, err := cryptoGeneratorConfigWithDefault(ctx, filter, secretGeneratorType, defaultConfig)
+		if err != nil {
+			return nil, "", err
+		}
+
+		hookResp, err := c.preOTPEmailCodeHook(ctx, userID, resourceOwner, effectiveConfig)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if hookResp != nil && hookResp.Code != nil {
+			code, err := encryptOverriddenOTPCode(*hookResp.Code, alg, overrideExpiry(effectiveConfig.Expiry, hookResp.Expiry))
+			if err != nil {
+				return nil, "", err
+			}
+			return code, "", nil
+		}
+
+		codeConfig := effectiveConfig
+		if hookResp != nil && (hookResp.Generate != nil || hookResp.Expiry != nil) {
+			codeConfig = applyGenerationOverrides(effectiveConfig, hookResp.Generate, hookResp.Expiry)
+			if err := validateGenerationConfig(codeConfig); err != nil {
+				return nil, "", err
+			}
+		}
+		crypted, plain, err := crypto.NewCode(crypto.NewEncryptionGenerator(*codeConfig, alg))
+		if err != nil {
+			return nil, "", err
+		}
+		return &EncryptedCode{Crypted: crypted, Plain: plain, Expiry: codeConfig.Expiry}, "", nil
+	}
+}
+
 func publicGeneratorConfigFrom(cfg *crypto.GeneratorConfig) *otp.PublicGeneratorConfig {
 	if cfg == nil {
 		return nil

--- a/internal/command/user_human_otp_hook_e2e_test.go
+++ b/internal/command/user_human_otp_hook_e2e_test.go
@@ -1,0 +1,277 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/muhlemmer/gu"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zitadel/zitadel/internal/api/action/otp"
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/crypto"
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/feature"
+	"github.com/zitadel/zitadel/internal/repository/user"
+)
+
+var (
+	hookTestDefaultGenerators = &SecretGenerators{
+		OTPSMS: &crypto.GeneratorConfig{
+			Length:              8,
+			Expiry:              time.Hour,
+			IncludeLowerLetters: true,
+			IncludeUpperLetters: true,
+			IncludeDigits:       true,
+			IncludeSymbols:      true,
+		},
+		OTPEmail: &crypto.GeneratorConfig{
+			Length:              8,
+			Expiry:              time.Hour,
+			IncludeLowerLetters: true,
+			IncludeUpperLetters: true,
+			IncludeDigits:       true,
+			IncludeSymbols:      true,
+		},
+	}
+
+	hookTestAuthRequest = &domain.AuthRequest{
+		ID:      "authRequestID",
+		AgentID: "userAgentID",
+		BrowserInfo: &domain.BrowserInfo{
+			UserAgent:      "user-agent",
+			AcceptLanguage: "en",
+			RemoteIP:       net.IP{192, 0, 2, 1},
+		},
+	}
+
+	hookTestAuthRequestInfo = &user.AuthRequestInfo{
+		ID:          "authRequestID",
+		UserAgentID: "userAgentID",
+		BrowserInfo: &user.BrowserInfo{
+			UserAgent:      "user-agent",
+			AcceptLanguage: "en",
+			RemoteIP:       net.IP{192, 0, 2, 1},
+		},
+	}
+)
+
+func flagOnCtx() context.Context {
+	return authz.NewMockContext("inst1", "org1", "user1",
+		authz.WithMockFeatures(feature.Features{AllowOTPCodeOverride: true}))
+}
+
+func TestCommandSide_HumanSendOTPSMS_hookReturnsCode(t *testing.T) {
+	ctx := flagOnCtx()
+
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanOTPSMSAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectFilter(), // lastActivated SMS config — none
+			expectFilter(), // getSMSConfig — none
+			expectFilter(), // secret generator config — fall back to default
+			expectPush(
+				user.NewHumanOTPSMSCodeAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate,
+					&crypto.CryptoValue{
+						CryptoType: crypto.TypeEncryption,
+						Algorithm:  "enc",
+						KeyID:      "id",
+						Crypted:    []byte("A7F2B9"),
+					},
+					5*time.Minute,
+					hookTestAuthRequestInfo,
+					"",
+				),
+			),
+		)(t),
+		defaultSecretGenerators: hookTestDefaultGenerators,
+		userEncryption:          crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+		preOTPSMSCodeHook: func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error) {
+			return &otp.PreOTPSMSCodeResponse{
+				Code:   gu.Ptr("A7F2B9"),
+				Expiry: gu.Ptr(otp.Duration(5 * time.Minute)),
+			}, nil
+		},
+	}
+	assert.NoError(t, r.HumanSendOTPSMS(ctx, "user1", "org1", hookTestAuthRequest))
+}
+
+func TestCommandSide_HumanSendOTPSMS_flagOffHookNotInvoked(t *testing.T) {
+	ctx := authz.NewMockContext("inst1", "org1", "user1") // no features
+
+	hookCalled := false
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanOTPSMSAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectFilter(), // lastActivated SMS config — none
+			expectFilter(), // getSMSConfig — none
+			expectPush(
+				user.NewHumanOTPSMSCodeAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate,
+					&crypto.CryptoValue{
+						CryptoType: crypto.TypeEncryption,
+						Algorithm:  "enc",
+						KeyID:      "id",
+						Crypted:    []byte("12345678"),
+					},
+					time.Hour,
+					hookTestAuthRequestInfo,
+					"",
+				),
+			),
+		)(t),
+		defaultSecretGenerators:     hookTestDefaultGenerators,
+		newEncryptedCodeWithDefault: mockEncryptedCodeWithDefault("12345678", time.Hour),
+		preOTPSMSCodeHook: func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error) {
+			hookCalled = true
+			return nil, nil
+		},
+	}
+	assert.NoError(t, r.HumanSendOTPSMS(ctx, "user1", "org1", hookTestAuthRequest))
+	assert.False(t, hookCalled, "preOTPSMSCodeHook must not be invoked when AllowOTPCodeOverride is off")
+}
+
+func TestCommandSide_HumanSendOTPSMS_flagOnNilHookFallsThrough(t *testing.T) {
+	ctx := flagOnCtx()
+
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanOTPSMSAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectFilter(), // lastActivated SMS config — none
+			expectFilter(), // getSMSConfig — none
+			expectPush(
+				user.NewHumanOTPSMSCodeAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate,
+					&crypto.CryptoValue{
+						CryptoType: crypto.TypeEncryption,
+						Algorithm:  "enc",
+						KeyID:      "id",
+						Crypted:    []byte("12345678"),
+					},
+					time.Hour,
+					hookTestAuthRequestInfo,
+					"",
+				),
+			),
+		)(t),
+		defaultSecretGenerators:     hookTestDefaultGenerators,
+		newEncryptedCodeWithDefault: mockEncryptedCodeWithDefault("12345678", time.Hour),
+		// preOTPSMSCodeHook left nil on purpose.
+	}
+	assert.NoError(t, r.HumanSendOTPSMS(ctx, "user1", "org1", hookTestAuthRequest))
+}
+
+func TestCommandSide_HumanSendOTPSMS_hookError(t *testing.T) {
+	ctx := flagOnCtx()
+
+	hookErr := errors.New("hook target unreachable")
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanOTPSMSAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectFilter(), // lastActivated SMS config — none
+			expectFilter(), // getSMSConfig — none
+			expectFilter(), // secret generator config — fall back to default
+		)(t),
+		defaultSecretGenerators: hookTestDefaultGenerators,
+		userEncryption:          crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+		preOTPSMSCodeHook: func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPSMSCodeResponse, error) {
+			return nil, hookErr
+		},
+	}
+	err := r.HumanSendOTPSMS(ctx, "user1", "org1", hookTestAuthRequest)
+	assert.ErrorIs(t, err, hookErr)
+}
+
+func TestCommandSide_HumanSendOTPEmail_hookReturnsCode(t *testing.T) {
+	ctx := flagOnCtx()
+
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanEmailVerifiedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+				eventFromEventPusher(user.NewHumanOTPEmailAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectFilter(), // secret generator config — fall back to default
+			expectPush(
+				user.NewHumanOTPEmailCodeAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate,
+					&crypto.CryptoValue{
+						CryptoType: crypto.TypeEncryption,
+						Algorithm:  "enc",
+						KeyID:      "id",
+						Crypted:    []byte("B8E3C1"),
+					},
+					10*time.Minute,
+					hookTestAuthRequestInfo,
+					"",
+				),
+			),
+		)(t),
+		defaultSecretGenerators: hookTestDefaultGenerators,
+		userEncryption:          crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+		preOTPEmailCodeHook: func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPEmailCodeResponse, error) {
+			return &otp.PreOTPEmailCodeResponse{
+				Code:   gu.Ptr("B8E3C1"),
+				Expiry: gu.Ptr(otp.Duration(10 * time.Minute)),
+			}, nil
+		},
+	}
+	assert.NoError(t, r.HumanSendOTPEmail(ctx, "user1", "org1", hookTestAuthRequest))
+}
+
+func TestCommandSide_HumanSendOTPEmail_flagOffHookNotInvoked(t *testing.T) {
+	ctx := authz.NewMockContext("inst1", "org1", "user1") // no features
+
+	hookCalled := false
+	r := &Commands{
+		eventstore: expectEventstore(
+			expectFilter(
+				eventFromEventPusher(user.NewHumanEmailVerifiedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+				eventFromEventPusher(user.NewHumanOTPEmailAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate)),
+			),
+			expectPush(
+				user.NewHumanOTPEmailCodeAddedEvent(ctx,
+					&user.NewAggregate("user1", "org1").Aggregate,
+					&crypto.CryptoValue{
+						CryptoType: crypto.TypeEncryption,
+						Algorithm:  "enc",
+						KeyID:      "id",
+						Crypted:    []byte("12345678"),
+					},
+					time.Hour,
+					hookTestAuthRequestInfo,
+					"",
+				),
+			),
+		)(t),
+		defaultSecretGenerators:     hookTestDefaultGenerators,
+		newEncryptedCodeWithDefault: mockEncryptedCodeWithDefault("12345678", time.Hour),
+		preOTPEmailCodeHook: func(ctx context.Context, userID, resourceOwner string, effectiveConfig *crypto.GeneratorConfig) (*otp.PreOTPEmailCodeResponse, error) {
+			hookCalled = true
+			return nil, nil
+		},
+	}
+	assert.NoError(t, r.HumanSendOTPEmail(ctx, "user1", "org1", hookTestAuthRequest))
+	assert.False(t, hookCalled, "preOTPEmailCodeHook must not be invoked when AllowOTPCodeOverride is off")
+}

--- a/internal/command/user_human_otp_hook_test.go
+++ b/internal/command/user_human_otp_hook_test.go
@@ -1,0 +1,154 @@
+package command
+
+import (
+	"testing"
+	"time"
+
+	"github.com/muhlemmer/gu"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zitadel/zitadel/internal/api/action/otp"
+	"github.com/zitadel/zitadel/internal/crypto"
+)
+
+func TestPublicGeneratorConfigFrom(t *testing.T) {
+	got := publicGeneratorConfigFrom(&crypto.GeneratorConfig{
+		Length:              8,
+		Expiry:              time.Hour,
+		IncludeLowerLetters: true,
+		IncludeDigits:       true,
+	})
+	want := &otp.PublicGeneratorConfig{
+		Length:              8,
+		Expiry:              otp.Duration(time.Hour),
+		IncludeLowerLetters: true,
+		IncludeDigits:       true,
+	}
+	assert.Equal(t, want, got)
+
+	assert.Nil(t, publicGeneratorConfigFrom(nil))
+}
+
+func TestApplyGenerationOverrides(t *testing.T) {
+	base := &crypto.GeneratorConfig{
+		Length:              8,
+		Expiry:              time.Hour,
+		IncludeLowerLetters: true,
+		IncludeUpperLetters: true,
+		IncludeDigits:       true,
+		IncludeSymbols:      true,
+	}
+	tests := []struct {
+		name   string
+		gen    *otp.GenerationOverrides
+		expiry *otp.Duration
+		want   *crypto.GeneratorConfig
+	}{
+		{
+			name: "no overrides returns clone",
+			want: base,
+		},
+		{
+			name: "length only",
+			gen:  &otp.GenerationOverrides{Length: gu.Ptr(uint32(4))},
+			want: &crypto.GeneratorConfig{
+				Length:              4,
+				Expiry:              time.Hour,
+				IncludeLowerLetters: true,
+				IncludeUpperLetters: true,
+				IncludeDigits:       true,
+				IncludeSymbols:      true,
+			},
+		},
+		{
+			name: "digits only voice SMS",
+			gen: &otp.GenerationOverrides{
+				Length:              gu.Ptr(uint32(4)),
+				IncludeDigits:       gu.Ptr(true),
+				IncludeLowerLetters: gu.Ptr(false),
+				IncludeUpperLetters: gu.Ptr(false),
+				IncludeSymbols:      gu.Ptr(false),
+			},
+			want: &crypto.GeneratorConfig{
+				Length:              4,
+				Expiry:              time.Hour,
+				IncludeLowerLetters: false,
+				IncludeUpperLetters: false,
+				IncludeDigits:       true,
+				IncludeSymbols:      false,
+			},
+		},
+		{
+			name:   "expiry only",
+			expiry: gu.Ptr(otp.Duration(5 * time.Minute)),
+			want: &crypto.GeneratorConfig{
+				Length:              8,
+				Expiry:              5 * time.Minute,
+				IncludeLowerLetters: true,
+				IncludeUpperLetters: true,
+				IncludeDigits:       true,
+				IncludeSymbols:      true,
+			},
+		},
+		{
+			name:   "gen and expiry together",
+			gen:    &otp.GenerationOverrides{Length: gu.Ptr(uint32(6))},
+			expiry: gu.Ptr(otp.Duration(2 * time.Minute)),
+			want: &crypto.GeneratorConfig{
+				Length:              6,
+				Expiry:              2 * time.Minute,
+				IncludeLowerLetters: true,
+				IncludeUpperLetters: true,
+				IncludeDigits:       true,
+				IncludeSymbols:      true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyGenerationOverrides(base, tt.gen, tt.expiry)
+			assert.Equal(t, tt.want, got)
+			// Ensure base is not mutated.
+			assert.Equal(t, uint(8), base.Length)
+			assert.Equal(t, time.Hour, base.Expiry)
+		})
+	}
+}
+
+func TestOverrideExpiry(t *testing.T) {
+	assert.Equal(t, time.Hour, overrideExpiry(time.Hour, nil))
+	assert.Equal(t, 5*time.Minute, overrideExpiry(time.Hour, gu.Ptr(otp.Duration(5*time.Minute))))
+}
+
+func TestEncryptOverriddenOTPCode(t *testing.T) {
+	alg := crypto.CreateMockEncryptionAlg(gomock.NewController(t))
+	code, err := encryptOverriddenOTPCode("A7F2B9", alg, 2*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, "A7F2B9", code.Plain)
+	assert.Equal(t, 2*time.Minute, code.Expiry)
+	assert.NotNil(t, code.Crypted)
+}
+
+func TestValidateGenerationConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *crypto.GeneratorConfig
+		wantErr bool
+	}{
+		{"length zero is tolerated", &crypto.GeneratorConfig{Length: 0}, false},
+		{"digits only is valid", &crypto.GeneratorConfig{Length: 6, IncludeDigits: true}, false},
+		{"lower+upper is valid", &crypto.GeneratorConfig{Length: 6, IncludeLowerLetters: true, IncludeUpperLetters: true}, false},
+		{"length with no classes is rejected", &crypto.GeneratorConfig{Length: 6}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGenerationConfig(tt.cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/command/user_human_otp_model.go
+++ b/internal/command/user_human_otp_model.go
@@ -393,6 +393,7 @@ func (wm *HumanOTPEmailCodeWriteModel) Reduce() error {
 				Code:         e.Code,
 				CreationDate: e.CreationDate(),
 				Expiry:       e.Expiry,
+				GeneratorID:  e.GeneratorID,
 			}
 		case *user.HumanOTPEmailCheckSucceededEvent:
 			wm.checkFailedCount = 0

--- a/internal/command/user_human_otp_test.go
+++ b/internal/command/user_human_otp_test.go
@@ -2942,6 +2942,7 @@ func TestCommandSide_HumanSendOTPEmail(t *testing.T) {
 							},
 							time.Hour,
 							nil,
+							"",
 						),
 					),
 				),
@@ -2989,6 +2990,7 @@ func TestCommandSide_HumanSendOTPEmail(t *testing.T) {
 									RemoteIP:       net.IP{192, 0, 2, 1},
 								},
 							},
+							"",
 						),
 					),
 				),
@@ -3125,9 +3127,10 @@ func TestCommandSide_HumanOTPEmailCodeSent(t *testing.T) {
 func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 	ctx := authz.NewMockContext("inst1", "org1", "user1")
 	type fields struct {
-		eventstore     func(*testing.T) *eventstore.Eventstore
-		userEncryption crypto.EncryptionAlgorithm
-		tarpit         Tarpit
+		eventstore        func(*testing.T) *eventstore.Eventstore
+		userEncryption    crypto.EncryptionAlgorithm
+		emailCodeVerifier func(ctx context.Context, id string) (senders.CodeGenerator, error)
+		tarpit            Tarpit
 	}
 	type (
 		args struct {
@@ -3251,6 +3254,7 @@ func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 										RemoteIP:       net.IP{192, 0, 2, 1},
 									},
 								},
+								"",
 							),
 						),
 					),
@@ -3329,6 +3333,7 @@ func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 										RemoteIP:       net.IP{192, 0, 2, 1},
 									},
 								},
+								"",
 							),
 						),
 					),
@@ -3410,6 +3415,7 @@ func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 										RemoteIP:       net.IP{192, 0, 2, 1},
 									},
 								},
+								"",
 							),
 						),
 					),
@@ -3482,6 +3488,7 @@ func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 										RemoteIP:       net.IP{192, 0, 2, 1},
 									},
 								},
+								"",
 							),
 						),
 					),
@@ -3513,13 +3520,87 @@ func TestCommandSide_HumanCheckOTPEmail(t *testing.T) {
 				err: zerrors.ThrowPreconditionFailed(nil, "COMMAND-S6h4R", "Errors.User.Locked"),
 			},
 		},
+		{
+			name: "code ok (external)",
+			fields: fields{
+				eventstore: expectEventstore(
+					expectFilter(
+						eventFromEventPusher(
+							user.NewHumanOTPEmailAddedEvent(ctx,
+								&user.NewAggregate("user1", "org1").Aggregate,
+							),
+						),
+						eventFromEventPusherWithCreationDateNow(
+							user.NewHumanOTPEmailCodeAddedEvent(ctx,
+								&user.NewAggregate("user1", "org1").Aggregate,
+								nil,
+								0,
+								&user.AuthRequestInfo{
+									ID:          "authRequestID",
+									UserAgentID: "userAgentID",
+									BrowserInfo: &user.BrowserInfo{
+										UserAgent:      "user-agent",
+										AcceptLanguage: "en",
+										RemoteIP:       net.IP{192, 0, 2, 1},
+									},
+								},
+								"id",
+							),
+						),
+					),
+					expectFilter(), // recheck
+					expectPush(
+						user.NewHumanOTPEmailCheckSucceededEvent(ctx,
+							&user.NewAggregate("user1", "org1").Aggregate,
+							&user.AuthRequestInfo{
+								ID:          "authRequestID",
+								UserAgentID: "userAgentID",
+								BrowserInfo: &user.BrowserInfo{
+									UserAgent:      "user-agent",
+									AcceptLanguage: "en",
+									RemoteIP:       net.IP{192, 0, 2, 1},
+								},
+							},
+						),
+					),
+				),
+				userEncryption: crypto.CreateMockEncryptionAlg(gomock.NewController(t)),
+				emailCodeVerifier: func(ctx context.Context, id string) (senders.CodeGenerator, error) {
+					sender := mock.NewMockCodeGenerator(gomock.NewController(t))
+					sender.EXPECT().VerifyCode("", "code").Return(nil)
+					return sender, nil
+				},
+				tarpit: expectTarpit(0),
+			},
+			args: args{
+				ctx:           ctx,
+				userID:        "user1",
+				code:          "code",
+				resourceOwner: "org1",
+				authRequest: &domain.AuthRequest{
+					ID:      "authRequestID",
+					AgentID: "userAgentID",
+					BrowserInfo: &domain.BrowserInfo{
+						UserAgent:      "user-agent",
+						AcceptLanguage: "en",
+						RemoteIP:       net.IP{192, 0, 2, 1},
+					},
+				},
+			},
+			res: res{
+				want: &domain.ObjectDetails{
+					ResourceOwner: "org1",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Commands{
-				eventstore:     tt.fields.eventstore(t),
-				userEncryption: tt.fields.userEncryption,
-				tarpit:         tt.fields.tarpit.tarpit,
+				eventstore:        tt.fields.eventstore(t),
+				userEncryption:    tt.fields.userEncryption,
+				emailCodeVerifier: tt.fields.emailCodeVerifier,
+				tarpit:            tt.fields.tarpit.tarpit,
 			}
 			err := r.HumanCheckOTPEmail(tt.args.ctx, tt.args.userID, tt.args.code, tt.args.resourceOwner, tt.args.authRequest)
 			assert.ErrorIs(t, err, tt.res.err)

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -54,6 +54,8 @@ const (
 	ActionFunctionPreUserinfo
 	ActionFunctionPreAccessToken
 	ActionFunctionPreSAMLResponse
+	ActionFunctionPreOTPSMSCode
+	ActionFunctionPreOTPEmailCode
 	actionFunctionCount
 )
 
@@ -73,6 +75,10 @@ func (s ActionFunction) LocalizationKey() string {
 		return "preaccesstoken"
 	case ActionFunctionPreSAMLResponse:
 		return "presamlresponse"
+	case ActionFunctionPreOTPSMSCode:
+		return "preotpsmscode"
+	case ActionFunctionPreOTPEmailCode:
+		return "preotpemailcode"
 	case ActionFunctionUnspecified, actionFunctionCount:
 		fallthrough
 	default:
@@ -85,6 +91,8 @@ func AllActionFunctions() []string {
 		ActionFunctionPreUserinfo.LocalizationKey(),
 		ActionFunctionPreAccessToken.LocalizationKey(),
 		ActionFunctionPreSAMLResponse.LocalizationKey(),
+		ActionFunctionPreOTPSMSCode.LocalizationKey(),
+		ActionFunctionPreOTPEmailCode.LocalizationKey(),
 	}
 }
 

--- a/internal/domain/action_test.go
+++ b/internal/domain/action_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionFunction_LocalizationKey(t *testing.T) {
+	tests := []struct {
+		fn   ActionFunction
+		want string
+	}{
+		{ActionFunctionPreUserinfo, "preuserinfo"},
+		{ActionFunctionPreAccessToken, "preaccesstoken"},
+		{ActionFunctionPreSAMLResponse, "presamlresponse"},
+		{ActionFunctionPreOTPSMSCode, "preotpsmscode"},
+		{ActionFunctionPreOTPEmailCode, "preotpemailcode"},
+		{ActionFunctionUnspecified, "unspecified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.fn.LocalizationKey())
+		})
+	}
+}
+
+func TestActionFunctionExists(t *testing.T) {
+	exists := ActionFunctionExists()
+	for _, name := range []string{"preuserinfo", "preaccesstoken", "presamlresponse", "preotpsmscode", "preotpemailcode"} {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, exists(name))
+		})
+	}
+	assert.False(t, exists("unspecified"))
+	assert.False(t, exists("bogus"))
+}

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -25,6 +25,7 @@ const (
 	KeyPermissionCheckV2              Key = 14
 	KeyConsoleUseV2UserApi            Key = 15
 	KeyEnableRelationalTables         Key = 16
+	KeyAllowOTPCodeOverride           Key = 17
 )
 
 //go:generate enumer -type Level -transform snake -trimprefix Level
@@ -51,6 +52,7 @@ type Features struct {
 	PermissionCheckV2              bool                      `json:"permission_check_v2,omitempty"`
 	ConsoleUseV2UserApi            bool                      `json:"console_use_v2_user_api,omitempty"`
 	EnableRelationalTables         bool                      `json:"enable_relational_tables,omitempty"`
+	AllowOTPCodeOverride           bool                      `json:"allow_otp_code_override,omitempty"`
 }
 
 /* Note: do not generate the stringer or enumer for this type, is it breaks existing events */

--- a/internal/feature/key_enumer.go
+++ b/internal/feature/key_enumer.go
@@ -16,8 +16,8 @@ const (
 	_KeyLowerName_2 = "improved_performance"
 	_KeyName_3      = "debug_oidc_parent_erroroidc_single_v1_session_termination"
 	_KeyLowerName_3 = "debug_oidc_parent_erroroidc_single_v1_session_termination"
-	_KeyName_4      = "login_v2permission_check_v2console_use_v2_user_apienable_relational_tables"
-	_KeyLowerName_4 = "login_v2permission_check_v2console_use_v2_user_apienable_relational_tables"
+	_KeyName_4      = "login_v2permission_check_v2console_use_v2_user_apienable_relational_tablesallow_otp_code_override"
+	_KeyLowerName_4 = "login_v2permission_check_v2console_use_v2_user_apienable_relational_tablesallow_otp_code_override"
 )
 
 var (
@@ -25,7 +25,7 @@ var (
 	_KeyIndex_1 = [...]uint8{0, 11}
 	_KeyIndex_2 = [...]uint8{0, 20}
 	_KeyIndex_3 = [...]uint8{0, 23, 57}
-	_KeyIndex_4 = [...]uint8{0, 8, 27, 50, 74}
+	_KeyIndex_4 = [...]uint8{0, 8, 27, 50, 74, 97}
 )
 
 func (i Key) String() string {
@@ -39,7 +39,7 @@ func (i Key) String() string {
 	case 9 <= i && i <= 10:
 		i -= 9
 		return _KeyName_3[_KeyIndex_3[i]:_KeyIndex_3[i+1]]
-	case 13 <= i && i <= 16:
+	case 13 <= i && i <= 17:
 		i -= 13
 		return _KeyName_4[_KeyIndex_4[i]:_KeyIndex_4[i+1]]
 	default:
@@ -61,9 +61,10 @@ func _KeyNoOp() {
 	_ = x[KeyPermissionCheckV2-(14)]
 	_ = x[KeyConsoleUseV2UserApi-(15)]
 	_ = x[KeyEnableRelationalTables-(16)]
+	_ = x[KeyAllowOTPCodeOverride-(17)]
 }
 
-var _KeyValues = []Key{KeyUnspecified, KeyLoginDefaultOrg, KeyUserSchema, KeyImprovedPerformance, KeyDebugOIDCParentError, KeyOIDCSingleV1SessionTermination, KeyLoginV2, KeyPermissionCheckV2, KeyConsoleUseV2UserApi, KeyEnableRelationalTables}
+var _KeyValues = []Key{KeyUnspecified, KeyLoginDefaultOrg, KeyUserSchema, KeyImprovedPerformance, KeyDebugOIDCParentError, KeyOIDCSingleV1SessionTermination, KeyLoginV2, KeyPermissionCheckV2, KeyConsoleUseV2UserApi, KeyEnableRelationalTables, KeyAllowOTPCodeOverride}
 
 var _KeyNameToValueMap = map[string]Key{
 	_KeyName_0[0:11]:       KeyUnspecified,
@@ -86,6 +87,8 @@ var _KeyNameToValueMap = map[string]Key{
 	_KeyLowerName_4[27:50]: KeyConsoleUseV2UserApi,
 	_KeyName_4[50:74]:      KeyEnableRelationalTables,
 	_KeyLowerName_4[50:74]: KeyEnableRelationalTables,
+	_KeyName_4[74:97]:      KeyAllowOTPCodeOverride,
+	_KeyLowerName_4[74:97]: KeyAllowOTPCodeOverride,
 }
 
 var _KeyNames = []string{
@@ -99,6 +102,7 @@ var _KeyNames = []string{
 	_KeyName_4[8:27],
 	_KeyName_4[27:50],
 	_KeyName_4[50:74],
+	_KeyName_4[74:97],
 }
 
 // KeyString retrieves an enum value from the enum constants string name.

--- a/internal/query/instance_features.go
+++ b/internal/query/instance_features.go
@@ -18,6 +18,7 @@ type InstanceFeatures struct {
 	PermissionCheckV2              FeatureSource[bool]
 	ManagementConsoleUseV2UserApi  FeatureSource[bool]
 	EnableRelationalTables         FeatureSource[bool]
+	AllowOTPCodeOverride           FeatureSource[bool]
 }
 
 func (q *Queries) GetInstanceFeatures(ctx context.Context, cascade bool) (_ *InstanceFeatures, err error) {

--- a/internal/query/instance_features_model.go
+++ b/internal/query/instance_features_model.go
@@ -71,6 +71,7 @@ func (m *InstanceFeaturesReadModel) Query() *eventstore.SearchQueryBuilder {
 			feature_v2.InstancePermissionCheckV2,
 			feature_v2.InstanceManagementConsoleUseV2UserApi,
 			feature_v2.InstanceEnableRelationalTables,
+			feature_v2.InstanceAllowOTPCodeOverride,
 		).
 		Builder().ResourceOwner(m.ResourceOwner)
 }
@@ -122,6 +123,8 @@ func reduceInstanceFeatureSet[T any](features *InstanceFeatures, event *feature_
 		features.ManagementConsoleUseV2UserApi.set(level, event.Value)
 	case feature.KeyEnableRelationalTables:
 		features.EnableRelationalTables.set(level, event.Value)
+	case feature.KeyAllowOTPCodeOverride:
+		features.AllowOTPCodeOverride.set(level, event.Value)
 	}
 	return nil
 }

--- a/internal/query/projection/instance_features.go
+++ b/internal/query/projection/instance_features.go
@@ -100,6 +100,10 @@ func (*instanceFeatureProjection) Reducers() []handler.AggregateReducer {
 				Event:  feature_v2.InstanceEnableRelationalTables,
 				Reduce: reduceInstanceSetFeature[bool],
 			},
+			{
+				Event:  feature_v2.InstanceAllowOTPCodeOverride,
+				Reduce: reduceInstanceSetFeature[bool],
+			},
 		},
 	}}
 }

--- a/internal/query/projection/system_features.go
+++ b/internal/query/projection/system_features.go
@@ -72,6 +72,10 @@ func (*systemFeatureProjection) Reducers() []handler.AggregateReducer {
 				Event:  feature_v2.SystemPermissionCheckV2,
 				Reduce: reduceSystemSetFeature[bool],
 			},
+			{
+				Event:  feature_v2.SystemAllowOTPCodeOverride,
+				Reduce: reduceSystemSetFeature[bool],
+			},
 		},
 	}}
 }

--- a/internal/query/system_features.go
+++ b/internal/query/system_features.go
@@ -27,6 +27,7 @@ type SystemFeatures struct {
 	LoginV2                        FeatureSource[*feature.LoginV2]
 	PermissionCheckV2              FeatureSource[bool]
 	EnableRelationalTables         FeatureSource[bool]
+	AllowOTPCodeOverride           FeatureSource[bool]
 }
 
 func (q *Queries) GetSystemFeatures(ctx context.Context) (_ *SystemFeatures, err error) {

--- a/internal/query/system_features_model.go
+++ b/internal/query/system_features_model.go
@@ -62,6 +62,7 @@ func (m *SystemFeaturesReadModel) Query() *eventstore.SearchQueryBuilder {
 			feature_v2.SystemLoginVersion,
 			feature_v2.SystemPermissionCheckV2,
 			feature_v2.SystemEnableRelationalTables,
+			feature_v2.SystemAllowOTPCodeOverride,
 		).
 		Builder().ResourceOwner(m.ResourceOwner)
 }
@@ -93,6 +94,8 @@ func reduceSystemFeatureSet[T any](features *SystemFeatures, event *feature_v2.S
 		features.PermissionCheckV2.set(level, event.Value)
 	case feature.KeyEnableRelationalTables:
 		features.EnableRelationalTables.set(level, event.Value)
+	case feature.KeyAllowOTPCodeOverride:
+		features.AllowOTPCodeOverride.set(level, event.Value)
 	}
 	return nil
 }

--- a/internal/repository/feature/feature_v2/eventstore.go
+++ b/internal/repository/feature/feature_v2/eventstore.go
@@ -14,6 +14,7 @@ func init() {
 	eventstore.RegisterFilterEventMapper(AggregateType, SystemLoginVersion, eventstore.GenericEventMapper[SetEvent[*feature.LoginV2]])
 	eventstore.RegisterFilterEventMapper(AggregateType, SystemPermissionCheckV2, eventstore.GenericEventMapper[SetEvent[bool]])
 	eventstore.RegisterFilterEventMapper(AggregateType, SystemEnableRelationalTables, eventstore.GenericEventMapper[SetEvent[bool]])
+	eventstore.RegisterFilterEventMapper(AggregateType, SystemAllowOTPCodeOverride, eventstore.GenericEventMapper[SetEvent[bool]])
 
 	eventstore.RegisterFilterEventMapper(AggregateType, InstanceResetEventType, eventstore.GenericEventMapper[ResetEvent])
 	eventstore.RegisterFilterEventMapper(AggregateType, InstanceLoginDefaultOrgEventType, eventstore.GenericEventMapper[SetEvent[bool]])
@@ -25,4 +26,5 @@ func init() {
 	eventstore.RegisterFilterEventMapper(AggregateType, InstancePermissionCheckV2, eventstore.GenericEventMapper[SetEvent[bool]])
 	eventstore.RegisterFilterEventMapper(AggregateType, InstanceManagementConsoleUseV2UserApi, eventstore.GenericEventMapper[SetEvent[bool]])
 	eventstore.RegisterFilterEventMapper(AggregateType, InstanceEnableRelationalTables, eventstore.GenericEventMapper[SetEvent[bool]])
+	eventstore.RegisterFilterEventMapper(AggregateType, InstanceAllowOTPCodeOverride, eventstore.GenericEventMapper[SetEvent[bool]])
 }

--- a/internal/repository/feature/feature_v2/feature.go
+++ b/internal/repository/feature/feature_v2/feature.go
@@ -19,6 +19,7 @@ var (
 	SystemLoginVersion                            = setEventTypeFromFeature(feature.LevelSystem, feature.KeyLoginV2)
 	SystemPermissionCheckV2                       = setEventTypeFromFeature(feature.LevelSystem, feature.KeyPermissionCheckV2)
 	SystemEnableRelationalTables                  = setEventTypeFromFeature(feature.LevelSystem, feature.KeyEnableRelationalTables)
+	SystemAllowOTPCodeOverride                    = setEventTypeFromFeature(feature.LevelSystem, feature.KeyAllowOTPCodeOverride)
 
 	InstanceResetEventType                          = resetEventTypeFromFeature(feature.LevelInstance)
 	InstanceLoginDefaultOrgEventType                = setEventTypeFromFeature(feature.LevelInstance, feature.KeyLoginDefaultOrg)
@@ -30,6 +31,7 @@ var (
 	InstancePermissionCheckV2                       = setEventTypeFromFeature(feature.LevelInstance, feature.KeyPermissionCheckV2)
 	InstanceManagementConsoleUseV2UserApi           = setEventTypeFromFeature(feature.LevelInstance, feature.KeyConsoleUseV2UserApi)
 	InstanceEnableRelationalTables                  = setEventTypeFromFeature(feature.LevelInstance, feature.KeyEnableRelationalTables)
+	InstanceAllowOTPCodeOverride                    = setEventTypeFromFeature(feature.LevelInstance, feature.KeyAllowOTPCodeOverride)
 )
 
 const (

--- a/internal/repository/user/human_mfa_otp.go
+++ b/internal/repository/user/human_mfa_otp.go
@@ -487,6 +487,7 @@ type HumanOTPEmailCodeAddedEvent struct {
 	Code              *crypto.CryptoValue `json:"code,omitempty"`
 	Expiry            time.Duration       `json:"expiry,omitempty"`
 	TriggeredAtOrigin string              `json:"triggerOrigin,omitempty"`
+	GeneratorID       string              `json:"generatorId,omitempty"`
 	*AuthRequestInfo
 }
 
@@ -512,6 +513,7 @@ func NewHumanOTPEmailCodeAddedEvent(
 	code *crypto.CryptoValue,
 	expiry time.Duration,
 	info *AuthRequestInfo,
+	generatorID string,
 ) *HumanOTPEmailCodeAddedEvent {
 	return &HumanOTPEmailCodeAddedEvent{
 		BaseEvent: *eventstore.NewBaseEventForPush(
@@ -523,6 +525,7 @@ func NewHumanOTPEmailCodeAddedEvent(
 		Expiry:            expiry,
 		AuthRequestInfo:   info,
 		TriggeredAtOrigin: http.DomainContext(ctx).Origin(),
+		GeneratorID:       generatorID,
 	}
 }
 

--- a/proto/zitadel/feature/v2/instance.proto
+++ b/proto/zitadel/feature/v2/instance.proto
@@ -94,6 +94,13 @@ message SetInstanceFeaturesRequest{
       description: "If this is enabled Zitadel will use the relational tables instead of the projections as the main source to store the data. Regardless of the flag state, both the relational table and the projections are kept up to date. Currently the flag has no effect.";
     }
   ];
+
+  optional bool allow_otp_code_override = 17 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "true";
+      description: "If enabled, Actions V2 pre-OTP-code hooks (preotpsmscode, preotpemailcode) are invoked before OTP code generation and may override the code value, generation parameters, or expiry. When disabled (default), the hooks are not called and OTP codes use the instance's configured secret generator.";
+    }
+  ];
 }
 
 message SetInstanceFeaturesResponse {
@@ -194,6 +201,13 @@ message GetInstanceFeaturesResponse {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "true";
       description: "If this is enabled Zitadel will use the relational tables instead of the projections as the main source to store the data. Regardless of the flag state, both the relational table and the projections are kept up to date. Currently the flag has no effect.";
+    }
+  ];
+
+  FeatureFlag allow_otp_code_override = 18 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "true";
+      description: "If enabled, Actions V2 pre-OTP-code hooks (preotpsmscode, preotpemailcode) are invoked before OTP code generation and may override the code value, generation parameters, or expiry.";
     }
   ];
 }

--- a/proto/zitadel/feature/v2/system.proto
+++ b/proto/zitadel/feature/v2/system.proto
@@ -81,6 +81,13 @@ message SetSystemFeaturesRequest{
     }
   ];
 
+  optional bool allow_otp_code_override = 14 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "true";
+      description: "If enabled, Actions V2 pre-OTP-code hooks (preotpsmscode, preotpemailcode) are invoked before OTP code generation and may override the code value, generation parameters, or expiry. When disabled (default), the hooks are not called and OTP codes use the instance's configured secret generator.";
+    }
+  ];
+
 }
 
 message SetSystemFeaturesResponse {
@@ -160,6 +167,13 @@ message GetSystemFeaturesResponse {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       example: "true";
       description: "If this is enabled Zitadel will use the relational tables instead of the projections as the main source to store the data. Regardless of the flag state, both the relational table and the projections are kept up to date. Currently the flag has no effect.";
+    }
+  ];
+
+  FeatureFlag allow_otp_code_override = 15 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      example: "true";
+      description: "If enabled, Actions V2 pre-OTP-code hooks (preotpsmscode, preotpemailcode) are invoked before OTP code generation and may override the code value, generation parameters, or expiry.";
     }
   ];
 }


### PR DESCRIPTION
# Which Problems Are Solved

- Zitadel has no per-request hook to influence OTP code generation. The instance-level secret generator policy is the only lever, so Actions V2 cannot override a code's value, generator parameters, or TTL on a per-send basis.
- `HumanCheckOTPEmail` (`internal/command/user_human_otp.go`) hardcoded `nil` for `getCodeVerifier` with the comment *"email currently always uses local code checks"*, blocking any external verifier path for email even if a provider supported it.
- Issue #8581 shipped Twilio Verify for OTP SMS but explicitly descoped the webhook-provider path, leaving no way to plug in non-Twilio SMS providers or action-based code control for either channel.

# How the Problems Are Solved

Introduces two Actions V2 function hooks — `preotpsmscode` and `preotpemailcode` — that fire before OTP code generation when the new instance feature flag `AllowOTPCodeOverride` is enabled (default `false`, so unchanged instances are byte-identical).

Each hook may:
- Supply a code value directly (stored and verified verbatim via the local-crypto path, `generatorID = ""`)
- Override generator parameters (length, include-lower/upper/digits/symbols) for this request only, leaving the instance policy untouched
- Override the code expiry independently of the code's source
- Return an empty response to use instance defaults

Structurally mirrors the existing `preuserinfo` / `preaccesstoken` / `presamlresponse` pattern:
- Wire-contract Go types at `internal/api/action/otp/hook.go` implementing `execution.ContextInfo`
- Default implementations at the command layer (`internal/command/user_human_otp_hook.go`) call `execution.CallTargets` with `c.targetEncryption`, `c.GetActiveSigningWebKey`, and `c.ActionsV2DenyList`
- `SetHTTPResponseBody` rejects mutually-exclusive `code` + `generate` responses with `Errors.Execution.Invalid`
- SMS wrapper preserves Twilio Verify: when `activeSMSProvider` returns a non-empty external ID (i.e. `VerifyServiceSID` is set on the active provider), the hook is skipped and the existing Twilio Verify flow runs unchanged

# Additional Changes

- Threads `c.emailCodeVerifier` through `HumanCheckOTPEmail` (removes the hardcoded `nil`), restoring parity between OTP Email and OTP SMS so future external verifier paths don't require further plumbing.
- Extends `HumanOTPEmailCodeAddedEvent` with a backward-compatible `GeneratorID string` field (`json:"generatorId,omitempty"`). Existing events without it unmarshal to empty → local-crypto verify path, unchanged.
- Adds `validateGenerationConfig`: rejects an override that would strip every character class while still requesting a non-zero length (would otherwise panic in `crypto.GenerateRandomString`).
- `cmd/start/start.go` wires `commands.GetActiveSigningWebKey = queries.GetActiveSigningWebKey` so the command layer can invoke action targets with signed payloads.
- Hook-skip debug paths use `log/slog` (stdlib) rather than pulling `github.com/zitadel/logging` into a new file.
- No new `TERMINOLOGY.md` entries: the new identifiers (`preotpsmscode`, `preotpemailcode`, `AllowOTPCodeOverride`) are technical constants, not user-facing terms. Happy to add entries if reviewers prefer.

# Additional Context

- Closes #8581 — addresses the webhook-provider item that was descoped when Twilio Verify shipped.
- @rajatcing suggested to submit a PR to help assess this change -  [Discord post](https://discord.com/channels/927474939156643850/1493875854521008198)
- **Draft** — seeking architectural feedback before expanding coverage.
- Deferred intentionally and scoped as follow-ups on this PR:
  - gRPC integration tests via `pnpm nx run @zitadel/api:test-integration`
  - Fumadocs documentation
  - Populating `PreOTP{SMS,Email}CodeContext.User` / `.Org` — fields are declared but not populated; symmetric gap, one follow-up commit once a clean path from the command layer to `*query.User` / `*query.UserInfoOrg` is agreed.

## Quality assurance

Per CONTRIBUTING.md:
- [x] `pnpm nx run @zitadel/api:lint` — 0 issues
- [x] `pnpm nx run @zitadel/api:build` — green
- [x] Command-layer unit tests green, including end-to-end hook branches via mocked `preOTPSMSCodeHook` / `preOTPEmailCodeHook`
- [x] Flag-off regression: all existing OTP SMS and OTP Email tests pass unchanged with the wrapped code generators in place
- [ ] Integration tests against the gRPC server — **deferred** pending architectural review
- [ ] Fumadocs documentation — **deferred** pending architectural review

---
*Concept, design, and implementation decisions are mine. AI was used to write code and documentation.*