### PR TITLE
Revert "docs: document TOTP issuer name configuration for self-hosted and cloud instances"

### DIFF
--- a/apps/docs/content/guides/manage/console/default-settings.mdx
+++ b/apps/docs/content/guides/manage/console/default-settings.mdx
@@ -197,13 +197,6 @@ Force a user to register and use a multifactor authentication, by checking the o
 Ensure that you have added the MFA methods you want to allow.
 Or you can enable the "Force MFA for local authenticated users", which will enforce this rule only on local authentication, but not on users authenticated through an Identity Provider.
 
-<Callout type="info" title="Customizing the TOTP issuer name">
-The issuer name shown in authenticator apps (e.g. Google Authenticator, Authy) when users register TOTP defaults to **ZITADEL**. It is not derived from your domain or instance name.
-
-- **Self-hosted:** Set the environment variable `ZITADEL_SYSTEMDEFAULTS_MULTIFACTORS_OTP_ISSUER=YourName`. Note that setting this via Helm values (`SystemDefaults.Multifactors.Issuer`) does **not** work — the raw environment variable must be used directly.
-- **ZITADEL Cloud:** The TOTP issuer name is not currently configurable. You can follow and upvote [this discussion](https://github.com/zitadel/zitadel/discussions/5453) to track progress.
-</Callout>
-
 ### Login Lifetimes
 
 Configure the different lifetimes checks for the login process:


### PR DESCRIPTION
Reverts zitadel/zitadel#12335