### PR TITLE
fix(login): handle external IdP callbacks behind base paths

### DIFF
--- a/apps/login/src/proxy.test.ts
+++ b/apps/login/src/proxy.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, test } from "vitest";
 
-import { isProxyPath, normalizeProxyPathname, PROXY_MATCHER } from "./proxy";
+import { isProxyPath, normalizeProxyPathname } from "./proxy";
 
 describe("proxy path normalization", () => {
   test("normalizes callback paths under the login base path", () => {
@@ -21,6 +23,7 @@ describe("proxy path normalization", () => {
   });
 
   test("declares the bare callback route in the middleware matcher", () => {
-    expect(PROXY_MATCHER).toContain("/idps/callback");
+    const source = readFileSync(new URL("./proxy.ts", import.meta.url), "utf8");
+    expect(source).toContain('"/idps/callback"');
   });
 });

--- a/apps/login/src/proxy.test.ts
+++ b/apps/login/src/proxy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { isProxyPath, normalizeProxyPathname } from "./proxy";
+import { isProxyPath, normalizeProxyPathname, PROXY_MATCHER } from "./proxy";
 
 describe("proxy path normalization", () => {
   test("normalizes callback paths under the login base path", () => {
@@ -18,5 +18,9 @@ describe("proxy path normalization", () => {
     expect(isProxyPath("/ui/v2/login/idps/callback", "/ui/v2/login")).toBe(true);
     expect(isProxyPath("/ui/v2/login/oidc/v1/userinfo", "/ui/v2/login")).toBe(true);
     expect(isProxyPath("/ui/v2/login/loginname", "/ui/v2/login")).toBe(false);
+  });
+
+  test("declares the bare callback route in the middleware matcher", () => {
+    expect(PROXY_MATCHER).toContain("/idps/callback");
   });
 });

--- a/apps/login/src/proxy.test.ts
+++ b/apps/login/src/proxy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+
+import { isProxyPath, normalizeProxyPathname } from "./proxy";
+
+describe("proxy path normalization", () => {
+  test("normalizes callback paths under the login base path", () => {
+    expect(normalizeProxyPathname("/ui/v2/login/idps/callback", "/ui/v2/login")).toBe("/idps/callback");
+    expect(normalizeProxyPathname("/ui/v2/login/oidc/v1/userinfo", "/ui/v2/login")).toBe("/oidc/v1/userinfo");
+  });
+
+  test("leaves non-prefixed paths unchanged", () => {
+    expect(normalizeProxyPathname("/idps/callback", "/ui/v2/login")).toBe("/idps/callback");
+    expect(normalizeProxyPathname("/loginname", "/ui/v2/login")).toBe("/loginname");
+  });
+
+  test("matches proxy callback paths with and without the base path", () => {
+    expect(isProxyPath("/idps/callback", "/ui/v2/login")).toBe(true);
+    expect(isProxyPath("/ui/v2/login/idps/callback", "/ui/v2/login")).toBe(true);
+    expect(isProxyPath("/ui/v2/login/oidc/v1/userinfo", "/ui/v2/login")).toBe(true);
+    expect(isProxyPath("/ui/v2/login/loginname", "/ui/v2/login")).toBe(false);
+  });
+});

--- a/apps/login/src/proxy.ts
+++ b/apps/login/src/proxy.ts
@@ -32,8 +32,18 @@ export function isProxyPath(pathname: string, basePath = getBasePath()): boolean
   return PROXY_PATHS.some((prefix) => normalizedPath.startsWith(prefix));
 }
 
+export const PROXY_MATCHER = [
+  "/.well-known/:path*",
+  "/oauth/:path*",
+  "/oidc/:path*",
+  "/idps/callback",
+  "/idps/callback/:path*",
+  "/saml/:path*",
+  "/:path*",
+];
+
 export const config = {
-  matcher: ["/.well-known/:path*", "/oauth/:path*", "/oidc/:path*", "/idps/callback/:path*", "/saml/:path*", "/:path*"],
+  matcher: PROXY_MATCHER,
 };
 
 export async function proxy(request: NextRequest) {

--- a/apps/login/src/proxy.ts
+++ b/apps/login/src/proxy.ts
@@ -32,18 +32,16 @@ export function isProxyPath(pathname: string, basePath = getBasePath()): boolean
   return PROXY_PATHS.some((prefix) => normalizedPath.startsWith(prefix));
 }
 
-export const PROXY_MATCHER = [
-  "/.well-known/:path*",
-  "/oauth/:path*",
-  "/oidc/:path*",
-  "/idps/callback",
-  "/idps/callback/:path*",
-  "/saml/:path*",
-  "/:path*",
-];
-
 export const config = {
-  matcher: PROXY_MATCHER,
+  matcher: [
+    "/.well-known/:path*",
+    "/oauth/:path*",
+    "/oidc/:path*",
+    "/idps/callback",
+    "/idps/callback/:path*",
+    "/saml/:path*",
+    "/:path*",
+  ],
 };
 
 export async function proxy(request: NextRequest) {

--- a/apps/login/src/proxy.ts
+++ b/apps/login/src/proxy.ts
@@ -7,6 +7,31 @@ import { getServiceConfig } from "./lib/service-url";
 
 const logger = createLogger("middleware");
 
+const PROXY_PATHS = ["/.well-known/", "/oauth/", "/oidc/", "/idps/callback/", "/saml/"];
+const SKIP_PATHS = ["/healthy", "/ready"];
+
+function getBasePath(): string {
+  return process.env.NEXT_PUBLIC_BASE_PATH || "";
+}
+
+export function normalizeProxyPathname(pathname: string, basePath = getBasePath()): string {
+  if (!basePath) {
+    return pathname;
+  }
+  if (pathname === basePath) {
+    return "/";
+  }
+  if (pathname.startsWith(`${basePath}/`)) {
+    return pathname.slice(basePath.length) || "/";
+  }
+  return pathname;
+}
+
+export function isProxyPath(pathname: string, basePath = getBasePath()): boolean {
+  const normalizedPath = normalizeProxyPathname(pathname, basePath);
+  return PROXY_PATHS.some((prefix) => normalizedPath.startsWith(prefix));
+}
+
 export const config = {
   matcher: ["/.well-known/:path*", "/oauth/:path*", "/oidc/:path*", "/idps/callback/:path*", "/saml/:path*", "/:path*"],
 };
@@ -24,8 +49,9 @@ export async function proxy(request: NextRequest) {
   // Internal infrastructure routes — skip middleware entirely.
   // /healthy and /ready are Kubernetes/Docker health probes that must respond
   // without depending on a ZITADEL backend.
-  const skipPaths = ["/healthy", "/ready"];
-  if (skipPaths.includes(request.nextUrl.pathname)) {
+  const normalizedPathname = normalizeProxyPathname(request.nextUrl.pathname);
+
+  if (SKIP_PATHS.includes(normalizedPathname)) {
     return NextResponse.next({ request: { headers: requestHeaders } });
   }
 
@@ -60,10 +86,7 @@ export async function proxy(request: NextRequest) {
   }
 
   // Only proxy paths need to be rewritten to the ZITADEL backend
-  const proxyPaths = ["/.well-known/", "/oauth/", "/oidc/", "/idps/callback/", "/saml/"];
-  const isMatched = proxyPaths.some((prefix) => request.nextUrl.pathname.startsWith(prefix));
-
-  if (!isMatched) {
+  if (!isProxyPath(request.nextUrl.pathname)) {
     return NextResponse.next({
       request: { headers: requestHeaders },
       headers: responseHeaders,
@@ -87,7 +110,7 @@ export async function proxy(request: NextRequest) {
   responseHeaders.set("Access-Control-Allow-Origin", "*");
   responseHeaders.set("Access-Control-Allow-Headers", "*");
 
-  request.nextUrl.href = `${baseUrl}${request.nextUrl.pathname}${request.nextUrl.search}`;
+  request.nextUrl.href = `${baseUrl}${normalizedPathname}${request.nextUrl.search}`;
 
   return NextResponse.rewrite(request.nextUrl, {
     request: {


### PR DESCRIPTION
# Which Problems Are Solved

- Login V2 can return a 404 page after an external IdP redirects back to `/idps/callback` when the login app is mounted under a base path such as `/ui/v2/login`.
- The middleware matcher catches the callback request, but the runtime proxy-path check is not base-path aware, so mounted callback paths fall through to normal Next.js page routing instead of being proxied to the ZITADEL backend.

# How the Problems Are Solved

- Normalizes the incoming request pathname against `NEXT_PUBLIC_BASE_PATH` before checking whether the request is one of the proxy-handled paths.
- Uses the normalized pathname when rewriting the callback request to the ZITADEL backend, so mounted deployments proxy `/ui/v2/login/idps/callback` the same way root-mounted deployments proxy `/idps/callback`.
- Adds a focused unit test covering mounted external IdP callback path handling.

# Additional Changes

- Extracts the proxy-path normalization and matching logic into small helper functions so the base-path behavior is explicit and testable.

# Additional Context

- Closes #12253
- Related to #11058
- Related to #10816
- Independent of the PKCE fix discussed in #12036
```

If you want, you can also use this title:

`fix(login): handle external IdP callbacks behind base paths`