### PR TITLE
fix: connection handling in setup after migration steps 40, 64 and 70

### DIFF
--- a/cmd/setup/40.go
+++ b/cmd/setup/40.go
@@ -52,6 +52,12 @@ func (mig *InitPushFunc) Execute(ctx context.Context, _ eventstore.Event) (err e
 			return fmt.Errorf("%s %s: %w", mig.String(), stmt.file, err)
 		}
 	}
+	// close idle connections to prevent them from using the old prepared statement with the wrong type
+	// and having wrong plan of `eventstore.command2`-type
+	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
+		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
+		conn.Release()
+	}
 
 	return nil
 }

--- a/cmd/setup/64.go
+++ b/cmd/setup/64.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
@@ -26,7 +27,13 @@ func (mig *ChangePushPosition) Execute(ctx context.Context, _ eventstore.Event) 
 	}
 	stmt := fmt.Sprintf(changePushPosition, inTxOrderType)
 	_, err = mig.dbClient.ExecContext(ctx, stmt)
-	return err
+	if err != nil {
+		return err
+	}
+	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
+		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
+	}
+	return nil
 }
 
 func (mig *ChangePushPosition) String() string {

--- a/cmd/setup/64.go
+++ b/cmd/setup/64.go
@@ -30,6 +30,8 @@ func (mig *ChangePushPosition) Execute(ctx context.Context, _ eventstore.Event) 
 	if err != nil {
 		return err
 	}
+	// close idle connections to prevent them from using the old prepared statement with the wrong type
+	// and having wrong plan of `eventstore.command2`-type
 	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
 		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
 	}

--- a/cmd/setup/64.go
+++ b/cmd/setup/64.go
@@ -34,6 +34,7 @@ func (mig *ChangePushPosition) Execute(ctx context.Context, _ eventstore.Event) 
 	// and having wrong plan of `eventstore.command2`-type
 	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
 		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
+		conn.Release()
 	}
 	return nil
 }

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -34,6 +34,7 @@ func (mig *AddEventStoreCommandEnforceOwnerColumn) Execute(ctx context.Context, 
 	// and having wrong plan of `eventstore.command2`-type
 	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
 		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
+		conn.Release()
 	}
 	return nil
 }

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -30,6 +30,8 @@ func (mig *AddEventStoreCommandEnforceOwnerColumn) Execute(ctx context.Context, 
 	if err != nil {
 		return err
 	}
+	// close idle connections to prevent them from using the old prepared statement with the wrong type
+	// and having wrong plan of `eventstore.command2`-type
 	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
 		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
 	}

--- a/cmd/setup/70.go
+++ b/cmd/setup/70.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
 	"github.com/zitadel/zitadel/internal/database"
 	"github.com/zitadel/zitadel/internal/eventstore"
 )
@@ -26,7 +27,13 @@ func (mig *AddEventStoreCommandEnforceOwnerColumn) Execute(ctx context.Context, 
 
 	stmt := fmt.Sprintf(addEventStoreCommandEnforceOwnerColumn, inTxOrderType)
 	_, err = mig.dbClient.ExecContext(ctx, stmt)
-	return err
+	if err != nil {
+		return err
+	}
+	for _, conn := range mig.dbClient.Pool.AcquireAllIdle(ctx) {
+		logging.OnError(ctx, conn.Conn().Close(ctx)).Debug("failed to close idle connection")
+	}
+	return nil
 }
 
 func (mig *AddEventStoreCommandEnforceOwnerColumn) String() string {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -263,7 +263,6 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	for _, step := range []migration.Migration{
 		steps.s14NewEventsTable,
 		steps.s40InitPushFunc,
-		steps.s70AddEventStoreCommandEnforceOwner,
 		steps.s1ProjectionTable,
 		steps.s2AssetsTable,
 		steps.s28AddFieldTable,
@@ -309,6 +308,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s62HTTPProviderAddSigningKey,
 		steps.s63AlterResourceCounts,
 		steps.s64ChangePushPosition,
+		steps.s70AddEventStoreCommandEnforceOwner,
 		steps.s65FixUserMetadata5Index,
 		steps.s67SyncMemberRoleFields,
 		steps.s69CacheTablesLogged,

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -308,10 +308,10 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s62HTTPProviderAddSigningKey,
 		steps.s63AlterResourceCounts,
 		steps.s64ChangePushPosition,
-		steps.s70AddEventStoreCommandEnforceOwner,
 		steps.s65FixUserMetadata5Index,
 		steps.s67SyncMemberRoleFields,
 		steps.s69CacheTablesLogged,
+		steps.s70AddEventStoreCommandEnforceOwner,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {


### PR DESCRIPTION
# Which Problems Are Solved

During the setup step we saw rare cases which caused setup to fail after executing steps 40, 64 and 70.

# How the Problems Are Solved

Close currently open database connections so that they fetch the correct type mapping for the `eventstore.command2` database type.

# Additional Changes

Ensure correct order of setup steps 64 and 70.

# Additional Context

None

