### PR TITLE
fix(i18n): add missing en/sv translations for intent, login policy and external IDP username events

### DIFF
--- a/internal/static/i18n/en.yaml
+++ b/internal/static/i18n/en.yaml
@@ -242,6 +242,7 @@ Errors:
     LoginPolicy:
       NotFound: "Login Policy not found"
       Invalid: "Login Policy is invalid"
+      NotChanged: "Login Policy not changed"
       RedirectURIInvalid: "Default Redirect URI is invalid"
       NotExisting: "Login Policy not existing"
       AlreadyExists: "Login Policy already exists"
@@ -538,6 +539,7 @@ Errors:
     TokenCreationFailed: "Token creation failed"
     InvalidToken: "Intent Token is invalid"
     OtherUser: "Intent meant for another user"
+    Invalid: "Intent is invalid"
   AuthRequest:
     AlreadyExists: "Auth Request already exists"
     NotExisting: "Auth Request does not exist"
@@ -744,6 +746,8 @@ EventTypes:
       externalidp:
         added: "External IDP added"
         removed: "External IDP removed"
+        username:
+          changed: "External IDP username changed"
         cascade:
           removed: "External IDP cascade removed"
         id:

--- a/internal/static/i18n/sv.yaml
+++ b/internal/static/i18n/sv.yaml
@@ -239,6 +239,7 @@ Errors:
     LoginPolicy:
       NotFound: "Inloggningspolicyn hittades inte"
       Invalid: "Inloggningspolicyn är ogiltig"
+      NotChanged: "Inloggningspolicyn har inte ändrats"
       RedirectURIInvalid: "Standard-Redirect URI är ogiltig"
       NotExisting: "Inloggningspolicyn finns inte"
       AlreadyExists: "Inloggningspolicyn finns redan"
@@ -533,6 +534,7 @@ Errors:
     TokenCreationFailed: "Token-skapande misslyckades"
     InvalidToken: "Avsiktstoken är ogiltig"
     OtherUser: "Avsikten är avsedd för en annan användare"
+    Invalid: "Avsikten är ogiltig"
   AuthRequest:
     AlreadyExists: "Autentiseringsbegäran finns redan"
     NotExisting: "Autentiseringsbegäran existerar inte"
@@ -739,6 +741,8 @@ EventTypes:
       externalidp:
         added: "Extern IDP tillagd"
         removed: "Extern IDP borttagen"
+        username:
+          changed: "Användarnamn för extern IDP ändrades"
         cascade:
           removed: "Extern IDP kaskadborttagen"
         id:


### PR DESCRIPTION
# Which Problems Are Solved

Three message keys are requested from the i18n translator at runtime but are missing from the bundle (`internal/static/i18n`). Each lookup falls through to `localize()` and logs a `level=warning msg="missing translation"` line on every occurrence. Because some of these are reached during notification/login rendering, the warning also dumps the request's template args (which can include user PII) into the logs.

The affected keys are missing from **`en.yaml` as well as `sv.yaml`**:

- `Errors.Intent.Invalid`
- `Errors.Org.LoginPolicy.NotChanged`
- `EventTypes.user.human.externalidp.username.changed` (display name for the `user.human.externalidp.username.changed` event)

# How the Problems Are Solved

- Added the three keys to `internal/static/i18n/en.yaml` with canonical English text, style-matched to their sibling entries.
- Added the corresponding Swedish translations to `internal/static/i18n/sv.yaml`.

# Additional Changes

None — the change is limited to the two translation files (+8 lines total).

# Additional Context

- These were observed as recurring `missing translation` warnings in a production v4.x instance.
- Related: #11841 (broader effort to add missing `Errors.*` translations). This PR only covers the specific keys observed in the wild; it does not attempt the full backlog, nor the (separate, all-languages) gap around the v2 typed-IDP event family under `EventTypes.org.idp.*`.