### PR TITLE
fix(login): forward login_hint as email prefill on prompt=create

### DIFF
--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -215,6 +215,10 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
     const registerUrl = constructUrl(request, "/register");
     registerUrl.searchParams.set("requestId", requestId);
 
+    if (authRequest.loginHint) {
+      registerUrl.searchParams.set("email", authRequest.loginHint);
+    }
+
     if (organization) {
       registerUrl.searchParams.set("organization", organization);
     }


### PR DESCRIPTION
When an authorize request carries `prompt=create` and `login_hint`, forward the hint to the register page as the `email` search param so the form is prefilled. The register page already supports the param; the `Prompt.LOGIN` branch already consumes `loginHint`.

Closes #12268
