### PR TITLE
fix(setup): use SHA-256 instead of MD5 for system.assets hash

### DIFF
--- a/cmd/setup/02.go
+++ b/cmd/setup/02.go
@@ -15,7 +15,7 @@ CREATE TABLE system.assets (
     resource_owner TEXT,
     name TEXT,
     content_type TEXT,
-    hash TEXT GENERATED ALWAYS AS (md5(data)) STORED,
+    hash TEXT GENERATED ALWAYS AS (encode(sha256(data), 'hex')) STORED,
     data BYTEA,
     updated_at TIMESTAMPTZ,
 

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -1,0 +1,27 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 70.sql
+	assetsHashSha256 string
+)
+
+type AssetsHashSha256 struct {
+	dbClient *database.DB
+}
+
+func (mig *AssetsHashSha256) Execute(ctx context.Context, _ eventstore.Event) error {
+	_, err := mig.dbClient.ExecContext(ctx, assetsHashSha256)
+	return err
+}
+
+func (mig *AssetsHashSha256) String() string {
+	return "70_assets_hash_sha256"
+}

--- a/cmd/setup/70.sql
+++ b/cmd/setup/70.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS system.assets
+    DROP COLUMN IF EXISTS hash;
+
+ALTER TABLE IF EXISTS system.assets
+    ADD COLUMN hash TEXT GENERATED ALWAYS AS (encode(sha256(data), 'hex')) STORED;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -185,6 +185,7 @@ type Steps struct {
 	s67SyncMemberRoleFields                 *SyncMemberRoleFields
 	s68TargetAddPayloadTypeColumn           *TargetAddPayloadTypeColumn
 	s69CacheTablesLogged                    *CacheTablesLogged
+	s70AssetsHashSha256                     *AssetsHashSha256
 	RelationalTables                        *TransactionalTables
 }
 

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -248,6 +248,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s67SyncMemberRoleFields = &SyncMemberRoleFields{dbClient: dbClient}
 	steps.s68TargetAddPayloadTypeColumn = &TargetAddPayloadTypeColumn{dbClient: dbClient}
 	steps.s69CacheTablesLogged = &CacheTablesLogged{dbClient: dbClient}
+	steps.s70AssetsHashSha256 = &AssetsHashSha256{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -305,6 +306,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s65FixUserMetadata5Index,
 		steps.s67SyncMemberRoleFields,
 		steps.s69CacheTablesLogged,
+		steps.s70AssetsHashSha256,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {


### PR DESCRIPTION
The `system.assets` table's generated `hash` column is computed as `md5(data)`, which fails on PostgreSQL servers whose libcrypto is FIPS-restricted. Switching this to a more modern hash, like SHA-256, enables easier running zitadel on strict FIPS-only environments.

This is my first contribution so apologies for any blunders.

NOTE! I'm creating this PR also for discussion. I know changing existing database data types is a bit iffy, but wanted to know upstream's opinion on whether this is acceptable/feasible.

<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

When ZITADEL runs against a PostgreSQL whose libcrypto enforces a FIPS-only provider, every write to `system.assets` fails because the table's generated `hash` column is computed as `md5(data)`. MD5 is disallowed in FIPS mode, so PostgreSQL returns:

```
ERROR: could not compute MD5 hash: unsupported (SQLSTATE XX000)
```

This surfaces as projection failures such as `adminapi.styling2`, which writes generated CSS into `system.assets` via the static storage layer. ZITADEL keeps running but the asset-touching projections never make progress.

# How the Problems Are Solved

The `hash` column is used only as an HTTP ETag (`internal/api/assets/asset.go`) and as the `?v=` cache-buster in `Asset.VersionedName` - both non-cryptographic. Replacing MD5 with SHA-256, a FIPS-approved algorithm, fixes the failure without changing the column's role.
Migration of existing data is attempted.

# Additional Changes

ETag and `?v=` values change format (64-char hex vs 32-char hex) after migration.

# Additional Context

Trade-off: rebuilding the `hash` column rewrites the `system.assets` table once during the migration. For deployments with many large assets this may take some time, but the rewrite only runs on upgrade.
