### PR TITLE
fix(login): support public URL override for redirect origins

### DIFF
--- a/apps/login/next-env-vars.d.ts
+++ b/apps/login/next-env-vars.d.ts
@@ -17,6 +17,13 @@ declare namespace NodeJS {
     ZITADEL_API_URL: string;
 
     /**
+     * Optional: public URL of the Login app used to build absolute redirects and callbacks.
+     * Use this when reverse proxies do not provide stable host headers.
+     * Must be an absolute URL, for example: https://login.example.com
+     */
+    ZITADEL_PUBLIC_URL?: string;
+
+    /**
      * The service account token
      * If ZITADEL_SERVICE_USER_TOKEN is set, its value is used.
      * If ZITADEL_SERVICE_USER_TOKEN is not set but ZITADEL_SERVICE_USER_TOKEN_FILE is set, the application blocks until the file is created.

--- a/apps/login/src/lib/server/host.test.ts
+++ b/apps/login/src/lib/server/host.test.ts
@@ -2,12 +2,16 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { getInstanceHost, getPublicHost, getPublicHostWithProtocol } from "./host";
 
 describe("Host utility functions", () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env = { ...originalEnv };
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    process.env = originalEnv;
   });
 
   describe("getInstanceHost", () => {
@@ -59,6 +63,17 @@ describe("Host utility functions", () => {
   });
 
   describe("getPublicHostWithProtocol", () => {
+    test("should prefer ZITADEL_PUBLIC_URL when configured", () => {
+      process.env.ZITADEL_PUBLIC_URL = "https://login.example.com";
+
+      const mockHeaders = {
+        get: vi.fn(() => "localhost:3000"),
+      } as any;
+
+      const result = getPublicHostWithProtocol(mockHeaders);
+      expect(result).toBe("https://login.example.com");
+    });
+
     test("should return https for production domain", () => {
       const mockHeaders = {
         get: vi.fn(() => "zitadel.com"),
@@ -204,6 +219,29 @@ describe("Host utility functions", () => {
   });
 
   describe("getPublicHost", () => {
+    test("should prefer ZITADEL_PUBLIC_URL when configured", () => {
+      process.env.ZITADEL_PUBLIC_URL = "https://login.example.com";
+
+      const mockHeaders = {
+        get: vi.fn(() => "localhost:3000"),
+      } as any;
+
+      const result = getPublicHost(mockHeaders);
+      expect(result).toBe("login.example.com");
+    });
+
+    test("should throw when ZITADEL_PUBLIC_URL is invalid", () => {
+      process.env.ZITADEL_PUBLIC_URL = "login.example.com";
+
+      const mockHeaders = {
+        get: vi.fn(() => "localhost:3000"),
+      } as any;
+
+      expect(() => getPublicHost(mockHeaders)).toThrow(
+        "ZITADEL_PUBLIC_URL must be a valid absolute URL, for example: https://login.example.com",
+      );
+    });
+
     test("should use x-zitadel-public-host when available", () => {
       const mockHeaders = {
         get: vi.fn((key: string) => {

--- a/apps/login/src/lib/server/host.test.ts
+++ b/apps/login/src/lib/server/host.test.ts
@@ -242,6 +242,38 @@ describe("Host utility functions", () => {
       );
     });
 
+    test("should throw when ZITADEL_PUBLIC_URL has unsupported scheme", () => {
+      process.env.ZITADEL_PUBLIC_URL = "javascript:alert(1)";
+
+      const mockHeaders = {
+        get: vi.fn(() => "localhost:3000"),
+      } as any;
+
+      expect(() => getPublicHost(mockHeaders)).toThrow(
+        "ZITADEL_PUBLIC_URL must be a valid absolute URL, for example: https://login.example.com",
+      );
+    });
+
+    test("should throw when ZITADEL_PUBLIC_URL includes path, query, hash, or credentials", () => {
+      const invalidPublicURLs = [
+        "https://user:pass@login.example.com",
+        "https://login.example.com/path",
+        "https://login.example.com?foo=bar",
+        "https://login.example.com#anchor",
+      ];
+
+      const mockHeaders = {
+        get: vi.fn(() => "localhost:3000"),
+      } as any;
+
+      for (const invalidURL of invalidPublicURLs) {
+        process.env.ZITADEL_PUBLIC_URL = invalidURL;
+        expect(() => getPublicHost(mockHeaders)).toThrow(
+          "ZITADEL_PUBLIC_URL must be a valid absolute URL, for example: https://login.example.com",
+        );
+      }
+    });
+
     test("should use x-zitadel-public-host when available", () => {
       const mockHeaders = {
         get: vi.fn((key: string) => {

--- a/apps/login/src/lib/server/host.ts
+++ b/apps/login/src/lib/server/host.ts
@@ -11,10 +11,39 @@ export function getConfiguredPublicURL(): URL | null {
   }
 
   try {
-    return new URL(configuredPublicURL);
+    const publicURL = new URL(configuredPublicURL);
+
+    const isValidOrigin =
+      (publicURL.protocol === "http:" || publicURL.protocol === "https:") &&
+      publicURL.host !== "" &&
+      publicURL.pathname === "/" &&
+      publicURL.search === "" &&
+      publicURL.hash === "" &&
+      publicURL.username === "" &&
+      publicURL.password === "";
+
+    if (!isValidOrigin) {
+      throw new Error(INVALID_PUBLIC_URL_ERROR);
+    }
+
+    return publicURL;
   } catch {
     throw new Error(INVALID_PUBLIC_URL_ERROR);
   }
+}
+
+function getPublicHostFromHeaders(headers: ReadonlyHeaders): string {
+  const publicHost =
+    headers.get("x-zitadel-public-host") ||
+    headers.get("x-zitadel-forward-host") ||
+    headers.get("x-forwarded-host") ||
+    headers.get("host");
+
+  if (!publicHost || typeof publicHost !== "string") {
+    throw new Error("No host found in headers");
+  }
+
+  return publicHost;
 }
 
 /**
@@ -50,26 +79,22 @@ export function getPublicHost(headers: ReadonlyHeaders): string {
 
   // Only use standard proxy headers (x-zitadel-public-host → x-zitadel-forward-host → x-forwarded-host → host)
   // Do NOT use x-zitadel-instance-host as it may differ from what the user sees
-  const publicHost =
-    headers.get("x-zitadel-public-host") ||
-    headers.get("x-zitadel-forward-host") ||
-    headers.get("x-forwarded-host") ||
-    headers.get("host");
+  return getPublicHostFromHeaders(headers);
+}
 
-  if (!publicHost || typeof publicHost !== "string") {
-    throw new Error("No host found in headers");
+export function getPublicOrigin(headers: ReadonlyHeaders, fallbackProtocol?: string): string {
+  const configuredPublicURL = getConfiguredPublicURL();
+  if (configuredPublicURL) {
+    return configuredPublicURL.origin;
   }
 
-  return publicHost;
+  const host = getPublicHostFromHeaders(headers);
+  const protocol = fallbackProtocol ?? (host.includes("localhost") ? "http:" : "https:");
+  const normalizedProtocol = protocol.endsWith(":") ? protocol : `${protocol}:`;
+
+  return `${normalizedProtocol}//${host}`;
 }
 
 export function getPublicHostWithProtocol(headers: ReadonlyHeaders): string {
-  const configuredPublicURL = getConfiguredPublicURL();
-  if (configuredPublicURL) {
-    return `${configuredPublicURL.protocol}//${configuredPublicURL.host}`;
-  }
-
-  const host = getPublicHost(headers);
-  const protocol = host.includes("localhost") ? "http://" : "https://";
-  return `${protocol}${host}`;
+  return getPublicOrigin(headers);
 }

--- a/apps/login/src/lib/server/host.ts
+++ b/apps/login/src/lib/server/host.ts
@@ -1,5 +1,22 @@
 import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 
+const INVALID_PUBLIC_URL_ERROR =
+  "ZITADEL_PUBLIC_URL must be a valid absolute URL, for example: https://login.example.com";
+
+export function getConfiguredPublicURL(): URL | null {
+  const configuredPublicURL = process.env.ZITADEL_PUBLIC_URL?.trim();
+
+  if (!configuredPublicURL) {
+    return null;
+  }
+
+  try {
+    return new URL(configuredPublicURL);
+  } catch {
+    throw new Error(INVALID_PUBLIC_URL_ERROR);
+  }
+}
+
 /**
  * Gets the original host that the user sees in their browser URL.
  * When using rewrites this function prioritizes forwarded headers that preserve the original host.
@@ -26,6 +43,11 @@ export function getInstanceHost(headers: ReadonlyHeaders): string | null {
  * @throws Error if no host is found
  */
 export function getPublicHost(headers: ReadonlyHeaders): string {
+  const configuredPublicURL = getConfiguredPublicURL();
+  if (configuredPublicURL) {
+    return configuredPublicURL.host;
+  }
+
   // Only use standard proxy headers (x-zitadel-public-host → x-zitadel-forward-host → x-forwarded-host → host)
   // Do NOT use x-zitadel-instance-host as it may differ from what the user sees
   const publicHost =
@@ -42,6 +64,11 @@ export function getPublicHost(headers: ReadonlyHeaders): string {
 }
 
 export function getPublicHostWithProtocol(headers: ReadonlyHeaders): string {
+  const configuredPublicURL = getConfiguredPublicURL();
+  if (configuredPublicURL) {
+    return `${configuredPublicURL.protocol}//${configuredPublicURL.host}`;
+  }
+
   const host = getPublicHost(headers);
   const protocol = host.includes("localhost") ? "http://" : "https://";
   return `${protocol}${host}`;

--- a/apps/login/src/lib/service-url.test.ts
+++ b/apps/login/src/lib/service-url.test.ts
@@ -91,6 +91,22 @@ describe("Service URL utilities", () => {
       expect(() => getServiceConfig(mockHeaders)).toThrow("No host found in headers");
     });
 
+    test("should use ZITADEL_PUBLIC_URL as public host override", () => {
+      process.env.ZITADEL_API_URL = "https://api.zitadel.cloud";
+      process.env.ZITADEL_PUBLIC_URL = "https://login.example.com";
+
+      const mockHeaders = {
+        get: vi.fn((key: string) => {
+          if (key === "host") return "localhost:3000";
+          return null;
+        }),
+      } as any;
+
+      const result = getServiceConfig(mockHeaders);
+
+      expect(result.serviceConfig.publicHost).toBe("login.example.com");
+    });
+
     test("should handle host with port number", () => {
       process.env.ZITADEL_API_URL = "https://api.zitadel.cloud";
 
@@ -192,6 +208,29 @@ describe("Service URL utilities", () => {
 
       // Should use https: from nextUrl.protocol, not http from header
       expect(result.protocol).toBe("https:");
+    });
+
+    test("should use ZITADEL_PUBLIC_URL for host and protocol override", () => {
+      process.env.NEXT_PUBLIC_BASE_PATH = "";
+      process.env.ZITADEL_PUBLIC_URL = "https://login.example.com";
+
+      const mockRequest = {
+        headers: {
+          get: vi.fn((key: string) => {
+            if (key === "host") return "localhost:3000";
+            return null;
+          }),
+        },
+        nextUrl: {
+          protocol: "http:",
+        },
+      } as any;
+
+      const result = constructUrl(mockRequest as NextRequest, "/test");
+
+      expect(result.protocol).toBe("https:");
+      expect(result.hostname).toBe("login.example.com");
+      expect(result.pathname).toBe("/test");
     });
 
     test("should include base path when NEXT_PUBLIC_BASE_PATH is set", () => {

--- a/apps/login/src/lib/service-url.ts
+++ b/apps/login/src/lib/service-url.ts
@@ -1,6 +1,6 @@
 import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { NextRequest } from "next/server";
-import { getConfiguredPublicURL, getInstanceHost, getPublicHost } from "./server/host";
+import { getInstanceHost, getPublicHost, getPublicOrigin } from "./server/host";
 import { ServiceConfig } from "./zitadel";
 
 /**
@@ -39,9 +39,7 @@ export function getServiceConfig(headers: ReadonlyHeaders): { serviceConfig: Ser
 }
 
 export function constructUrl(request: NextRequest, path: string) {
-  const configuredPublicURL = getConfiguredPublicURL();
-  const protocol = configuredPublicURL?.protocol ?? request.nextUrl.protocol;
-  const forwardedHost = configuredPublicURL?.host ?? getPublicHost(request.headers);
+  const origin = getPublicOrigin(request.headers, request.nextUrl.protocol);
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-  return new URL(`${basePath}${path}`, `${protocol}//${forwardedHost}`);
+  return new URL(`${basePath}${path}`, origin);
 }

--- a/apps/login/src/lib/service-url.ts
+++ b/apps/login/src/lib/service-url.ts
@@ -1,6 +1,6 @@
 import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import { NextRequest } from "next/server";
-import { getInstanceHost, getPublicHost } from "./server/host";
+import { getConfiguredPublicURL, getInstanceHost, getPublicHost } from "./server/host";
 import { ServiceConfig } from "./zitadel";
 
 /**
@@ -39,9 +39,9 @@ export function getServiceConfig(headers: ReadonlyHeaders): { serviceConfig: Ser
 }
 
 export function constructUrl(request: NextRequest, path: string) {
-  const protocol = request.nextUrl.protocol;
-
-  const forwardedHost = getPublicHost(request.headers);
+  const configuredPublicURL = getConfiguredPublicURL();
+  const protocol = configuredPublicURL?.protocol ?? request.nextUrl.protocol;
+  const forwardedHost = configuredPublicURL?.host ?? getPublicHost(request.headers);
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return new URL(`${basePath}${path}`, `${protocol}//${forwardedHost}`);
 }


### PR DESCRIPTION
Fixes #10979

Adds optional `ZITADEL_PUBLIC_URL` to override public login origin when forwarded host headers are unreliable in proxied deployments. URL construction now prefers this absolute origin for callback/redirect generation, while preserving existing header-based behavior when unset. Includes regression tests for host/protocol override and service config resolution.