### PR TITLE
chore(test): disable event_testing in backend/v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,7 +339,7 @@ go test -count 1 -tags integration ./internal/api/grpc/management/integration_te
 To run all available integration tests:
 
 ```bash
-go test -count 1 -tags integration -parallel 1 $(go list -tags integration ./... | grep -e \"integration_test\" -e \"events_testing\")
+go test -count 1 -tags integration -parallel 1 $(go list -tags integration ./... | grep -e \"integration_test\")
 ```
 
 It is also possible to run the API in a debugger and run the integrations tests against it.

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -6,7 +6,6 @@
         "sources": [
             "{workspaceRoot}/cmd/**/*.go",
             "{workspaceRoot}/internal/**/*.go",
-            "{workspaceRoot}/backend/**/*.go",
             "{workspaceRoot}/proto/**/*.go",
             "{workspaceRoot}/pkg/**/*.go",
             "{workspaceRoot}/main.go",
@@ -235,8 +234,8 @@
                 },
                 "commands": [
                     "wait-on --verbose --interval 2000 --simultaneous 1 --timeout 30m \"${ZITADEL_API_URL}/debug/ready\"",
-                    "bash -c 'go test -race -count 1 -tags integration -timeout 60m -parallel 1 $(go list -tags integration ./... | grep -e \"integration_test\" -e \"events_testing\")'",
-                    "go tool covdata textfmt -i=$GOCOVERDIR -pkg=github.com/zitadel/zitadel/internal/...,github.com/zitadel/zitadel/cmd/...,github.com/zitadel/zitadel/backend/... -o profile.api.test-integration.cov",
+                    "bash -c 'go test -race -count 1 -tags integration -timeout 60m -parallel 1 $(go list -tags integration ./... | grep -e \"integration_test\")'",
+                    "go tool covdata textfmt -i=$GOCOVERDIR -pkg=github.com/zitadel/zitadel/internal/...,github.com/zitadel/zitadel/cmd/... -o profile.api.test-integration.cov",
                     "nx run @zitadel/api:test-integration-stop"
                 ]
             },


### PR DESCRIPTION
# Which Problems Are Solved

`backed/v3` tests are flaky, but the code is not productive. Development is paused for the moment. Disabling flaky tests helps us to maintain the product easier.

# How the Problems Are Solved


- Removed 'events_testing' from the integration test command in both `CONTRIBUTING.md` and `apps/api/project.json` to streamline the testing process.
- Adjusted the command to ensure it only includes relevant integration tests, improving clarity and focus for contributors.