### PR TITLE
chore: edit issue templates to encourage GitHub account linking for Cloud customers

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -8,6 +8,8 @@ body:
     value: |
       Thanks for taking the time to fill out this bug report!  
       Learn more in our [contribution guide](https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#product-management) on how we will process your issue.
+
+      **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
 - type: checkboxes
   id: preflight
   attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -9,7 +9,7 @@ body:
       Thanks for taking the time to fill out this bug report!  
       Learn more in our [contribution guide](https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#product-management) on how we will process your issue.
 
-      **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
+      **To help us better prioritize your bug report**, if you have an active ZITADEL Cloud subscription, please [link your GitHub account to your Cloud account in the Customer Portal](https://zitadel.com/admin/support).
 - type: checkboxes
   id: preflight
   attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to fill out this issue.
 
-        **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
+        **To help us better prioritize your issue**, if you have an active ZITADEL Cloud subscription, please [link your GitHub account to your Cloud account in the Customer Portal](https://zitadel.com/admin/support).
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -7,6 +7,8 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this issue.
+
+        **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this proposal / feature reqeust
+
+        **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -5,9 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this proposal / feature reqeust
+        Thanks for taking the time to fill out this proposal / feature request.
 
-        **To help us better prioritize your requests**, if you have an active subscription, please navigate to the ZITADEL Customer Portal to [link your GitHub account to your Cloud account](https://zitadel.com/admin/support).
+        **To help us better prioritize**, if you have an active ZITADEL Cloud subscription, please [link your GitHub account to your Cloud account in the Customer Portal](https://zitadel.com/admin/support).
   - type: checkboxes
     id: preflight
     attributes:


### PR DESCRIPTION
To help us better identify and prioritize issues and requests from our paying customers, this PR adds a quick callout to the top of our GitHub issue templates. It prompts users with active ZITADEL Cloud subscriptions to link their GitHub accounts to their Cloud accounts via the Customer Portal.