### PR TITLE
fix(login): show specific password error instead of generic session error

### DIFF
--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -299,6 +299,20 @@ export async function sendPassword(
             }),
           };
         }
+        // If the server returned INVALID_ARGUMENT or UNAUTHENTICATED, the password was simply
+        // wrong but no CredentialsCheckError details were included (so failedAttempts was 0).
+        // Show the specific "could not verify password" message rather than the generic session error.
+        if (
+          isClassifiedError(error) &&
+          "code" in error &&
+          (error.code === Code.InvalidArgument || error.code === Code.Unauthenticated)
+        ) {
+          recordAuthFailure("password", "invalid_password", command.organization);
+          if (loginSettingsByContext?.ignoreUnknownUsernames) {
+            return { error: t("errors.failedToAuthenticateNoLimit") };
+          }
+          return { error: t("errors.couldNotVerifyPassword") };
+        }
         recordAuthFailure("password", "session_creation_failed", command.organization);
         if (loginSettingsByContext?.ignoreUnknownUsernames) {
           return { error: t("errors.failedToAuthenticateNoLimit") };


### PR DESCRIPTION
When a wrong password is submitted and Zitadel returns INVALID_ARGUMENT or UNAUTHENTICATED without CredentialsCheckError details, the catch block in sendPassword was falling through to the generic "could not create session for user" message instead of "could not verify password".

Added a gRPC code check before the generic fallthrough using isClassifiedError and Code (both already imported) to return the correct error message.

Fixes #12098