### PR TITLE
docs: Fix Gzip link in Networking section

### DIFF
--- a/apps/docs/content/self-hosting/manage/production.mdx
+++ b/apps/docs/content/self-hosting/manage/production.mdx
@@ -32,7 +32,7 @@ Also, not all configuration options are available as environment variables.
 - To enable and restrict access to **HTTPS**, head over to [the description of your TLS options](/self-hosting/manage/tls_modes).
 - If you want to front ZITADEL with a reverse proxy, web application firewall or content delivery network, make sure to support **[HTTP/2](/self-hosting/manage/http2)**.
 - You can also refer to some **[example reverse proxy configurations](/self-hosting/manage/reverseproxy/reverse_proxy)**.
-- The ZITADEL Management Console web GUI uses many gRPC-Web stubs. This results in a fairly big JavaScript bundle. You might want to compress it using [Gzip](/self-hosting/manage/custom-domain) or [Brotli](https://www.gnu.org/software/gzip/) or [Brotli](https://github.com/google/brotli).
+- The ZITADEL Management Console web GUI uses many gRPC-Web stubs. This results in a fairly big JavaScript bundle. You might want to compress it using [Gzip](https://www.gnu.org/software/gzip/) or [Brotli](https://github.com/google/brotli).
 - Serving and caching the assets using a content delivery network could improve network latencies and shield your ZITADEL runtime.
 
 ## Monitoring


### PR DESCRIPTION
# Which Problems Are Solved

The link to the Gzip project was a bit messed up in the fifth item in the Deploy & Operate > Self-Hosted > Manage > Production & Operations > Production Setup > Networking bullet list in the documentation. There was one link with incorrect URL and one link with incorrect text.

# How the Problems Are Solved

Remove the one with incorrect URL and fixing the text in the one with correct URL.