### PR TITLE
docs: clarify human PAT limitation and link issue #10915

### DIFF
--- a/apps/docs/content/guides/integrate/service-accounts/personal-access-token.mdx
+++ b/apps/docs/content/guides/integrate/service-accounts/personal-access-token.mdx
@@ -5,7 +5,7 @@ sidebar_label: Personal access token authentication
 ---
 
 A Personal Access Token (PAT) is a ready-to-use token that can be used as an _Authorization_ header.
-At the moment ZITADEL only allows PATs for service accounts.
+At the moment ZITADEL only allows PATs for service accounts. Human PATs are currently not supported. You can track and upvote this capability in [GitHub Issue #10915](https://github.com/zitadel/zitadel/issues/10915).
 
 It is an alternative to the [private key JWT](./private-key-jwt) and [client credentials](./client-credentials). Read more about the different [authentication methods for service accounts](./authenticate-service-accounts).
 


### PR DESCRIPTION
Clarifies that human PATs are currently not supported in the Personal Access Token documentation and links to GitHub Issue #10915 so users can track and upvote this capability.