### PR TITLE
fix(console): restore forced user initial password change

### DIFF
--- a/console/src/app/pages/users/user-create/user-create-v2/user-create-v2.component.ts
+++ b/console/src/app/pages/users/user-create/user-create-v2/user-create-v2.component.ts
@@ -212,6 +212,7 @@ export class UserCreateV2Component implements OnInit {
         case: 'password',
         value: {
           password,
+          changeRequired: true,
         },
       };
     }


### PR DESCRIPTION
# Which Problems Are Solved

  - After upgrading from ZITADEL v3 to v4, when an admin creates a user with an initial password via the Management Console, the user is no longer forced to change their password on first login. 
- Forcing a password change on first login is an important security control: it ensures the admin-chosen initial password (which may have been transmitted over chat, email, or other side channels) cannot be reused as the user's long-lived credential.
# How the Problems Are Solved

- The new V2 user-create Console component (`user-create-v2.component.ts`) now sets `changeRequired: true` on the `Password` message when building the `AddHumanUserRequest`, restoring the behavior of the V1 path.

# Additional Changes

- None.

# Additional Context

- The regression is not a backend code change. The V2 User API (`AddUserRequestToAddHuman` in `internal/api/grpc/user/v2/user.go`) has always read `change_required` from the proto request — defaulting to `false` per proto3 semantics. The V1 Management API (`AddHumanUserRequestToAddHuman` in `internal/api/grpc/management/user.go`)hardcodes `PasswordChangeRequired: true` for admin-set initial passwords.
- The Console picks between v1 and v2 user-create components via the `ConsoleUseV2UserApi` feature flag. The flag's default flipped from `false` to `true` in v4.2.0 (commit `7ba6870ba`), silently switching the Console from the v1 path (hardcoded `true`) to the v2 path (defaulting to `false`) and dropping the change-required bit.
- The fix is scoped to the Console caller; the V2 API contract is intentionally caller-controlled and is left unchanged so other v2 consumers (login app, SDKs, terraform provider) are unaffected.
