### PR TITLE
fix(login): disable Lato auto-fallback to stop clipping non-Latin descenders

### DIFF
--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -19,6 +19,9 @@ import React, { Suspense } from "react";
 const lato = Lato({
   weight: ["400", "700", "900"],
   subsets: ["latin"],
+  // Lato ships only Latin glyphs; the auto-generated Lato Fallback
+  // metrics clip Cyrillic descenders.
+  adjustFontFallback: false,
 });
 
 export async function generateMetadata(): Promise<Metadata> {


### PR DESCRIPTION
# Which Problems Are Solved

The login UI clips the bottom of Cyrillic descenders (з, у, р, щ, …) on every page that renders non-Latin headings or labels — the welcome heading on the password page ("С возвращением!"), labels in localized signup, error messages in any non-Latin locale, etc. The clip is consistent across browsers and zoom levels.

The bug also reproduces on every other script whose glyphs descend further than Latin: Greek, Devanagari, Thai, Arabic, etc. Anything that falls through to the auto-generated fallback metrics is affected.

# How the Problems Are Solved

`apps/login/src/app/(login)/layout.tsx` loads Lato via `next/font/google` with `subsets: ["latin"]`. Lato on Google Fonts has only Latin (and Latin Extended) — no Cyrillic, Greek, or other scripts. For any character not in Lato, `next/font/google` auto-generates a same-size fallback face called "Lato Fallback" that delegates to `local(Arial)` with explicit metric overrides:

```css
@font-face {
  font-family: Lato Fallback;
  src: local(Arial);
  ascent-override: 101.03%;
  descent-override: 21.8%;
  line-gap-override: 0.0%;
  size-adjust: 97.69%;
}
```

Those overrides are calibrated against Lato's Latin glyph metrics so Latin substitution looks visually stable while Lato is loading. They are wrong for any non-Latin script that descends further: `descent-override: 21.8%` shrinks the line-box's descender area below what Arial's actual Cyrillic glyphs need, so the bottom 4–6 pixels of "з", "у", "р", "щ" get cropped against the next line.

The minimal fix is `adjustFontFallback: false`, which drops the Lato Fallback face altogether. Latin still uses the loaded Lato; non-Latin text falls back through the natural `sans-serif` cascade where each font is measured by its own metrics, so descenders render in full.

```diff
 const lato = Lato({
   weight: ["400", "700", "900"],
   subsets: ["latin"],
+  // Lato ships only Latin glyphs; the auto-generated Lato Fallback
+  // metrics clip Cyrillic descenders.
+  adjustFontFallback: false,
 });
```

# Additional Changes

None. Pure font-loader configuration change, no refactor.

# Additional Context

**Trade-off**: with the override gone, Latin text experiences a small amount of CLS until Lato finishes loading (the system fallback's metrics differ slightly from Lato's). For an alternative fix that keeps fallback metrics for Latin while supporting Cyrillic natively, a second `next/font/google` call could load a Cyrillic-capable companion (PT Sans, Open Sans, Noto Sans) and chain via CSS variables — happy to switch to that approach if maintainers prefer.

Reproduction:

1. Open the login UI in any non-English locale that uses non-Latin glyphs (`/ui/v2/login/login?...&ui_locales=ru`).
2. Submit a username and observe the password page — heading "С возвращением!" (or its equivalent in other languages) has the bottom of "з" / "щ" / similar glyphs cut off.

Inspecting the served CSS (`apps/login/.next/static/chunks/0nd7.*.css`) shows the Lato @font-face declarations carry only Latin / Latin Extended unicode-ranges and the Lato Fallback declaration with the offending `descent-override`.
