### PR TITLE
fix(login): improve error handling for user registration

### DIFF
--- a/apps/login/src/lib/server/register.ts
+++ b/apps/login/src/lib/server/register.ts
@@ -87,6 +87,9 @@ export async function registerUser(
     lastName: command.lastName,
     password: command.password ? command.password : undefined,
     organization: command.organization,
+  }).catch((error) => {
+    logger.error("Failed to create user", { error, email: command.email });
+    return null;
   });
 
   if (!addResponse) {
@@ -110,8 +113,12 @@ export async function registerUser(
     checks,
     requestId: command.requestId,
     lifetime: command.password ? loginSettings?.passwordCheckLifetime : undefined,
+  }).catch((error) => {
+    logger.error("Failed to create session after user creation", { error, userId: addResponse.userId });
+    return null;
   });
-  const session = result.session;
+
+  const session = result?.session;
 
   if (!session || !session.factors?.user) {
     return { error: t("errors.couldNotCreateSession") };
@@ -144,9 +151,12 @@ export async function registerUser(
 
     return { redirect: "/passkey/set?" + params };
   } else {
-    const userResponse = await getUserByID({ serviceConfig, userId: session?.factors?.user?.id });
+    const userResponse = await getUserByID({ serviceConfig, userId: session?.factors?.user?.id }).catch((error) => {
+      logger.error("Failed to get user after session creation", { error, userId: session?.factors?.user?.id });
+      return null;
+    });
 
-    if (!userResponse.user) {
+    if (!userResponse?.user) {
       return { error: t("errors.userNotFound") };
     }
 

--- a/apps/login/src/lib/server/register.ts
+++ b/apps/login/src/lib/server/register.ts
@@ -88,7 +88,7 @@ export async function registerUser(
     password: command.password ? command.password : undefined,
     organization: command.organization,
   }).catch((error) => {
-    logger.error("Failed to create user", { error, email: command.email });
+    logger.error("Failed to create user", { error });
     return null;
   });
 
@@ -114,7 +114,7 @@ export async function registerUser(
     requestId: command.requestId,
     lifetime: command.password ? loginSettings?.passwordCheckLifetime : undefined,
   }).catch((error) => {
-    logger.error("Failed to create session after user creation", { error, userId: addResponse.userId });
+    logger.error("Failed to create session after user creation", { error });
     return null;
   });
 
@@ -152,7 +152,7 @@ export async function registerUser(
     return { redirect: "/passkey/set?" + params };
   } else {
     const userResponse = await getUserByID({ serviceConfig, userId: session?.factors?.user?.id }).catch((error) => {
-      logger.error("Failed to get user after session creation", { error, userId: session?.factors?.user?.id });
+      logger.error("Failed to get user after session creation", { error });
       return null;
     });
 


### PR DESCRIPTION
# Which Problems Are Solved

When the registerUser server action failed during registration, all errors from addHumanUser, createSessionWithRetry, and getUserByID propagated as uncaught exceptions to the client component's generic catch block, which always showed the same "Could not register user" message. This made it impossible to distinguish between user creation failures, session creation failures, and user lookup failures — both for end users and in server logs.

# How the Problems Are Solved

Added .catch() handlers on the three gRPC calls in registerUser that log the actual error and return null, allowing the existing null-check guard clauses to return step-specific error messages (couldNotCreateUser, couldNotCreateSession, userNotFound) through handleServerActionResponse. This gives users more specific feedback and provides server-side logging to narrow down the root cause of flaky signup failures.

