### PR TITLE
fix(login): Correct autocomplete attributes for credential and name autofill

### DIFF
--- a/apps/login/src/components/ldap-username-password-form.test.tsx
+++ b/apps/login/src/components/ldap-username-password-form.test.tsx
@@ -21,4 +21,9 @@ describe("LDAPUsernamePasswordForm", () => {
     const { getByTestId } = render(<LDAPUsernamePasswordForm idpId="idp-1" link={false} />);
     expect(getByTestId("username-text-input")).toHaveFocus();
   });
+
+  test("should set autocomplete=current-password on the password input", () => {
+    const { getByTestId } = render(<LDAPUsernamePasswordForm idpId="idp-1" link={false} />);
+    expect(getByTestId("password-text-input")).toHaveAttribute("autocomplete", "current-password");
+  });
 });

--- a/apps/login/src/components/ldap-username-password-form.tsx
+++ b/apps/login/src/components/ldap-username-password-form.tsx
@@ -98,7 +98,7 @@ export function LDAPUsernamePasswordForm({
       <div className={`${error && "animate-shake transform-gpu"}`}>
         <TextInput
           type="password"
-          autoComplete="password"
+          autoComplete="current-password"
           {...register("password", { required: t("required.password") })}
           label={t("labels.password")}
           data-testid="password-text-input"

--- a/apps/login/src/components/password-form.test.tsx
+++ b/apps/login/src/components/password-form.test.tsx
@@ -22,4 +22,21 @@ describe("PasswordForm", () => {
     const { getByTestId } = render(<PasswordForm loginSettings={undefined} loginName="test@example.com" />);
     expect(getByTestId("password-text-input")).toHaveFocus();
   });
+
+  test("should set autocomplete=current-password on the password input", () => {
+    const { getByTestId } = render(<PasswordForm loginSettings={undefined} loginName="test@example.com" />);
+    expect(getByTestId("password-text-input")).toHaveAttribute("autocomplete", "current-password");
+  });
+
+  test("should render the hidden username field before the password input when loginName is provided", () => {
+    const { container, getByTestId } = render(<PasswordForm loginSettings={undefined} loginName="test@example.com" />);
+
+    const username = container.querySelector('input[autocomplete="username"]');
+    expect(username).not.toBeNull();
+    expect(username).toHaveValue("test@example.com");
+
+    // password managers pair the password with a preceding username field
+    const password = getByTestId("password-text-input");
+    expect(username!.compareDocumentPosition(password) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/apps/login/src/components/password-form.tsx
+++ b/apps/login/src/components/password-form.tsx
@@ -113,9 +113,11 @@ export function PasswordForm({ loginSettings, loginName, organization, defaultOr
       {samlData && <AutoSubmitForm url={samlData.url} fields={samlData.fields} />}
       <form className="w-full">
         <div className={`${error && "animate-shake transform-gpu"}`}>
+          {loginName && <input type="hidden" name="loginName" autoComplete="username" value={loginName} />}
+
           <TextInput
             type="password"
-            autoComplete="password"
+            autoComplete="current-password"
             autoFocus
             {...register("password", { required: t("verify.required.password") })}
             label={t("verify.labels.password")}
@@ -132,8 +134,6 @@ export function PasswordForm({ loginSettings, loginName, organization, defaultOr
               <Translated i18nKey="verify.resetPassword" namespace="password" />
             </button>
           )}
-
-          {loginName && <input type="hidden" name="loginName" autoComplete="username" value={loginName} />}
         </div>
 
         {info && (

--- a/apps/login/src/components/register-form-idp-incomplete.test.tsx
+++ b/apps/login/src/components/register-form-idp-incomplete.test.tsx
@@ -37,4 +37,10 @@ describe("RegisterFormIDPIncomplete", () => {
     const { getByTestId } = render(<RegisterFormIDPIncomplete {...defaultProps} idpUserName="existing-user" />);
     expect(getByTestId("firstname-text-input")).toHaveFocus();
   });
+
+  test("should set standard name autofill tokens on the name inputs", () => {
+    const { getByTestId } = render(<RegisterFormIDPIncomplete {...defaultProps} idpUserName="existing-user" />);
+    expect(getByTestId("firstname-text-input")).toHaveAttribute("autocomplete", "given-name");
+    expect(getByTestId("lastname-text-input")).toHaveAttribute("autocomplete", "family-name");
+  });
 });

--- a/apps/login/src/components/register-form-idp-incomplete.tsx
+++ b/apps/login/src/components/register-form-idp-incomplete.tsx
@@ -112,8 +112,8 @@ export function RegisterFormIDPIncomplete({
           <div className="grid grid-cols-2 gap-4">
             <div className="">
               <TextInput
-                type="firstname"
-                autoComplete="firstname"
+                type="text"
+                autoComplete="given-name"
                 autoFocus={!!idpUserName}
                 required
                 {...register("firstname", { required: t("required.firstname") })}
@@ -124,8 +124,8 @@ export function RegisterFormIDPIncomplete({
             </div>
             <div className="">
               <TextInput
-                type="lastname"
-                autoComplete="lastname"
+                type="text"
+                autoComplete="family-name"
                 required
                 {...register("lastname", { required: t("required.lastname") })}
                 label={t("labels.lastname")}

--- a/apps/login/src/components/register-form.test.tsx
+++ b/apps/login/src/components/register-form.test.tsx
@@ -29,4 +29,10 @@ describe("RegisterForm", () => {
     const { getByTestId } = render(<RegisterForm legal={defaultLegal} organization="org-1" idpCount={0} />);
     expect(getByTestId("firstname-text-input")).toHaveFocus();
   });
+
+  test("should set standard name autofill tokens on the name inputs", () => {
+    const { getByTestId } = render(<RegisterForm legal={defaultLegal} organization="org-1" idpCount={0} />);
+    expect(getByTestId("firstname-text-input")).toHaveAttribute("autocomplete", "given-name");
+    expect(getByTestId("lastname-text-input")).toHaveAttribute("autocomplete", "family-name");
+  });
 });

--- a/apps/login/src/components/register-form.tsx
+++ b/apps/login/src/components/register-form.tsx
@@ -120,8 +120,8 @@ export function RegisterForm({
         <div className="mb-4 grid grid-cols-2 gap-4">
           <div className="">
             <TextInput
-              type="firstname"
-              autoComplete="firstname"
+              type="text"
+              autoComplete="given-name"
               autoFocus
               required
               {...register("firstname", { required: t("required.firstname") })}
@@ -132,8 +132,8 @@ export function RegisterForm({
           </div>
           <div className="">
             <TextInput
-              type="lastname"
-              autoComplete="lastname"
+              type="text"
+              autoComplete="family-name"
               required
               {...register("lastname", { required: t("required.lastname") })}
               label={t("labels.lastname")}

--- a/apps/login/src/components/set-password-form.test.tsx
+++ b/apps/login/src/components/set-password-form.test.tsx
@@ -56,4 +56,22 @@ describe("SetPasswordForm", () => {
     );
     expect(getByTestId("password-set-text-input")).toHaveFocus();
   });
+
+  test("should render a hidden username field before the password input so managers save the right account", () => {
+    const { container, getByTestId } = render(
+      <SetPasswordForm
+        passwordComplexitySettings={defaultComplexitySettings}
+        loginName="test@example.com"
+        userId="user-1"
+        codeRequired={false}
+      />,
+    );
+
+    const username = container.querySelector('input[autocomplete="username"]');
+    expect(username).not.toBeNull();
+    expect(username).toHaveValue("test@example.com");
+
+    const password = getByTestId("password-set-text-input");
+    expect(username!.compareDocumentPosition(password) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/apps/login/src/components/set-password-form.test.tsx
+++ b/apps/login/src/components/set-password-form.test.tsx
@@ -57,21 +57,25 @@ describe("SetPasswordForm", () => {
     expect(getByTestId("password-set-text-input")).toHaveFocus();
   });
 
-  test("should render a hidden username field before the password input so managers save the right account", () => {
-    const { container, getByTestId } = render(
-      <SetPasswordForm
-        passwordComplexitySettings={defaultComplexitySettings}
-        loginName="test@example.com"
-        userId="user-1"
-        codeRequired={false}
-      />,
-    );
+  test.each([true, false])(
+    "should render a hidden username field immediately before the password input (codeRequired=%s)",
+    (codeRequired) => {
+      const { container, getByTestId } = render(
+        <SetPasswordForm
+          passwordComplexitySettings={defaultComplexitySettings}
+          loginName="test@example.com"
+          userId="user-1"
+          codeRequired={codeRequired}
+        />,
+      );
 
-    const username = container.querySelector('input[autocomplete="username"]');
-    expect(username).not.toBeNull();
-    expect(username).toHaveValue("test@example.com");
+      const username = container.querySelector('input[autocomplete="username"]');
+      expect(username).not.toBeNull();
+      expect(username).toHaveValue("test@example.com");
 
-    const password = getByTestId("password-set-text-input");
-    expect(username!.compareDocumentPosition(password) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
+      const password = getByTestId("password-set-text-input") as HTMLInputElement;
+      const inputs = Array.from(container.querySelectorAll("input"));
+      expect(inputs[inputs.indexOf(password) - 1]).toBe(username);
+    },
+  );
 });

--- a/apps/login/src/components/set-password-form.tsx
+++ b/apps/login/src/components/set-password-form.tsx
@@ -194,6 +194,8 @@ export function SetPasswordForm({
               </div>
             </Alert>
           )}
+          {loginName && <input type="hidden" name="loginName" autoComplete="username" value={loginName} />}
+
           {codeRequired && (
             <div>
               <TextInput

--- a/apps/login/src/components/set-password-form.tsx
+++ b/apps/login/src/components/set-password-form.tsx
@@ -194,8 +194,6 @@ export function SetPasswordForm({
               </div>
             </Alert>
           )}
-          {loginName && <input type="hidden" name="loginName" autoComplete="username" value={loginName} />}
-
           {codeRequired && (
             <div>
               <TextInput
@@ -212,6 +210,8 @@ export function SetPasswordForm({
               />
             </div>
           )}
+          {loginName && <input type="hidden" name="loginName" autoComplete="username" value={loginName} />}
+
           <div>
             <TextInput
               type="password"


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- On the password step, the username field (`autocomplete="username"`) was rendered after the autofocused password input, and the password input used an invalid `autocomplete="password"` token. With macOS Passwords and Safari for example, this caused both stored values to be filled into the single focused field (e.g. `pass` + `user` -> `passuser`).
- The LDAP username/password form used the same invalid `autocomplete="password"` token.
- The registration forms used non-standard `firstname`/`lastname` autocomplete tokens (with matching invalid `type` values), which browsers ignore, so name autofill never triggered.
- The set/update-password form had no username field (not even a hidden one), so password managers saved the OTP code as the account name instead of the login name.

# How the Problems Are Solved

- Render the hidden username field before the password input and switch the password input to `autocomplete="current-password"`.
- Use `autocomplete="given-name"` / `autocomplete="family-name"` with `type="text"` on the registration name fields.
- Add a hidden `autocomplete="username"` field carrying the login name before the password fields on the set/update-password form.
- Use `autocomplete="current-password"` on the LDAP password field.
- Add tests asserting the autocomplete attributes and the hidden username fields.

# Additional Changes

- None.

# Additional Context

- Closes:
    - #11416
    - #12273
        Item 3 (`UsernameForm` using `type="email"` when email-only login is configured) is intentionally not changed: to my understanding, Zitadel has no email-only login mode. Login settings expose only `disable_login_with_email` and `disable_login_with_phone`, and the login-name field always accepts a username (hence, when both are disabled the field is username-only). Forcing `type="email"` would reject valid usernames, so `type="text"` with `autocomplete="username"` is the correct approach.