### PR TITLE
fix: remove unnecessary entry from default denylist

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -1095,7 +1095,6 @@ HTTPClient:
     - "198.18.0.0/15"   # Benchmark/inter-network communication testing
     - "::/128"          # Unspecified IPv6 address
     - "::1/128"         # IPv6 loopback address
-    - "::ffff:0:0/96"   # IPv4-mapped IPv6 addresses (Prevents IPv6 encapsulation bypasses)
     - "fc00::/7"        # Unique local addresses / IPv6 equivalent to private IPv4 subnets
     - "fe80::/10"       # Link-local addresses / IPv6 equivalent to cloud metadata subnets
 

--- a/internal/command/device_auth_test.go
+++ b/internal/command/device_auth_test.go
@@ -936,6 +936,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 		ctx                  context.Context
 		deviceCode           string
 		backChannelLogoutURI string
+		clientID             string
 	}
 	tests := []struct {
 		name    string
@@ -954,6 +955,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 			args: args{
 				ctx,
 				"device1",
+				"",
 				"",
 			},
 			wantErr: io.ErrClosedPipe,
@@ -980,6 +982,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: DeviceAuthStateError(domain.DeviceAuthStateInitiated),
 		},
@@ -993,6 +996,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 			args: args{
 				ctx,
 				"123",
+				"",
 				"",
 			},
 			wantErr: zerrors.ThrowNotFound(nil, "COMMAND-ua1Vo", "Errors.DeviceAuth.NotFound"),
@@ -1023,6 +1027,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: DeviceAuthStateError(domain.DeviceAuthStateExpired),
 		},
@@ -1055,6 +1060,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: DeviceAuthStateError(domain.DeviceAuthStateExpired),
 		},
@@ -1087,6 +1093,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: DeviceAuthStateError(domain.DeviceAuthStateDenied),
 		},
@@ -1125,6 +1132,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: DeviceAuthStateError(domain.DeviceAuthStateDone),
 		},
@@ -1189,6 +1197,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			wantErr: zerrors.ThrowPreconditionFailed(nil, "OIDCS-kj3g2", "Errors.User.NotActive"),
 		},
@@ -1268,6 +1277,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			want: &OIDCSession{
 				TokenID:           "V2_oidcSessionID-at_accessTokenID",
@@ -1372,6 +1382,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"backChannelLogoutURI",
+				"clientID",
 			},
 			want: &OIDCSession{
 				TokenID:           "V2_oidcSessionID-at_accessTokenID",
@@ -1472,6 +1483,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				ctx,
 				"123",
 				"",
+				"clientID",
 			},
 			want: &OIDCSession{
 				TokenID:           "V2_oidcSessionID-at_accessTokenID",
@@ -1506,7 +1518,7 @@ func TestCommands_CreateOIDCSessionFromDeviceAuth(t *testing.T) {
 				keyAlgorithm:                    tt.fields.keyAlgorithm,
 				authAlgorithm:                   &mockAuthCrypto{},
 			}
-			got, err := c.CreateOIDCSessionFromDeviceAuth(tt.args.ctx, tt.args.deviceCode, tt.args.backChannelLogoutURI)
+			got, err := c.CreateOIDCSessionFromDeviceAuth(tt.args.ctx, tt.args.deviceCode, tt.args.backChannelLogoutURI, tt.args.clientID)
 			c.jobs.Wait()
 
 			require.ErrorIs(t, err, tt.wantErr)


### PR DESCRIPTION
# Which Problems Are Solved

The updated default denylist added an entry for IPv4-mapped IPv6 addresses to prevent IPv6 encapsulation bypasses.
This is not necessary since the IP already gets resolved into v4 and now blocks them all.

# How the Problems Are Solved

Removed the entry.

# Additional Changes

None

# Additional Context

None