### PR TITLE
fix(login): improve contrast of IDP processing message

### DIFF
--- a/apps/login/src/components/idp-process-handler.tsx
+++ b/apps/login/src/components/idp-process-handler.tsx
@@ -99,7 +99,7 @@ export function IdpProcessHandler({
       {loading && (
         <div className="flex flex-col items-center space-y-4">
           <Spinner className="h-8 w-8" />
-          <p className="text-sm text-gray-600">{t("processing.message")}</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{t("processing.message")}</p>
         </div>
       )}
       {error && (

--- a/apps/login/src/lib/server/idp-intent.test.ts
+++ b/apps/login/src/lib/server/idp-intent.test.ts
@@ -103,8 +103,8 @@ describe("processIDPCallback", () => {
         email: "test@example.com",
         verification: {
           case: "isVerified",
-          value: true
-        }
+          value: true,
+        },
       },
     },
     updateHumanUser: {
@@ -118,8 +118,8 @@ describe("processIDPCallback", () => {
         email: "test@example.com",
         verification: {
           case: "isVerified",
-          value: true
-        }
+          value: true,
+        },
       },
     },
   };

--- a/apps/login/src/lib/server/idp-intent.ts
+++ b/apps/login/src/lib/server/idp-intent.ts
@@ -359,7 +359,8 @@ async function handleAutoLinking(ctx: IDPHandlerContext): Promise<IDPHandlerResu
   if (options?.autoLinking) {
     let foundUser;
     const email = addHumanUser?.email?.email;
-    const emailVerified = addHumanUser?.email?.verification?.case === "isVerified" && addHumanUser?.email?.verification?.value;
+    const emailVerified =
+      addHumanUser?.email?.verification?.case === "isVerified" && addHumanUser?.email?.verification?.value;
 
     if (options.autoLinking === AutoLinkingOption.EMAIL && email && emailVerified) {
       foundUser = await listUsers({ serviceConfig, email, organizationId: organization }).then((response) => {


### PR DESCRIPTION
# Which Problems Are Solved

This improves the contrast of the “Processing authentication...” message shown while Login V2 processes the IDP authentication flow.

The previous style used text-gray-600 without a dark-mode variant. This color is hard-coded in the component and is not affected by the branding colors, so users may see low contrast depending on the active theme/background.

This PR updates the message text to use a higher-contrast light/dark color pair.