### PR TITLE
fix(login): drop doubled `device.` namespace prefix from consent screen i18nKeys

### DIFF
--- a/apps/login/src/components/consent.tsx
+++ b/apps/login/src/components/consent.tsx
@@ -49,7 +49,7 @@ export function ConsentScreen({
       <ul className="w-full list-disc space-y-2">
         {scopes?.length === 0 && (
           <span className="border-divider-light bg-background-light-400 dark:bg-background-dark-400 flex w-full flex-row items-center rounded-md border px-4 py-2 text-sm transition-all">
-            <Translated i18nKey="device.scope.openid" namespace="device" />
+            <Translated i18nKey="scope.openid" namespace="device" />
           </span>
         )}
         {scopes?.map((s) => {
@@ -89,13 +89,13 @@ export function ConsentScreen({
           data-testid="deny-button"
         >
           {loading && <Spinner className="mr-2 h-5 w-5" />}
-          <Translated i18nKey="device.request.deny" namespace="device" />
+          <Translated i18nKey="request.deny" namespace="device" />
         </Button>
         <span className="flex-grow"></span>
 
         <Link href={nextUrl}>
           <Button data-testid="submit-button" type="submit" className="self-end" variant={ButtonVariants.Primary}>
-            <Translated i18nKey="device.request.submit" namespace="device" />
+            <Translated i18nKey="request.submit" namespace="device" />
           </Button>
         </Link>
       </div>


### PR DESCRIPTION
## Which Problems Are Solved

OAuth device-authorization consent screen at `/ui/v2/login/device/consent` renders both buttons (Deny / Allow) as **unlabeled** and floods the browser console with `MISSING_MESSAGE` errors. The screen is unusable for any device-code login flow (CLI tools, smart TVs, etc.).

```
Error: MISSING_MESSAGE: device.device.request.deny (en)
Error: MISSING_MESSAGE: device.device.request.submit (en)
Error: MISSING_MESSAGE: device.device.scope.openid (en)   # only fires when scope list is empty
```

## Screenshots

Before:

<img width="481" height="544" alt="image" src="https://github.com/user-attachments/assets/610f3df7-b8eb-4238-bb9c-5563dd4d252b" />

After:

<img width="438" height="526" alt="image" src="https://github.com/user-attachments/assets/3f77a2da-2ebe-471a-898e-697903293de9" />

## How the Problems Are Solved

`apps/login/src/components/translated.tsx` calls `useTranslations(namespace)` and then `t(i18nKey)`, which composes the lookup as `<namespace>.<i18nKey>`. In `apps/login/src/components/consent.tsx` three calls pass `namespace="device"` together with an `i18nKey` that already starts with `device.`, producing `device.device.*` — keys that don't exist in `apps/login/locales/en.json`.

The keys exist correctly under `device.request.{deny,submit}` and `device.scope.openid`. Dropping the redundant `device.` prefix from the three i18nKey strings resolves the lookups against the existing translations:

## Affected Versions

The same pattern (i18nKey starting with its own namespace) appears in `apps/login/src/app/(login)/verify/page.tsx` and `apps/login/src/components/verify-form.tsx` (6 sites total), but those don't manifest as runtime errors because `apps/login/locales/en.json` happens to have a doubled-nested `verify.verify.*` structure that absorbs them. This PR scopes to the `consent.tsx` cases that actually break the UI; un-doubling `verify.*` would require touching the JSON across all locales and is left for a follow-up.

## How to Reproduce

1. Configure a Native OIDC application with **Device Code** auth flow.
2. Initiate device authorization:
   ```bash
   curl -X POST https://<instance>/oauth/v2/device_authorization \
     -d "client_id=<native-app-client-id>" \
     -d "scope=openid offline_access"
   ```
3. Open the returned `verification_uri_complete` in a browser, submit the user code.
4. Observe the consent screen: buttons render without labels; browser console shows the `MISSING_MESSAGE` errors above.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>