### PR TITLE
fix(login): avoid duplicate public host header when fetching security settings

### DIFF
--- a/apps/login/src/lib/server/security-settings.test.ts
+++ b/apps/login/src/lib/server/security-settings.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getIframeOrigins } from "./security-settings";
+
+// Suppress logger output during tests
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/deployment", () => ({
+  hasSystemUserCredentials: () => false,
+  hasLoginClientKey: () => false,
+  hasServiceUserToken: () => true,
+}));
+
+const RESPONSE = {
+  settings: {
+    embeddedIframe: {
+      enabled: true,
+      allowedOrigins: ["https://allowed.example.com"],
+    },
+  },
+};
+
+describe("getIframeOrigins", () => {
+  // Results are cached per instance host, so each test uses a fresh host
+  let instanceHost: string;
+  let seq = 0;
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    instanceHost = `instance-${++seq}.example.com`;
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(RESPONSE), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("ZITADEL_SERVICE_USER_TOKEN", "token");
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  // Headers combines duplicate names into a comma-separated value, which
+  // exposes headers that were accidentally sent twice
+  const sentHeaders = () => new Headers(fetchMock.mock.calls[0][1].headers);
+
+  test("sends instance and public host headers", async () => {
+    const origins = await getIframeOrigins("http://zitadel:8080", instanceHost, "public.example.com");
+
+    expect(origins).toEqual(["https://allowed.example.com"]);
+    expect(sentHeaders().get("x-zitadel-instance-host")).toBe(instanceHost);
+    expect(sentHeaders().get("x-zitadel-public-host")).toBe("public.example.com");
+  });
+
+  test("CUSTOM_REQUEST_HEADERS replaces derived headers regardless of casing", async () => {
+    vi.stubEnv("CUSTOM_REQUEST_HEADERS", "X-Zitadel-Public-Host:custom.example.com");
+
+    await getIframeOrigins("http://zitadel:8080", instanceHost, "public.example.com");
+
+    expect(sentHeaders().get("x-zitadel-public-host")).toBe("custom.example.com");
+  });
+
+  test("CUSTOM_REQUEST_HEADERS removes headers regardless of casing", async () => {
+    vi.stubEnv("CUSTOM_REQUEST_HEADERS", "X-Zitadel-Public-Host:");
+
+    await getIframeOrigins("http://zitadel:8080", instanceHost, "public.example.com");
+
+    expect(sentHeaders().get("x-zitadel-public-host")).toBeNull();
+  });
+});

--- a/apps/login/src/lib/server/security-settings.ts
+++ b/apps/login/src/lib/server/security-settings.ts
@@ -86,27 +86,25 @@ export async function getIframeOrigins(
 
 async function fetchIframeOrigins(baseUrl: string, instanceHost?: string, publicHost?: string): Promise<string[] | null> {
   const token = await resolveAuthToken();
-  const reqHeaders: Record<string, string> = {
+  // Headers (not a plain object) so CUSTOM_REQUEST_HEADERS entries replace
+  // derived headers regardless of name casing instead of duplicating them
+  const reqHeaders = new Headers({
     "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
-  };
+  });
 
   // Apply instance/public host headers — same pattern as createServerTransport
   if (instanceHost) {
-    reqHeaders["x-zitadel-instance-host"] = instanceHost;
+    reqHeaders.set("x-zitadel-instance-host", instanceHost);
   }
   if (publicHost) {
-    reqHeaders["x-zitadel-public-host"] = publicHost;
+    reqHeaders.set("x-zitadel-public-host", publicHost);
   }
 
   // Apply custom headers from environment
   applyCustomHeaders({
-    set: (key, value) => {
-      reqHeaders[key] = value;
-    },
-    remove: (key) => {
-      delete reqHeaders[key];
-    },
+    set: (key, value) => reqHeaders.set(key, value),
+    remove: (key) => reqHeaders.delete(key),
   });
 
   const response = await fetch(`${baseUrl}/zitadel.settings.v2.SettingsService/GetSecuritySettings`, {


### PR DESCRIPTION
# Which Problems Are Solved

The hosted login can't be embedded in an iframe even when the instance security policy enables it: every response sends `frame-ancestors 'none'`, and the login logs `Failed to fetch security settings from API` with status 404.

`fetchIframeOrigins` builds its request headers in a plain object, so header names are case-sensitive. It sets `x-zitadel-public-host`, then `applyCustomHeaders` applies `CUSTOM_REQUEST_HEADERS`. The Helm chart's default uses `X-Zitadel-Public-Host`, which adds a second key instead of replacing the first. Both are sent, ZITADEL joins them into one value (`"host, host"`), rejects the request as an untrusted domain (404), and the login falls back to the strict default CSP.

# How the Problems Are Solved

Build the request headers with a `Headers` instance instead of a plain object, matching `proxy.ts` and `createServerTransport`. `Headers.set()` is case-insensitive, so custom headers replace derived ones regardless of casing.

# Additional Changes

Adds tests for `getIframeOrigins` covering the custom-header override and removal cases.

# Additional Context

Reproduced on a self-hosted deployment (core + login v4.15.0, chart 10.0.2) using the chart's default `CUSTOM_REQUEST_HEADERS`.
