### PR TITLE
fix(api): tolerate partial IdP profiles in brokered user/v2 intents

### DIFF
--- a/internal/api/grpc/user/v2/intent.go
+++ b/internal/api/grpc/user/v2/intent.go
@@ -345,11 +345,66 @@ func (s *Server) checkIntentToken(token string, intentID string) error {
 	return crypto.CheckToken(s.idpAlg, token, intentID)
 }
 
+// idpUserFallbackUsername returns a non-empty username for an external user,
+// preferring the upstream preferred_username, then the email, then the stable
+// external subject id. Many real-world IdPs (e.g. Auth0, Supabase) do not emit
+// a preferred_username, so a fallback is required to satisfy the non-empty
+// IDPLink.UserName / username constraints during brokered onboarding.
+func idpUserFallbackUsername(idpUser idp.User) string {
+	if username := strings.TrimSpace(idpUser.GetPreferredUsername()); username != "" {
+		return username
+	}
+	if email := strings.TrimSpace(string(idpUser.GetEmail())); email != "" {
+		return email
+	}
+	return strings.TrimSpace(idpUser.GetID())
+}
+
+// idpUserFallbackNames resolves given and family names for an external user.
+// Names provided by the IdP always win; when they are missing the values are
+// derived from the display name and finally the local part of the email so that
+// brokered onboarding succeeds even when the upstream profile only carries a
+// subject and email. Both returned values are guaranteed to be non-empty as
+// long as the user has a username, email or external id.
+func idpUserFallbackNames(idpUser idp.User) (givenName, familyName string) {
+	givenName = strings.TrimSpace(idpUser.GetFirstName())
+	familyName = strings.TrimSpace(idpUser.GetLastName())
+	if givenName != "" && familyName != "" {
+		return givenName, familyName
+	}
+
+	source := strings.TrimSpace(idpUser.GetDisplayName())
+	if source == "" {
+		if email := strings.TrimSpace(string(idpUser.GetEmail())); email != "" {
+			source = strings.SplitN(email, "@", 2)[0]
+		}
+	}
+	if parts := strings.Fields(source); len(parts) > 0 {
+		if givenName == "" {
+			givenName = parts[0]
+		}
+		if familyName == "" && len(parts) > 1 {
+			familyName = strings.Join(parts[1:], " ")
+		}
+	}
+
+	// Guarantee both fields are non-empty so the profile passes validation even
+	// when only a single token (or no name at all) could be derived.
+	if givenName == "" {
+		givenName = idpUserFallbackUsername(idpUser)
+	}
+	if familyName == "" {
+		familyName = givenName
+	}
+	return givenName, familyName
+}
+
 func idpUserToAddHumanUser(idpUser idp.User, idpID string) *user.AddHumanUserRequest {
+	givenName, familyName := idpUserFallbackNames(idpUser)
 	addHumanUser := &user.AddHumanUserRequest{
 		Profile: &user.SetHumanProfile{
-			GivenName:  idpUser.GetFirstName(),
-			FamilyName: idpUser.GetLastName(),
+			GivenName:  givenName,
+			FamilyName: familyName,
 		},
 		Email: &user.SetHumanEmail{
 			Email:        string(idpUser.GetEmail()),
@@ -360,7 +415,7 @@ func idpUserToAddHumanUser(idpUser idp.User, idpID string) *user.AddHumanUserReq
 			{
 				IdpId:    idpID,
 				UserId:   idpUser.GetID(),
-				UserName: idpUser.GetPreferredUsername(),
+				UserName: idpUserFallbackUsername(idpUser),
 			},
 		},
 	}
@@ -433,12 +488,13 @@ func idpUserToUpdateHumanUser(userID string, idpUser idp.User) *user.UpdateHuman
 }
 
 func idpUserToCreateUser(idpUser idp.User, idpID string) *user.RetrieveIdentityProviderIntentResponse_CreateUser {
+	givenName, familyName := idpUserFallbackNames(idpUser)
 	createUser := &user.CreateUserRequest{
 		UserType: &user.CreateUserRequest_Human_{
 			Human: &user.CreateUserRequest_Human{
 				Profile: &user.SetHumanProfile{
-					GivenName:  idpUser.GetFirstName(),
-					FamilyName: idpUser.GetLastName(),
+					GivenName:  givenName,
+					FamilyName: familyName,
 				},
 				Email: &user.SetHumanEmail{
 					Email:        string(idpUser.GetEmail()),
@@ -448,7 +504,7 @@ func idpUserToCreateUser(idpUser idp.User, idpID string) *user.RetrieveIdentityP
 					{
 						IdpId:    idpID,
 						UserId:   idpUser.GetID(),
-						UserName: idpUser.GetPreferredUsername(),
+						UserName: idpUserFallbackUsername(idpUser),
 					},
 				},
 			},

--- a/internal/api/grpc/user/v2/intent.go
+++ b/internal/api/grpc/user/v2/intent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"

--- a/internal/api/grpc/user/v2/intent_test.go
+++ b/internal/api/grpc/user/v2/intent_test.go
@@ -22,19 +22,19 @@ type fakeIDPUser struct {
 	phone             domain.PhoneNumber
 }
 
-func (u fakeIDPUser) GetID() string                       { return u.id }
-func (u fakeIDPUser) GetFirstName() string                { return u.firstName }
-func (u fakeIDPUser) GetLastName() string                 { return u.lastName }
-func (u fakeIDPUser) GetDisplayName() string              { return u.displayName }
-func (u fakeIDPUser) GetNickname() string                 { return u.nickname }
-func (u fakeIDPUser) GetPreferredUsername() string        { return u.preferredUsername }
-func (u fakeIDPUser) GetEmail() domain.EmailAddress       { return u.email }
-func (u fakeIDPUser) IsEmailVerified() bool               { return false }
-func (u fakeIDPUser) GetPhone() domain.PhoneNumber        { return u.phone }
-func (u fakeIDPUser) IsPhoneVerified() bool               { return false }
-func (u fakeIDPUser) GetPreferredLanguage() language.Tag  { return language.Und }
-func (u fakeIDPUser) GetAvatarURL() string                { return "" }
-func (u fakeIDPUser) GetProfile() string                  { return "" }
+func (u fakeIDPUser) GetID() string                      { return u.id }
+func (u fakeIDPUser) GetFirstName() string               { return u.firstName }
+func (u fakeIDPUser) GetLastName() string                { return u.lastName }
+func (u fakeIDPUser) GetDisplayName() string             { return u.displayName }
+func (u fakeIDPUser) GetNickname() string                { return u.nickname }
+func (u fakeIDPUser) GetPreferredUsername() string       { return u.preferredUsername }
+func (u fakeIDPUser) GetEmail() domain.EmailAddress      { return u.email }
+func (u fakeIDPUser) IsEmailVerified() bool              { return false }
+func (u fakeIDPUser) GetPhone() domain.PhoneNumber       { return u.phone }
+func (u fakeIDPUser) IsPhoneVerified() bool              { return false }
+func (u fakeIDPUser) GetPreferredLanguage() language.Tag { return language.Und }
+func (u fakeIDPUser) GetAvatarURL() string               { return "" }
+func (u fakeIDPUser) GetProfile() string                 { return "" }
 
 func Test_idpUserFallbackUsername(t *testing.T) {
 	tests := []struct {

--- a/internal/api/grpc/user/v2/intent_test.go
+++ b/internal/api/grpc/user/v2/intent_test.go
@@ -1,0 +1,163 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
+
+	"github.com/zitadel/zitadel/internal/domain"
+)
+
+// fakeIDPUser is a minimal idp.User implementation for exercising the brokered
+// onboarding fallbacks without depending on a concrete provider mapper.
+type fakeIDPUser struct {
+	id                string
+	firstName         string
+	lastName          string
+	displayName       string
+	nickname          string
+	preferredUsername string
+	email             domain.EmailAddress
+	phone             domain.PhoneNumber
+}
+
+func (u fakeIDPUser) GetID() string                       { return u.id }
+func (u fakeIDPUser) GetFirstName() string                { return u.firstName }
+func (u fakeIDPUser) GetLastName() string                 { return u.lastName }
+func (u fakeIDPUser) GetDisplayName() string              { return u.displayName }
+func (u fakeIDPUser) GetNickname() string                 { return u.nickname }
+func (u fakeIDPUser) GetPreferredUsername() string        { return u.preferredUsername }
+func (u fakeIDPUser) GetEmail() domain.EmailAddress       { return u.email }
+func (u fakeIDPUser) IsEmailVerified() bool               { return false }
+func (u fakeIDPUser) GetPhone() domain.PhoneNumber        { return u.phone }
+func (u fakeIDPUser) IsPhoneVerified() bool               { return false }
+func (u fakeIDPUser) GetPreferredLanguage() language.Tag  { return language.Und }
+func (u fakeIDPUser) GetAvatarURL() string                { return "" }
+func (u fakeIDPUser) GetProfile() string                  { return "" }
+
+func Test_idpUserFallbackUsername(t *testing.T) {
+	tests := []struct {
+		name string
+		user fakeIDPUser
+		want string
+	}{
+		{
+			name: "preferred username wins",
+			user: fakeIDPUser{preferredUsername: "minnie", email: "minnie@example.com", id: "sub-1"},
+			want: "minnie",
+		},
+		{
+			name: "falls back to email",
+			user: fakeIDPUser{email: "brightsparc@gmail.com", id: "sub-1"},
+			want: "brightsparc@gmail.com",
+		},
+		{
+			name: "falls back to external subject",
+			user: fakeIDPUser{id: "google-oauth2|118092360802169819584"},
+			want: "google-oauth2|118092360802169819584",
+		},
+		{
+			name: "whitespace preferred username is ignored",
+			user: fakeIDPUser{preferredUsername: "   ", email: "user@example.com"},
+			want: "user@example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, idpUserFallbackUsername(tt.user))
+		})
+	}
+}
+
+func Test_idpUserFallbackNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		user       fakeIDPUser
+		wantGiven  string
+		wantFamily string
+	}{
+		{
+			name:       "provided names win",
+			user:       fakeIDPUser{firstName: "Julian", lastName: "Bright", displayName: "ignored me"},
+			wantGiven:  "Julian",
+			wantFamily: "Bright",
+		},
+		{
+			name:       "derive both from display name",
+			user:       fakeIDPUser{displayName: "Julian Bright", email: "brightsparc@gmail.com"},
+			wantGiven:  "Julian",
+			wantFamily: "Bright",
+		},
+		{
+			name:       "single-token display name reuses given as family",
+			user:       fakeIDPUser{displayName: "Julian"},
+			wantGiven:  "Julian",
+			wantFamily: "Julian",
+		},
+		{
+			name:       "derive from email local part when no names or display name",
+			user:       fakeIDPUser{email: "brightsparc@gmail.com"},
+			wantGiven:  "brightsparc",
+			wantFamily: "brightsparc",
+		},
+		{
+			name:       "missing family is derived from display name",
+			user:       fakeIDPUser{firstName: "Julian", displayName: "Julian Bright"},
+			wantGiven:  "Julian",
+			wantFamily: "Bright",
+		},
+		{
+			name:       "email-only profile still yields non-empty names",
+			user:       fakeIDPUser{id: "sub-only"},
+			wantGiven:  "sub-only",
+			wantFamily: "sub-only",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			given, family := idpUserFallbackNames(tt.user)
+			assert.Equal(t, tt.wantGiven, given)
+			assert.Equal(t, tt.wantFamily, family)
+			assert.NotEmpty(t, given)
+			assert.NotEmpty(t, family)
+		})
+	}
+}
+
+// Test_idpUserToAddHumanUser_PartialProfiles mirrors the reported Auth0 and
+// Supabase brokered-onboarding cases: the request handed to AddHumanUser must
+// satisfy the non-empty given_name/family_name and IDPLink.user_name proto
+// constraints even when the upstream IdP omits those claims.
+func Test_idpUserToAddHumanUser_PartialProfiles(t *testing.T) {
+	t.Run("auth0 without preferred_username", func(t *testing.T) {
+		idpUser := fakeIDPUser{
+			id:          "google-oauth2|118092360802169819584",
+			email:       "brightsparc@gmail.com",
+			displayName: "Julian Bright",
+			firstName:   "Julian",
+			lastName:    "Bright",
+		}
+
+		req := idpUserToAddHumanUser(idpUser, "idpID")
+
+		assert.Equal(t, "Julian", req.GetProfile().GetGivenName())
+		assert.Equal(t, "Bright", req.GetProfile().GetFamilyName())
+		assert.NotEmpty(t, req.GetIdpLinks()[0].GetUserName())
+		assert.Equal(t, "brightsparc@gmail.com", req.GetIdpLinks()[0].GetUserName())
+	})
+
+	t.Run("supabase email only", func(t *testing.T) {
+		idpUser := fakeIDPUser{
+			id:    "sub-123",
+			email: "brightsparc@gmail.com",
+		}
+
+		req := idpUserToAddHumanUser(idpUser, "idpID")
+
+		assert.NotEmpty(t, req.GetProfile().GetGivenName())
+		assert.NotEmpty(t, req.GetProfile().GetFamilyName())
+		assert.Equal(t, "brightsparc", req.GetProfile().GetGivenName())
+		assert.Equal(t, "brightsparc@gmail.com", req.GetIdpLinks()[0].GetUserName())
+	})
+}


### PR DESCRIPTION
# Which Problems Are Solved

Closes #12265

Brokered OIDC onboarding through the v2 login fails when the upstream IdP does not supply a full profile. Real-world providers frequently omit optional claims:

- **Auth0** does not emit `preferred_username` → `RetrieveIdentityProviderIntent` returns an `AddHumanUserRequest` with an empty `IDPLink.user_name`, and `AddHumanUser` fails proto validation: `invalid IDPLink.UserName: value length must be between 1 and 200 runes`.
- **Supabase** (and other minimal OIDC servers) may supply only `sub` + `email` → empty `given_name`/`family_name` fails `invalid SetHumanProfile.GivenName`.

In both cases the end user completes the upstream login successfully and then lands on `/ui/v2/login/idp/oidc/failure?...error=user_creation_failed`, with no way to proceed.

# How the Problems Are Solved

Apply fallbacks in the intent→request mapping (`idpUserToAddHumanUser`, `idpUserToCreateUser`) so a minimal identity (`sub` + `email`) is enough to onboard, while all proto/command validation stays strict:

- **username / IDP link name:** `preferred_username` → `email` → `sub` (first non-empty)
- **given/family name:** provided names always win; missing parts are derived from `display_name` tokens, then the email local-part; as a last resort the given name is reused for the family name so both are always non-empty

The fallbacks only engage when the upstream claim is empty — profiles that already carry the claims are mapped exactly as before. If you would prefer this behind a feature flag / instance setting, happy to rework it that way.

# Additional Changes

None.

# Additional Context

- Unit tests cover the fallback orderings and the Auth0/Supabase claim shapes (`internal/api/grpc/user/v2/intent_test.go`)
- Verified end-to-end against live Auth0 and Supabase brokered logins (generic OIDC providers with PKCE)
