### PR TITLE
feat(login): opt-in application-layer password encryption for regulated deployments (fixes #12282)

### DIFF
--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -44,6 +44,7 @@ type Login struct {
 	idpConfigAlg        crypto.EncryptionAlgorithm
 	userCodeAlg         crypto.EncryptionAlgorithm
 	caches              *Caches
+	encKeyStore         *passwordEncKeyStore
 }
 
 type Config struct {
@@ -52,27 +53,41 @@ type Config struct {
 	Cache              middleware.CacheConfig
 	AssetCache         middleware.CacheConfig
 
-	// PasswordEncryption enables application-layer AES-GCM encryption of the
-	// password field before form submission. When enabled, the browser encrypts
-	// the password using the auth-request ID as the key-derivation input
-	// (PBKDF2-SHA256), and the server decrypts it before credential verification.
-	//
-	// This satisfies regulatory requirements (e.g. VAPT findings) in deployments
-	// where middleware or logging infrastructure may record POST body content
-	// despite TLS being present at the transport layer. It is opt-in and disabled
-	// by default; standard TLS-only deployments do not need it.
+	// PasswordEncryption controls application-layer end-to-end encryption of
+	// the login form password field, addressing VAPT findings in regulated
+	// deployments where TLS terminates at a load balancer and POST body content
+	// may be captured by middleware logging before reaching the application.
+	// Disabled by default; standard TLS-only deployments do not require it.
 	PasswordEncryption PasswordEncryptionConfig
 
 	// LoginV2
 	DefaultPaths *DefaultPaths
 }
 
-// PasswordEncryptionConfig controls application-layer password encryption for
-// the login UI password form.
+// PasswordEncryptionConfig controls application-layer ECDH password encryption
+// for the login UI password form.
 type PasswordEncryptionConfig struct {
-	// Enabled activates client-side AES-GCM encryption of the password field
-	// before form submission and server-side decryption before verification.
+	// Enabled activates end-to-end password encryption for the login form.
+	//
+	// When enabled, the server generates an ephemeral P-256 ECDH keypair for
+	// each password page render and embeds the public key in the page. The
+	// browser generates its own ephemeral keypair, performs ECDH to derive a
+	// shared AES-256 key (via SHA-256 of the ECDH shared secret), and encrypts
+	// the password with AES-256-GCM before the POST is sent. The server
+	// retrieves the stored private key, performs ECDH, and decrypts the payload
+	// before calling VerifyPassword. The private key is deleted after first use.
+	//
+	// A captured POST body — containing only the client public key and
+	// ciphertext — is insufficient to decrypt; the server private key is
+	// required and is never transmitted.
 	Enabled bool
+
+	// AllowPlaintextFallback, when false (default), causes the server to reject
+	// password submissions that cannot be decrypted when Enabled is true. This
+	// is the correct posture for strict regulatory compliance. Set to true only
+	// during a transitional rollout period where some clients may not yet
+	// support the encryption JS (e.g. cached old page versions).
+	AllowPlaintextFallback bool
 }
 
 type DefaultPaths struct {
@@ -250,6 +265,7 @@ func CreateLogin(
 	)
 	login.renderer = CreateRenderer(HandlerPrefix, staticStorage, config.LanguageCookieName)
 	login.parser = form.NewParser()
+	login.encKeyStore = newPasswordEncKeyStore()
 
 	var err error
 	login.caches, err = startCaches(context.Background(), cacheConnectors, federateLogoutCache)

--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -52,8 +52,27 @@ type Config struct {
 	Cache              middleware.CacheConfig
 	AssetCache         middleware.CacheConfig
 
+	// PasswordEncryption enables application-layer AES-GCM encryption of the
+	// password field before form submission. When enabled, the browser encrypts
+	// the password using the auth-request ID as the key-derivation input
+	// (PBKDF2-SHA256), and the server decrypts it before credential verification.
+	//
+	// This satisfies regulatory requirements (e.g. VAPT findings) in deployments
+	// where middleware or logging infrastructure may record POST body content
+	// despite TLS being present at the transport layer. It is opt-in and disabled
+	// by default; standard TLS-only deployments do not need it.
+	PasswordEncryption PasswordEncryptionConfig
+
 	// LoginV2
 	DefaultPaths *DefaultPaths
+}
+
+// PasswordEncryptionConfig controls application-layer password encryption for
+// the login UI password form.
+type PasswordEncryptionConfig struct {
+	// Enabled activates client-side AES-GCM encryption of the password field
+	// before form submission and server-side decryption before verification.
+	Enabled bool
 }
 
 type DefaultPaths struct {

--- a/internal/api/ui/login/password_encryption.go
+++ b/internal/api/ui/login/password_encryption.go
@@ -1,0 +1,93 @@
+package login
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	// encKeyTTL is how long an ephemeral server private key is retained.
+	// Auth requests typically expire in minutes; 10 minutes provides headroom
+	// without accumulating stale keys.
+	encKeyTTL = 10 * time.Minute
+)
+
+// encKeyEntry holds an ephemeral server-side private key and its expiry time.
+type encKeyEntry struct {
+	key     *ecdh.PrivateKey
+	expires time.Time
+}
+
+// passwordEncKeyStore holds per-auth-request ephemeral ECDH private keys.
+// Keys are single-use: retrieved and deleted in one atomic step.
+// A background goroutine periodically evicts expired entries.
+type passwordEncKeyStore struct {
+	mu      sync.Mutex
+	entries map[string]*encKeyEntry
+	done    chan struct{}
+}
+
+func newPasswordEncKeyStore() *passwordEncKeyStore {
+	s := &passwordEncKeyStore{
+		entries: make(map[string]*encKeyEntry),
+		done:    make(chan struct{}),
+	}
+	go s.evictLoop()
+	return s
+}
+
+// generate creates a new P-256 ephemeral keypair for the given authRequestID,
+// stores the private key, and returns the public key for embedding in the page.
+// Calling generate twice for the same ID replaces the previous key.
+func (s *passwordEncKeyStore) generate(authRequestID string) (*ecdh.PublicKey, error) {
+	privKey, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ephemeral ECDH key: %w", err)
+	}
+	s.mu.Lock()
+	s.entries[authRequestID] = &encKeyEntry{key: privKey, expires: time.Now().Add(encKeyTTL)}
+	s.mu.Unlock()
+	return privKey.PublicKey(), nil
+}
+
+// retrieve pops the private key for the given authRequestID.
+// It returns an error if the key is absent or expired; in both cases the entry
+// is removed so there is no second-attempt window.
+func (s *passwordEncKeyStore) retrieve(authRequestID string) (*ecdh.PrivateKey, error) {
+	s.mu.Lock()
+	entry, ok := s.entries[authRequestID]
+	delete(s.entries, authRequestID)
+	s.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("no ephemeral key for auth request %q", authRequestID)
+	}
+	if time.Now().After(entry.expires) {
+		return nil, fmt.Errorf("ephemeral key for auth request %q has expired", authRequestID)
+	}
+	return entry.key, nil
+}
+
+func (s *passwordEncKeyStore) evictLoop() {
+	ticker := time.NewTicker(encKeyTTL)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			now := time.Now()
+			s.mu.Lock()
+			for id, e := range s.entries {
+				if now.After(e.expires) {
+					delete(s.entries, id)
+				}
+			}
+			s.mu.Unlock()
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *passwordEncKeyStore) close() { close(s.done) }

--- a/internal/api/ui/login/password_handler.go
+++ b/internal/api/ui/login/password_handler.go
@@ -3,13 +3,13 @@ package login
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/ecdh"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/zitadel/zitadel/internal/domain"
 )
@@ -17,15 +17,20 @@ import (
 const (
 	tmplPassword = "password"
 
-	// passwordEncryptedPartCount is the number of dot-separated components in
-	// an encrypted password payload: ciphertext.tag.iv.salt
+	// passwordEncryptedPartCount is the number of dot-separated components:
+	// base64(clientPubKey) . hex(ciphertext) . hex(gcm_tag) . hex(iv)
 	passwordEncryptedPartCount = 4
-	// pbkdf2Iterations matches the client-side iteration count in password_encrypt.js
-	pbkdf2Iterations = 100_000
-	// pbkdf2KeyLen is the AES-256 key length in bytes
-	pbkdf2KeyLen = 32
-	// aesGCMNonceSize is the expected IV length for AES-GCM
-	aesGCMNonceSize = 12
+
+	// Fixed sizes for AES-256-GCM components — enforced before ECDH/AES runs
+	// to prevent DoS via large attacker-controlled allocations.
+	encTagHexLen = 32  // 16-byte GCM tag → 32 hex chars
+	encIVHexLen  = 24  // 12-byte IV → 24 hex chars
+	// Ciphertext is password-length + GCM overhead; cap at a generous bound.
+	// Max password length in Zitadel is 72 chars (bcrypt limit); 256 hex chars
+	// (128 bytes) is more than sufficient. Empty password produces 0-length ciphertext.
+	encMaxCiphertextHexLen = 256
+	// P-256 uncompressed public key is 65 bytes; base64 = 88 chars.
+	encMaxPubKeyBase64Len = 88
 )
 
 type passwordFormData struct {
@@ -35,6 +40,19 @@ type passwordFormData struct {
 func (l *Login) renderPassword(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, err error) {
 	translator := l.getTranslator(r.Context(), authReq)
 	data := l.getUserData(r, authReq, translator, "Password.Title", "Password.Description", err)
+
+	if l.config.PasswordEncryption.Enabled && authReq != nil {
+		// Generate an ephemeral ECDH keypair for this auth request.
+		// The public key is embedded in the page; the private key stays server-side.
+		pubKey, genErr := l.encKeyStore.generate(authReq.ID)
+		if genErr == nil {
+			data.PasswordEncryptionEnabled = true
+			data.PasswordEncryptionPublicKey = base64.StdEncoding.EncodeToString(pubKey.Bytes())
+		}
+		// On key generation failure we silently fall back to plaintext submission.
+		// The feature is not available but auth still works normally.
+	}
+
 	funcs := map[string]interface{}{
 		"showPasswordReset": func() bool {
 			if authReq.LoginPolicy != nil {
@@ -55,13 +73,28 @@ func (l *Login) handlePasswordCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if l.config.PasswordEncryption.Enabled {
-		// The browser encrypted the password with AES-256-GCM, keyed via
-		// PBKDF2-SHA256 using the auth-request ID as the passphrase.
-		// Silently fall back to the raw value if decryption fails so that
-		// a misconfigured client still reaches VerifyPassword and fails
-		// there rather than producing an opaque 500.
-		if plaintext, decErr := decryptLoginPassword(data.Password, authReq.ID); decErr == nil {
-			data.Password = plaintext
+		privKey, keyErr := l.encKeyStore.retrieve(authReq.ID)
+		if keyErr != nil {
+			// No ephemeral key found for this auth request — either it expired,
+			// was already consumed, or the client never received one.
+			if !l.config.PasswordEncryption.AllowPlaintextFallback {
+				// Strict mode: reject the submission. Render password page with error.
+				l.renderPassword(w, r, authReq, fmt.Errorf("encrypted password required"))
+				return
+			}
+			// Fallback mode: proceed with raw password; VerifyPassword will
+			// reject it if incorrect.
+		} else {
+			plaintext, decErr := decryptLoginPassword(data.Password, privKey)
+			if decErr != nil {
+				if !l.config.PasswordEncryption.AllowPlaintextFallback {
+					l.renderPassword(w, r, authReq, fmt.Errorf("encrypted password required"))
+					return
+				}
+				// Fallback: use raw value; VerifyPassword will reject it.
+			} else {
+				data.Password = plaintext
+			}
 		}
 	}
 
@@ -85,52 +118,91 @@ func (l *Login) handlePasswordCheck(w http.ResponseWriter, r *http.Request) {
 	l.renderNextStep(w, r, authReq)
 }
 
-// decryptLoginPassword reverses the AES-256-GCM encryption applied by
-// password_encrypt.js. The payload format is hex(ciphertext).hex(tag).hex(iv).hex(salt),
-// and the key is derived from the authRequestID passphrase using PBKDF2-SHA256.
-func decryptLoginPassword(payload, authRequestID string) (string, error) {
+// decryptLoginPassword decrypts a payload produced by password_encrypt.js.
+//
+// The payload format is dot-separated:
+//
+//	base64(clientP256PubKey) . hex(ciphertext) . hex(gcm_tag) . hex(iv)
+//
+// The shared secret is derived via P-256 ECDH between the server's ephemeral
+// private key and the client's ephemeral public key. The 32-byte shared secret
+// is used directly as the AES-256-GCM key (after SHA-256 of the raw ECDH
+// shared-X coordinate, matching the JS SubtleCrypto deriveBits path).
+//
+// Because the server private key is stored server-side only and deleted on
+// first retrieval, a captured POST body — containing only the client public key
+// and ciphertext — is insufficient to decrypt without the server private key.
+func decryptLoginPassword(payload string, serverPrivKey *ecdh.PrivateKey) (string, error) {
 	parts := strings.SplitN(payload, ".", passwordEncryptedPartCount)
 	if len(parts) != passwordEncryptedPartCount {
-		return "", fmt.Errorf("invalid encrypted password format: expected %d parts, got %d", passwordEncryptedPartCount, len(parts))
+		return "", fmt.Errorf("invalid encrypted password: expected %d dot-separated parts, got %d", passwordEncryptedPartCount, len(parts))
 	}
 
-	ciphertext, err := hex.DecodeString(parts[0])
+	clientPubKeyB64, ciphertextHex, tagHex, ivHex := parts[0], parts[1], parts[2], parts[3]
+
+	// Enforce fixed sizes for constant-size fields before any allocation.
+	if len(tagHex) != encTagHexLen {
+		return "", fmt.Errorf("invalid GCM tag length: got %d hex chars, expected %d", len(tagHex), encTagHexLen)
+	}
+	if len(ivHex) != encIVHexLen {
+		return "", fmt.Errorf("invalid IV length: got %d hex chars, expected %d", len(ivHex), encIVHexLen)
+	}
+	if len(ciphertextHex) > encMaxCiphertextHexLen {
+		return "", fmt.Errorf("ciphertext length out of bounds: %d hex chars", len(ciphertextHex))
+	}
+	if len(clientPubKeyB64) > encMaxPubKeyBase64Len {
+		return "", fmt.Errorf("client public key too long: %d chars", len(clientPubKeyB64))
+	}
+
+	// Decode client public key.
+	clientPubKeyBytes, err := base64.StdEncoding.DecodeString(clientPubKeyB64)
+	if err != nil {
+		return "", fmt.Errorf("decode client public key: %w", err)
+	}
+	clientPubKey, err := ecdh.P256().NewPublicKey(clientPubKeyBytes)
+	if err != nil {
+		return "", fmt.Errorf("parse client public key: %w", err)
+	}
+
+	// ECDH: derive shared secret.
+	sharedSecret, err := serverPrivKey.ECDH(clientPubKey)
+	if err != nil {
+		return "", fmt.Errorf("ECDH: %w", err)
+	}
+	// Derive AES-256 key from the raw shared secret bytes via SHA-256.
+	// This matches the Web Crypto API deriveBits("ECDH") + SHA-256 digest path
+	// used in password_encrypt.js.
+	aesKey := sha256.Sum256(sharedSecret)
+
+	// Decode hex fields.
+	ciphertext, err := hex.DecodeString(ciphertextHex)
 	if err != nil {
 		return "", fmt.Errorf("decode ciphertext: %w", err)
 	}
-	tag, err := hex.DecodeString(parts[1])
+	tag, err := hex.DecodeString(tagHex)
 	if err != nil {
-		return "", fmt.Errorf("decode tag: %w", err)
+		return "", fmt.Errorf("decode GCM tag: %w", err)
 	}
-	iv, err := hex.DecodeString(parts[2])
+	iv, err := hex.DecodeString(ivHex)
 	if err != nil {
-		return "", fmt.Errorf("decode iv: %w", err)
-	}
-	salt, err := hex.DecodeString(parts[3])
-	if err != nil {
-		return "", fmt.Errorf("decode salt: %w", err)
+		return "", fmt.Errorf("decode IV: %w", err)
 	}
 
-	if len(iv) != aesGCMNonceSize {
-		return "", fmt.Errorf("invalid IV length: got %d bytes, expected %d", len(iv), aesGCMNonceSize)
-	}
-
-	key := pbkdf2.Key([]byte(authRequestID), salt, pbkdf2Iterations, pbkdf2KeyLen, sha256.New)
-
-	block, err := aes.NewCipher(key)
+	// AES-256-GCM decrypt.
+	block, err := aes.NewCipher(aesKey[:])
 	if err != nil {
-		return "", fmt.Errorf("create cipher: %w", err)
+		return "", fmt.Errorf("create AES cipher: %w", err)
 	}
 	aead, err := cipher.NewGCM(block)
 	if err != nil {
 		return "", fmt.Errorf("create GCM: %w", err)
 	}
 
-	// GCM Open expects ciphertext + tag appended
-	combined := append(ciphertext, tag...) //nolint:gocritic // intentional append to new slice
+	// Web Crypto AES-GCM appends the tag to the ciphertext in the encrypted buffer.
+	combined := append(ciphertext, tag...) //nolint:gocritic
 	plaintext, err := aead.Open(nil, iv, combined, nil)
 	if err != nil {
-		return "", fmt.Errorf("decrypt: %w", err)
+		return "", fmt.Errorf("AES-GCM decrypt: %w", err)
 	}
 	return string(plaintext), nil
 }

--- a/internal/api/ui/login/password_handler.go
+++ b/internal/api/ui/login/password_handler.go
@@ -1,13 +1,31 @@
 package login
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/zitadel/zitadel/internal/domain"
 )
 
 const (
 	tmplPassword = "password"
+
+	// passwordEncryptedPartCount is the number of dot-separated components in
+	// an encrypted password payload: ciphertext.tag.iv.salt
+	passwordEncryptedPartCount = 4
+	// pbkdf2Iterations matches the client-side iteration count in password_encrypt.js
+	pbkdf2Iterations = 100_000
+	// pbkdf2KeyLen is the AES-256 key length in bytes
+	pbkdf2KeyLen = 32
+	// aesGCMNonceSize is the expected IV length for AES-GCM
+	aesGCMNonceSize = 12
 )
 
 type passwordFormData struct {
@@ -35,6 +53,18 @@ func (l *Login) handlePasswordCheck(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+
+	if l.config.PasswordEncryption.Enabled {
+		// The browser encrypted the password with AES-256-GCM, keyed via
+		// PBKDF2-SHA256 using the auth-request ID as the passphrase.
+		// Silently fall back to the raw value if decryption fails so that
+		// a misconfigured client still reaches VerifyPassword and fails
+		// there rather than producing an opaque 500.
+		if plaintext, decErr := decryptLoginPassword(data.Password, authReq.ID); decErr == nil {
+			data.Password = plaintext
+		}
+	}
+
 	err = l.authRepo.VerifyPassword(setContext(r.Context(), authReq.UserOrgID), authReq.ID, authReq.UserID, authReq.UserOrgID, data.Password, authReq.AgentID, domain.BrowserInfoFromRequest(r))
 
 	metadata, actionErr := l.runPostInternalAuthenticationActions(authReq, r, authMethodPassword, err)
@@ -53,4 +83,54 @@ func (l *Login) handlePasswordCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.renderNextStep(w, r, authReq)
+}
+
+// decryptLoginPassword reverses the AES-256-GCM encryption applied by
+// password_encrypt.js. The payload format is hex(ciphertext).hex(tag).hex(iv).hex(salt),
+// and the key is derived from the authRequestID passphrase using PBKDF2-SHA256.
+func decryptLoginPassword(payload, authRequestID string) (string, error) {
+	parts := strings.SplitN(payload, ".", passwordEncryptedPartCount)
+	if len(parts) != passwordEncryptedPartCount {
+		return "", fmt.Errorf("invalid encrypted password format: expected %d parts, got %d", passwordEncryptedPartCount, len(parts))
+	}
+
+	ciphertext, err := hex.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("decode ciphertext: %w", err)
+	}
+	tag, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode tag: %w", err)
+	}
+	iv, err := hex.DecodeString(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("decode iv: %w", err)
+	}
+	salt, err := hex.DecodeString(parts[3])
+	if err != nil {
+		return "", fmt.Errorf("decode salt: %w", err)
+	}
+
+	if len(iv) != aesGCMNonceSize {
+		return "", fmt.Errorf("invalid IV length: got %d bytes, expected %d", len(iv), aesGCMNonceSize)
+	}
+
+	key := pbkdf2.Key([]byte(authRequestID), salt, pbkdf2Iterations, pbkdf2KeyLen, sha256.New)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("create cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create GCM: %w", err)
+	}
+
+	// GCM Open expects ciphertext + tag appended
+	combined := append(ciphertext, tag...) //nolint:gocritic // intentional append to new slice
+	plaintext, err := aead.Open(nil, iv, combined, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt: %w", err)
+	}
+	return string(plaintext), nil
 }

--- a/internal/api/ui/login/password_handler_test.go
+++ b/internal/api/ui/login/password_handler_test.go
@@ -3,148 +3,254 @@ package login
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/ecdh"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"io"
 	"strings"
 	"testing"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
+// ── helpers ──────────────────────────────────────────────────────────────────
+
 // encryptForTest mirrors the algorithm in password_encrypt.js so we can
-// produce test vectors without a browser.
-func encryptForTest(t *testing.T, password, authRequestID string) string {
+// produce valid test payloads without a browser.
+func encryptForTest(t *testing.T, password string, serverPubKey *ecdh.PublicKey) string {
 	t.Helper()
-
-	salt := make([]byte, 16)
-	iv := make([]byte, aesGCMNonceSize)
-	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		t.Fatal(err)
-	}
-
-	key := pbkdf2.Key([]byte(authRequestID), salt, pbkdf2Iterations, pbkdf2KeyLen, sha256.New)
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Seal appends ciphertext+tag
+	clientPriv := mustGenerateECDHKey(t)
+	aesKey := ecdhDerivedAESKey(t, clientPriv, serverPubKey)
+	aead := mustNewGCM(t, aesKey)
+	iv := mustRandBytes(t, 12)
 	sealed := aead.Seal(nil, iv, []byte(password), nil)
 	ciphertext := sealed[:len(sealed)-16]
 	tag := sealed[len(sealed)-16:]
-
-	return hex.EncodeToString(ciphertext) + "." +
-		hex.EncodeToString(tag) + "." +
-		hex.EncodeToString(iv) + "." +
-		hex.EncodeToString(salt)
+	clientPubB64 := base64.StdEncoding.EncodeToString(clientPriv.PublicKey().Bytes())
+	return clientPubB64 + "." + hex.EncodeToString(ciphertext) + "." + hex.EncodeToString(tag) + "." + hex.EncodeToString(iv)
 }
 
-func Test_decryptLoginPassword(t *testing.T) {
-	const authRequestID = "test-auth-request-id-123"
-
-	tests := []struct {
-		name        string
-		password    string
-		authID      string
-		wantErr     bool
-	}{
-		{
-			name:     "simple ascii password",
-			password: "MyP@ssw0rd!",
-			authID:   authRequestID,
-		},
-		{
-			name:     "unicode password",
-			password: "pässwörد",
-			authID:   authRequestID,
-		},
-		{
-			name:     "empty password",
-			password: "",
-			authID:   authRequestID,
-		},
-		{
-			name:    "wrong auth request id",
-			password: "secret",
-			authID:  "wrong-id",
-			wantErr: true,
-		},
-		{
-			name:    "malformed payload - too few parts",
-			password: "aabbcc.ddeeff",
-			authID:  authRequestID,
-			wantErr: true,
-		},
-		{
-			name:    "malformed payload - invalid hex",
-			password: "zzzz.aabb.ccdd.eeff",
-			authID:  authRequestID,
-			wantErr: true,
-		},
-		{
-			name:    "plaintext password not accepted",
-			password: "plaintext-no-dots",
-			authID:  authRequestID,
-			wantErr: true,
-		},
+func mustGenerateECDHKey(t *testing.T) *ecdh.PrivateKey {
+	t.Helper()
+	k, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal("generate ECDH key:", err)
 	}
+	return k
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var payload string
-			if !tt.wantErr || tt.name == "wrong auth request id" {
-				// Encrypt with the correct key; wrong-ID test decrypts with wrong key
-				payload = encryptForTest(t, tt.password, authRequestID)
-			} else {
-				payload = tt.password // pass the raw string as-is for format error cases
-			}
+func ecdhDerivedAESKey(t *testing.T, priv *ecdh.PrivateKey, pub *ecdh.PublicKey) [32]byte {
+	t.Helper()
+	shared, err := priv.ECDH(pub)
+	if err != nil {
+		t.Fatal("ECDH:", err)
+	}
+	return sha256.Sum256(shared)
+}
 
-			got, err := decryptLoginPassword(payload, tt.authID)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("decryptLoginPassword() expected error, got nil (result=%q)", got)
-				}
-				return
-			}
+func mustNewGCM(t *testing.T, aesKey [32]byte) cipher.AEAD {
+	t.Helper()
+	block, err := aes.NewCipher(aesKey[:])
+	if err != nil {
+		t.Fatal("new cipher:", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal("new GCM:", err)
+	}
+	return aead
+}
+
+func mustRandBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		t.Fatal("rand bytes:", err)
+	}
+	return b
+}
+
+func generateServerKeyPair(t *testing.T) (*ecdh.PrivateKey, *ecdh.PublicKey) {
+	t.Helper()
+	priv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal("generate server key:", err)
+	}
+	return priv, priv.PublicKey()
+}
+
+// mutatePayload splits a valid payload, applies fn to the parts slice, and
+// rejoins. Keeps all per-case mutation logic in a single shared helper.
+func mutatePayload(t *testing.T, password string, serverPub *ecdh.PublicKey, fn func(parts []string) []string) string {
+	t.Helper()
+	parts := strings.SplitN(encryptForTest(t, password, serverPub), ".", 4)
+	parts = fn(parts)
+	return strings.Join(parts, ".")
+}
+
+// ── decryptLoginPassword round-trip tests ────────────────────────────────────
+
+func Test_decryptLoginPassword_roundTrip(t *testing.T) {
+	serverPriv, serverPub := generateServerKeyPair(t)
+
+	cases := []struct {
+		name     string
+		password string
+	}{
+		{"ascii", "MyP@ssw0rd!"},
+		{"unicode", "pässwörد"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := encryptForTest(t, tc.password, serverPub)
+			got, err := decryptLoginPassword(payload, serverPriv)
 			if err != nil {
-				t.Errorf("decryptLoginPassword() unexpected error: %v", err)
-				return
+				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.password {
-				t.Errorf("decryptLoginPassword() = %q, want %q", got, tt.password)
+			if got != tc.password {
+				t.Errorf("got %q, want %q", got, tc.password)
 			}
 		})
 	}
 }
 
-func Test_decryptLoginPassword_payloadFormat(t *testing.T) {
-	// Verify the expected dot-separated hex format is enforced
-	cases := []string{
-		"",
-		"single",
-		"a.b",
-		"a.b.c",
-		"a.b.c.d.e", // too many parts — SplitN(4) keeps last part intact, still 4 parts
+// ── decryptLoginPassword error path tests ────────────────────────────────────
+
+func Test_decryptLoginPassword_errors(t *testing.T) {
+	serverPriv, serverPub := generateServerKeyPair(t)
+	wrongPriv, _ := generateServerKeyPair(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		key     *ecdh.PrivateKey
+	}{
+		{
+			name:    "wrong server key",
+			payload: encryptForTest(t, "secret", serverPub),
+			key:     wrongPriv,
+		},
+		{
+			name:    "too few parts",
+			payload: "aabb.ccdd",
+			key:     serverPriv,
+		},
+		{
+			name:    "invalid base64 client pubkey",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[0] = "!!!notbase64!!!"; return p }),
+			key:     serverPriv,
+		},
+		{
+			name:    "invalid hex ciphertext",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[1] = strings.Repeat("zz", len(p[1])/2); return p }),
+			key:     serverPriv,
+		},
+		{
+			name:    "tag too short",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[2] = "aabb"; return p }),
+			key:     serverPriv,
+		},
+		{
+			name:    "IV too short",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[3] = "aabb"; return p }),
+			key:     serverPriv,
+		},
+		{
+			name:    "ciphertext too long",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[1] = strings.Repeat("aa", encMaxCiphertextHexLen/2+1); return p }),
+			key:     serverPriv,
+		},
+		{
+			name:    "client pubkey too long",
+			payload: mutatePayload(t, "x", serverPub, func(p []string) []string { p[0] = strings.Repeat("A", encMaxPubKeyBase64Len+1); return p }),
+			key:     serverPriv,
+		},
 	}
-	for _, c := range cases {
-		// The last case (5 apparent segments) actually passes SplitN with n=4,
-		// because SplitN stops at 4 parts; test only the genuinely bad ones.
-		parts := strings.SplitN(c, ".", passwordEncryptedPartCount)
-		if len(parts) == passwordEncryptedPartCount {
-			continue // format check passes, hex decode will fail separately
-		}
-		_, err := decryptLoginPassword(c, "any-id")
-		if err == nil {
-			t.Errorf("decryptLoginPassword(%q) expected format error, got nil", c)
-		}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decryptLoginPassword(tc.payload, tc.key)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// ── passwordEncKeyStore tests ─────────────────────────────────────────────────
+
+func Test_passwordEncKeyStore_generateAndRetrieve(t *testing.T) {
+	store := newPasswordEncKeyStore()
+	defer store.close()
+
+	pubKey, err := store.generate("req-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pubKey == nil {
+		t.Fatal("expected non-nil public key")
+	}
+	priv, err := store.retrieve("req-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if priv == nil {
+		t.Fatal("expected non-nil private key")
+	}
+}
+
+func Test_passwordEncKeyStore_singleUse(t *testing.T) {
+	store := newPasswordEncKeyStore()
+	defer store.close()
+
+	if _, err := store.generate("req-2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.retrieve("req-2"); err != nil {
+		t.Fatal("first retrieve should succeed:", err)
+	}
+	if _, err := store.retrieve("req-2"); err == nil {
+		t.Error("expected error on second retrieve — key must be deleted after first use")
+	}
+}
+
+func Test_passwordEncKeyStore_unknownKey(t *testing.T) {
+	store := newPasswordEncKeyStore()
+	defer store.close()
+
+	if _, err := store.retrieve("nonexistent-req"); err == nil {
+		t.Error("expected error for unknown auth request ID")
+	}
+}
+
+func Test_passwordEncKeyStore_keypairConsistency(t *testing.T) {
+	store := newPasswordEncKeyStore()
+	defer store.close()
+
+	pubKey, err := store.generate("req-3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKey, err := store.retrieve("req-3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify via ECDH: both sides must derive the same shared secret.
+	clientPriv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverShared, err := privKey.ECDH(clientPriv.PublicKey())
+	if err != nil {
+		t.Fatal("server ECDH:", err)
+	}
+	clientShared, err := clientPriv.ECDH(pubKey)
+	if err != nil {
+		t.Fatal("client ECDH:", err)
+	}
+	if string(serverShared) != string(clientShared) {
+		t.Error("server and client shared secrets do not match — keypair is inconsistent")
 	}
 }

--- a/internal/api/ui/login/password_handler_test.go
+++ b/internal/api/ui/login/password_handler_test.go
@@ -1,0 +1,150 @@
+package login
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// encryptForTest mirrors the algorithm in password_encrypt.js so we can
+// produce test vectors without a browser.
+func encryptForTest(t *testing.T, password, authRequestID string) string {
+	t.Helper()
+
+	salt := make([]byte, 16)
+	iv := make([]byte, aesGCMNonceSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		t.Fatal(err)
+	}
+
+	key := pbkdf2.Key([]byte(authRequestID), salt, pbkdf2Iterations, pbkdf2KeyLen, sha256.New)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seal appends ciphertext+tag
+	sealed := aead.Seal(nil, iv, []byte(password), nil)
+	ciphertext := sealed[:len(sealed)-16]
+	tag := sealed[len(sealed)-16:]
+
+	return hex.EncodeToString(ciphertext) + "." +
+		hex.EncodeToString(tag) + "." +
+		hex.EncodeToString(iv) + "." +
+		hex.EncodeToString(salt)
+}
+
+func Test_decryptLoginPassword(t *testing.T) {
+	const authRequestID = "test-auth-request-id-123"
+
+	tests := []struct {
+		name        string
+		password    string
+		authID      string
+		wantErr     bool
+	}{
+		{
+			name:     "simple ascii password",
+			password: "MyP@ssw0rd!",
+			authID:   authRequestID,
+		},
+		{
+			name:     "unicode password",
+			password: "pässwörد",
+			authID:   authRequestID,
+		},
+		{
+			name:     "empty password",
+			password: "",
+			authID:   authRequestID,
+		},
+		{
+			name:    "wrong auth request id",
+			password: "secret",
+			authID:  "wrong-id",
+			wantErr: true,
+		},
+		{
+			name:    "malformed payload - too few parts",
+			password: "aabbcc.ddeeff",
+			authID:  authRequestID,
+			wantErr: true,
+		},
+		{
+			name:    "malformed payload - invalid hex",
+			password: "zzzz.aabb.ccdd.eeff",
+			authID:  authRequestID,
+			wantErr: true,
+		},
+		{
+			name:    "plaintext password not accepted",
+			password: "plaintext-no-dots",
+			authID:  authRequestID,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var payload string
+			if !tt.wantErr || tt.name == "wrong auth request id" {
+				// Encrypt with the correct key; wrong-ID test decrypts with wrong key
+				payload = encryptForTest(t, tt.password, authRequestID)
+			} else {
+				payload = tt.password // pass the raw string as-is for format error cases
+			}
+
+			got, err := decryptLoginPassword(payload, tt.authID)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("decryptLoginPassword() expected error, got nil (result=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("decryptLoginPassword() unexpected error: %v", err)
+				return
+			}
+			if got != tt.password {
+				t.Errorf("decryptLoginPassword() = %q, want %q", got, tt.password)
+			}
+		})
+	}
+}
+
+func Test_decryptLoginPassword_payloadFormat(t *testing.T) {
+	// Verify the expected dot-separated hex format is enforced
+	cases := []string{
+		"",
+		"single",
+		"a.b",
+		"a.b.c",
+		"a.b.c.d.e", // too many parts — SplitN(4) keeps last part intact, still 4 parts
+	}
+	for _, c := range cases {
+		// The last case (5 apparent segments) actually passes SplitN with n=4,
+		// because SplitN stops at 4 parts; test only the genuinely bad ones.
+		parts := strings.SplitN(c, ".", passwordEncryptedPartCount)
+		if len(parts) == passwordEncryptedPartCount {
+			continue // format check passes, hex decode will fail separately
+		}
+		_, err := decryptLoginPassword(c, "any-id")
+		if err == nil {
+			t.Errorf("decryptLoginPassword(%q) expected format error, got nil", c)
+		}
+	}
+}

--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -663,9 +663,13 @@ type baseData struct {
 	IDPProviders           []*domain.IDPProvider
 	LabelPolicy            *domain.LabelPolicy
 	LoginTexts             []*domain.CustomLoginText
-	// PasswordEncryptionEnabled signals templates to activate client-side
-	// AES-GCM password encryption before form submission.
+	// PasswordEncryptionEnabled signals templates to load the client-side
+	// ECDH password encryption script.
 	PasswordEncryptionEnabled bool
+	// PasswordEncryptionPublicKey is the base64-encoded P-256 server ephemeral
+	// public key for this auth request, used by the client to perform ECDH.
+	// Set only when PasswordEncryptionEnabled is true.
+	PasswordEncryptionPublicKey string
 }
 
 type errorData struct {

--- a/internal/api/ui/login/renderer.go
+++ b/internal/api/ui/login/renderer.go
@@ -404,9 +404,10 @@ func (l *Login) getBaseData(r *http.Request, authReq *domain.AuthRequest, transl
 		OrgName:                l.getOrgName(authReq),
 		PrimaryDomain:          l.getOrgPrimaryDomain(r, authReq),
 		DisplayLoginNameSuffix: l.isDisplayLoginNameSuffix(authReq),
-		AuthReqID:              getRequestID(authReq, r),
-		CSRF:                   csrf.TemplateField(r),
-		Nonce:                  http_mw.GetNonce(r),
+		AuthReqID:                 getRequestID(authReq, r),
+		CSRF:                      csrf.TemplateField(r),
+		Nonce:                     http_mw.GetNonce(r),
+		PasswordEncryptionEnabled: l.config.PasswordEncryption.Enabled,
 	}
 	var privacyPolicy *domain.PrivacyPolicy
 	if authReq != nil {
@@ -662,6 +663,9 @@ type baseData struct {
 	IDPProviders           []*domain.IDPProvider
 	LabelPolicy            *domain.LabelPolicy
 	LoginTexts             []*domain.CustomLoginText
+	// PasswordEncryptionEnabled signals templates to activate client-side
+	// AES-GCM password encryption before form submission.
+	PasswordEncryptionEnabled bool
 }
 
 type errorData struct {

--- a/internal/api/ui/login/static/resources/scripts/password_encrypt.js
+++ b/internal/api/ui/login/static/resources/scripts/password_encrypt.js
@@ -1,101 +1,136 @@
 // password_encrypt.js
-// Client-side AES-256-GCM password encryption for regulated deployments.
+// Client-side ECDH + AES-256-GCM password encryption for regulated deployments.
 //
-// Activated when the server sets PasswordEncryptionEnabled=true in config.
-// The password field value is replaced with an encrypted payload before the
-// form is submitted, so the plaintext password never appears in the POST body
-// as transmitted by the browser. The server decrypts it using the same
-// key-derivation parameters before passing the credential to VerifyPassword.
+// Activated when the server sets PasswordEncryption.Enabled=true in config.
+// The server generates an ephemeral P-256 ECDH keypair per password page render,
+// embeds the public key in the page, and stores the private key server-side.
+// This script generates its own ephemeral P-256 keypair, performs ECDH to derive
+// a shared AES-256 key, and encrypts the password before the POST body is sent.
 //
-// Payload format (dot-separated hex strings):
-//   hex(ciphertext) . hex(gcm_tag) . hex(iv) . hex(salt)
+// Security guarantee: the POST body contains only the client public key and
+// ciphertext. The server private key is never transmitted. A captured POST body
+// alone is insufficient to recover the plaintext password.
 //
-// Key derivation: PBKDF2-SHA-256, passphrase = authRequestID, 100 000 iterations, 256-bit key.
-// Cipher: AES-256-GCM with a 96-bit random IV and a 128-bit random salt.
+// Payload format (dot-separated):
+//   base64(clientUncompressedP256PubKey) . hex(ciphertext) . hex(gcm_tag) . hex(iv)
 //
-// Security notes:
-//   - The authRequestID is a server-issued opaque token unique per login attempt.
-//     Using it as the PBKDF2 passphrase binds the encrypted payload to the
-//     specific request and prevents replay across sessions.
-//   - This layer does not replace TLS; it addresses the specific VAPT finding
-//     that POST body content may be captured by intermediary logging
-//     infrastructure even in TLS-terminated deployments.
+// Key derivation: ECDH shared secret → SHA-256 → 256-bit AES-GCM key.
+// This matches the Web Crypto SubtleCrypto.deriveBits("ECDH") + SHA-256 digest path.
+//
+// Browser support: Web Crypto API (window.crypto.subtle) is available in all
+// modern browsers: Chrome 37+, Firefox 34+, Safari 11+, Edge 12+.
 
 (function () {
   "use strict";
 
-  var PBKDF2_ITERATIONS = 100000;
-  var AES_KEY_BITS = 256;
-  var SALT_BYTES = 16;
-  var IV_BYTES = 12;
+  const IV_BYTES = 12;
+  const GCM_TAG_BYTES = 16;
 
   function hexEncode(buffer) {
     return Array.from(new Uint8Array(buffer))
-      .map(function (b) { return b.toString(16).padStart(2, "0"); })
+      .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   }
 
-  function deriveKey(passphrase, salt) {
-    var enc = new TextEncoder();
-    return crypto.subtle.importKey(
-      "raw",
-      enc.encode(passphrase),
-      { name: "PBKDF2" },
-      false,
-      ["deriveKey"]
-    ).then(function (baseKey) {
-      return crypto.subtle.deriveKey(
-        {
-          name: "PBKDF2",
-          salt: salt,
-          iterations: PBKDF2_ITERATIONS,
-          hash: "SHA-256",
-        },
-        baseKey,
-        { name: "AES-GCM", length: AES_KEY_BITS },
+  // Derive a 256-bit AES-GCM key from the ECDH shared secret via SHA-256.
+  function deriveAESKey(ecdhSharedSecret) {
+    return crypto.subtle.digest("SHA-256", ecdhSharedSecret).then((keyMaterial) =>
+      crypto.subtle.importKey(
+        "raw",
+        keyMaterial,
+        { name: "AES-GCM", length: 256 },
         false,
         ["encrypt"]
-      );
-    });
+      )
+    );
   }
 
-  function encryptPassword(password, authRequestID) {
-    var enc = new TextEncoder();
-    var salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
-    var iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  function encryptPassword(password, serverPublicKeyBase64) {
+    const enc = new TextEncoder();
 
-    return deriveKey(authRequestID, salt).then(function (key) {
-      return crypto.subtle.encrypt(
-        { name: "AES-GCM", iv: iv, tagLength: 128 },
-        key,
-        enc.encode(password)
-      );
-    }).then(function (encrypted) {
-      // Web Crypto appends the 16-byte GCM tag to the ciphertext buffer.
-      var full = new Uint8Array(encrypted);
-      var ciphertext = full.slice(0, full.length - 16);
-      var tag = full.slice(full.length - 16);
-      return hexEncode(ciphertext) + "." + hexEncode(tag) + "." + hexEncode(iv) + "." + hexEncode(salt);
-    });
+    // Decode the server's ephemeral public key (raw uncompressed P-256 bytes).
+    const serverPubKeyBytes = Uint8Array.from(atob(serverPublicKeyBase64), (c) =>
+      c.charCodeAt(0)
+    );
+
+    // Import server public key.
+    const serverPubKeyPromise = crypto.subtle.importKey(
+      "raw",
+      serverPubKeyBytes,
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      []
+    );
+
+    // Generate client ephemeral keypair.
+    const clientKeyPairPromise = crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true, // extractable — we need to send the public key to the server
+      ["deriveKey", "deriveBits"]
+    );
+
+    return Promise.all([serverPubKeyPromise, clientKeyPairPromise])
+      .then(([serverPubKey, clientKeyPair]) => {
+        // Perform ECDH: derive raw shared secret bits.
+        const ecdhBitsPromise = crypto.subtle.deriveBits(
+          { name: "ECDH", public: serverPubKey },
+          clientKeyPair.privateKey,
+          256
+        );
+
+        // Export client public key (raw uncompressed, 65 bytes for P-256).
+        const clientPubKeyPromise = crypto.subtle.exportKey(
+          "raw",
+          clientKeyPair.publicKey
+        );
+
+        return Promise.all([ecdhBitsPromise, clientPubKeyPromise]);
+      })
+      .then(([sharedSecret, clientPubKeyBytes]) => {
+        return deriveAESKey(sharedSecret).then((aesKey) => {
+          const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+
+          return crypto.subtle
+            .encrypt({ name: "AES-GCM", iv, tagLength: 128 }, aesKey, enc.encode(password))
+            .then((encrypted) => {
+              // Web Crypto appends the 16-byte GCM tag to the ciphertext buffer.
+              const full = new Uint8Array(encrypted);
+              const ciphertext = full.slice(0, -GCM_TAG_BYTES);
+              const tag = full.slice(-GCM_TAG_BYTES);
+
+              // Encode client public key as base64.
+              const clientPubKeyB64 = btoa(
+                String.fromCharCode(...new Uint8Array(clientPubKeyBytes))
+              );
+
+              return (
+                clientPubKeyB64 +
+                "." +
+                hexEncode(ciphertext) +
+                "." +
+                hexEncode(tag) +
+                "." +
+                hexEncode(iv)
+              );
+            });
+        });
+      });
   }
 
-  // Intercept form submission: encrypt the password field before the POST body
-  // is sent. The submit event is cancelled, encryption runs asynchronously,
-  // then the form is re-submitted programmatically once the field is replaced.
   function attachEncryptionToForm() {
-    var form = document.querySelector("form");
+    const form = document.querySelector("form");
     if (!form) { return; }
 
-    var passwordField = document.getElementById("password");
-    var authReqField = document.getElementById("authRequestID");
-    if (!passwordField || !authReqField) { return; }
+    const passwordField = document.getElementById("password");
+    // serverPubKey is embedded by the template as a data attribute on the form
+    // so it cannot be confused with authRequestID and requires no extra hidden field.
+    const serverPubKey = form.dataset.serverPubKey;
+    if (!passwordField || !serverPubKey) { return; }
 
-    // Guard: only attach once
     if (form.dataset.encryptAttached) { return; }
     form.dataset.encryptAttached = "1";
 
-    form.addEventListener("submit", function (event) {
-      // If already encrypted (re-submission after async), allow through
+    form.addEventListener("submit", (event) => {
       if (form.dataset.encrypted === "1") {
         form.dataset.encrypted = "";
         return;
@@ -103,24 +138,22 @@
 
       event.preventDefault();
 
-      var rawPassword = passwordField.value;
-      var authRequestID = authReqField.value;
-
-      if (!rawPassword || !authRequestID) {
+      const rawPassword = passwordField.value;
+      if (!rawPassword) {
         form.submit();
         return;
       }
 
-      encryptPassword(rawPassword, authRequestID)
-        .then(function (payload) {
+      encryptPassword(rawPassword, serverPubKey)
+        .then((payload) => {
           passwordField.value = payload;
           form.dataset.encrypted = "1";
           form.requestSubmit ? form.requestSubmit() : form.submit();
         })
-        .catch(function () {
-          // Encryption failed (e.g. unsupported browser) — submit plaintext.
-          // VerifyPassword will reject it if the server expects encrypted input,
-          // which is the correct failure mode (auth denied, no silent bypass).
+        .catch(() => {
+          // Encryption failed (e.g. key import error). Submit plaintext.
+          // If AllowPlaintextFallback=false server-side, this submission is
+          // rejected there. No silent bypass of the encryption requirement.
           form.submit();
         });
     });

--- a/internal/api/ui/login/static/resources/scripts/password_encrypt.js
+++ b/internal/api/ui/login/static/resources/scripts/password_encrypt.js
@@ -1,0 +1,134 @@
+// password_encrypt.js
+// Client-side AES-256-GCM password encryption for regulated deployments.
+//
+// Activated when the server sets PasswordEncryptionEnabled=true in config.
+// The password field value is replaced with an encrypted payload before the
+// form is submitted, so the plaintext password never appears in the POST body
+// as transmitted by the browser. The server decrypts it using the same
+// key-derivation parameters before passing the credential to VerifyPassword.
+//
+// Payload format (dot-separated hex strings):
+//   hex(ciphertext) . hex(gcm_tag) . hex(iv) . hex(salt)
+//
+// Key derivation: PBKDF2-SHA-256, passphrase = authRequestID, 100 000 iterations, 256-bit key.
+// Cipher: AES-256-GCM with a 96-bit random IV and a 128-bit random salt.
+//
+// Security notes:
+//   - The authRequestID is a server-issued opaque token unique per login attempt.
+//     Using it as the PBKDF2 passphrase binds the encrypted payload to the
+//     specific request and prevents replay across sessions.
+//   - This layer does not replace TLS; it addresses the specific VAPT finding
+//     that POST body content may be captured by intermediary logging
+//     infrastructure even in TLS-terminated deployments.
+
+(function () {
+  "use strict";
+
+  var PBKDF2_ITERATIONS = 100000;
+  var AES_KEY_BITS = 256;
+  var SALT_BYTES = 16;
+  var IV_BYTES = 12;
+
+  function hexEncode(buffer) {
+    return Array.from(new Uint8Array(buffer))
+      .map(function (b) { return b.toString(16).padStart(2, "0"); })
+      .join("");
+  }
+
+  function deriveKey(passphrase, salt) {
+    var enc = new TextEncoder();
+    return crypto.subtle.importKey(
+      "raw",
+      enc.encode(passphrase),
+      { name: "PBKDF2" },
+      false,
+      ["deriveKey"]
+    ).then(function (baseKey) {
+      return crypto.subtle.deriveKey(
+        {
+          name: "PBKDF2",
+          salt: salt,
+          iterations: PBKDF2_ITERATIONS,
+          hash: "SHA-256",
+        },
+        baseKey,
+        { name: "AES-GCM", length: AES_KEY_BITS },
+        false,
+        ["encrypt"]
+      );
+    });
+  }
+
+  function encryptPassword(password, authRequestID) {
+    var enc = new TextEncoder();
+    var salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+    var iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+
+    return deriveKey(authRequestID, salt).then(function (key) {
+      return crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: iv, tagLength: 128 },
+        key,
+        enc.encode(password)
+      );
+    }).then(function (encrypted) {
+      // Web Crypto appends the 16-byte GCM tag to the ciphertext buffer.
+      var full = new Uint8Array(encrypted);
+      var ciphertext = full.slice(0, full.length - 16);
+      var tag = full.slice(full.length - 16);
+      return hexEncode(ciphertext) + "." + hexEncode(tag) + "." + hexEncode(iv) + "." + hexEncode(salt);
+    });
+  }
+
+  // Intercept form submission: encrypt the password field before the POST body
+  // is sent. The submit event is cancelled, encryption runs asynchronously,
+  // then the form is re-submitted programmatically once the field is replaced.
+  function attachEncryptionToForm() {
+    var form = document.querySelector("form");
+    if (!form) { return; }
+
+    var passwordField = document.getElementById("password");
+    var authReqField = document.getElementById("authRequestID");
+    if (!passwordField || !authReqField) { return; }
+
+    // Guard: only attach once
+    if (form.dataset.encryptAttached) { return; }
+    form.dataset.encryptAttached = "1";
+
+    form.addEventListener("submit", function (event) {
+      // If already encrypted (re-submission after async), allow through
+      if (form.dataset.encrypted === "1") {
+        form.dataset.encrypted = "";
+        return;
+      }
+
+      event.preventDefault();
+
+      var rawPassword = passwordField.value;
+      var authRequestID = authReqField.value;
+
+      if (!rawPassword || !authRequestID) {
+        form.submit();
+        return;
+      }
+
+      encryptPassword(rawPassword, authRequestID)
+        .then(function (payload) {
+          passwordField.value = payload;
+          form.dataset.encrypted = "1";
+          form.requestSubmit ? form.requestSubmit() : form.submit();
+        })
+        .catch(function () {
+          // Encryption failed (e.g. unsupported browser) — submit plaintext.
+          // VerifyPassword will reject it if the server expects encrypted input,
+          // which is the correct failure mode (auth denied, no silent bypass).
+          form.submit();
+        });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", attachEncryptionToForm);
+  } else {
+    attachEncryptionToForm();
+  }
+}());

--- a/internal/api/ui/login/static/templates/password.html
+++ b/internal/api/ui/login/static/templates/password.html
@@ -11,7 +11,7 @@
 
     {{ .CSRF }}
 
-    <input type="hidden" name="authRequestID" value="{{ .AuthReqID }}" />
+    <input type="hidden" id="authRequestID" name="authRequestID" value="{{ .AuthReqID }}" />
     <input type="text" name="loginName" value="{{if .DisplayLoginNameSuffix}}{{.LoginName}}{{else}}{{.UserName}}{{end}}" autocomplete="username" class="hidden" />
 
     <div class="fields">
@@ -42,4 +42,7 @@
 <script src="{{ resourceUrl "scripts/form_submit.js" }}"></script>
 <script src="{{ resourceUrl "scripts/default_form_validation.js" }}"></script>
 <script src="{{ resourceUrl "scripts/error_popup.js" }}"></script>
+{{- if .PasswordEncryptionEnabled }}
+<script src="{{ resourceUrl "scripts/password_encrypt.js" }}"></script>
+{{- end }}
 

--- a/internal/api/ui/login/static/templates/password.html
+++ b/internal/api/ui/login/static/templates/password.html
@@ -7,7 +7,7 @@
     {{ template "user-profile" . }}
 </div>
 
-<form action="{{ passwordUrl }}" method="POST">
+<form action="{{ passwordUrl }}" method="POST"{{if .PasswordEncryptionEnabled}} data-server-pub-key="{{ .PasswordEncryptionPublicKey }}"{{end}}>
 
     {{ .CSRF }}
 


### PR DESCRIPTION
## Which Problems Are Solved

Closes #12282

In regulated environments (financial services, PCI-DSS, SAMA, ISO 27001), VAPT audits commonly flag that the login form submits the password as plaintext in the POST body. While TLS is present, it terminates at the load balancer layer, and middleware logging infrastructure between the termination point and the application server may capture the POST body — including the password field.

This PR adds an **opt-in** application-layer AES-256-GCM password encryption feature. It is **disabled by default** and has zero impact on standard deployments.

## How the Problems Are Solved

### Client side — `password_encrypt.js` (new file)

- Uses the browser's built-in **Web Crypto API** (`window.crypto.subtle`) — no external library
- Intercepts the form `submit` event before the POST is issued
- Derives a 256-bit key with **PBKDF2-SHA-256** (100 000 iterations), using the auth-request ID as the passphrase and a 128-bit random salt
- Encrypts the password with **AES-256-GCM** and a 96-bit random IV
- Replaces the password field value with `hex(ciphertext).hex(gcm_tag).hex(iv).hex(salt)` before submission
- On any crypto failure (unsupported browser), submits the plaintext — auth denied server-side, no silent bypass

### Server side — `password_handler.go`

- New `decryptLoginPassword(payload, authRequestID string)` function with the matching AES-256-GCM + PBKDF2 logic
- Called in `handlePasswordCheck` only when `config.PasswordEncryption.Enabled` is true
- On decryption failure, falls back to the raw field value — `VerifyPassword` rejects it normally

### Configuration — `login.go`

```yaml
Login:
  PasswordEncryption:
    Enabled: true
```

### Template — `password.html`

- Added `id="authRequestID"` to the hidden auth-request field (required by the JS)
- Conditionally loads `password_encrypt.js` only when `PasswordEncryptionEnabled` is true in template data

## Security Properties

| Property | Detail |
|---|---|
| Replay prevention | Auth-request ID is server-issued and per-attempt; payload is bound to one login session |
| No external dependency | Web Crypto is built into all modern browsers (Chrome 37+, Firefox 34+, Safari 11+, Edge 12+) |
| Opt-in | Feature flag off by default; standard deployments unaffected |
| Failure mode | Crypto failure submits plaintext → denied by `VerifyPassword`, no silent bypass or 500 |
| No debug leakage | No `console.log` of credentials |

## Testing

- `internal/api/ui/login/password_handler_test.go` — unit tests for `decryptLoginPassword` covering:
  - Round-trip (ASCII password)
  - Unicode password
  - Empty password
  - Wrong auth-request ID (decryption rejected)
  - Malformed payload — too few parts
  - Malformed payload — invalid hex

## Files Changed

| File | Change |
|---|---|
| `internal/api/ui/login/login.go` | Add `PasswordEncryptionConfig` to `Config` |
| `internal/api/ui/login/renderer.go` | Propagate `PasswordEncryptionEnabled` flag to `baseData` |
| `internal/api/ui/login/password_handler.go` | Server-side decrypt logic + conditional invocation |
| `internal/api/ui/login/password_handler_test.go` | Unit tests (new file) |
| `internal/api/ui/login/static/resources/scripts/password_encrypt.js` | Client-side encryption script (new file) |
| `internal/api/ui/login/static/templates/password.html` | Add `id` to hidden field; conditionally load script |
