### PR TITLE
fix(login): show error message when TOTP registration code verification fails

### DIFF
--- a/apps/login/locales/ar.json
+++ b/apps/login/locales/ar.json
@@ -404,6 +404,8 @@
       "couldNotVerifyInvite": "تعذر التحقق من الدعوة",
       "couldNotVerifyEmail": "تعذر التحقق من البريد الإلكتروني",
       "couldNotVerify": "تعذر التحقق",
+      "couldNotVerifyTOTP": "تعذر التحقق من الرمز",
+      "invalidCode": "الرمز غير صالح. يرجى المحاولة مرة أخرى.",
       "couldNotLoadUser": "تعذر تحميل المستخدم",
       "couldNotLoadAuthenticators": "تعذر تحميل المصادقين المحتملين",
       "couldNotCreateSession": "تعذر إنشاء الجلسة",

--- a/apps/login/locales/de.json
+++ b/apps/login/locales/de.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Einladung konnte nicht verifiziert werden",
       "couldNotVerifyEmail": "E-Mail konnte nicht verifiziert werden",
       "couldNotVerify": "Konnte nicht verifizieren",
+      "couldNotVerifyTOTP": "Code konnte nicht verifiziert werden",
+      "invalidCode": "Der Code ist ungültig. Bitte versuchen Sie es erneut.",
       "couldNotLoadUser": "Benutzer konnte nicht geladen werden",
       "couldNotLoadAuthenticators": "Mögliche Authentifikatoren konnten nicht geladen werden",
       "couldNotCreateSession": "Sitzung konnte nicht erstellt werden",

--- a/apps/login/locales/en.json
+++ b/apps/login/locales/en.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Could not verify invite",
       "couldNotVerifyEmail": "Could not verify email",
       "couldNotVerify": "Could not verify",
+      "couldNotVerifyTOTP": "Could not verify code",
+      "invalidCode": "The code is invalid. Please try again.",
       "couldNotLoadUser": "Could not load user",
       "couldNotLoadAuthenticators": "Could not load possible authenticators",
       "couldNotCreateSession": "Could not create session",

--- a/apps/login/locales/es.json
+++ b/apps/login/locales/es.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "No se pudo verificar la invitación",
       "couldNotVerifyEmail": "No se pudo verificar el correo electrónico",
       "couldNotVerify": "No se pudo verificar",
+      "couldNotVerifyTOTP": "No se pudo verificar el código",
+      "invalidCode": "El código no es válido. Inténtelo de nuevo.",
       "couldNotLoadUser": "No se pudo cargar al usuario",
       "couldNotLoadAuthenticators": "No se pudieron cargar los autenticadores posibles",
       "couldNotCreateSession": "No se pudo crear la sesión",

--- a/apps/login/locales/fr.json
+++ b/apps/login/locales/fr.json
@@ -373,6 +373,8 @@
       "couldNotVerifyInvite": "Impossible de vérifier l'invitation",
       "couldNotVerifyEmail": "Impossible de vérifier l'e-mail",
       "couldNotVerify": "Impossible de vérifier",
+      "couldNotVerifyTOTP": "Impossible de vérifier le code",
+      "invalidCode": "Le code est invalide. Veuillez réessayer.",
       "couldNotLoadUser": "Impossible de charger l'utilisateur",
       "couldNotLoadAuthenticators": "Impossible de charger les authentificateurs disponibles",
       "couldNotCreateSession": "Impossible de créer la session",

--- a/apps/login/locales/it.json
+++ b/apps/login/locales/it.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Impossibile verificare l'invito",
       "couldNotVerifyEmail": "Impossibile verificare l'email",
       "couldNotVerify": "Impossibile verificare",
+      "couldNotVerifyTOTP": "Impossibile verificare il codice",
+      "invalidCode": "Il codice non è valido. Riprova.",
       "couldNotLoadUser": "Impossibile caricare l'utente",
       "couldNotLoadAuthenticators": "Impossibile caricare gli autenticatori possibili",
       "couldNotCreateSession": "Impossibile creare la sessione",

--- a/apps/login/locales/ja.json
+++ b/apps/login/locales/ja.json
@@ -398,6 +398,8 @@
       "couldNotVerifyInvite": "招待を確認できませんでした",
       "couldNotVerifyEmail": "メールアドレスを確認できませんでした",
       "couldNotVerify": "確認できませんでした",
+      "couldNotVerifyTOTP": "コードを確認できませんでした",
+      "invalidCode": "コードが無効です。もう一度お試しください。",
       "couldNotLoadUser": "ユーザーを読み込めませんでした",
       "couldNotLoadAuthenticators": "認証方法を読み込めませんでした",
       "couldNotCreateSession": "セッションを作成できませんでした",

--- a/apps/login/locales/nl.json
+++ b/apps/login/locales/nl.json
@@ -403,6 +403,8 @@
       "couldNotVerifyInvite": "Kon uitnodiging niet verifiëren",
       "couldNotVerifyEmail": "Kon e-mail niet verifiëren",
       "couldNotVerify": "Kon niet verifiëren",
+      "couldNotVerifyTOTP": "Kon de code niet verifiëren",
+      "invalidCode": "De code is ongeldig. Probeer het opnieuw.",
       "couldNotLoadUser": "Kon gebruiker niet laden",
       "couldNotLoadAuthenticators": "Kon mogelijke authenticators niet laden",
       "couldNotCreateSession": "Kon sessie niet aanmaken",

--- a/apps/login/locales/pl.json
+++ b/apps/login/locales/pl.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Nie udało się zweryfikować zaproszenia",
       "couldNotVerifyEmail": "Nie udało się zweryfikować adresu e-mail",
       "couldNotVerify": "Nie udało się zweryfikować",
+      "couldNotVerifyTOTP": "Nie udało się zweryfikować kodu",
+      "invalidCode": "Kod jest nieprawidłowy. Spróbuj ponownie.",
       "couldNotLoadUser": "Nie udało się załadować użytkownika",
       "couldNotLoadAuthenticators": "Nie udało się wczytać dostępnych metod uwierzytelniania",
       "couldNotCreateSession": "Nie udało się utworzyć sesji",

--- a/apps/login/locales/pt.json
+++ b/apps/login/locales/pt.json
@@ -404,6 +404,8 @@
       "couldNotVerifyInvite": "Não foi possível verificar o convite",
       "couldNotVerifyEmail": "Não foi possível verificar o e-mail",
       "couldNotVerify": "Não foi possível verificar",
+      "couldNotVerifyTOTP": "Não foi possível verificar o código",
+      "invalidCode": "O código é inválido. Tente novamente.",
       "couldNotLoadUser": "Não foi possível carregar o usuário",
       "couldNotLoadAuthenticators": "Não foi possível carregar os autenticadores disponíveis",
       "couldNotCreateSession": "Não foi possível criar a sessão",

--- a/apps/login/locales/ru.json
+++ b/apps/login/locales/ru.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Не удалось подтвердить приглашение",
       "couldNotVerifyEmail": "Не удалось подтвердить электронную почту",
       "couldNotVerify": "Не удалось подтвердить",
+      "couldNotVerifyTOTP": "Не удалось подтвердить код",
+      "invalidCode": "Неверный код. Пожалуйста, попробуйте снова.",
       "couldNotLoadUser": "Не удалось загрузить пользователя",
       "couldNotLoadAuthenticators": "Не удалось загрузить доступные средства аутентификации",
       "couldNotCreateSession": "Не удалось создать сеанс",

--- a/apps/login/locales/tr.json
+++ b/apps/login/locales/tr.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Davet doğrulanamadı",
       "couldNotVerifyEmail": "E-posta doğrulanamadı",
       "couldNotVerify": "Doğrulanamadı",
+      "couldNotVerifyTOTP": "Kod doğrulanamadı",
+      "invalidCode": "Kod geçersiz. Lütfen tekrar deneyin.",
       "couldNotLoadUser": "Kullanıcı yüklenemedi",
       "couldNotLoadAuthenticators": "Olası kimlik doğrulayıcılar yüklenemedi",
       "couldNotCreateSession": "Oturum oluşturulamadı",

--- a/apps/login/locales/uk.json
+++ b/apps/login/locales/uk.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "Не вдалося підтвердити запрошення",
       "couldNotVerifyEmail": "Не вдалося підтвердити електронну пошту",
       "couldNotVerify": "Не вдалося підтвердити",
+      "couldNotVerifyTOTP": "Не вдалося підтвердити код",
+      "invalidCode": "Невірний код. Будь ласка, спробуйте ще раз.",
       "couldNotLoadUser": "Не вдалося завантажити користувача",
       "couldNotLoadAuthenticators": "Не вдалося завантажити можливі автентифікатори",
       "couldNotCreateSession": "Не вдалося створити сеанс",

--- a/apps/login/locales/zh.json
+++ b/apps/login/locales/zh.json
@@ -405,6 +405,8 @@
       "couldNotVerifyInvite": "无法验证邀请",
       "couldNotVerifyEmail": "无法验证邮箱",
       "couldNotVerify": "无法验证",
+      "couldNotVerifyTOTP": "无法验证验证码",
+      "invalidCode": "验证码无效。请重试。",
       "couldNotLoadUser": "无法加载用户",
       "couldNotLoadAuthenticators": "无法加载可用的身份验证器",
       "couldNotCreateSession": "无法创建会话",

--- a/apps/login/src/components/totp-register.test.tsx
+++ b/apps/login/src/components/totp-register.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, render } from "@testing-library/react";
+import { verifyTOTP } from "@/lib/server/verify";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { TotpRegister } from "./totp-register";
 
@@ -29,5 +30,19 @@ describe("TotpRegister", () => {
   test("should autofocus the code input on mount", () => {
     const { getByTestId } = render(<TotpRegister uri="otpauth://totp/test" secret="SECRET" />);
     expect(getByTestId("code-text-input")).toHaveFocus();
+  });
+
+  test("should show the error returned by verifyTOTP when code verification fails", async () => {
+    vi.mocked(verifyTOTP).mockResolvedValue({ error: "The code is invalid. Please try again." });
+
+    const { getByTestId, findByText } = render(
+      <TotpRegister uri="otpauth://totp/test" secret="SECRET" loginName="user@example.com" />,
+    );
+
+    fireEvent.input(getByTestId("code-text-input"), { target: { value: "123456" } });
+    await waitFor(() => expect(getByTestId("submit-button")).toBeEnabled());
+    fireEvent.click(getByTestId("submit-button"));
+
+    expect(await findByText("The code is invalid. Please try again.")).toBeInTheDocument();
   });
 });

--- a/apps/login/src/components/totp-register.tsx
+++ b/apps/login/src/components/totp-register.tsx
@@ -50,7 +50,12 @@ export function TotpRegister({ uri, loginName, sessionId, requestId, organizatio
   async function continueWithCode(values: Inputs) {
     setLoading(true);
     return verifyTOTP(values.code, loginName, organization)
-      .then(async () => {
+      .then(async (response) => {
+        if (response && "error" in response && response.error) {
+          setError(response.error);
+          return;
+        }
+
         // if attribute is set, validate MFA after it is setup, otherwise proceed as usual (when mfa is enforced to login)
         if (checkAfter) {
           const params = new URLSearchParams({});

--- a/apps/login/src/lib/server/verify.ts
+++ b/apps/login/src/lib/server/verify.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { isClassifiedError } from "@/lib/grpc/interceptors/error-classification";
 import { createLogger } from "@/lib/logger";
 import {
   createInviteCode,
@@ -14,6 +15,7 @@ import {
 } from "@/lib/zitadel";
 import crypto from "crypto";
 
+import { Code } from "@connectrpc/connect";
 import { create } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
@@ -32,6 +34,7 @@ import { getPublicHostWithProtocol } from "./host";
 const logger = createLogger("verify");
 
 export async function verifyTOTP(code: string, loginName?: string, organization?: string) {
+  const t = await getTranslations("verify");
   const _headers = await headers();
   const { serviceConfig } = getServiceConfig(_headers);
 
@@ -43,9 +46,21 @@ export async function verifyTOTP(code: string, loginName?: string, organization?
     },
   }).then((session) => {
     if (session?.factors?.user?.id) {
-      return verifyTOTPRegistration({ serviceConfig, code, userId: session.factors.user.id });
+      return verifyTOTPRegistration({ serviceConfig, code, userId: session.factors.user.id }).catch((error) => {
+        if (isClassifiedError(error) && error.isUserError) {
+          logger.warn("Could not verify TOTP registration (client error)", {
+            grpcCode: error.code,
+            httpStatus: error.httpStatus,
+          });
+          return {
+            error: error.code === Code.InvalidArgument ? t("errors.invalidCode") : t("errors.couldNotVerifyTOTP"),
+          };
+        }
+        logger.error("Could not verify TOTP registration", { error });
+        return { error: t("errors.couldNotVerifyTOTP") };
+      });
     } else {
-      throw Error("No user id found in session.");
+      return { error: t("errors.couldNotVerify") };
     }
   });
 }


### PR DESCRIPTION
# Which Problems Are Solved

When a user enters a wrong code during TOTP registration (`/otp/time-based/set`), the `verifyTOTP` server action lets the `ConnectError` (`invalid_argument: Code is invalid (EVENT-8isk2)`) escape uncaught. Next.js redacts thrown server-action error messages in production builds, so instead of being told the code is invalid, the user sees:

> An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.

The user has no way to understand what went wrong or that simply retrying with a fresh code would succeed. Observed in production against ZITADEL v4.15.1 (login container `ghcr.io/zitadel/zitadel-login:v4.15.1`); the code path is unchanged on `main`.

The same applies when no user id is found in the most recent session (previously a raw `throw Error(...)`).

# How the Problems Are Solved

- `verifyTOTP` (`apps/login/src/lib/server/verify.ts`) now catches errors from `verifyTOTPRegistration` and returns `{ error }` — the same pattern its sibling email/invite verification actions in the same file already use.
- The existing error-classification interceptor is used to distinguish failures: `Code.InvalidArgument` (wrong code) returns a dedicated "The code is invalid. Please try again." message; other user errors and server failures return a generic "Could not verify code". Client errors are logged at `warn`, server failures at `error`.
- The missing-session branch returns `{ error }` instead of throwing.
- `TotpRegister` (`apps/login/src/components/totp-register.tsx`) checks the response for `error` and renders it in the existing `<Alert>`, instead of only relying on the (production-redacted) rejection message.

# Additional Changes

- Two new translation keys (`verify.errors.invalidCode`, `verify.errors.couldNotVerifyTOTP`) added to all 14 locale files.
- New unit test in `totp-register.test.tsx` asserting the returned error is rendered.

# Additional Context

- Same underlying failure mode (uncaught server-action error → redacted Server Components error in production) as reported in #12306, with a different trigger.
- Verified locally: `@zitadel/login` unit tests 809/809 pass, prettier clean, `tsc --noEmit` introduces no new errors relative to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
