### PR TITLE
fix: Add RootCA assignment to LDAPIDPWriteModel.reduceChangedEvent

### DIFF
--- a/internal/command/idp_model.go
+++ b/internal/command/idp_model.go
@@ -1490,6 +1490,9 @@ func (wm *LDAPIDPWriteModel) reduceChangedEvent(e *idp.LDAPIDPChangedEvent) {
 	if e.Timeout != nil {
 		wm.Timeout = *e.Timeout
 	}
+	if e.RootCA != nil {
+    	wm.RootCA = e.RootCA
+	}
 	wm.LDAPAttributes.ReduceChanges(e.LDAPAttributeChanges)
 	wm.Options.ReduceChanges(e.OptionChanges)
 }

--- a/internal/command/idp_model.go
+++ b/internal/command/idp_model.go
@@ -1460,9 +1460,6 @@ func (wm *LDAPIDPWriteModel) reduceChangedEvent(e *idp.LDAPIDPChangedEvent) {
 	if e.Name != nil {
 		wm.Name = *e.Name
 	}
-	if e.Name != nil {
-		wm.Name = *e.Name
-	}
 	if e.Servers != nil {
 		wm.Servers = e.Servers
 	}
@@ -1491,7 +1488,7 @@ func (wm *LDAPIDPWriteModel) reduceChangedEvent(e *idp.LDAPIDPChangedEvent) {
 		wm.Timeout = *e.Timeout
 	}
 	if e.RootCA != nil {
-    	wm.RootCA = e.RootCA
+		wm.RootCA = e.RootCA
 	}
 	wm.LDAPAttributes.ReduceChanges(e.LDAPAttributeChanges)
 	wm.Options.ReduceChanges(e.OptionChanges)


### PR DESCRIPTION
# Which Problems Are Solved

Resolves #12364

`StartIdentityProviderIntent` builds the LDAP provider from the
command-side write model (`GetProvider` → `LDAPIDPWriteModel.ToProvider` →
`ldap.New(..., wm.RootCA, ...)`). In `internal/command/idp_model.go`,
`reduceAddedEvent` sets `wm.RootCA = e.RootCA`, but **`reduceChangedEvent` never
assigns `RootCA`** — it updates every other LDAP field (Servers, StartTLS, BaseDN,
BindDN, BindPassword, UserBase, UserObjectClasses, UserFilters, Timeout, attributes,
options) but has no `RootCA` branch.

So an IdP that was **created with an empty/placeholder `rootCA` and later updated**
with the real CA keeps an empty `RootCA` in the write model → `ldap.New` gets no
custom CA → Go verifies against system roots only → private CA is "unknown authority".

The `LDAPIDPChangedEvent` **does** carry the new CA (visible in the eventstore:
`org.idp.ldap.changed` payload with `rootCA` set), and the **projection**
(`projections.idp_templates6_ldap2.root_ca`) is updated correctly — which is why
`GetProviderByID`/console show the right CA and mask the bug. Only the write model
used by the actual bind is stale.

# How the Problems Are Solved

In `internal/command/idp_model.go`, `LDAPIDPWriteModel.reduceChangedEvent`, add:

```go
if e.RootCA != nil {
    wm.RootCA = e.RootCA
}
```

# Additional Changes

None

# Additional Context

- Closes #12364
