### PR TITLE
fix(eventstore/handler): decouple SAVEPOINT rollback from request ctx

### DIFF
--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -729,7 +729,18 @@ func (h *Handler) executeStatement(ctx context.Context, tx *sql.Tx, statement *S
 	if err = statement.Execute(ctx, tx, h.projection.Name()); err != nil {
 		logging.WithError(ctx, err).Error("statement execution failed")
 
-		_, rollbackErr := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT exec_stmt")
+		// Use a context that is decoupled from the parent ctx for the
+		// rollback. If the request ctx was already cancelled by the time
+		// the projection statement returned (e.g. h.txDuration timeout
+		// fired, or the caller cancelled), ExecContext on the parent ctx
+		// short-circuits with context.Canceled BEFORE issuing the SQL.
+		// The savepoint then stays live server-side and the underlying
+		// connection is handed back to the pool with the outer
+		// BEGIN + SAVEPOINT still open. Postgres terminates the session
+		// after idle_in_transaction_session_timeout (SQLSTATE 25P03),
+		// effectively leaking one connection per projection cancel.
+		rollbackCtx := context.WithoutCancel(ctx)
+		_, rollbackErr := tx.ExecContext(rollbackCtx, "ROLLBACK TO SAVEPOINT exec_stmt")
 		logging.OnError(ctx, rollbackErr).Debug("rollback to savepoint failed")
 
 		shouldContinue := h.handleFailedStmt(ctx, tx, failureFromStatement(statement, err))

--- a/internal/eventstore/handler/v2/handler.go
+++ b/internal/eventstore/handler/v2/handler.go
@@ -739,7 +739,14 @@ func (h *Handler) executeStatement(ctx context.Context, tx *sql.Tx, statement *S
 		// BEGIN + SAVEPOINT still open. Postgres terminates the session
 		// after idle_in_transaction_session_timeout (SQLSTATE 25P03),
 		// effectively leaking one connection per projection cancel.
-		rollbackCtx := context.WithoutCancel(ctx)
+		//
+		// context.WithoutCancel strips the parent's Done channel,
+		// Deadline and Err (only Values are inherited — see Go stdlib
+		// context docs). We still cap the rollback with a small
+		// dedicated timeout so a wedged connection cannot hold this
+		// goroutine indefinitely.
+		rollbackCtx, cancelRollback := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancelRollback()
 		_, rollbackErr := tx.ExecContext(rollbackCtx, "ROLLBACK TO SAVEPOINT exec_stmt")
 		logging.OnError(ctx, rollbackErr).Debug("rollback to savepoint failed")
 

--- a/internal/eventstore/handler/v2/handler_test.go
+++ b/internal/eventstore/handler/v2/handler_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+// TestHandler_executeStatement_rollbackSurvivesContextCancellation reproduces
+// the SAVEPOINT leak fixed alongside this test. With the broken code the
+// `ROLLBACK TO SAVEPOINT exec_stmt` call inherited the request ctx, so when
+// the ctx had been cancelled by the time the projection statement returned
+// an error the ExecContext call short-circuited with context.Canceled
+// BEFORE issuing the SQL. The connection went back to the pool with
+// BEGIN + SAVEPOINT still alive server-side and was killed by Postgres
+// after idle_in_transaction_session_timeout (SQLSTATE 25P03). The fix
+// detaches the rollback from the parent ctx with context.WithoutCancel;
+// this test asserts the rollback actually reaches the database.
+func TestHandler_executeStatement_rollbackSurvivesContextCancellation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SAVEPOINT exec_stmt").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// The smoking-gun expectation: this MUST fire even though the
+	// projection cancels ctx before returning. Without the fix this
+	// expectation is unmet and ExpectationsWereMet() reports the leak.
+	mock.ExpectExec("ROLLBACK TO SAVEPOINT exec_stmt").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// handleFailedStmt() does an embedded SELECT on the failure-count
+	// table; we make it fail so the function short-circuits without a
+	// follow-up UPDATE and executeStatement returns &executionError{}.
+	// This keeps the test focused on the rollback signal and avoids
+	// duplicating the failed_event SQL contract in the assertion.
+	mock.ExpectQuery(".*").WillReturnError(sql.ErrConnDone)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h := &Handler{
+		projection:      &projection{name: "test_projection"},
+		maxFailureCount: 5,
+	}
+
+	stmt := &Statement{
+		Aggregate:    &eventstore.Aggregate{InstanceID: "i", ID: "a", Type: "t"},
+		Sequence:     1,
+		Position:     decimal.NewFromInt(1),
+		CreationDate: time.Now(),
+		Execute: func(ctx context.Context, _ Executer, _ string) error {
+			// Mimic the real-world race: the request ctx gets cancelled
+			// (h.txDuration timeout, caller cancel, pod-shutdown SIGTERM,
+			// gRPC deadline) while the projection statement is in flight.
+			// The projection then returns an error.
+			cancel()
+			return errors.New("projection logic failed mid-flight")
+		},
+	}
+
+	execErr := h.executeStatement(ctx, tx, stmt)
+	// With handleFailedStmt forced to short-circuit, executeStatement
+	// returns the wrapped executionError. The exact error type is
+	// secondary to the real assertion: ExpectationsWereMet().
+	assert.Error(t, execErr)
+	require.NoError(t, mock.ExpectationsWereMet(),
+		"ROLLBACK TO SAVEPOINT must reach the database even when the request context was cancelled during statement execution")
+}

--- a/internal/eventstore/handler/v2/handler_test.go
+++ b/internal/eventstore/handler/v2/handler_test.go
@@ -43,11 +43,15 @@ func TestHandler_executeStatement_rollbackSurvivesContextCancellation(t *testing
 	// follow-up UPDATE and executeStatement returns &executionError{}.
 	// This keeps the test focused on the rollback signal and avoids
 	// duplicating the failed_event SQL contract in the assertion.
-	mock.ExpectQuery(".*").WillReturnError(sql.ErrConnDone)
+	// Match the actual failure_event_get_count.sql shape rather than
+	// any query — keeps the test strict against unrelated statements.
+	mock.ExpectQuery(`(?i)SELECT.+failed_events`).WillReturnError(sql.ErrConnDone)
+	// The deferred tx.Rollback() in t.Cleanup() below issues a ROLLBACK
+	// that sqlmock would otherwise flag as unexpected.
+	mock.ExpectRollback()
 
 	tx, err := db.Begin()
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = tx.Rollback() })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -77,6 +81,13 @@ func TestHandler_executeStatement_rollbackSurvivesContextCancellation(t *testing
 	// returns the wrapped executionError. The exact error type is
 	// secondary to the real assertion: ExpectationsWereMet().
 	assert.Error(t, execErr)
+
+	// Close the outer tx so the ExpectRollback expectation can settle
+	// before we verify all expectations. This mirrors what the
+	// production caller (processEvents) does in its deferred
+	// tx.Rollback() / tx.Commit() chain.
+	require.NoError(t, tx.Rollback(), "outer tx.Rollback() must succeed")
+
 	require.NoError(t, mock.ExpectationsWereMet(),
 		"ROLLBACK TO SAVEPOINT must reach the database even when the request context was cancelled during statement execution")
 }


### PR DESCRIPTION
# Which Problems Are Solved

The projection handler in `internal/eventstore/handler/v2/handler.go` issues a `SAVEPOINT exec_stmt` before each `statement.Execute` and a `ROLLBACK TO SAVEPOINT exec_stmt` on failure. Both `ExecContext` calls share the request `ctx`.

If `ctx` is already cancelled by the time the projection statement returns an error (`h.txDuration` timeout firing, caller cancellation, pod-shutdown SIGTERM, gRPC deadline), the rollback `ExecContext` short-circuits with `context.Canceled` **before** issuing the SQL. The connection is returned to the `database/sql` pool with the outer `BEGIN + SAVEPOINT` still live on the Postgres side. Postgres then terminates the session after `idle_in_transaction_session_timeout` (SQLSTATE `25P03`), leaking one client connection per cancelled projection iteration.

Observed in production as a steady stream of `SQLSTATE 25P03` disconnects all sharing the same `pg_stat_statements` queryid:

```
queryid              | calls | rows | mean_ms | query
3858529678823240928  | 1760  |  0   |  0.00   | SAVEPOINT $1
```

(`pg_stat_statements` normalises the literal identifier `exec_stmt` to `$1`.) About 1 in 7 savepoint paths leaked on a busy auth deployment (~250/day), each consuming one PG connection slot until the server-side timeout reaped it.

# How the Problems Are Solved

Detach the rollback `ExecContext` from the parent `ctx` via `context.WithoutCancel`, so the rollback always reaches the server even when the parent has been cancelled. `tx.Rollback()` / `tx.Commit()` on the outer transaction are unaffected (they do not take a ctx and rely on the connection state).

```go
rollbackCtx := context.WithoutCancel(ctx)
_, rollbackErr := tx.ExecContext(rollbackCtx, "ROLLBACK TO SAVEPOINT exec_stmt")
```

# Additional Changes

- Adds `internal/eventstore/handler/v2/handler_test.go` with a regression test using `sqlmock`. With the fix the test passes; with the previous code it fails because the rollback expectation goes unmet (proving the savepoint stayed alive on the server).

# Additional Context

- The bug is invisible without `pg_stat_statements`: only the **last** statement run on the leaked session is recorded by Postgres (a SAVEPOINT), and the session sits idle for up to `idle_in_transaction_session_timeout` before being killed. Without query-id mapping, the symptom looks like generic disconnect noise.
- Production reproducer details: Zitadel v2.67.2 running against CNPG/pgEdge Postgres with `idle_in_transaction_session_timeout = 60000ms` and ~10 idle-in-tx events per hour, all `application_name = "zitadel"`, all SQLSTATE 25P03, all sharing the same `pg_stat_statements` queryid.
- No existing open issue in this repo reports SQLSTATE 25P03 / savepoint leak; PR #8614 ("perf(query): remove transactions for queries") cut idle-tx volume in the **query** pool but did not touch the projection-handler SAVEPOINT path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)