### PR TITLE
feat(oidc): add client ID metadata document (CIMD) support

### DIFF
--- a/apps/docs/content/apis/openidoauth/endpoints.mdx
+++ b/apps/docs/content/apis/openidoauth/endpoints.mdx
@@ -693,6 +693,22 @@ served whenever dynamic client registration is enabled in the instance's securit
 
 See the [Dynamic Client Registration guide](/guides/integrate/dynamic-client-registration) for the supported metadata, the available registration modes, managing a registration and the current limitations.
 
+## Client ID Metadata Document
+
+A [Client ID Metadata Document (CIMD)](/guides/integrate/client-id-metadata-document) lets a client use an HTTPS URL
+that serves its metadata directly as its `client_id`, without registering ahead of time. There is no dedicated endpoint:
+the `client_id` itself is the URL of the document.
+
+<Callout type="warn">
+This is disabled by default. When it is
+[enabled](/guides/integrate/client-id-metadata-document#enable-client-id-metadata-documents) in the instance's security
+settings, the discovery document advertises `client_id_metadata_document_supported: true` and a `client_id` that is an
+HTTPS URL is resolved as a metadata document.
+</Callout>
+
+See the [Client ID Metadata Document guide](/guides/integrate/client-id-metadata-document) for the document format, the
+origin match requirement and the security model.
+
 ## OAuth 2.0 metadata
 
 **ZITADEL** does not yet provide a OAuth 2.0 Metadata endpoint but instead provides a [OpenID Connect Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html).

--- a/apps/docs/content/guides/integrate/client-id-metadata-document.mdx
+++ b/apps/docs/content/guides/integrate/client-id-metadata-document.mdx
@@ -1,0 +1,105 @@
+---
+title: Client ID Metadata Document
+description: "Let clients use an HTTPS URL that serves their metadata as their client_id, without registering ahead of time, for example for Model Context Protocol (MCP) clients."
+sidebar_label: Client ID Metadata Document
+---
+
+A Client ID Metadata Document (CIMD) lets a client use an HTTPS URL as its `client_id`. The URL serves a document of
+client metadata, in the same shape as an [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591) registration request.
+When a client authorizes with such a `client_id`, ZITADEL fetches the document, validates it and treats the client as an
+ephemeral public client, without creating any database entry.
+
+This is the stateless counterpart to [Dynamic Client Registration](/guides/integrate/dynamic-client-registration): there
+is nothing to register and nothing to clean up, which makes it well suited to ecosystems with many short-lived clients
+such as [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
+
+<Callout type="warn">
+Client ID Metadata Documents are disabled by default. ZITADEL fetches the document from a URL the client controls, so
+only enable it once you understand the security model described below.
+</Callout>
+
+## Enable client ID metadata documents
+
+A `client_id` that is an HTTPS URL is only resolved as a metadata document when it is enabled in the instance's security
+settings. This is a separate switch from
+[`dynamicClientRegistration`](/guides/integrate/dynamic-client-registration#enable-dynamic-client-registration), because
+fetching client-controlled URLs has a different security profile and must be enabled deliberately.
+
+Enable it through the [settings API](/apis/resources/settings_service_v2/settings-service-set-security-settings):
+
+```bash
+curl --request PUT \
+  --url ${CUSTOM_DOMAIN}/v2/settings/security \
+  --header 'Authorization: Bearer <token of an IAM_OWNER>' \
+  --header 'Content-Type: application/json' \
+  --data '{ "clientIdMetadataDocument": { "enabled": true } }'
+```
+
+<Callout type="warn">
+`SetSecuritySettings` replaces the whole security policy. Send the settings you want to keep in the same request, for
+example `embeddedIframe`, `enableImpersonation` and `dynamicClientRegistration`; omitted messages are reset to their
+defaults. Read the current values first with
+[`GetSecuritySettings`](/apis/resources/settings_service_v2/settings-service-get-security-settings).
+</Callout>
+
+When enabled, the [discovery document](/apis/openidoauth/endpoints#openid-connect-10-discovery) advertises
+`client_id_metadata_document_supported: true`.
+
+<Callout type="info">
+CIMD clients always use the v2 login, so the instance must have a v2 login configured
+(`OIDC.DefaultLoginURLV2`, or a per-client login base URI). Without it the authorization request
+cannot be routed to a login UI.
+</Callout>
+
+The setting is stored on the same security policy as the other instance security settings. Upgrading adds a column to
+`projections.security_policies3` through a setup step, so run `zitadel setup` as usual before starting the new version.
+
+## Document format
+
+Serve a JSON document at the URL you want to use as the `client_id`. It uses the same members as a
+[Dynamic Client Registration request](/guides/integrate/dynamic-client-registration#supported-metadata):
+
+```json
+{
+  "client_name": "My MCP Client",
+  "redirect_uris": ["https://client.example.com/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+A client then starts an [authorization code flow](/guides/integrate/login/oidc/login-users) with the document URL as its
+`client_id`, for example `https://client.example.com/oauth/metadata`. Because the resolved client is public, it must use
+[PKCE](https://datatracker.ietf.org/doc/html/rfc7636).
+
+## Security model
+
+The document is fetched and validated on every cache miss. The validation is strict, because the document is served by a
+host the client controls:
+
+- **HTTPS only.** The `client_id` must be an absolute `https` URL. Plain `http` URLs are treated as regular client ids
+  and are not resolved as documents.
+- **Origin match.** Every `redirect_uri` must share the exact origin (scheme, host and port) of the `client_id` URL. A
+  document can therefore only authorize redirects back to the host that serves it. Redirect URIs with a different origin
+  are dropped; if none remain the request is rejected with `invalid_client`.
+- **Public clients only.** `token_endpoint_auth_method` must be `none` (or omitted). A confidential method is rejected,
+  as a public URL cannot safely be tied to a client secret. The `jwks` and `jwks_uri` members are rejected as well.
+- **SSRF protection.** The document is fetched through ZITADEL's hardened HTTP client. Its operator denylist blocks
+  loopback, private, link-local and cloud-metadata addresses at dial time (see `HTTPClient.DenyList`), the fetch uses a
+  short timeout and the response body is bounded.
+- **Caching.** A resolved document is cached per instance, honoring its `Cache-Control` and `Expires` headers up to a
+  capped maximum. A `no-store` or `no-cache` response is never cached.
+
+Resolved clients have no project, no client secret and never run in dev mode, so no redirect URI wildcards are allowed.
+
+## Limitations
+
+- Software statements (a signed JWT of the metadata) are not yet validated.
+- Free-form metadata such as `logo_uri`, `client_uri` or `contacts` is accepted but not persisted.
+- Resolved clients use the v2 login.
+- Resolved clients have no project, so they carry no project roles. The `resource` parameter
+  ([RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)) is accepted and ignored, and the audience of an issued
+  token is derived from the requested scopes only.
+- A failed resolution is cached for a short window, so a client whose document was briefly unreachable stays
+  unresolvable until that window passes.

--- a/apps/docs/content/guides/integrate/index.mdx
+++ b/apps/docs/content/guides/integrate/index.mdx
@@ -15,5 +15,6 @@ import { FileText, Folder, Link as LinkIcon } from 'lucide-react';
     <Card title="SCIM" href="/guides/manage/user/scim2" icon={<Folder />} />
     <Card title="Token Introspection" href="/guides/integrate/token-introspection" icon={<Folder />} />
     <Card title="Back Channel Logout" href="/guides/integrate/back-channel-logout" icon={<FileText />} />
+    <Card title="Client Id Metadata Document" href="/guides/integrate/client-id-metadata-document" icon={<FileText />} />
     <Card title="Build your own Login UI" href="/guides/integrate/login-ui" icon={<Folder />} />
 </Cards>

--- a/apps/docs/lib/sidebar-data.ts
+++ b/apps/docs/lib/sidebar-data.ts
@@ -411,6 +411,7 @@ export const guidesSidebar: readonly SidebarItem[] = [
         ]
       },
       "guides/integrate/back-channel-logout",
+      "guides/integrate/client-id-metadata-document",
       {
         type: "category",
         label: "External Integrations",

--- a/backend/v3/domain/settings.go
+++ b/backend/v3/domain/settings.go
@@ -326,6 +326,7 @@ type securitySettingsJSONChanges interface {
 	SetEnableImpersonation(value bool) db_json.JsonUpdate
 	SetEnableDynamicClientRegistration(value bool) db_json.JsonUpdate
 	SetAllowUnauthenticatedDynamicClientRegistration(value bool) db_json.JsonUpdate
+	SetEnableClientIDMetadataDocument(value bool) db_json.JsonUpdate
 }
 
 type SecuritySettings struct {
@@ -340,6 +341,8 @@ type SecuritySettingsAttributes struct {
 
 	EnableDynamicClientRegistration               *bool `json:"enableDynamicClientRegistration,omitempty"`
 	AllowUnauthenticatedDynamicClientRegistration *bool `json:"allowUnauthenticatedDynamicClientRegistration,omitempty"`
+
+	EnableClientIDMetadataDocument *bool `json:"enableClientIdMetadataDocument,omitempty"`
 }
 
 //go:generate mockgen -typed -package domainmock -destination ./mock/security_settings.mock.go . SecuritySettingsRepository

--- a/backend/v3/storage/database/repository/settings.go
+++ b/backend/v3/storage/database/repository/settings.go
@@ -983,6 +983,9 @@ func (s securitySettings) SetSettingFields(value domain.SecuritySettingsAttribut
 	if value.AllowUnauthenticatedDynamicClientRegistration != nil {
 		changes = append(changes, s.SetAllowUnauthenticatedDynamicClientRegistration(*value.AllowUnauthenticatedDynamicClientRegistration))
 	}
+	if value.EnableClientIDMetadataDocument != nil {
+		changes = append(changes, s.SetEnableClientIDMetadataDocument(*value.EnableClientIDMetadataDocument))
+	}
 	return db_json.NewJsonChanges(s.SettingsColumn(), changes...)
 }
 
@@ -1004,6 +1007,10 @@ func (securitySettings) SetEnableDynamicClientRegistration(value bool) db_json.J
 
 func (securitySettings) SetAllowUnauthenticatedDynamicClientRegistration(value bool) db_json.JsonUpdate {
 	return db_json.NewFieldChange([]string{"allowUnauthenticatedDynamicClientRegistration"}, value)
+}
+
+func (securitySettings) SetEnableClientIDMetadataDocument(value bool) db_json.JsonUpdate {
+	return db_json.NewFieldChange([]string{"enableClientIdMetadataDocument"}, value)
 }
 
 func SecuritySettingsRepository() domain.SecuritySettingsRepository {

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -461,6 +461,19 @@ Caches:
       AddSource: true
       Formatter:
         Format: text
+  # Client ID Metadata Documents are fetched, validated and cached when a client_id is an
+  # HTTPS URL and the instance security settings enable client ID metadata documents. MaxAge
+  # caps the document lifetime regardless of the Cache-Control or Expires header it is served
+  # with.
+  ClientIDMetadataDocuments:
+    Connector: "postgres"
+    MaxAge: 15m
+    LastUseAge: 10m
+    Log:
+      Level: error
+      AddSource: true
+      Formatter:
+        Format: text
 
 Machine:
   # Cloud-hosted VMs need to specify their metadata endpoint so that the machine can be uniquely identified.

--- a/cmd/setup/75.go
+++ b/cmd/setup/75.go
@@ -1,0 +1,27 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 75.sql
+	addSecurityPolicyClientIDMetadataDocument string
+)
+
+type SecurityPolicies3AddClientIDMetadataDocument struct {
+	dbClient *database.DB
+}
+
+func (mig *SecurityPolicies3AddClientIDMetadataDocument) Execute(ctx context.Context, _ eventstore.Event) error {
+	_, err := mig.dbClient.ExecContext(ctx, addSecurityPolicyClientIDMetadataDocument)
+	return err
+}
+
+func (mig *SecurityPolicies3AddClientIDMetadataDocument) String() string {
+	return "75_security_policies3_add_client_id_metadata_document"
+}

--- a/cmd/setup/75.sql
+++ b/cmd/setup/75.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS projections.security_policies3
+ADD COLUMN IF NOT EXISTS enable_client_id_metadata_document BOOLEAN NOT NULL DEFAULT FALSE;

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -194,6 +194,7 @@ type Steps struct {
 	s72AddColumnsToLoginNamesView           *AddColumnsToLoginNamesView
 	s73FixUserGrantRoles                    *FixUserGrantRoles
 	s74Apps7OIDCConfigsAddRegistrationToken *Apps7OIDCConfigsAddRegistrationToken
+	s75SecurityPolicies3AddCIMD             *SecurityPolicies3AddClientIDMetadataDocument
 	RelationalTables                        *TransactionalTables
 }
 

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -257,6 +257,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s72AddColumnsToLoginNamesView = &AddColumnsToLoginNamesView{dbClient: dbClient}
 	steps.s73FixUserGrantRoles = &FixUserGrantRoles{eventstore: eventstoreClient}
 	steps.s74Apps7OIDCConfigsAddRegistrationToken = &Apps7OIDCConfigsAddRegistrationToken{dbClient: dbClient}
+	steps.s75SecurityPolicies3AddCIMD = &SecurityPolicies3AddClientIDMetadataDocument{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -390,6 +391,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s72AddColumnsToLoginNamesView,
 		steps.s73FixUserGrantRoles,
 		steps.s74Apps7OIDCConfigsAddRegistrationToken,
+		steps.s75SecurityPolicies3AddCIMD,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -643,6 +643,11 @@ func startAPIs(
 		return nil, err
 	}
 
+	clientIDMetadataDocumentsCache, err := oidc.StartClientIDMetadataDocumentCache(ctx, cacheConnectors.Config.ClientIDMetadataDocuments, cacheConnectors)
+	if err != nil {
+		return nil, err
+	}
+
 	apis.RegisterHandlerOnPrefix(idp.HandlerPrefix, idp.NewHandler(commands, queries, keys.IDPConfig, instanceInterceptor.Handler, federatedLogoutsCache))
 
 	userAgentInterceptor, err := middleware.NewUserAgentHandler(config.UserAgentCookie, keys.UserAgentCookieKey, id.SonyFlakeGenerator(), config.ExternalSecure, login.EndpointResources, login.EndpointExternalLoginCallbackFormPost, login.EndpointSAMLACS)
@@ -682,6 +687,7 @@ func startAPIs(
 		config.Log.Slog(),
 		config.SystemDefaults.SecretHasher,
 		federatedLogoutsCache,
+		clientIDMetadataDocumentsCache,
 		httpClient,
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/georgysavva/scany/v2 v2.1.4
-	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/go-resty/resty/v2 v2.17.2
@@ -100,7 +100,7 @@ require (
 	github.com/veqryn/slog-context/otel v0.9.0
 	github.com/zitadel/exifremove v0.1.0
 	github.com/zitadel/logging v0.7.0
-	github.com/zitadel/oidc/v3 v3.47.5
+	github.com/zitadel/oidc/v3 v3.48.0
 	github.com/zitadel/passwap v0.12.1
 	github.com/zitadel/saml v0.4.1
 	github.com/zitadel/schema v1.3.2
@@ -109,7 +109,7 @@ require (
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
-	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
@@ -121,11 +121,11 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
-	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
-	go.opentelemetry.io/otel/trace v1.43.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 h1:BP4M0CvQ
 github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
+github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
@@ -841,6 +843,8 @@ github.com/zitadel/logging v0.7.0 h1:eugftwMM95Wgqwftsvj81isL0JK/hoScVqp/7iA2adQ
 github.com/zitadel/logging v0.7.0/go.mod h1:9A6h9feBF/3u0IhA4uffdzSDY7mBaf7RE78H5sFMINQ=
 github.com/zitadel/oidc/v3 v3.47.5 h1:cR2z0oqa5XZkwpXQiPCUGqKtndrjHgEXb81y3oXocK4=
 github.com/zitadel/oidc/v3 v3.47.5/go.mod h1:XxFh0666HRXycyrKmono+3gY0RACpYJLgy4r/+kliKY=
+github.com/zitadel/oidc/v3 v3.48.0 h1:bJmwMyBXeeC5y+i/tx1k7Lq+eLMYrPrVCNsB5fbujtA=
+github.com/zitadel/oidc/v3 v3.48.0/go.mod h1:HwoguOGo0eem0RK5Gb+P6Q4aQLVinJ9LhomlVEA57ck=
 github.com/zitadel/passwap v0.12.1 h1:QAMccBfdQ2b0hRKXJ/qY4/kdddXkXqlDNXeVwEr2318=
 github.com/zitadel/passwap v0.12.1/go.mod h1:atRozvPTTrwYUJdyxpxoxlIbI6Sr2O/ef/9URcn5EmY=
 github.com/zitadel/saml v0.4.1 h1:4PPOAvnUFcfwOFIAFZ3oGTMD+tKVeF96ySfGBf5j3IU=
@@ -870,6 +874,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8V
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0/go.mod h1:BuhAPThV8PBHBvg8ZzZ/Ok3idOdhWIodywz2xEcRbJo=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
+go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0 h1:Dn8rkudDzY6KV9dr/D/bTUuWgqDf9xe0rr4G2elrn0Y=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0/go.mod h1:gMk9F0xDgyN9M/3Ed5Y1wKcx/9mlU91NXY2SNq7RQuU=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=
@@ -896,6 +902,8 @@ go.opentelemetry.io/otel/log v0.19.0 h1:KUZs/GOsw79TBBMfDWsXS+KZ4g2Ckzksd1ymzsIE
 go.opentelemetry.io/otel/log v0.19.0/go.mod h1:5DQYeGmxVIr4n0/BcJvF4upsraHjg6vudJJpnkL6Ipk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
+go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
+go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
 go.opentelemetry.io/otel/sdk v1.43.0/go.mod h1:P+IkVU3iWukmiit/Yf9AWvpyRDlUeBaRg6Y+C58QHzg=
 go.opentelemetry.io/otel/sdk/log v0.19.0 h1:scYVLqT22D2gqXItnWiocLUKGH9yvkkeql5dBDiXyko=
@@ -906,6 +914,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
+go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/api/authz/context_mock.go
+++ b/internal/api/authz/context_mock.go
@@ -29,6 +29,12 @@ func WithMockDynamicClientRegistration(enabled, allowUnauthenticated bool) MockC
 	}
 }
 
+func WithMockClientIDMetadataDocument(enabled bool) MockContextInstanceOpts {
+	return func(i *instance) {
+		i.enableCIMD = enabled
+	}
+}
+
 func WithMockProjectID(projectID string) MockContextInstanceOpts {
 	return func(i *instance) {
 		i.projectID = projectID

--- a/internal/api/authz/instance.go
+++ b/internal/api/authz/instance.go
@@ -32,6 +32,9 @@ type Instance interface {
 	// AllowUnauthenticatedDynamicClientRegistration states if clients may register without
 	// an access token. It implies EnableDynamicClientRegistration.
 	AllowUnauthenticatedDynamicClientRegistration() bool
+	// EnableClientIDMetadataDocument states if a client_id that is an absolute HTTPS URL is
+	// resolved as a Client ID Metadata Document instead of being looked up in the database.
+	EnableClientIDMetadataDocument() bool
 	Block() *bool
 	AuditLogRetention() *time.Duration
 	Features() feature.Features
@@ -58,6 +61,7 @@ type instance struct {
 	executionTargets        target.Router
 	enableDCR               bool
 	allowUnauthenticatedDCR bool
+	enableCIMD              bool
 }
 
 func (i *instance) Block() *bool {
@@ -110,6 +114,10 @@ func (i *instance) EnableDynamicClientRegistration() bool {
 
 func (i *instance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return i.enableDCR && i.allowUnauthenticatedDCR
+}
+
+func (i *instance) EnableClientIDMetadataDocument() bool {
+	return i.enableCIMD
 }
 
 func (i *instance) Features() feature.Features {

--- a/internal/api/authz/instance_test.go
+++ b/internal/api/authz/instance_test.go
@@ -139,6 +139,10 @@ func (m *mockInstance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return false
 }
 
+func (m *mockInstance) EnableClientIDMetadataDocument() bool {
+	return false
+}
+
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
 }

--- a/internal/api/grpc/server/middleware/instance_interceptor_test.go
+++ b/internal/api/grpc/server/middleware/instance_interceptor_test.go
@@ -317,6 +317,10 @@ func (m *mockInstance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return false
 }
 
+func (m *mockInstance) EnableClientIDMetadataDocument() bool {
+	return false
+}
+
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
 }

--- a/internal/api/grpc/settings/v2/settings_converter.go
+++ b/internal/api/grpc/settings/v2/settings_converter.go
@@ -250,6 +250,9 @@ func securityPolicyToSettingsPb(policy *query.SecurityPolicy) *settings.Security
 			Enabled:              policy.EnableDynamicClientRegistration,
 			AllowUnauthenticated: policy.AllowUnauthenticatedDynamicClientRegistration,
 		},
+		ClientIdMetadataDocument: &settings.ClientIDMetadataDocumentSettings{
+			Enabled: policy.EnableClientIDMetadataDocument,
+		},
 	}
 }
 
@@ -261,6 +264,8 @@ func securitySettingsToCommand(req *settings.SetSecuritySettingsRequest) *comman
 
 		EnableDynamicClientRegistration:               req.GetDynamicClientRegistration().GetEnabled(),
 		AllowUnauthenticatedDynamicClientRegistration: req.GetDynamicClientRegistration().GetAllowUnauthenticated(),
+
+		EnableClientIDMetadataDocument: req.GetClientIdMetadataDocument().GetEnabled(),
 	}
 }
 

--- a/internal/api/grpc/settings/v2/settings_converter_test.go
+++ b/internal/api/grpc/settings/v2/settings_converter_test.go
@@ -540,6 +540,9 @@ func Test_securityPolicyToSettingsPb(t *testing.T) {
 			Enabled:              true,
 			AllowUnauthenticated: true,
 		},
+		ClientIdMetadataDocument: &settings.ClientIDMetadataDocumentSettings{
+			Enabled: true,
+		},
 	}
 	got := securityPolicyToSettingsPb(&query.SecurityPolicy{
 		EnableIframeEmbedding: true,
@@ -548,6 +551,8 @@ func Test_securityPolicyToSettingsPb(t *testing.T) {
 
 		EnableDynamicClientRegistration:               true,
 		AllowUnauthenticatedDynamicClientRegistration: true,
+
+		EnableClientIDMetadataDocument: true,
 	})
 	assert.Equal(t, want, got)
 }
@@ -555,6 +560,11 @@ func Test_securityPolicyToSettingsPb(t *testing.T) {
 func Test_securityPolicyToSettingsPb_dynamicClientRegistrationDisabled(t *testing.T) {
 	got := securityPolicyToSettingsPb(&query.SecurityPolicy{})
 	assert.Equal(t, &settings.DynamicClientRegistrationSettings{}, got.GetDynamicClientRegistration())
+}
+
+func Test_securityPolicyToSettingsPb_clientIDMetadataDocumentDisabled(t *testing.T) {
+	got := securityPolicyToSettingsPb(&query.SecurityPolicy{})
+	assert.Equal(t, &settings.ClientIDMetadataDocumentSettings{}, got.GetClientIdMetadataDocument())
 }
 
 func Test_securitySettingsToCommand(t *testing.T) {
@@ -565,6 +575,8 @@ func Test_securitySettingsToCommand(t *testing.T) {
 
 		EnableDynamicClientRegistration:               true,
 		AllowUnauthenticatedDynamicClientRegistration: true,
+
+		EnableClientIDMetadataDocument: true,
 	}
 	got := securitySettingsToCommand(&settings.SetSecuritySettingsRequest{
 		EmbeddedIframe: &settings.EmbeddedIframeSettings{
@@ -576,6 +588,9 @@ func Test_securitySettingsToCommand(t *testing.T) {
 			Enabled:              true,
 			AllowUnauthenticated: true,
 		},
+		ClientIdMetadataDocument: &settings.ClientIDMetadataDocumentSettings{
+			Enabled: true,
+		},
 	})
 	assert.Equal(t, want, got)
 }
@@ -586,4 +601,11 @@ func Test_securitySettingsToCommand_dynamicClientRegistrationOmitted(t *testing.
 	got := securitySettingsToCommand(&settings.SetSecuritySettingsRequest{})
 	assert.False(t, got.EnableDynamicClientRegistration)
 	assert.False(t, got.AllowUnauthenticatedDynamicClientRegistration)
+}
+
+// A request that omits client_id_metadata_document must leave the setting off rather than
+// panicking on the nil message.
+func Test_securitySettingsToCommand_clientIDMetadataDocumentOmitted(t *testing.T) {
+	got := securitySettingsToCommand(&settings.SetSecuritySettingsRequest{})
+	assert.False(t, got.EnableClientIDMetadataDocument)
 }

--- a/internal/api/http/middleware/instance_interceptor_test.go
+++ b/internal/api/http/middleware/instance_interceptor_test.go
@@ -405,6 +405,10 @@ func (m *mockInstance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return false
 }
 
+func (m *mockInstance) EnableClientIDMetadataDocument() bool {
+	return false
+}
+
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
 }

--- a/internal/api/oidc/auth_request.go
+++ b/internal/api/oidc/auth_request.go
@@ -63,6 +63,12 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
 	}
 
+	// Client ID Metadata Document clients are ephemeral and have neither a stored login
+	// version nor a legacy (v1) login configuration, so they always use the v2 login.
+	if clientIDMetadataDocumentEnabled(ctx, req.ClientID) {
+		return o.createAuthRequestLoginClient(ctx, req, userID, loginClient)
+	}
+
 	version, err := o.query.OIDCClientLoginVersion(ctx, req.ClientID)
 	if err != nil {
 		return nil, err
@@ -82,6 +88,16 @@ func (o *OPStorage) CreateAuthRequest(ctx context.Context, req *oidc.AuthRequest
 }
 
 func (o *OPStorage) createAuthRequestScopeAndAudience(ctx context.Context, clientID string, reqScope []string) (scope, audience []string, orgID string, err error) {
+	if clientIDMetadataDocumentEnabled(ctx, clientID) {
+		// Client ID Metadata Document clients have no project, so there are no project roles
+		// to assert and the audience is derived from the requested scopes only.
+		orgID, err = o.assertOrgScope(ctx, reqScope)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		audience = domain.AddAudScopeToAudience(ctx, nil, reqScope)
+		return reqScope, audience, orgID, nil
+	}
 	project, err := o.query.ProjectByClientID(ctx, clientID)
 	if err != nil {
 		return nil, nil, "", err

--- a/internal/api/oidc/client.go
+++ b/internal/api/oidc/client.go
@@ -47,6 +47,13 @@ func (o *OPStorage) GetClientByClientID(ctx context.Context, id string) (_ op.Cl
 		err = oidcError(ctx, err)
 		span.EndWithError(err)
 	}()
+	if clientIDMetadataDocumentEnabled(ctx, id) {
+		client, err := o.clientIDMetadataResolver.ResolveClient(ctx, authz.GetInstance(ctx).InstanceID(), id)
+		if err != nil {
+			return nil, err
+		}
+		return ClientFromBusiness(client, o.defaultLoginURL, o.defaultLoginURLV2), nil
+	}
 	client, err := o.query.ActiveOIDCClientByID(ctx, id, false)
 	if err != nil {
 		return nil, err
@@ -197,6 +204,15 @@ func (s *Server) VerifyClient(ctx context.Context, r *op.Request[op.ClientCreden
 	clientID, assertion, err := clientIDFromCredentials(ctx, r.Data)
 	if err != nil {
 		return nil, err
+	}
+	if clientIDMetadataDocumentEnabled(ctx, clientID) {
+		client, err := s.clientIDMetadataResolver.ResolveClient(ctx, authz.GetInstance(ctx).InstanceID(), clientID)
+		if err != nil {
+			return nil, err
+		}
+		// CIMD clients are public (auth method none); there is no client secret or
+		// assertion to verify.
+		return ClientFromBusiness(client, s.defaultLoginURL, s.defaultLoginURLV2), nil
 	}
 	client, err := s.query.ActiveOIDCClientByID(ctx, clientID, assertion)
 	if zerrors.IsNotFound(err) {

--- a/internal/api/oidc/client_metadata_document.go
+++ b/internal/api/oidc/client_metadata_document.go
@@ -1,0 +1,474 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"golang.org/x/net/idna"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/cache"
+	"github.com/zitadel/zitadel/internal/cache/connector"
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/query"
+)
+
+// Client ID Metadata Document (CIMD) support. A client_id that is an absolute HTTPS URL is
+// treated as a pointer to a document of client metadata (the same shape as an RFC 7591
+// registration request). The document is fetched, validated and the client is treated as an
+// ephemeral public client without any database entry.
+//
+// The security anchor is the origin match: every redirect_uri must share the exact origin
+// (scheme, host, port) of the client_id URL, so a document can only authorize redirects back
+// to the host that serves it. CIMD clients are always public (token_endpoint_auth_method
+// none) and never run in dev mode, so no client secret is trusted and no redirect wildcards
+// are allowed. The document is fetched through the shared SSRF-safe HTTP client, whose
+// operator denylist blocks loopback, private, link-local and cloud-metadata addresses at dial
+// time.
+//
+// The fetch happens inline on the public, unauthenticated authorization endpoint, so it is
+// guarded against amplification: concurrent resolutions of the same client_id are collapsed
+// with a singleflight group, and failures are negatively cached for a short floor so a
+// repeated unresolvable client_id does not trigger an outbound request on every call.
+
+const (
+	// clientIDMetadataMaxBodyBytes bounds the size of a fetched Client ID Metadata Document.
+	clientIDMetadataMaxBodyBytes = 100 * 1024
+	// clientIDMetadataFetchTimeout bounds a single document fetch. It is intentionally
+	// tighter than the shared HTTP client timeout, as the fetch happens inline on the
+	// authorization and token endpoints.
+	clientIDMetadataFetchTimeout = 5 * time.Second
+	// clientIDMetadataMaxCacheTTL caps how long a fetched document is cached, regardless of
+	// the Cache-Control or Expires headers the document is served with. It is the authoritative
+	// upper bound; the Caches.ClientIDMetadataDocuments.MaxAge config is a second, independent
+	// ceiling and should be kept in sync.
+	clientIDMetadataMaxCacheTTL = 15 * time.Minute
+	// clientIDMetadataNegativeTTL is how long a failed resolution is cached, so a repeated
+	// unresolvable client_id on the public authorize endpoint collapses to one fetch per window.
+	clientIDMetadataNegativeTTL = time.Minute
+)
+
+// clientIDMetadataDocumentEnabled reports whether the client_id should be resolved as a
+// Client ID Metadata Document: the instance security settings must enable it and the client_id
+// must look like a CIMD URL.
+func clientIDMetadataDocumentEnabled(ctx context.Context, clientID string) bool {
+	return authz.GetInstance(ctx).EnableClientIDMetadataDocument() && looksLikeClientIDMetadataURL(clientID)
+}
+
+// looksLikeClientIDMetadataURL reports whether the client_id should be resolved as a Client
+// ID Metadata Document. A regular ZITADEL client_id is a numeric snowflake (optionally
+// suffixed) and is never an absolute HTTPS URL, so this branch is unambiguous.
+func looksLikeClientIDMetadataURL(clientID string) bool {
+	u, err := url.Parse(clientID)
+	return err == nil && u.IsAbs() && strings.EqualFold(u.Scheme, "https") && u.Host != ""
+}
+
+type clientIDMetadataCacheIndex int
+
+const (
+	clientIDMetadataCacheIndexUnspecified clientIDMetadataCacheIndex = iota
+	clientIDMetadataCacheIndexURL
+)
+
+// clientIDMetadataCacheEntry caches the outcome of a resolution. A nil Client marks a
+// negatively cached (failed) resolution. The per-entry Expiry is honored by the resolver on
+// read, on top of the cache's own max age, so the document's own Cache-Control or Expires
+// lifetime is respected and capped.
+type clientIDMetadataCacheEntry struct {
+	Key    string            `json:"key"`
+	Client *query.OIDCClient `json:"client,omitempty"`
+	Expiry time.Time         `json:"expiry"`
+}
+
+// Keys implements cache.Entry.
+func (e *clientIDMetadataCacheEntry) Keys(index clientIDMetadataCacheIndex) []string {
+	if index == clientIDMetadataCacheIndexURL {
+		return []string{e.Key}
+	}
+	return nil
+}
+
+func clientIDMetadataCacheKey(instanceID, clientID string) string {
+	return instanceID + "|" + clientID
+}
+
+// StartClientIDMetadataDocumentCache starts the cache that holds resolved Client ID Metadata
+// Documents. The cached entry type wraps a *query.OIDCClient, so it stays in this package
+// rather than a domain sub-package (unlike the federated logout cache) to avoid a domain to
+// query dependency; the cache is therefore constructed here instead of exposing its element
+// types from the package API.
+func StartClientIDMetadataDocumentCache(background context.Context, conf *cache.Config, connectors connector.Connectors) (cache.Cache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry], error) {
+	return connector.StartCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry](
+		background,
+		[]clientIDMetadataCacheIndex{clientIDMetadataCacheIndexURL},
+		cache.PurposeClientIDMetadataDocument,
+		conf,
+		connectors,
+	)
+}
+
+// clientIDMetadataResolver fetches and validates Client ID Metadata Documents and turns them
+// into ephemeral, in-memory OIDC clients. It reuses the shared SSRF-safe HTTP client and the
+// generic cache; it never touches the database.
+type clientIDMetadataResolver struct {
+	httpClient          *http.Client
+	cache               cache.Cache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]
+	group               singleflight.Group
+	accessTokenLifetime time.Duration
+	idTokenLifetime     time.Duration
+	logger              *slog.Logger
+}
+
+func newClientIDMetadataResolver(
+	httpClient *http.Client,
+	documentCache cache.Cache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry],
+	accessTokenLifetime, idTokenLifetime time.Duration,
+	logger *slog.Logger,
+) *clientIDMetadataResolver {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &clientIDMetadataResolver{
+		httpClient:          httpClient,
+		cache:               documentCache,
+		accessTokenLifetime: accessTokenLifetime,
+		idTokenLifetime:     idTokenLifetime,
+		logger:              logger,
+	}
+}
+
+// ResolveClient returns the synthetic public OIDC client described by the Client ID Metadata
+// Document located at clientID, which must be an absolute HTTPS URL. A valid cache entry
+// (positive or negative) is served without a fetch; otherwise the document is fetched,
+// validated and cached. Concurrent resolutions of the same client_id share a single fetch.
+// Any fetch or validation failure is reported as an invalid_client error.
+//
+// The shared resolution deliberately does not inherit the caller's cancellation. It is started
+// by whichever request happens to miss the cache first, but its result is shared, so binding it
+// to that one request would let a single client disconnect abort the fetch for every waiter and,
+// worse, store the resulting failure as a negative cache entry that blocks the client_id for
+// everyone until it expires. context.WithoutCancel keeps the values (instance, features,
+// tracing) the resolution needs; the fetch stays bounded by clientIDMetadataFetchTimeout, so
+// detaching cannot leak a request that runs forever. Each caller still waits on its own
+// context, so a disconnected caller returns immediately instead of blocking on the shared work.
+func (r *clientIDMetadataResolver) ResolveClient(ctx context.Context, instanceID, clientID string) (*query.OIDCClient, error) {
+	key := clientIDMetadataCacheKey(instanceID, clientID)
+	if client, negative, ok := r.cached(ctx, key); ok {
+		if negative {
+			return nil, r.invalidClient(ctx, nil, "client id metadata document could not be resolved")
+		}
+		return client, nil
+	}
+	resolveCtx := context.WithoutCancel(ctx)
+	results := r.group.DoChan(key, func() (any, error) {
+		return r.resolveAndCache(resolveCtx, clientID, key)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-results:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		return result.Val.(*query.OIDCClient), nil
+	}
+}
+
+func (r *clientIDMetadataResolver) resolveAndCache(ctx context.Context, clientID, key string) (*query.OIDCClient, error) {
+	client, ttl, err := r.fetchAndValidate(ctx, clientID)
+	if err != nil {
+		// Negatively cache the failure for a short floor so a repeated unresolvable client_id
+		// on the public authorize endpoint does not trigger an outbound request every time.
+		r.cacheSet(ctx, key, nil, clientIDMetadataNegativeTTL)
+		return nil, err
+	}
+	if ttl > 0 {
+		r.cacheSet(ctx, key, client, ttl)
+	}
+	return client, nil
+}
+
+// cached returns the cached resolution for key, if any is still valid. negative is true when
+// the entry records a failed resolution. The returned client must be treated as immutable: it
+// is shared across requests (the in-memory connector hands back the stored pointer).
+func (r *clientIDMetadataResolver) cached(ctx context.Context, key string) (client *query.OIDCClient, negative, ok bool) {
+	if r.cache == nil {
+		return nil, false, false
+	}
+	entry, found := r.cache.Get(ctx, clientIDMetadataCacheIndexURL, key)
+	if !found || entry == nil {
+		return nil, false, false
+	}
+	if time.Now().After(entry.Expiry) {
+		_ = r.cache.Invalidate(ctx, clientIDMetadataCacheIndexURL, key)
+		return nil, false, false
+	}
+	return entry.Client, entry.Client == nil, true
+}
+
+func (r *clientIDMetadataResolver) cacheSet(ctx context.Context, key string, client *query.OIDCClient, ttl time.Duration) {
+	if r.cache == nil {
+		return
+	}
+	r.cache.Set(ctx, &clientIDMetadataCacheEntry{
+		Key:    key,
+		Client: client,
+		Expiry: time.Now().Add(ttl),
+	})
+}
+
+func (r *clientIDMetadataResolver) fetchAndValidate(ctx context.Context, clientID string) (*query.OIDCClient, time.Duration, error) {
+	clientURL, err := url.Parse(clientID)
+	if err != nil || !clientURL.IsAbs() || !strings.EqualFold(clientURL.Scheme, "https") || clientURL.Host == "" {
+		return nil, 0, r.invalidClient(ctx, err, "client_id is not a valid https url")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, clientIDMetadataFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, clientID, nil)
+	if err != nil {
+		return nil, 0, r.invalidClient(ctx, err, "client id metadata document request could not be built")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		// The SSRF-safe client blocks loopback, private, link-local and cloud-metadata
+		// addresses at dial time, so a blocked target surfaces here as a transport error.
+		return nil, 0, r.invalidClient(ctx, err, "client id metadata document could not be fetched")
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, r.invalidClient(ctx, nil, "client id metadata document could not be fetched")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, clientIDMetadataMaxBodyBytes+1))
+	if err != nil {
+		return nil, 0, r.invalidClient(ctx, err, "client id metadata document could not be read")
+	}
+	if int64(len(body)) > clientIDMetadataMaxBodyBytes {
+		return nil, 0, r.invalidClient(ctx, nil, "client id metadata document is too large")
+	}
+
+	var doc clientRegistrationRequest
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, 0, r.invalidClient(ctx, err, "client id metadata document could not be parsed")
+	}
+
+	client, err := r.documentToClient(ctx, clientID, clientURL, &doc)
+	if err != nil {
+		return nil, 0, err
+	}
+	return client, cacheTTLFromResponse(resp.Header, clientIDMetadataMaxCacheTTL), nil
+}
+
+// documentToClient maps a validated metadata document to a synthetic public OIDC client.
+// CIMD clients are always public and identified by an HTTPS URL, so they are treated as web
+// clients without a project, secret or dev mode. The reused RFC 7591 mappers reject
+// unsupported grant, response and application types; the origin match restricts the redirect
+// URIs to the client_id origin.
+func (r *clientIDMetadataResolver) documentToClient(ctx context.Context, clientID string, clientURL *url.URL, doc *clientRegistrationRequest) (*query.OIDCClient, error) {
+	if doc.JWKsURI != "" || len(doc.JWKs) > 0 {
+		return nil, r.invalidClient(ctx, nil, "jwks and jwks_uri are not supported for client id metadata documents")
+	}
+	// A document that declares a confidential auth method is rejected: a client_id that is a
+	// public URL cannot safely be associated with a client secret. An empty value defaults to
+	// the only supported method, none.
+	if doc.TokenEndpointAuthMethod != "" && doc.TokenEndpointAuthMethod != "none" {
+		return nil, r.invalidClient(ctx, nil, "only token_endpoint_auth_method none is supported for client id metadata documents")
+	}
+	// application_type is validated but its result is not used: a CIMD client is identified by
+	// an HTTPS URL and its redirect URIs are origin matched against it, so it is always treated
+	// as a web client (a native document would in any case fail the origin match for its
+	// loopback or custom-scheme redirect URIs).
+	if _, regErr := registrationApplicationTypeToDomain(doc.ApplicationType, doc.RedirectURIs); regErr != nil {
+		return nil, r.invalidClient(ctx, regErr, regErr.ErrorDescription)
+	}
+	grantTypes, regErr := registrationGrantTypesToDomain(doc.GrantTypes)
+	if regErr != nil {
+		return nil, r.invalidClient(ctx, regErr, regErr.ErrorDescription)
+	}
+	responseTypes, regErr := registrationResponseTypesToDomain(doc.ResponseTypes)
+	if regErr != nil {
+		return nil, r.invalidClient(ctx, regErr, regErr.ErrorDescription)
+	}
+
+	redirectURIs := originMatchedURIs(clientURL, doc.RedirectURIs)
+	if len(redirectURIs) == 0 {
+		return nil, r.invalidClient(ctx, nil, "no redirect_uri matches the client_id origin")
+	}
+	postLogoutRedirectURIs := originMatchedURIs(clientURL, doc.PostLogoutRedirectURIs)
+
+	applicationType := domain.OIDCApplicationTypeWeb
+	authMethod := domain.OIDCAuthMethodTypeNone
+	if compliance := domain.GetOIDCV1Compliance(&applicationType, grantTypes, &authMethod, redirectURIs); compliance.NoneCompliant {
+		return nil, r.invalidClient(ctx, nil, "the client id metadata document is not compliant")
+	}
+
+	return &query.OIDCClient{
+		InstanceID:      authz.GetInstance(ctx).InstanceID(),
+		ClientID:        clientID,
+		State:           domain.AppStateActive,
+		RedirectURIs:    redirectURIs,
+		ResponseTypes:   responseTypes,
+		GrantTypes:      grantTypes,
+		ApplicationType: applicationType,
+		AuthMethodType:  authMethod,
+		// PostLogoutRedirectURIs are origin matched as well so they cannot point off-origin.
+		PostLogoutRedirectURIs: postLogoutRedirectURIs,
+		IsDevMode:              false,
+		AccessTokenType:        domain.OIDCTokenTypeBearer,
+		// No project: CIMD clients are ephemeral and carry no project roles. The token flow
+		// already tolerates an empty project id.
+		ProjectID: "",
+		Settings: &query.OIDCSettings{
+			AccessTokenLifetime: r.accessTokenLifetime,
+			IdTokenLifetime:     r.idTokenLifetime,
+		},
+	}, nil
+}
+
+// invalidClient is the single funnel for every resolution failure. They are all reported to the
+// caller as invalid_client, because at this layer an unreachable or malformed document is not
+// distinguishable from an unknown client and both mean the same thing to the client: this
+// client_id does not resolve.
+//
+// The underlying cause is logged so an operator can tell a client-side problem (bad document,
+// origin mismatch) from an instance-side one (egress broken, denylist too wide), which the
+// invalid_client answer alone hides. It is logged at debug level: the resolution happens on the
+// public, unauthenticated authorize endpoint, so the client_id is attacker controlled and a
+// higher level would let anyone fill the logs.
+func (r *clientIDMetadataResolver) invalidClient(ctx context.Context, parent error, description string) error {
+	r.logger.DebugContext(ctx, "client id metadata document not resolved",
+		"instanceID", authz.GetInstance(ctx).InstanceID(),
+		"reason", description,
+		"err", parent,
+	)
+	// description is passed as an argument rather than as the format string: some
+	// descriptions are derived from attacker-controlled document fields and could contain
+	// formatting verbs.
+	return oidc.ErrInvalidClient().
+		WithParent(parent).
+		WithReturnParentToClient(authz.GetFeatures(ctx).DebugOIDCParentError).
+		WithDescription("%s", description)
+}
+
+// originMatchedURIs returns the subset of uris whose origin (scheme, host, port) exactly
+// matches the client_id URL. This is the CIMD trust anchor: a document can only authorize
+// redirects back to the origin that serves it.
+func originMatchedURIs(clientURL *url.URL, uris []string) []string {
+	matched := make([]string, 0, len(uris))
+	for _, raw := range trimSpaceSlice(uris) {
+		if sameOrigin(clientURL, raw) {
+			matched = append(matched, raw)
+		}
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+	return matched
+}
+
+// sameOrigin reports whether rawURI is absolute and shares the exact origin of clientURL.
+// The scheme comparison is case-insensitive, the host is compared in lower-case ASCII
+// (punycode) form, and the port is normalized to the scheme default. Only the origin is
+// compared; any userinfo, path or query on the redirect URI is ignored, which is safe because
+// it does not change the destination origin.
+func sameOrigin(clientURL *url.URL, rawURI string) bool {
+	u, err := url.Parse(rawURI)
+	if err != nil || !u.IsAbs() {
+		return false
+	}
+	// A redirect URI with embedded credentials is rejected: it is non-standard and only
+	// invites confusion, while the origin it points to is unchanged.
+	if u.User != nil {
+		return false
+	}
+	if !strings.EqualFold(u.Scheme, clientURL.Scheme) {
+		return false
+	}
+	return normalizedHostPort(u) == normalizedHostPort(clientURL)
+}
+
+func normalizedHostPort(u *url.URL) string {
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
+		host = ascii
+	}
+	port := u.Port()
+	if port == "" {
+		port = defaultPortForScheme(u.Scheme)
+	}
+	return host + ":" + port
+}
+
+func defaultPortForScheme(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+// cacheTTLFromResponse derives a cache lifetime from the response Cache-Control and Expires
+// headers, capped at max. A no-store or no-cache directive disables caching (returns 0). When
+// no caching information is present the lifetime defaults to max.
+func cacheTTLFromResponse(header http.Header, max time.Duration) time.Duration {
+	cacheControl := strings.ToLower(header.Get("Cache-Control"))
+	if strings.Contains(cacheControl, "no-store") || strings.Contains(cacheControl, "no-cache") {
+		return 0
+	}
+	if maxAge, ok := maxAgeFromCacheControl(cacheControl); ok {
+		if maxAge <= 0 {
+			return 0
+		}
+		return capDuration(maxAge, max)
+	}
+	if expires := header.Get("Expires"); expires != "" {
+		if t, err := http.ParseTime(expires); err == nil {
+			ttl := time.Until(t)
+			if ttl <= 0 {
+				return 0
+			}
+			return capDuration(ttl, max)
+		}
+	}
+	return max
+}
+
+func maxAgeFromCacheControl(cacheControl string) (time.Duration, bool) {
+	for _, directive := range strings.Split(cacheControl, ",") {
+		directive = strings.TrimSpace(directive)
+		value, ok := strings.CutPrefix(directive, "max-age=")
+		if !ok {
+			continue
+		}
+		seconds, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	return 0, false
+}
+
+func capDuration(d, max time.Duration) time.Duration {
+	if d > max {
+		return max
+	}
+	return d
+}

--- a/internal/api/oidc/client_metadata_document_test.go
+++ b/internal/api/oidc/client_metadata_document_test.go
@@ -1,0 +1,467 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+	http_util "github.com/zitadel/zitadel/internal/api/http"
+	"github.com/zitadel/zitadel/internal/cache"
+	"github.com/zitadel/zitadel/internal/cache/connector/gomap"
+	"github.com/zitadel/zitadel/internal/cache/connector/noop"
+	"github.com/zitadel/zitadel/internal/denylist"
+	"github.com/zitadel/zitadel/internal/domain"
+)
+
+func TestLooksLikeClientIDMetadataURL(t *testing.T) {
+	tests := []struct {
+		clientID string
+		want     bool
+	}{
+		{"https://app.example.com/oauth/client", true},
+		{"https://app.example.com", true},
+		{"https://app.example.com:8443/client", true},
+		{"HTTPS://app.example.com/client", true},
+		{"http://app.example.com/client", false},
+		{"320948502934092851", false},
+		{"320948502934092851@project", false},
+		{"app.example.com/client", false},
+		{"/oauth/client", false},
+		{"", false},
+		{"ftp://app.example.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.clientID, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeClientIDMetadataURL(tt.clientID))
+		})
+	}
+}
+
+// TestClientIDMetadataDocumentEnabled pins the control plane: resolution is gated on the
+// instance security setting, not on the shape of the client_id alone. With the setting off an
+// https client_id must fall through to the regular database lookup.
+func TestClientIDMetadataDocumentEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		clientID string
+		want     bool
+	}{
+		{"enabled, url client_id", true, "https://app.example.com/client", true},
+		{"enabled, regular client_id", true, "320948502934092851", false},
+		{"disabled, url client_id", false, "https://app.example.com/client", false},
+		{"disabled, regular client_id", false, "320948502934092851", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := authz.NewMockContext("instance", "org", "", authz.WithMockClientIDMetadataDocument(tt.enabled))
+			assert.Equal(t, tt.want, clientIDMetadataDocumentEnabled(ctx, tt.clientID))
+		})
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	clientID := mustParseURL(t, "https://app.example.com/oauth/client")
+	tests := []struct {
+		name   string
+		rawURI string
+		want   bool
+	}{
+		{"same origin", "https://app.example.com/callback", true},
+		{"same origin explicit default port", "https://app.example.com:443/callback", true},
+		{"same origin upper case host", "https://APP.EXAMPLE.COM/callback", true},
+		{"same origin trailing dot host", "https://app.example.com./callback", true},
+		{"different host", "https://other.example.com/callback", false},
+		{"different scheme", "http://app.example.com/callback", false},
+		{"different port", "https://app.example.com:8443/callback", false},
+		{"subdomain", "https://sub.app.example.com/callback", false},
+		{"relative uri", "/callback", false},
+		{"custom scheme", "com.example.app://callback", false},
+		{"loopback", "http://127.0.0.1/callback", false},
+		{"userinfo is rejected", "https://user@app.example.com/callback", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sameOrigin(clientID, tt.rawURI))
+		})
+	}
+}
+
+func TestSameOrigin_PortNormalization(t *testing.T) {
+	// An explicit default port on the client_id must match an implicit one on the redirect.
+	explicitDefault := mustParseURL(t, "https://app.example.com:443/client")
+	assert.True(t, sameOrigin(explicitDefault, "https://app.example.com/callback"))
+
+	nonDefault := mustParseURL(t, "https://app.example.com:8443/client")
+	assert.True(t, sameOrigin(nonDefault, "https://app.example.com:8443/callback"))
+	assert.False(t, sameOrigin(nonDefault, "https://app.example.com/callback"))
+}
+
+func TestSameOrigin_IPv6Host(t *testing.T) {
+	clientID := mustParseURL(t, "https://[2001:db8::1]/client")
+	assert.True(t, sameOrigin(clientID, "https://[2001:db8::1]/callback"))
+	assert.False(t, sameOrigin(clientID, "https://[2001:db8::2]/callback"))
+}
+
+func TestSameOrigin_PunycodeHost(t *testing.T) {
+	// The client_id uses the unicode host while the redirect_uri uses its punycode form.
+	clientID := mustParseURL(t, "https://bücher.example/client")
+	assert.True(t, sameOrigin(clientID, "https://xn--bcher-kva.example/callback"))
+}
+
+func TestOriginMatchedURIs(t *testing.T) {
+	clientID := mustParseURL(t, "https://app.example.com/client")
+	got := originMatchedURIs(clientID, []string{
+		"https://app.example.com/callback",
+		" https://app.example.com/second ",
+		"https://evil.example.com/callback",
+		"http://app.example.com/callback",
+		"",
+	})
+	assert.Equal(t, []string{"https://app.example.com/callback", "https://app.example.com/second"}, got)
+
+	assert.Nil(t, originMatchedURIs(clientID, []string{"https://evil.example.com/callback"}))
+	assert.Nil(t, originMatchedURIs(clientID, nil))
+}
+
+func TestCacheTTLFromResponse(t *testing.T) {
+	const max = 15 * time.Minute
+	tests := []struct {
+		name   string
+		header http.Header
+		want   time.Duration
+	}{
+		{"no headers default to cap", http.Header{}, max},
+		{"no-store", http.Header{"Cache-Control": {"no-store"}}, 0},
+		{"no-cache", http.Header{"Cache-Control": {"no-cache"}}, 0},
+		{"max-age below cap", http.Header{"Cache-Control": {"max-age=60"}}, time.Minute},
+		{"max-age above cap", http.Header{"Cache-Control": {"max-age=3600"}}, max},
+		{"max-age zero", http.Header{"Cache-Control": {"max-age=0"}}, 0},
+		{"max-age with other directives", http.Header{"Cache-Control": {"public, max-age=120"}}, 2 * time.Minute},
+		{"expires past", http.Header{"Expires": {"Mon, 02 Jan 2006 15:04:05 GMT"}}, 0},
+		{"no-store wins over max-age", http.Header{"Cache-Control": {"no-store, max-age=600"}}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cacheTTLFromResponse(tt.header, max))
+		})
+	}
+}
+
+func TestClientIDMetadataResolver_ResolveClient(t *testing.T) {
+	ctx := authz.NewMockContext("instance", "org", "")
+
+	t.Run("valid document", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{
+				RedirectURIs:            []string{clientID + "/callback"},
+				GrantTypes:              []string{"authorization_code", "refresh_token"},
+				ResponseTypes:           []string{"code"},
+				TokenEndpointAuthMethod: "none",
+			}
+		})
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		client, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, server.URL, client.ClientID)
+		assert.Equal(t, "instance", client.InstanceID)
+		assert.Equal(t, domain.OIDCAuthMethodTypeNone, client.AuthMethodType)
+		assert.Equal(t, domain.OIDCApplicationTypeWeb, client.ApplicationType)
+		assert.Equal(t, []string{server.URL + "/callback"}, client.RedirectURIs)
+		assert.Empty(t, client.ProjectID)
+		assert.Empty(t, client.HashedSecret)
+		assert.False(t, client.IsDevMode)
+		require.NotNil(t, client.Settings)
+		assert.Equal(t, time.Hour, client.Settings.AccessTokenLifetime)
+	})
+
+	t.Run("only origin matched redirect_uris are kept", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{
+				RedirectURIs:            []string{clientID + "/callback", "https://evil.example.com/callback"},
+				TokenEndpointAuthMethod: "none",
+			}
+		})
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		client, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, []string{server.URL + "/callback"}, client.RedirectURIs)
+	})
+
+	t.Run("no origin matched redirect_uri is rejected", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{
+				RedirectURIs:            []string{"https://evil.example.com/callback"},
+				TokenEndpointAuthMethod: "none",
+			}
+		})
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+
+	t.Run("confidential auth method is rejected", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{
+				RedirectURIs:            []string{clientID + "/callback"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+			}
+		})
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+
+	t.Run("jwks is rejected", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{
+				RedirectURIs: []string{clientID + "/callback"},
+				JWKsURI:      "https://app.example.com/jwks",
+			}
+		})
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+
+	t.Run("non-200 response is rejected", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusNotFound, "", nil)
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+
+	t.Run("oversized body is rejected", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"redirect_uris":["` + strings.Repeat("a", clientIDMetadataMaxBodyBytes) + `"]}`))
+		}))
+		t.Cleanup(server.Close)
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+
+	t.Run("invalid json is rejected", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("not json"))
+		}))
+		t.Cleanup(server.Close)
+		resolver := newTestResolver(server.Client(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+	})
+}
+
+func TestClientIDMetadataResolver_Cache(t *testing.T) {
+	ctx := authz.NewMockContext("instance", "org", "")
+	documentCache := gomap.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry](
+		context.Background(),
+		[]clientIDMetadataCacheIndex{clientIDMetadataCacheIndexURL},
+		cache.Config{MaxAge: time.Hour, LastUseAge: time.Hour},
+	)
+
+	t.Run("cacheable document is fetched once", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "max-age=600", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{RedirectURIs: []string{clientID + "/callback"}, TokenEndpointAuthMethod: "none"}
+		})
+		resolver := newTestResolver(server.Client(), documentCache)
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		_, err = resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), server.hits.Load())
+	})
+
+	t.Run("no-store document is fetched every time", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "no-store", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{RedirectURIs: []string{clientID + "/callback"}, TokenEndpointAuthMethod: "none"}
+		})
+		resolver := newTestResolver(server.Client(), documentCache)
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		_, err = resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), server.hits.Load())
+	})
+
+	t.Run("failed resolution is negatively cached", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusNotFound, "", nil)
+		resolver := newTestResolver(server.Client(), documentCache)
+
+		_, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+		_, err = resolver.ResolveClient(ctx, "instance", server.URL)
+		assertInvalidClient(t, err)
+		assert.Equal(t, int32(1), server.hits.Load(), "an unresolvable client_id must not be fetched again within the negative cache window")
+	})
+
+	t.Run("expired entry is re-fetched", func(t *testing.T) {
+		server := newMetadataServer(t, http.StatusOK, "max-age=600", func(clientID string) clientRegistrationRequest {
+			return clientRegistrationRequest{RedirectURIs: []string{clientID + "/callback"}, TokenEndpointAuthMethod: "none"}
+		})
+		resolver := newTestResolver(server.Client(), documentCache)
+
+		client, err := resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), server.hits.Load())
+
+		// Force the cached entry to be expired; the next resolution must re-fetch.
+		documentCache.Set(ctx, &clientIDMetadataCacheEntry{
+			Key:    clientIDMetadataCacheKey("instance", server.URL),
+			Client: client,
+			Expiry: time.Now().Add(-time.Hour),
+		})
+		_, err = resolver.ResolveClient(ctx, "instance", server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), server.hits.Load())
+	})
+}
+
+func TestClientIDMetadataResolver_SSRFDenylist(t *testing.T) {
+	ctx := authz.NewMockContext("instance", "org", "")
+	// The test server listens on a loopback address, which the operator denylist blocks at
+	// dial time, so the request must never reach the handler.
+	server := newMetadataServer(t, http.StatusOK, "", func(clientID string) clientRegistrationRequest {
+		return clientRegistrationRequest{RedirectURIs: []string{clientID + "/callback"}, TokenEndpointAuthMethod: "none"}
+	})
+
+	checkers, err := denylist.ParseDenyList([]string{"127.0.0.0/8", "::1/128"})
+	require.NoError(t, err)
+	config := &http_util.ClientConfig{
+		MaxBodySize:  clientIDMetadataMaxBodyBytes,
+		Timeout:      5 * time.Second,
+		MaxRedirects: 2,
+		DenyList:     checkers,
+	}
+	resolver := newTestResolver(config.NewClient(), noop.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]())
+
+	_, err = resolver.ResolveClient(ctx, "instance", server.URL)
+	assertInvalidClient(t, err)
+	assert.Equal(t, int32(0), server.hits.Load(), "the denylist should block the dial before the request reaches the server")
+}
+
+// helpers
+
+// TestClientIDMetadataResolver_CallerCancellation pins that the shared resolution does not
+// inherit the cancellation of whichever caller happened to start it. Binding it to that one
+// request would let a single client disconnect abort the fetch for every concurrent waiter and
+// store the failure as a negative cache entry, blocking the client_id for everyone until it
+// expired.
+func TestClientIDMetadataResolver_CallerCancellation(t *testing.T) {
+	documentCache := gomap.NewCache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry](
+		context.Background(),
+		[]clientIDMetadataCacheIndex{clientIDMetadataCacheIndexURL},
+		cache.Config{MaxAge: time.Hour, LastUseAge: time.Hour},
+	)
+
+	// The server blocks until released, so the caller is guaranteed to cancel while the shared
+	// resolution is still in flight.
+	release := make(chan struct{})
+	reached := make(chan struct{})
+	var once sync.Once
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(reached) })
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(clientRegistrationRequest{
+			RedirectURIs:            []string{"https://" + r.Host + "/callback"},
+			TokenEndpointAuthMethod: "none",
+		})
+	}))
+	defer server.Close()
+	resolver := newTestResolver(server.Client(), documentCache)
+
+	cancelCtx, cancel := context.WithCancel(authz.NewMockContext("instance", "org", ""))
+	cancelled := make(chan error, 1)
+	go func() {
+		_, err := resolver.ResolveClient(cancelCtx, "instance", server.URL)
+		cancelled <- err
+	}()
+
+	<-reached
+	cancel()
+	// The abandoning caller returns promptly with its own cancellation rather than blocking on
+	// the shared fetch.
+	select {
+	case err := <-cancelled:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("cancelled caller did not return")
+	}
+
+	close(release)
+
+	// The resolution survived the cancellation, so a later caller resolves normally instead of
+	// hitting a negatively cached failure.
+	client, err := resolver.ResolveClient(authz.NewMockContext("instance", "org", ""), "instance", server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, server.URL, client.ClientID)
+}
+
+func newTestResolver(httpClient *http.Client, documentCache cache.Cache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry]) *clientIDMetadataResolver {
+	return newClientIDMetadataResolver(httpClient, documentCache, time.Hour, time.Hour, nil)
+}
+
+type metadataServer struct {
+	*httptest.Server
+	hits atomic.Int32
+}
+
+// newMetadataServer starts a TLS test server that serves the document returned by build for
+// its own URL. When build is nil it only writes the given status code.
+func newMetadataServer(t *testing.T, status int, cacheControl string, build func(clientID string) clientRegistrationRequest) *metadataServer {
+	t.Helper()
+	server := &metadataServer{}
+	server.Server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server.hits.Add(1)
+		if cacheControl != "" {
+			w.Header().Set("Cache-Control", cacheControl)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(build("https://" + r.Host))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func assertInvalidClient(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var oidcErr *oidc.Error
+	require.ErrorAs(t, err, &oidcErr)
+	assert.Equal(t, oidc.InvalidClient, oidcErr.ErrorType)
+}

--- a/internal/api/oidc/integration_test/client_metadata_document_test.go
+++ b/internal/api/oidc/integration_test/client_metadata_document_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package oidc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/zitadel/zitadel/internal/integration"
+	"github.com/zitadel/zitadel/pkg/grpc/settings/v2"
+)
+
+// TestServer_ClientIDMetadataDocument covers Client ID Metadata Documents (CIMD) with the
+// setting enabled. The resolver itself (document fetch, origin match, SSRF handling,
+// public-only enforcement and caching) is covered end to end by the unit tests. A full
+// authorize to token flow against a live document is not exercised here for one reason only:
+// CIMD requires https and the server's outbound HTTP client validates certificates against the
+// system roots, so it does not trust the self-signed certificate of an in-process test server
+// (the empty integration denylist and the http issuer are not the blockers). These tests
+// therefore assert that support is advertised and that the interception actually runs in the
+// live server by observing the outbound fetch.
+func TestServer_ClientIDMetadataDocument(t *testing.T) {
+	enableClientIDMetadataDocument(t, CTXIAM, Instance)
+
+	issuer := Instance.OIDCIssuer()
+
+	t.Run("discovery advertises client id metadata document support", func(t *testing.T) {
+		discovery := fetchDiscoveryRaw(t, issuer)
+		assert.Equal(t, true, discovery["client_id_metadata_document_supported"])
+	})
+
+	t.Run("an https client_id triggers an outbound document fetch", func(t *testing.T) {
+		// Serve a metadata document over TLS and count inbound connections. With the setting
+		// on, an https client_id is intercepted and the resolver fetches the document, so the
+		// server observes a connection (the TLS handshake then fails because the cert is not
+		// trusted, which is why the authorization itself errors). A database lookup would never
+		// produce an outbound connection, so this distinguishes "the resolver ran" from a plain
+		// unknown-client error.
+		var connections atomic.Int32
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"redirect_uris":              []string{redirectURI},
+				"token_endpoint_auth_method": "none",
+			})
+		}))
+		server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+			if state == http.StateNew {
+				connections.Add(1)
+			}
+		}
+		server.StartTLS()
+		defer server.Close()
+
+		_, _, err := Instance.CreateOIDCAuthRequest(CTX, server.URL, Instance.Users.Get(integration.UserTypeLogin).ID, redirectURI, oidc.ScopeOpenID)
+		require.Error(t, err)
+		assert.GreaterOrEqual(t, connections.Load(), int32(1), "the resolver must have attempted to fetch the metadata document")
+	})
+
+	// Non-URL client_ids keep going through the regular database lookup unchanged: the rest of
+	// the OIDC integration suite runs against this same instance with the setting enabled, so a
+	// regression on the normal client path would surface there.
+}
+
+// TestServer_ClientIDMetadataDocument_disabled verifies that without the setting CIMD is
+// neither advertised nor active: an https-url client_id is treated as a regular (unknown)
+// client and the discovery document does not carry the support metadata.
+func TestServer_ClientIDMetadataDocument_disabled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	instance := integration.NewInstance(ctx)
+	issuer := instance.OIDCIssuer()
+
+	discovery := fetchDiscoveryRaw(t, issuer)
+	_, advertised := discovery["client_id_metadata_document_supported"]
+	assert.False(t, advertised, "CIMD support must not be advertised when the feature is disabled")
+
+	_, _, err := instance.CreateOIDCAuthRequest(ctx, "https://app.example.com/client", instance.Users.Get(integration.UserTypeLogin).ID, redirectURI, oidc.ScopeOpenID)
+	require.Error(t, err, "an https client_id must not resolve when the feature is disabled")
+}
+
+// enableClientIDMetadataDocument turns CIMD on through the instance's security settings and
+// waits until the change is observable, i.e. until the projection behind the cached instance
+// has caught up and discovery advertises the support.
+//
+// SetSecuritySettings replaces the whole policy, so the current settings are read first and
+// carried over: several tests share an instance and the dynamic client registration tests
+// enable their own switch on it. It is safe to call more than once: a write that changes
+// nothing is answered with a failed precondition ("Errors.NoChangesFound"), which here means
+// the desired state is already reached rather than a failure.
+func enableClientIDMetadataDocument(t *testing.T, ctx context.Context, instance *integration.Instance) {
+	t.Helper()
+	current, err := instance.Client.SettingsV2.GetSecuritySettings(ctx, &settings.GetSecuritySettingsRequest{})
+	require.NoError(t, err)
+
+	_, err = instance.Client.SettingsV2.SetSecuritySettings(ctx, &settings.SetSecuritySettingsRequest{
+		EmbeddedIframe:            current.GetSettings().GetEmbeddedIframe(),
+		EnableImpersonation:       current.GetSettings().GetEnableImpersonation(),
+		DynamicClientRegistration: current.GetSettings().GetDynamicClientRegistration(),
+		ClientIdMetadataDocument: &settings.ClientIDMetadataDocumentSettings{
+			Enabled: true,
+		},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		require.NoError(t, err)
+	}
+
+	issuer := instance.OIDCIssuer()
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(ctx, time.Minute)
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := http.Get(issuer + "/.well-known/openid-configuration")
+		if !assert.NoError(tt, err) {
+			return
+		}
+		defer resp.Body.Close()
+		var discovery map[string]any
+		if !assert.NoError(tt, json.NewDecoder(resp.Body).Decode(&discovery)) {
+			return
+		}
+		assert.Equal(tt, true, discovery["client_id_metadata_document_supported"])
+	}, retryDuration, tick, "client id metadata document support not advertised")
+}
+
+func fetchDiscoveryRaw(t testing.TB, issuer string) map[string]any {
+	t.Helper()
+	resp, err := http.Get(issuer + "/.well-known/openid-configuration")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var discovery map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&discovery))
+	return discovery
+}

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -89,6 +89,7 @@ type OPStorage struct {
 	assetAPIPrefix                    func(ctx context.Context) string
 	contextToIssuer                   func(context.Context) string
 	federateLogoutCache               cache.Cache[federatedlogout.Index, string, *federatedlogout.FederatedLogout]
+	clientIDMetadataResolver          *clientIDMetadataResolver
 }
 
 // Provider is used to overload certain [op.Provider] methods
@@ -129,13 +130,15 @@ func NewServer(
 	fallbackLogger *slog.Logger,
 	hashConfig crypto.HashConfig,
 	federatedLogoutCache cache.Cache[federatedlogout.Index, string, *federatedlogout.FederatedLogout],
+	clientIDMetadataDocumentCache cache.Cache[clientIDMetadataCacheIndex, string, *clientIDMetadataCacheEntry],
 	httpClient *http.Client,
 ) (*Server, error) {
 	opConfig, err := createOPConfig(config, defaultLogoutRedirectURI, cryptoKey)
 	if err != nil {
 		return nil, zerrors.ThrowInternal(err, "OIDC-EGrqd", "cannot create op config: %w")
 	}
-	storage := newStorage(config, command, query, repo, authAlg, es, ContextToIssuer, federatedLogoutCache)
+	clientIDMetadataResolver := newClientIDMetadataResolver(httpClient, clientIDMetadataDocumentCache, config.DefaultAccessTokenLifetime, config.DefaultIdTokenLifetime, fallbackLogger)
+	storage := newStorage(config, command, query, repo, authAlg, es, ContextToIssuer, federatedLogoutCache, clientIDMetadataResolver)
 	keyCache := newPublicKeyCache(ctx, config.PublicKeyCacheMaxAge, queryKeyFunc(query))
 	accessTokenKeySet := newOidcKeySet(keyCache, withKeyExpiryCheck(true))
 	idTokenHintKeySet := newOidcKeySet(keyCache)
@@ -194,6 +197,7 @@ func NewServer(
 		assetAPIPrefix:             assets.AssetAPI(),
 		httpClient:                 httpClient,
 		registrationEndpoint:       registrationEndpoint(config.CustomEndpoints),
+		clientIDMetadataResolver:   clientIDMetadataResolver,
 	}
 	metricTypes := []metrics.MetricType{metrics.MetricTypeRequestCount, metrics.MetricTypeStatusCode, metrics.MetricTypeTotalCount}
 
@@ -304,6 +308,7 @@ func newStorage(
 	es *eventstore.Eventstore,
 	contextToIssuer func(context.Context) string,
 	federateLogoutCache cache.Cache[federatedlogout.Index, string, *federatedlogout.FederatedLogout],
+	clientIDMetadataResolver *clientIDMetadataResolver,
 ) *OPStorage {
 	return &OPStorage{
 		repo:                              repo,
@@ -321,6 +326,7 @@ func newStorage(
 		assetAPIPrefix:                    assets.AssetAPI(),
 		contextToIssuer:                   contextToIssuer,
 		federateLogoutCache:               federateLogoutCache,
+		clientIDMetadataResolver:          clientIDMetadataResolver,
 	}
 }
 

--- a/internal/api/oidc/server.go
+++ b/internal/api/oidc/server.go
@@ -46,7 +46,8 @@ type Server struct {
 	assetAPIPrefix func(ctx context.Context) string
 	httpClient     *http.Client
 
-	registrationEndpoint *op.Endpoint
+	registrationEndpoint     *op.Endpoint
+	clientIDMetadataResolver *clientIDMetadataResolver
 }
 
 func endpoints(endpointConfig *EndpointConfig) op.Endpoints {

--- a/internal/api/oidc/server.go
+++ b/internal/api/oidc/server.go
@@ -187,8 +187,12 @@ func (s *Server) createDiscoveryConfig(ctx context.Context, supportedUILocales o
 	}
 
 	return &oidc.DiscoveryConfiguration{
-		Issuer:                      issuer,
-		RegistrationEndpoint:        registrationEndpoint,
+		Issuer:               issuer,
+		RegistrationEndpoint: registrationEndpoint,
+		// Client ID Metadata Documents are only advertised when they are enabled in the
+		// instance's security settings.
+		ClientIDMetadataDocumentSupported: authz.GetInstance(ctx).EnableClientIDMetadataDocument(),
+
 		AuthorizationEndpoint:       s.Endpoints().Authorization.Absolute(issuer),
 		TokenEndpoint:               s.Endpoints().Token.Absolute(issuer),
 		IntrospectionEndpoint:       s.Endpoints().Introspection.Absolute(issuer),

--- a/internal/api/oidc/server_test.go
+++ b/internal/api/oidc/server_test.go
@@ -162,3 +162,42 @@ func TestServer_createDiscoveryConfig_registrationEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestServer_createDiscoveryConfig_clientIDMetadataDocument(t *testing.T) {
+	s := &Server{
+		LegacyServer: op.NewLegacyServer(
+			func() *op.Provider {
+				//nolint:staticcheck
+				provider, _ := op.NewForwardedOpenIDProvider("path", &op.Config{}, nil)
+				return provider
+			}(),
+			op.Endpoints{Authorization: op.NewEndpoint("auth")},
+		),
+		registrationEndpoint: op.NewEndpoint("register"),
+	}
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want bool
+	}{
+		{
+			name: "setting disabled, support not advertised",
+			ctx:  op.ContextWithIssuer(context.Background(), "https://issuer.com"),
+			want: false,
+		},
+		{
+			name: "setting enabled, support advertised",
+			ctx: op.ContextWithIssuer(
+				authz.NewMockContext("instance", "org", "", authz.WithMockClientIDMetadataDocument(true)),
+				"https://issuer.com",
+			),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.createDiscoveryConfig(tt.ctx, nil)
+			assert.Equal(t, tt.want, got.ClientIDMetadataDocumentSupported)
+		})
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,6 +19,7 @@ const (
 	PurposeOrganization
 	PurposeIdPFormCallback
 	PurposeFederatedLogout
+	PurposeClientIDMetadataDocument
 )
 
 // Cache stores objects with a value of type `V`.

--- a/internal/cache/connector/connector.go
+++ b/internal/cache/connector/connector.go
@@ -20,11 +20,12 @@ type CachesConfig struct {
 		Postgres pg.Config
 		Redis    redis.Config
 	}
-	Instance         *cache.Config
-	Milestones       *cache.Config
-	Organization     *cache.Config
-	IdPFormCallbacks *cache.Config
-	FederatedLogouts *cache.Config
+	Instance                  *cache.Config
+	Milestones                *cache.Config
+	Organization              *cache.Config
+	IdPFormCallbacks          *cache.Config
+	FederatedLogouts          *cache.Config
+	ClientIDMetadataDocuments *cache.Config
 }
 
 type Connectors struct {

--- a/internal/cache/purpose_enumer.go
+++ b/internal/cache/purpose_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _PurposeName = "unspecifiedauthz_instancemilestonesorganizationid_p_form_callbackfederated_logout"
+const _PurposeName = "unspecifiedauthz_instancemilestonesorganizationid_p_form_callbackfederated_logoutclient_id_metadata_document"
 
-var _PurposeIndex = [...]uint8{0, 11, 25, 35, 47, 65, 81}
+var _PurposeIndex = [...]uint8{0, 11, 25, 35, 47, 65, 81, 108}
 
-const _PurposeLowerName = "unspecifiedauthz_instancemilestonesorganizationid_p_form_callbackfederated_logout"
+const _PurposeLowerName = "unspecifiedauthz_instancemilestonesorganizationid_p_form_callbackfederated_logoutclient_id_metadata_document"
 
 func (i Purpose) String() string {
 	if i < 0 || i >= Purpose(len(_PurposeIndex)-1) {
@@ -30,23 +30,26 @@ func _PurposeNoOp() {
 	_ = x[PurposeOrganization-(3)]
 	_ = x[PurposeIdPFormCallback-(4)]
 	_ = x[PurposeFederatedLogout-(5)]
+	_ = x[PurposeClientIDMetadataDocument-(6)]
 }
 
-var _PurposeValues = []Purpose{PurposeUnspecified, PurposeAuthzInstance, PurposeMilestones, PurposeOrganization, PurposeIdPFormCallback, PurposeFederatedLogout}
+var _PurposeValues = []Purpose{PurposeUnspecified, PurposeAuthzInstance, PurposeMilestones, PurposeOrganization, PurposeIdPFormCallback, PurposeFederatedLogout, PurposeClientIDMetadataDocument}
 
 var _PurposeNameToValueMap = map[string]Purpose{
-	_PurposeName[0:11]:       PurposeUnspecified,
-	_PurposeLowerName[0:11]:  PurposeUnspecified,
-	_PurposeName[11:25]:      PurposeAuthzInstance,
-	_PurposeLowerName[11:25]: PurposeAuthzInstance,
-	_PurposeName[25:35]:      PurposeMilestones,
-	_PurposeLowerName[25:35]: PurposeMilestones,
-	_PurposeName[35:47]:      PurposeOrganization,
-	_PurposeLowerName[35:47]: PurposeOrganization,
-	_PurposeName[47:65]:      PurposeIdPFormCallback,
-	_PurposeLowerName[47:65]: PurposeIdPFormCallback,
-	_PurposeName[65:81]:      PurposeFederatedLogout,
-	_PurposeLowerName[65:81]: PurposeFederatedLogout,
+	_PurposeName[0:11]:        PurposeUnspecified,
+	_PurposeLowerName[0:11]:   PurposeUnspecified,
+	_PurposeName[11:25]:       PurposeAuthzInstance,
+	_PurposeLowerName[11:25]:  PurposeAuthzInstance,
+	_PurposeName[25:35]:       PurposeMilestones,
+	_PurposeLowerName[25:35]:  PurposeMilestones,
+	_PurposeName[35:47]:       PurposeOrganization,
+	_PurposeLowerName[35:47]:  PurposeOrganization,
+	_PurposeName[47:65]:       PurposeIdPFormCallback,
+	_PurposeLowerName[47:65]:  PurposeIdPFormCallback,
+	_PurposeName[65:81]:       PurposeFederatedLogout,
+	_PurposeLowerName[65:81]:  PurposeFederatedLogout,
+	_PurposeName[81:108]:      PurposeClientIDMetadataDocument,
+	_PurposeLowerName[81:108]: PurposeClientIDMetadataDocument,
 }
 
 var _PurposeNames = []string{
@@ -56,6 +59,7 @@ var _PurposeNames = []string{
 	_PurposeName[35:47],
 	_PurposeName[47:65],
 	_PurposeName[65:81],
+	_PurposeName[81:108],
 }
 
 // PurposeString retrieves an enum value from the enum constants string name.

--- a/internal/command/instance_policy_security.go
+++ b/internal/command/instance_policy_security.go
@@ -17,6 +17,8 @@ type SecurityPolicy struct {
 
 	EnableDynamicClientRegistration               bool
 	AllowUnauthenticatedDynamicClientRegistration bool
+
+	EnableClientIDMetadataDocument bool
 }
 
 func (c *Commands) SetSecurityPolicy(ctx context.Context, policy *SecurityPolicy) (*domain.ObjectDetails, error) {

--- a/internal/command/instance_policy_security_model.go
+++ b/internal/command/instance_policy_security_model.go
@@ -44,6 +44,9 @@ func (wm *InstanceSecurityPolicyWriteModel) Reduce() error {
 			if e.AllowUnauthenticatedDynamicClientRegistration != nil {
 				wm.AllowUnauthenticatedDynamicClientRegistration = *e.AllowUnauthenticatedDynamicClientRegistration
 			}
+			if e.EnableClientIDMetadataDocument != nil {
+				wm.EnableClientIDMetadataDocument = *e.EnableClientIDMetadataDocument
+			}
 		}
 	}
 	return wm.WriteModel.Reduce()
@@ -65,7 +68,7 @@ func (wm *InstanceSecurityPolicyWriteModel) NewSetEvent(
 	aggregate *eventstore.Aggregate,
 	policy *SecurityPolicy,
 ) (*instance.SecurityPolicySetEvent, error) {
-	changes := make([]instance.SecurityPolicyChanges, 0, 5)
+	changes := make([]instance.SecurityPolicyChanges, 0, 6)
 	var err error
 
 	if wm.EnableIframeEmbedding != policy.EnableIframeEmbedding {
@@ -82,6 +85,9 @@ func (wm *InstanceSecurityPolicyWriteModel) NewSetEvent(
 	}
 	if wm.AllowUnauthenticatedDynamicClientRegistration != policy.AllowUnauthenticatedDynamicClientRegistration {
 		changes = append(changes, instance.ChangeSecurityPolicyAllowUnauthenticatedDynamicClientRegistration(policy.AllowUnauthenticatedDynamicClientRegistration))
+	}
+	if wm.EnableClientIDMetadataDocument != policy.EnableClientIDMetadataDocument {
+		changes = append(changes, instance.ChangeSecurityPolicyEnableClientIDMetadataDocument(policy.EnableClientIDMetadataDocument))
 	}
 	changeEvent, err := instance.NewSecurityPolicySetEvent(ctx, aggregate, changes)
 	if err != nil {

--- a/internal/command/main_test.go
+++ b/internal/command/main_test.go
@@ -233,6 +233,10 @@ func (m *mockInstance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return false
 }
 
+func (m *mockInstance) EnableClientIDMetadataDocument() bool {
+	return false
+}
+
 func (m *mockInstance) Features() feature.Features {
 	return feature.Features{}
 }

--- a/internal/query/instance.go
+++ b/internal/query/instance.go
@@ -468,6 +468,7 @@ type authzInstance struct {
 	CSP                    csp                        `json:"csp,omitempty"`
 	Impersonation          bool                       `json:"impersonation,omitempty"`
 	DCR                    dcr                        `json:"dcr,omitempty"`
+	CIMD                   bool                       `json:"cimd,omitempty"`
 	IsBlocked              *bool                      `json:"is_blocked,omitempty"`
 	LogRetention           *time.Duration             `json:"log_retention,omitempty"`
 	Feature                feature.Features           `json:"feature,omitempty"`
@@ -535,6 +536,10 @@ func (i *authzInstance) AllowUnauthenticatedDynamicClientRegistration() bool {
 	return i.DCR.Enabled && i.DCR.AllowUnauthenticated
 }
 
+func (i *authzInstance) EnableClientIDMetadataDocument() bool {
+	return i.CIMD
+}
+
 func (i *authzInstance) Block() *bool {
 	return i.IsBlocked
 }
@@ -585,6 +590,7 @@ func scanAuthzInstance() (*authzInstance, func(row *sql.Row) error) {
 			enableImpersonation   sql.NullBool
 			enableDCR             sql.NullBool
 			allowUnauthDCR        sql.NullBool
+			enableCIMD            sql.NullBool
 			auditLogRetention     database.NullDuration
 			block                 sql.NullBool
 			features              []byte
@@ -603,6 +609,7 @@ func scanAuthzInstance() (*authzInstance, func(row *sql.Row) error) {
 			&enableImpersonation,
 			&enableDCR,
 			&allowUnauthDCR,
+			&enableCIMD,
 			&auditLogRetention,
 			&block,
 			&features,
@@ -628,6 +635,7 @@ func scanAuthzInstance() (*authzInstance, func(row *sql.Row) error) {
 		instance.Impersonation = enableImpersonation.Bool
 		instance.DCR.Enabled = enableDCR.Bool
 		instance.DCR.AllowUnauthenticated = allowUnauthDCR.Bool
+		instance.CIMD = enableCIMD.Bool
 		if len(features) > 0 {
 			if err = json.Unmarshal(features, &instance.Feature); err != nil {
 				return zerrors.ThrowInternal(err, "QUERY-Po8ki", "Errors.Internal")

--- a/internal/query/instance_by_domain.sql
+++ b/internal/query/instance_by_domain.sql
@@ -70,6 +70,7 @@ select
 	s.enable_impersonation,
 	s.enable_dynamic_client_registration,
 	s.allow_unauthenticated_dynamic_client_registration,
+	s.enable_client_id_metadata_document,
     l.audit_log_retention,
     l.block,
 	f.features,

--- a/internal/query/instance_by_id.sql
+++ b/internal/query/instance_by_id.sql
@@ -60,6 +60,7 @@ select
 	s.enable_impersonation,
 	s.enable_dynamic_client_registration,
 	s.allow_unauthenticated_dynamic_client_registration,
+	s.enable_client_id_metadata_document,
     l.audit_log_retention,
     l.block,
 	f.features,

--- a/internal/query/projection/security_policy.go
+++ b/internal/query/projection/security_policy.go
@@ -22,6 +22,8 @@ const (
 
 	SecurityPolicyColumnEnableDynamicClientRegistration               = "enable_dynamic_client_registration"
 	SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration = "allow_unauthenticated_dynamic_client_registration"
+
+	SecurityPolicyColumnEnableClientIDMetadataDocument = "enable_client_id_metadata_document"
 )
 
 type securityPolicyProjection struct{}
@@ -46,6 +48,7 @@ func (*securityPolicyProjection) Init() *old_handler.Check {
 			handler.NewColumn(SecurityPolicyColumnEnableImpersonation, handler.ColumnTypeBool, handler.Default(false)),
 			handler.NewColumn(SecurityPolicyColumnEnableDynamicClientRegistration, handler.ColumnTypeBool, handler.Default(false)),
 			handler.NewColumn(SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration, handler.ColumnTypeBool, handler.Default(false)),
+			handler.NewColumn(SecurityPolicyColumnEnableClientIDMetadataDocument, handler.ColumnTypeBool, handler.Default(false)),
 		},
 			handler.NewPrimaryKey(SecurityPolicyColumnInstanceID),
 		),
@@ -97,6 +100,9 @@ func (p *securityPolicyProjection) reduceSecurityPolicySet(event eventstore.Even
 	}
 	if e.AllowUnauthenticatedDynamicClientRegistration != nil {
 		changes = append(changes, handler.NewCol(SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration, e.AllowUnauthenticatedDynamicClientRegistration))
+	}
+	if e.EnableClientIDMetadataDocument != nil {
+		changes = append(changes, handler.NewCol(SecurityPolicyColumnEnableClientIDMetadataDocument, e.EnableClientIDMetadataDocument))
 	}
 	return handler.NewUpsertStatement(
 		e,

--- a/internal/query/projection/settings_relational.go
+++ b/internal/query/projection/settings_relational.go
@@ -1388,6 +1388,8 @@ func (p *relationalTablesProjection) reduceSecurityPolicySet(event eventstore.Ev
 
 				EnableDynamicClientRegistration:               policyEvent.EnableDynamicClientRegistration,
 				AllowUnauthenticatedDynamicClientRegistration: policyEvent.AllowUnauthenticatedDynamicClientRegistration,
+
+				EnableClientIDMetadataDocument: policyEvent.EnableClientIDMetadataDocument,
 			},
 		}
 		return settingsRepo.Set(ctx, v3_sql.SQLTx(tx), &settings)

--- a/internal/query/security_policy.go
+++ b/internal/query/security_policy.go
@@ -55,6 +55,10 @@ var (
 		name:  projection.SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration,
 		table: securityPolicyTable,
 	}
+	SecurityPolicyColumnEnableClientIDMetadataDocument = Column{
+		name:  projection.SecurityPolicyColumnEnableClientIDMetadataDocument,
+		table: securityPolicyTable,
+	}
 )
 
 type SecurityPolicy struct {
@@ -70,6 +74,8 @@ type SecurityPolicy struct {
 
 	EnableDynamicClientRegistration               bool
 	AllowUnauthenticatedDynamicClientRegistration bool
+
+	EnableClientIDMetadataDocument bool
 }
 
 func (q *Queries) SecurityPolicy(ctx context.Context) (policy *SecurityPolicy, err error) {
@@ -99,7 +105,8 @@ func prepareSecurityPolicyQuery() (sq.SelectBuilder, func(*sql.Row) (*SecurityPo
 			SecurityPolicyColumnAllowedOrigins.identifier(),
 			SecurityPolicyColumnEnableImpersonation.identifier(),
 			SecurityPolicyColumnEnableDynamicClientRegistration.identifier(),
-			SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration.identifier()).
+			SecurityPolicyColumnAllowUnauthenticatedDynamicClientRegistration.identifier(),
+			SecurityPolicyColumnEnableClientIDMetadataDocument.identifier()).
 			From(securityPolicyTable.identifier()).
 			PlaceholderFormat(sq.Dollar),
 		func(row *sql.Row) (*SecurityPolicy, error) {
@@ -115,6 +122,7 @@ func prepareSecurityPolicyQuery() (sq.SelectBuilder, func(*sql.Row) (*SecurityPo
 				&securityPolicy.EnableImpersonation,
 				&securityPolicy.EnableDynamicClientRegistration,
 				&securityPolicy.AllowUnauthenticatedDynamicClientRegistration,
+				&securityPolicy.EnableClientIDMetadataDocument,
 			)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) { // ignore not found errors
 				return nil, zerrors.ThrowInternal(err, "QUERY-Dfrt2", "Errors.Internal")

--- a/internal/repository/instance/policy_security.go
+++ b/internal/repository/instance/policy_security.go
@@ -28,6 +28,10 @@ type SecurityPolicySetEvent struct {
 	// AllowUnauthenticatedDynamicClientRegistration additionally allows registration
 	// without an access token. It only has an effect if EnableDynamicClientRegistration.
 	AllowUnauthenticatedDynamicClientRegistration *bool `json:"allow_unauthenticated_dynamic_client_registration,omitempty"`
+
+	// EnableClientIDMetadataDocument resolves a client_id that is an absolute HTTPS URL as a
+	// Client ID Metadata Document instead of looking it up in the database.
+	EnableClientIDMetadataDocument *bool `json:"enable_client_id_metadata_document,omitempty"`
 }
 
 func NewSecurityPolicySetEvent(
@@ -83,6 +87,12 @@ func ChangeSecurityPolicyEnableDynamicClientRegistration(enabled bool) func(even
 func ChangeSecurityPolicyAllowUnauthenticatedDynamicClientRegistration(allow bool) func(event *SecurityPolicySetEvent) {
 	return func(e *SecurityPolicySetEvent) {
 		e.AllowUnauthenticatedDynamicClientRegistration = &allow
+	}
+}
+
+func ChangeSecurityPolicyEnableClientIDMetadataDocument(enabled bool) func(event *SecurityPolicySetEvent) {
+	return func(e *SecurityPolicySetEvent) {
+		e.EnableClientIDMetadataDocument = &enabled
 	}
 }
 

--- a/proto/zitadel/settings/v2/security_settings.proto
+++ b/proto/zitadel/settings/v2/security_settings.proto
@@ -18,6 +18,10 @@ message SecuritySettings {
   // DynamicClientRegistrationSettings defines if OAuth 2.0 clients may register
   // themselves at runtime (RFC 7591) and whether they may do so without a token.
   DynamicClientRegistrationSettings dynamic_client_registration = 3;
+
+  // ClientIDMetadataDocumentSettings defines if a client_id that is an HTTPS URL is
+  // resolved as a Client ID Metadata Document instead of being looked up in the database.
+  ClientIDMetadataDocumentSettings client_id_metadata_document = 4;
 }
 
 message DynamicClientRegistrationSettings {
@@ -34,6 +38,18 @@ message DynamicClientRegistrationSettings {
   // `project.app.register_dynamic` permission in the token's organization, and the
   // client is homed in that organization.
   bool allow_unauthenticated = 2;
+}
+
+message ClientIDMetadataDocumentSettings {
+  // Enabled states if a client_id that is an absolute HTTPS URL is resolved as a Client ID
+  // Metadata Document, and advertised as `client_id_metadata_document_supported` in the
+  // discovery document. When disabled, such a client_id is looked up in the database like
+  // any other and therefore rejected as an unknown client.
+  //
+  // Enabling this makes ZITADEL fetch client-controlled URLs from the public authorization
+  // and token endpoints. The fetch goes through the SSRF-safe HTTP client and every
+  // redirect_uri must share the origin of the client_id URL.
+  bool enabled = 1;
 }
 
 message EmbeddedIframeSettings{

--- a/proto/zitadel/settings/v2/settings_service.proto
+++ b/proto/zitadel/settings/v2/settings_service.proto
@@ -814,6 +814,10 @@ message SetSecuritySettingsRequest{
   // DynamicClientRegistrationSettings defines if OAuth 2.0 clients may register
   // themselves at runtime (RFC 7591) and whether they may do so without a token.
   DynamicClientRegistrationSettings dynamic_client_registration = 3;
+
+  // ClientIDMetadataDocumentSettings defines if a client_id that is an HTTPS URL is
+  // resolved as a Client ID Metadata Document instead of being looked up in the database.
+  ClientIDMetadataDocumentSettings client_id_metadata_document = 4;
 }
 
 message SetSecuritySettingsResponse{


### PR DESCRIPTION
# Which Problems Are Solved

The Model Context Protocol (MCP) ecosystem is moving toward Client ID Metadata
Documents (CIMD) as a stateless alternative to dynamic client registration: the
`client_id` is an HTTPS URL that serves the client metadata, so there is nothing
to register ahead of time and nothing to clean up.

ZITADEL had no way to use such a `client_id`. A `client_id` that is a URL was
simply looked up in the database and rejected as an unknown client.

# How the Problems Are Solved

## Control plane: instance security settings

Following the direction set in the review of #12313, there is no feature flag
and no runtime config. A `ClientIDMetadataDocumentSettings` message is nested
under the instance `SecuritySettings` in `settings/v2`, next to
`embedded_iframe`, `enable_impersonation` and `dynamic_client_registration`:

| `client_id_metadata_document.enabled` | Behaviour |
| --- | --- |
| `false` (default) | An HTTPS `client_id` is looked up in the database like any other and therefore rejected as unknown. `client_id_metadata_document_supported` is absent from discovery. |
| `true` | An absolute HTTPS `client_id` is resolved as a Client ID Metadata Document. Discovery advertises `client_id_metadata_document_supported: true`. |

The value is carried on `authz.Instance` and loaded with the instance, exactly
like `EnableImpersonation` and the dynamic client registration settings, so the
discovery document and the client lookup read it per request without an extra
query.

This is a separate switch from `dynamic_client_registration` on purpose: CIMD
fetches client controlled URLs and therefore has a different security profile
that must be enableable independently.

Adding the column does not bump the projection table. Setup step 75 adds
`enable_client_id_metadata_document` to `projections.security_policies3`, so
upgrading does not rebuild the projection the way the `security_policies2` to
`security_policies3` move did.

I used a nested message rather than a plain `bool` for symmetry with
`dynamic_client_registration` and to leave room for later options (allowlists,
software statements). Happy to flatten it to
`enable_client_id_metadata_document` if you prefer the `enable_impersonation`
shape.

## Resolution

- A new resolver fetches the document through the existing SSRF safe HTTP client
  (its operator denylist blocks loopback, private, link local and cloud metadata
  addresses at dial time), with a tight per request timeout and a bounded body.
- Because the fetch happens inline on the public, unauthenticated authorize
  endpoint, it is guarded against amplification: concurrent resolutions of the
  same `client_id` are collapsed with a singleflight group, and failures are
  negatively cached for a short floor so a repeated unresolvable `client_id` does
  not trigger an outbound request on every call.
- The document is parsed with the RFC 7591 metadata struct and mappers, a public
  (`none`) auth method is enforced, and only redirect URIs whose origin exactly
  matches the `client_id` URL are kept (scheme, host and port, host compared in
  lower case punycode form). The origin match is the trust anchor: a document can
  only authorize redirects back to the host that serves it.
- The validated document becomes an in memory `query.OIDCClient` with no project,
  no secret and no dev mode, wrapped through the existing `ClientFromBusiness`. It
  is cached per instance with a `Cache-Control` aware, capped TTL.
- The resolution is wired into every site that resolves a `client_id`:
  `GetClientByClientID` (authorize and v1 login), `VerifyClient` (token endpoint,
  where there is no secret to verify), `CreateAuthRequest` (CIMD clients always
  use the v2 login) and `createAuthRequestScopeAndAudience` (no project, so the
  audience is derived from the requested scopes).

Every resolution failure is answered with `invalid_client`, because at this layer
an unreachable or malformed document is not distinguishable from an unknown
client and both mean the same thing to the caller. Picking up the "do not mask
operational errors" thread from the reviews of #12313 and #12315, the underlying
cause is logged so an operator can tell a client side problem (bad document,
origin mismatch) from an instance side one (egress broken, denylist too wide).
It is logged at debug level on purpose: the `client_id` on that endpoint is
attacker controlled, so a higher level would let anyone fill the logs.

# Additional Changes

- **`go.mod` bump, and the discovery wrapper is gone.** `zitadel/oidc` v3.48.0
  carries `client_id_metadata_document_supported` (zitadel/oidc#904,
  zitadel/oidc#905), so the local wrapper around `oidc.DiscoveryConfiguration`
  that the previous revision of this PR needed is removed and the field is set
  directly in `createDiscoveryConfig`. This is the pickup you agreed to in the
  #12313 review. It is isolated in its own commit; the chi and otel bumps are the
  minimum versions the new release requires. No follow up cleanup PR needed.
- A dedicated `internal/cache` purpose and connector config
  (`ClientIDMetadataDocuments`) for the document cache.
- Docs: a Client ID Metadata Document integration guide and the discovery
  metadata on the OpenID Connect endpoints page. The guide notes that
  `SetSecuritySettings` replaces the whole policy, which is a sharp edge worth
  spelling out now that three features share it, and it lists the limitations you
  asked for on #12313 (no project, so `resource` / RFC 8707 does not narrow the
  audience).

# Additional Context

- Part of the MCP authorization effort, following #12313 (RFC 7591) and #12315
  (RFC 7592), both merged. Related issue #9810.
- Rebased onto `main` now that both land there, so the diff is CIMD only.
- Software statements (a signed JWT of the metadata) are left as a seam for a
  follow up.
- Testing note: the resolver is covered end to end by unit tests against an
  httptest TLS server (fetch, validation, origin match including punycode, IPv6
  and port normalization, public only enforcement, SSRF denylist, positive and
  negative caching), plus a table test pinning that resolution is gated on the
  setting rather than on the shape of the `client_id`. The integration tests
  assert the discovery advertisement, the no impact when disabled behavior, and
  that the interception actually runs in the live server by observing the
  outbound fetch (the server makes a connection to a test metadata host, then the
  TLS handshake fails). A full live authorize to token flow is not driven end to
  end for one reason only: CIMD is https only and the server's outbound client
  validates against the system roots, so it does not trust an in process test
  server's self signed certificate.
