### PR TITLE
fix(login): handle LDAP IDP mapping and nullable SSR settings

### DIFF
--- a/apps/login/acceptance/tests/idp-ldap.spec.ts
+++ b/apps/login/acceptance/tests/idp-ldap.spec.ts
@@ -1,4 +1,14 @@
-import test from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+test("ldap login page renders without crashing", async ({ page }) => {
+  await page.goto("./idp/ldap?idpId=test-idp&requestId=oidc_test");
+
+  await expect(page.getByTestId("username-text-input").first()).toBeVisible({
+    timeout: 120_000,
+  });
+  await expect(page.getByTestId("password-text-input").first()).toBeVisible();
+  await expect(page.locator("body")).not.toContainText("An error occurred in the Server Components render");
+});
 
 test("login with LDAP IDP", async ({ page }) => {
   test.skip();

--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -33,7 +33,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   let languages = LANGS;
   try {
     const settings = await getAllowedLanguages({ serviceConfig });
-    if (settings.allowedLanguages?.length) {
+    if (settings?.allowedLanguages?.length) {
       languages = settings.allowedLanguages
         .filter((code) => LANGS.find((l) => l.code === code))
         .map((code) => getLanguage(code));

--- a/apps/login/src/i18n/request.ts
+++ b/apps/login/src/i18n/request.ts
@@ -18,11 +18,11 @@ export default getRequestConfig(async () => {
 
   try {
     const settings = await getAllowedLanguages({ serviceConfig });
-    if (settings.allowedLanguages?.length) {
+    if (settings?.allowedLanguages?.length) {
       const localLanguageCodes = LANGS.map((l) => l.code);
       allowedLanguages = settings.allowedLanguages.filter((l) => localLanguageCodes.includes(l));
     }
-    if (settings.defaultLanguage) {
+    if (settings?.defaultLanguage) {
       defaultLanguage = settings.defaultLanguage;
     }
   } catch (e) {

--- a/apps/login/src/lib/cache.test.ts
+++ b/apps/login/src/lib/cache.test.ts
@@ -57,6 +57,23 @@ describe("PromiseCache", () => {
       expect(callCount).toBe(1);
     });
 
+    test("should cache undefined results without treating them as fetch failures", async () => {
+      cache = new PromiseCache(10);
+      let callCount = 0;
+      const fetcher = () => {
+        callCount++;
+        return Promise.resolve(undefined as undefined);
+      };
+
+      const first = await cache.getOrFetch("key1", fetcher, 60_000);
+      const second = await cache.getOrFetch("key1", fetcher, 60_000);
+
+      expect(first).toBeUndefined();
+      expect(second).toBeUndefined();
+      expect(callCount).toBe(1);
+      expect(cache.size).toBe(1);
+    });
+
     test("should return stale value immediately after TTL expires (SWR)", async () => {
       const clock = mockClock();
       cache = new PromiseCache(10, clock.perf);

--- a/apps/login/src/lib/cache.ts
+++ b/apps/login/src/lib/cache.ts
@@ -4,6 +4,21 @@ interface FetchContext {
   fetcher: () => Promise<any>;
 }
 
+type CacheEntry<T> = { kind: "value"; value: T } | { kind: "undefined" };
+
+// lru-cache treats a raw undefined return from fetchMethod as a fetch failure,
+// so we box it before it reaches the cache and unwrap it on read.
+function wrapValue<T>(value: T): CacheEntry<T> {
+  return value === undefined ? { kind: "undefined" } : { kind: "value", value };
+}
+
+function unwrapValue<T>(entry: CacheEntry<T> | undefined): T | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  return entry.kind === "undefined" ? undefined : entry.value;
+}
+
 /**
  * A bounded, stale-while-revalidate in-memory promise cache backed by lru-cache.
  *
@@ -15,10 +30,10 @@ interface FetchContext {
  * - Bounded to `maxSize` entries to prevent unbounded memory growth
  */
 export class PromiseCache {
-  private readonly cache: LRUCache<string, any, FetchContext>;
+  private readonly cache: LRUCache<string, CacheEntry<any>, FetchContext>;
 
   constructor(maxSize = 100_000, perf?: { now: () => number }) {
-    this.cache = new LRUCache<string, any, FetchContext>({
+    this.cache = new LRUCache<string, CacheEntry<any>, FetchContext>({
       max: Math.max(1, maxSize),
       // A global TTL is required to initialize lru-cache's TTL tracking internals.
       // Per-entry TTLs passed to fetch() will override this default.
@@ -28,7 +43,7 @@ export class PromiseCache {
       noDeleteOnFetchRejection: true,
       allowStaleOnFetchRejection: true,
       fetchMethod: async (_key, _staleValue, { context }) => {
-        return context.fetcher();
+        return wrapValue(await context.fetcher());
       },
       ...(perf ? { perf, ttlResolution: 0 } : {}),
     });
@@ -42,11 +57,13 @@ export class PromiseCache {
    * Only the very first call for a key (or after eviction) blocks
    * on the fetch.
    */
-  getOrFetch<T>(key: string, fetcher: () => Promise<T>, ttlMs: number): Promise<T> {
-    return this.cache.forceFetch(key, {
-      ttl: ttlMs,
-      context: { fetcher },
-    }) as Promise<T>;
+  getOrFetch<T>(key: string, fetcher: () => Promise<T>, ttlMs: number): Promise<T | undefined> {
+    return this.cache
+      .forceFetch(key, {
+        ttl: ttlMs,
+        context: { fetcher },
+      })
+      .then((entry) => unwrapValue(entry));
   }
 
   /** Current number of entries (including stale). */

--- a/apps/login/src/lib/idp.test.ts
+++ b/apps/login/src/lib/idp.test.ts
@@ -283,6 +283,7 @@ describe("idp type mapping utilities", () => {
         { idpType: IDPType.IDP_TYPE_APPLE, slug: "apple" },
         { idpType: IDPType.IDP_TYPE_GOOGLE, slug: "google" },
         { idpType: IDPType.IDP_TYPE_AZURE_AD, slug: "azure" },
+        { idpType: IDPType.IDP_TYPE_LDAP, slug: "ldap" },
         { idpType: IDPType.IDP_TYPE_SAML, slug: "saml" },
         { idpType: IDPType.IDP_TYPE_OAUTH, slug: "oauth" },
         { idpType: IDPType.IDP_TYPE_OIDC, slug: "oidc" },

--- a/apps/login/src/lib/idp.ts
+++ b/apps/login/src/lib/idp.ts
@@ -57,6 +57,9 @@ export function idpTypeToIdentityProviderType(idpType: IDPType): IdentityProvide
     case IDPType.IDP_TYPE_AZURE_AD:
       return IdentityProviderType.AZURE_AD;
 
+    case IDPType.IDP_TYPE_LDAP:
+      return IdentityProviderType.LDAP;
+
     case IDPType.IDP_TYPE_SAML:
       return IdentityProviderType.SAML;
 

--- a/apps/login/src/lib/server/flow-initiation.test.ts
+++ b/apps/login/src/lib/server/flow-initiation.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FlowInitiationParams, handleOIDCFlowInitiation } from "./flow-initiation";
+import { IdentityProviderType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 
 vi.mock("@/lib/cookies", () => ({
   getLanguageCookie: vi.fn(),
@@ -177,5 +178,54 @@ describe("handleOIDCFlowInitiation — locale / cookie handling", () => {
 
       expect(mockSetLanguageCookie).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("handleOIDCFlowInitiation — IDP scoped routing", () => {
+  let mockGetAuthRequest: ReturnType<typeof vi.fn>;
+  let mockGetActiveIdentityProviders: ReturnType<typeof vi.fn>;
+  let mockConstructUrl: ReturnType<typeof vi.fn>;
+  let mockStartIdentityProviderFlow: ReturnType<typeof vi.fn>;
+  let mockIdpTypeToSlug: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const zitadel = await import("@/lib/zitadel");
+    const serviceUrl = await import("@/lib/service-url");
+    const idp = await import("@/lib/idp");
+
+    mockGetAuthRequest = vi.mocked(zitadel.getAuthRequest);
+    mockGetActiveIdentityProviders = vi.mocked(zitadel.getActiveIdentityProviders);
+    mockConstructUrl = vi.mocked(serviceUrl.constructUrl);
+    mockStartIdentityProviderFlow = vi.mocked(zitadel.startIdentityProviderFlow);
+    mockIdpTypeToSlug = vi.mocked(idp.idpTypeToSlug);
+
+    mockConstructUrl.mockImplementation((_req: any, path: string) => {
+      return new URL(`https://example.com${path}`);
+    });
+  });
+
+  test("should redirect to the LDAP page for the selected LDAP IDP even when it is not the first active provider", async () => {
+    mockGetAuthRequest.mockResolvedValue({
+      authRequest: {
+        id: "abc123",
+        uiLocales: [],
+        scope: ["urn:zitadel:iam:org:idp:id:ldap-idp"],
+        prompt: [],
+      },
+    });
+    mockGetActiveIdentityProviders.mockResolvedValue({
+      identityProviders: [
+        { id: "oidc-idp", type: IdentityProviderType.OIDC },
+        { id: "ldap-idp", type: IdentityProviderType.LDAP },
+      ],
+    });
+
+    const response = await handleOIDCFlowInitiation(makeBaseParams());
+
+    expect(response.headers.get("location")).toBe("https://example.com/ldap?requestId=oidc_abc123");
+    expect(mockStartIdentityProviderFlow).not.toHaveBeenCalled();
+    expect(mockIdpTypeToSlug).not.toHaveBeenCalled();
   });
 });

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -141,7 +141,7 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       const idp = identityProviders.find((idp) => idp.id === idpId);
 
       if (idp) {
-        const identityProviderType = identityProviders[0].type;
+        const identityProviderType = idp.type;
 
         if (identityProviderType === IdentityProviderType.LDAP) {
           const ldapUrl = constructUrl(request, "/ldap");

--- a/apps/login/src/lib/server/security-settings.ts
+++ b/apps/login/src/lib/server/security-settings.ts
@@ -75,13 +75,13 @@ export async function getIframeOrigins(
 ): Promise<string[] | null> {
   const cacheKey = instanceHost || "__default__";
 
-  // The fetcher returns null (not undefined) because lru-cache treats
-  // undefined as a fetch failure.
-  return cache.getOrFetch<string[] | null>(
+  const origins = await cache.getOrFetch<string[] | null>(
     cacheKey,
     () => fetchIframeOrigins(baseUrl, instanceHost, publicHost),
     CACHE_TTL_MS,
   );
+
+  return origins ?? null;
 }
 
 async function fetchIframeOrigins(baseUrl: string, instanceHost?: string, publicHost?: string): Promise<string[] | null> {
@@ -121,8 +121,6 @@ async function fetchIframeOrigins(baseUrl: string, instanceHost?: string, public
       status: response.status,
       statusText: response.statusText,
     });
-    // Return null instead of undefined — lru-cache treats undefined as a
-    // fetch failure and throws "fetch() returned undefined".
     return null;
   }
 

--- a/apps/login/src/lib/zitadel.test.ts
+++ b/apps/login/src/lib/zitadel.test.ts
@@ -44,4 +44,16 @@ describe("zitadel settings helpers", () => {
 
     expect(result).toBeUndefined();
   });
+
+  test("getDefaultOrg returns null when the backend call fails", async () => {
+    const { createServiceForHost } = await import("./service");
+    vi.mocked(createServiceForHost).mockResolvedValue({
+      listOrganizations: vi.fn().mockRejectedValue(new Error("backend unavailable")),
+    } as any);
+
+    const { getDefaultOrg } = await import("./zitadel");
+    const result = await getDefaultOrg({ serviceConfig: { baseUrl: "https://api.example.com" } as any });
+
+    expect(result).toBeNull();
+  });
 });

--- a/apps/login/src/lib/zitadel.test.ts
+++ b/apps/login/src/lib/zitadel.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("./cache", () => ({
+  PromiseCache: class {
+    getOrFetch(_key: string, fetcher: () => Promise<unknown>) {
+      return fetcher();
+    }
+  },
+}));
+
+vi.mock("./service", () => ({
+  createServiceForHost: vi.fn(),
+}));
+
+describe("zitadel settings helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  test("getBrandingSettings returns undefined when the backend omits branding settings", async () => {
+    const { createServiceForHost } = await import("./service");
+    vi.mocked(createServiceForHost).mockResolvedValue({
+      getBrandingSettings: vi.fn().mockResolvedValue({}),
+    } as any);
+
+    const { getBrandingSettings } = await import("./zitadel");
+    const result = await getBrandingSettings({ serviceConfig: { baseUrl: "https://api.example.com" } as any });
+
+    expect(result).toBeUndefined();
+  });
+
+  test("getHostedLoginTranslation returns undefined when the backend omits translations", async () => {
+    const { createServiceForHost } = await import("./service");
+    vi.mocked(createServiceForHost).mockResolvedValue({
+      getHostedLoginTranslation: vi.fn().mockResolvedValue({}),
+    } as any);
+
+    const { getHostedLoginTranslation } = await import("./zitadel");
+    const result = await getHostedLoginTranslation({
+      serviceConfig: { baseUrl: "https://api.example.com" } as any,
+      locale: "en",
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -36,6 +36,7 @@ import { getUserAgent } from "./fingerprint";
 import { applyCustomHeaders } from "@/lib/custom-headers";
 import { errorClassificationInterceptor, isClassifiedError } from "@/lib/grpc/interceptors/error-classification";
 import { otelGrpcInterceptor } from "@/lib/grpc/interceptors/otel";
+import { createLogger } from "@/lib/logger";
 import { Code, Interceptor } from "@connectrpc/connect";
 import { PromiseCache } from "./cache";
 import { createServiceForHost } from "./service";
@@ -53,6 +54,7 @@ try {
 
 const defaultCacheTTL = (cacheConfig.defaultMinutes ?? 15) * 60 * 1000; // 15 mins default
 const longCacheTTL = (cacheConfig.longMinutes ?? 60) * 60 * 1000; // 1 hour default
+const logger = createLogger("zitadel");
 
 /**
  * Helper to determine the TTL for a specific API method.
@@ -835,10 +837,10 @@ export async function searchUsers({
 }
 
 export async function getDefaultOrg({ serviceConfig }: WithServiceConfig): Promise<Organization | null> {
-  const fetcher = async () => {
-    const orgService: Client<typeof OrganizationService> = await createServiceForHost(OrganizationService, serviceConfig);
+  try {
+    const fetcher = async () => {
+      const orgService: Client<typeof OrganizationService> = await createServiceForHost(OrganizationService, serviceConfig);
 
-    try {
       const resp = await orgService.listOrganizations(
         {
           queries: [
@@ -854,20 +856,37 @@ export async function getDefaultOrg({ serviceConfig }: WithServiceConfig): Promi
       );
 
       return resp?.result && resp.result[0] ? resp.result[0] : null;
-    } catch {
-      return null;
+    };
+
+    const org = useCache
+      ? await freshCache(
+          instanceCacheKey(serviceConfig, "getDefaultOrg-instance"),
+          fetcher,
+          getTTLForKey("getDefaultOrg", defaultCacheTTL),
+        )
+      : await fetcher();
+
+    return org ?? null;
+  } catch (error) {
+    if (isClassifiedError(error)) {
+      const log = error.code === Code.NotFound ? logger.warn : logger.error;
+      log("Failed to load default organization", {
+        instanceHost: serviceConfig.instanceHost,
+        publicHost: serviceConfig.publicHost,
+        code: error.code,
+        httpStatus: error.httpStatus,
+        isUserError: error.isUserError,
+      });
+    } else {
+      logger.error("Failed to load default organization", {
+        instanceHost: serviceConfig.instanceHost,
+        publicHost: serviceConfig.publicHost,
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      });
     }
-  };
 
-  const org = useCache
-    ? await freshCache(
-        instanceCacheKey(serviceConfig, "getDefaultOrg-instance"),
-        fetcher,
-        getTTLForKey("getDefaultOrg", defaultCacheTTL),
-      )
-    : await fetcher();
-
-  return org ?? null;
+    return null;
+  }
 }
 
 export async function getOrgsByDomain({ serviceConfig, domain }: WithServiceConfig<{ domain: string }>) {

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -84,7 +84,7 @@ const promiseCache = new PromiseCache(Number(cacheConfig.maxSize) || 100);
  * The cache is bounded and periodically swept for expired entries
  * to prevent unbounded memory growth.
  */
-function freshCache<T>(key: string, fetcher: () => Promise<T>, ttlMs: number): Promise<T> {
+function freshCache<T>(key: string, fetcher: () => Promise<T>, ttlMs: number): Promise<T | undefined> {
   if (!useCache) {
     return fetcher();
   }
@@ -120,7 +120,7 @@ export async function getHostedLoginTranslation({
         {},
       )
       .then((resp) => {
-        return resp.translations ? resp.translations : undefined;
+        return resp.translations ?? undefined;
       });
   };
 
@@ -142,7 +142,7 @@ export async function getBrandingSettings({
 
     return settingsService
       .getBrandingSettings({ ctx: makeReqCtx(organization) }, {})
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+      .then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -163,7 +163,7 @@ export async function getLoginSettings({
 
     return settingsService
       .getLoginSettings({ ctx: makeReqCtx(organization) }, {})
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+      .then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -177,7 +177,7 @@ export async function getSecuritySettings({ serviceConfig }: WithServiceConfig) 
   const fetcher = async () => {
     const settingsService: Client<typeof SettingsService> = await createServiceForHost(SettingsService, serviceConfig);
 
-    return settingsService.getSecuritySettings({}).then((resp) => (resp.settings ? resp.settings : undefined));
+    return settingsService.getSecuritySettings({}).then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -191,9 +191,7 @@ export async function getLockoutSettings({ serviceConfig, orgId }: WithServiceCo
   const fetcher = async () => {
     const settingsService: Client<typeof SettingsService> = await createServiceForHost(SettingsService, serviceConfig);
 
-    return settingsService
-      .getLockoutSettings({ ctx: makeReqCtx(orgId) }, {})
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+    return settingsService.getLockoutSettings({ ctx: makeReqCtx(orgId) }, {}).then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -209,7 +207,7 @@ export async function getPasswordExpirySettings({ serviceConfig, orgId }: WithSe
 
     return settingsService
       .getPasswordExpirySettings({ ctx: makeReqCtx(orgId) }, {})
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+      .then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -273,7 +271,7 @@ export async function getLegalAndSupportSettings({
 
     return settingsService
       .getLegalAndSupportSettings({ ctx: makeReqCtx(organization) }, {})
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+      .then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -294,7 +292,7 @@ export async function getPasswordComplexitySettings({
 
     return settingsService
       .getPasswordComplexitySettings({ ctx: makeReqCtx(organization) })
-      .then((resp) => (resp.settings ? resp.settings : undefined));
+      .then((resp) => resp.settings ?? undefined);
   };
 
   return freshCache(
@@ -857,13 +855,15 @@ export async function getDefaultOrg({ serviceConfig }: WithServiceConfig): Promi
       .then((resp) => (resp?.result && resp.result[0] ? resp.result[0] : null));
   };
 
-  return useCache
-    ? freshCache(
+  const org = useCache
+    ? await freshCache(
         instanceCacheKey(serviceConfig, "getDefaultOrg-instance"),
         fetcher,
         getTTLForKey("getDefaultOrg", defaultCacheTTL),
       )
-    : fetcher();
+    : await fetcher();
+
+  return org ?? null;
 }
 
 export async function getOrgsByDomain({ serviceConfig, domain }: WithServiceConfig<{ domain: string }>) {

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -838,8 +838,8 @@ export async function getDefaultOrg({ serviceConfig }: WithServiceConfig): Promi
   const fetcher = async () => {
     const orgService: Client<typeof OrganizationService> = await createServiceForHost(OrganizationService, serviceConfig);
 
-    return orgService
-      .listOrganizations(
+    try {
+      const resp = await orgService.listOrganizations(
         {
           queries: [
             {
@@ -851,8 +851,12 @@ export async function getDefaultOrg({ serviceConfig }: WithServiceConfig): Promi
           ],
         },
         {},
-      )
-      .then((resp) => (resp?.result && resp.result[0] ? resp.result[0] : null));
+      );
+
+      return resp?.result && resp.result[0] ? resp.result[0] : null;
+    } catch {
+      return null;
+    }
   };
 
   const org = useCache


### PR DESCRIPTION
## Which Problems Are Solved

- Login V2 could crash in the username-driven login flow when a user had an LDAP IDP link, because `idpTypeToIdentityProviderType()` did not map `IDP_TYPE_LDAP`.
- Login SSR could crash when cached settings helpers returned `undefined`, because `lru-cache` treats a raw `undefined` result from `fetchMethod` as a fetch failure.
- SSR language/i18n bootstrap and iframe-origin security settings handling expected nullable/optional results inconsistently.

## How the Problems Are Solved

- Add LDAP mapping from `IDP_TYPE_LDAP` to `IdentityProviderType.LDAP`.
- Box `undefined` values inside `PromiseCache` before storing them in `lru-cache`, then unwrap them on read.
- Preserve the `getIframeOrigins()` contract by normalizing cached `undefined` values to `null`.
- Guard login layout and i18n bootstrap against omitted general settings.
- Normalize omitted settings responses with nullish coalescing in the ZITADEL settings helpers.

## Tests

- Added regression coverage for LDAP IDP type mapping.
- Added regression coverage for cached `undefined` values in `PromiseCache`.
- Added regression coverage for omitted branding and hosted-login translation settings.

## Security Notes

- No new credential handling, redirect construction, or authorization bypass path is introduced.
- Iframe-origin behavior remains fail-closed to `null` when settings are missing, disabled, empty, or cannot be fetched.

Closes #12210, Closes #12221