### PR TITLE
fix(admin): export user grants after all project grants are collected

### DIFF
--- a/internal/api/grpc/admin/export.go
+++ b/internal/api/grpc/admin/export.go
@@ -222,7 +222,8 @@ func (s *Server) ExportData(ctx context.Context, req *admin_pb.ExportDataRequest
 		}
 
 		/******************************************************************************************************************
-		  Grants
+		  Project grants — collected for all orgs before user grants so authorizations on
+		  granted projects are not dropped when org export order differs from project-grant ownership.
 		  ******************************************************************************************************************/
 		org.ProjectGrants, err = s.getNecessaryProjectGrantsForOrg(ctx, org.OrgId, processedOrgs, processedProjects)
 		if err != nil {
@@ -231,7 +232,12 @@ func (s *Server) ExportData(ctx context.Context, req *admin_pb.ExportDataRequest
 		for _, processedGrant := range org.ProjectGrants {
 			processedGrants = append(processedGrants, processedGrant.GrantId)
 		}
+	}
 
+	for _, org := range orgs {
+		/******************************************************************************************************************
+		  Authorizations
+		  ******************************************************************************************************************/
 		org.UserGrants, err = s.getNecessaryUserGrantsForOrg(ctx, org.OrgId, processedProjects, processedGrants, processedUsers)
 		if err != nil {
 			return nil, err

--- a/internal/api/grpc/admin/integration_test/export_test.go
+++ b/internal/api/grpc/admin/integration_test/export_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/integration"
+	"github.com/zitadel/zitadel/pkg/grpc/admin"
+)
+
+func TestServer_ExportData_includesUserGrantsOnGrantedProject(t *testing.T) {
+	roleKey := integration.RoleKey()
+
+	selfOrgID := Instance.CreateOrganization(AdminCTX, integration.OrganizationName(), integration.Email()).OrganizationId
+	foreignOrg := Instance.CreateOrganization(AdminCTX, integration.OrganizationName(), integration.Email())
+
+	projectID := Instance.CreateProject(AdminCTX, t, foreignOrg.OrganizationId, integration.ProjectName(), false, false).Id
+	Instance.AddProjectRole(AdminCTX, t, projectID, roleKey, integration.RoleDisplayName(), "")
+	Instance.CreateProjectGrant(AdminCTX, t, projectID, selfOrgID, roleKey)
+
+	humanUser := Instance.CreateHumanUserVerified(AdminCTX, selfOrgID, integration.Email(), integration.Phone())
+	machineUser := Instance.CreateUserTypeMachine(AdminCTX, selfOrgID)
+	Instance.CreateAuthorizationProjectGrant(t, AdminCTX, projectID, selfOrgID, humanUser.GetUserId(), roleKey)
+	Instance.CreateAuthorizationProjectGrant(t, AdminCTX, projectID, selfOrgID, machineUser.GetId(), roleKey)
+
+	var export *admin.ExportDataResponse
+	require.Eventually(t, func() bool {
+		resp, err := Client.ExportData(AdminCTX, &admin.ExportDataRequest{
+			// Granted org before project owner org: export must not depend on org processing order.
+			OrgIds:         []string{selfOrgID, foreignOrg.OrganizationId},
+			WithPasswords:  true,
+			WithOtp:        true,
+			ResponseOutput: true,
+			Timeout:        time.Minute.String(),
+		})
+		if err != nil {
+			return false
+		}
+		export = resp
+		return userGrantsExported(export, selfOrgID, projectID, roleKey, humanUser.GetUserId(), machineUser.GetId())
+	}, time.Minute, 200*time.Millisecond)
+
+	require.True(t, userGrantsExported(export, selfOrgID, projectID, roleKey, humanUser.GetUserId(), machineUser.GetId()))
+}
+
+func userGrantsExported(export *admin.ExportDataResponse, orgID, projectID, roleKey string, userIDs ...string) bool {
+	for _, userID := range userIDs {
+		if !userGrantExported(export, orgID, userID, projectID, roleKey) {
+			return false
+		}
+	}
+	return true
+}
+
+func userGrantExported(export *admin.ExportDataResponse, orgID, userID, projectID, roleKey string) bool {
+	for _, org := range export.GetOrgs() {
+		if org.GetOrgId() != orgID {
+			continue
+		}
+		for _, grant := range org.GetUserGrants() {
+			if grant.GetUserId() != userID || grant.GetProjectId() != projectID {
+				continue
+			}
+			for _, key := range grant.GetRoleKeys() {
+				if key == roleKey {
+					return grant.GetProjectGrantId() != ""
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Which Problems Are Solved

When exporting multiple organizations via `POST /admin/v1/export`, `userGrants` for users who have role assignments on a granted project can be missing from the export payload, even though:

- the authorizations exist and are visible via `AuthorizationService/ListAuthorizations` (v2), and
- the export includes the owning org’s `projectGrants` and the granted org’s user.

This breaks migration/sync scenarios where consumers expect the export to be self-contained for import via `admin/v1/import`.

# How the Problems Are Solved

In `internal/api/grpc/admin/export.go`, `getNecessaryUserGrantsForOrg` only includes user grants when all cross-references are already in the “processed” sets:

- `projectId` ∈ `processedProjects`
- `userId` ∈ `processedUsers`
- if `userGrant.GrantID != ""`: grant id ∈ `processedGrants`

`processedGrants` is populated in the same loop that exports `userGrants` per org:

```go
for _, org := range orgs {
    org.ProjectGrants, err = s.getNecessaryProjectGrantsForOrg(...)
    for _, processedGrant := range org.ProjectGrants {
        processedGrants = append(processedGrants, processedGrant.GrantId)
    }
    org.UserGrants, err = s.getNecessaryUserGrantsForOrg(ctx, org.OrgId, processedProjects, processedGrants, processedUsers)
}
```

If the org that got the project grant is processed before the org that owns the project, `processedGrants` does not yet contain the grant id when granted org `userGrants` are computed, so those authorizations are silently dropped.

Additionally, `SearchOrgs` uses a SQL `IN (...)` filter (`NewOrgIDsSearchQuery`) and does not preserve `org_ids` request order, making this failure dependent on result ordering.

# Additional Changes

This PR also includes a test case for this scenario

# Additional Context

