### PR TITLE
feat(login): add password visibility toggle to TextInput

### DIFF
--- a/apps/login/locales/ar.json
+++ b/apps/login/locales/ar.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "رجوع",
-    "title": "تسجيل الدخول باستخدام Zitadel"
+    "title": "تسجيل الدخول باستخدام Zitadel",
+    "showPassword": "إظهار كلمة المرور",
+    "hidePassword": "إخفاء كلمة المرور"
   },
   "accounts": {
     "title": "الحسابات",

--- a/apps/login/locales/de.json
+++ b/apps/login/locales/de.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Zurück",
-    "title": "Anmelden mit Zitadel"
+    "title": "Anmelden mit Zitadel",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort verbergen"
   },
   "accounts": {
     "title": "Konten",

--- a/apps/login/locales/en.json
+++ b/apps/login/locales/en.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Back",
-    "title": "Login with Zitadel"
+    "title": "Login with Zitadel",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   },
   "accounts": {
     "title": "Accounts",

--- a/apps/login/locales/es.json
+++ b/apps/login/locales/es.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Atrás",
-    "title": "Iniciar sesión con Zitadel"
+    "title": "Iniciar sesión con Zitadel",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña"
   },
   "accounts": {
     "title": "Cuentas",

--- a/apps/login/locales/fr.json
+++ b/apps/login/locales/fr.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Retour",
-    "title": "Connexion avec Zitadel"
+    "title": "Connexion avec Zitadel",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe"
   },
   "accounts": {
     "title": "Comptes",

--- a/apps/login/locales/it.json
+++ b/apps/login/locales/it.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Indietro",
-    "title": "Accedi con Zitadel"
+    "title": "Accedi con Zitadel",
+    "showPassword": "Mostra password",
+    "hidePassword": "Nascondi password"
   },
   "accounts": {
     "title": "Account",

--- a/apps/login/locales/ja.json
+++ b/apps/login/locales/ja.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "戻る",
-    "title": "Zitadelでログイン"
+    "title": "Zitadelでログイン",
+    "showPassword": "パスワードを表示",
+    "hidePassword": "パスワードを非表示"
   },
   "accounts": {
     "title": "アカウント",

--- a/apps/login/locales/nl.json
+++ b/apps/login/locales/nl.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Terug",
-    "title": "Inloggen met Zitadel"
+    "title": "Inloggen met Zitadel",
+    "showPassword": "Wachtwoord tonen",
+    "hidePassword": "Wachtwoord verbergen"
   },
   "accounts": {
     "title": "Accounts",

--- a/apps/login/locales/pl.json
+++ b/apps/login/locales/pl.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Powrót",
-    "title": "Zaloguj się za pomocą Zitadel"
+    "title": "Zaloguj się za pomocą Zitadel",
+    "showPassword": "Pokaż hasło",
+    "hidePassword": "Ukryj hasło"
   },
   "accounts": {
     "title": "Konta",

--- a/apps/login/locales/pt.json
+++ b/apps/login/locales/pt.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Voltar",
-    "title": "Entrar com Zitadel"
+    "title": "Entrar com Zitadel",
+    "showPassword": "Mostrar senha",
+    "hidePassword": "Ocultar senha"
   },
   "accounts": {
     "title": "Contas",

--- a/apps/login/locales/ru.json
+++ b/apps/login/locales/ru.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Назад",
-    "title": "Войти с Zitadel"
+    "title": "Войти с Zitadel",
+    "showPassword": "Показать пароль",
+    "hidePassword": "Скрыть пароль"
   },
   "accounts": {
     "title": "Аккаунты",

--- a/apps/login/locales/tr.json
+++ b/apps/login/locales/tr.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Geri",
-    "title": "Zitadel ile Giriş"
+    "title": "Zitadel ile Giriş",
+    "showPassword": "Parolayı göster",
+    "hidePassword": "Parolayı gizle"
   },
   "accounts": {
     "title": "Hesaplar",

--- a/apps/login/locales/uk.json
+++ b/apps/login/locales/uk.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "Назад",
-    "title": "Вхід через Zitadel"
+    "title": "Вхід через Zitadel",
+    "showPassword": "Показати пароль",
+    "hidePassword": "Сховати пароль"
   },
   "accounts": {
     "title": "Облікові записи",

--- a/apps/login/locales/zh.json
+++ b/apps/login/locales/zh.json
@@ -1,7 +1,9 @@
 {
   "common": {
     "back": "返回",
-    "title": "使用 Zitadel 登录"
+    "title": "使用 Zitadel 登录",
+    "showPassword": "显示密码",
+    "hidePassword": "隐藏密码"
   },
   "accounts": {
     "title": "账户",

--- a/apps/login/src/components/input.test.tsx
+++ b/apps/login/src/components/input.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TextInput } from "./input";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
 
 describe("TextInput Component", () => {
   const originalEnv = process.env;
@@ -189,6 +193,54 @@ describe("TextInput Component", () => {
       const { container } = render(<TextInput label="UniqueRequiredField" required />);
       const label = container.querySelector("label");
       expect(label?.textContent).toContain("*");
+    });
+  });
+
+  describe("Password Reveal Toggle", () => {
+    const revealButton = (container: HTMLElement) =>
+      container.querySelector('[data-testid="password-reveal-button"]') as HTMLButtonElement | null;
+
+    it("renders a reveal button for password inputs and toggles visibility", () => {
+      const { container } = render(<TextInput label="Password" type="password" />);
+      const input = container.querySelector("input");
+      const button = revealButton(container);
+
+      expect(input?.type).toBe("password");
+      expect(button?.getAttribute("aria-pressed")).toBe("false");
+
+      fireEvent.click(button!);
+      expect(input?.type).toBe("text");
+      expect(button?.getAttribute("aria-pressed")).toBe("true");
+
+      fireEvent.click(button!);
+      expect(input?.type).toBe("password");
+    });
+
+    it("does not render the reveal button for non-password inputs", () => {
+      const { container } = render(<TextInput label="Email" type="text" />);
+      expect(revealButton(container)).toBeNull();
+    });
+
+    it("hides the reveal button when showPasswordToggle is false", () => {
+      const { container } = render(<TextInput label="Password" type="password" showPasswordToggle={false} />);
+      expect(revealButton(container)).toBeNull();
+      expect(container.querySelector("input")?.type).toBe("password");
+    });
+
+    it("does not submit the surrounding form when the reveal button is clicked", () => {
+      let submitted = false;
+      const { container } = render(
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submitted = true;
+          }}
+        >
+          <TextInput label="Password" type="password" />
+        </form>,
+      );
+      fireEvent.click(revealButton(container)!);
+      expect(submitted).toBe(false);
     });
   });
 });

--- a/apps/login/src/components/input.tsx
+++ b/apps/login/src/components/input.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { getComponentRoundness } from "@/lib/theme";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon } from "@heroicons/react/24/solid";
 import { clsx } from "clsx";
-import { ChangeEvent, DetailedHTMLProps, forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { ChangeEvent, DetailedHTMLProps, forwardRef, InputHTMLAttributes, ReactNode, useState } from "react";
 
 export type TextInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
   label: string;
@@ -16,6 +18,7 @@ export type TextInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElem
   onChange?: (value: ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (value: ChangeEvent<HTMLInputElement>) => void;
   roundness?: string; // Allow override via props
+  showPasswordToggle?: boolean; // Escape hatch to hide the reveal button on password inputs
 };
 
 const styles = (error: boolean, disabled: boolean, roundnessClasses: string = "rounded-md") =>
@@ -51,12 +54,20 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       onChange,
       onBlur,
       roundness,
+      type,
+      showPasswordToggle = true,
       ...props
     },
     ref,
   ) => {
+    const t = useTranslations("common");
+
     // Use theme-based roundness if not explicitly provided
     const actualRoundness = roundness || getDefaultInputRoundness();
+
+    const [passwordRevealed, setPasswordRevealed] = useState(false);
+    const isPassword = type === "password";
+    const hasToggle = isPassword && showPasswordToggle && !disabled;
 
     return (
       <label className="text-12px text-input-light-label dark:text-input-dark-label relative flex flex-col">
@@ -66,7 +77,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         <input
           suppressHydrationWarning
           ref={ref}
-          className={styles(!!error, !!disabled, actualRoundness)}
+          className={clsx(styles(!!error, !!disabled, actualRoundness), hasToggle && "pr-10")}
           defaultValue={defaultValue}
           required={required}
           disabled={disabled}
@@ -75,7 +86,30 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           onChange={(e) => onChange && onChange(e)}
           onBlur={(e) => onBlur && onBlur(e)}
           {...props}
+          type={isPassword && passwordRevealed ? "text" : type}
         />
+
+        {hasToggle && (
+          <button
+            type="button"
+            data-testid="password-reveal-button"
+            aria-label={passwordRevealed ? t("hidePassword") : t("showPassword")}
+            aria-pressed={passwordRevealed}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.preventDefault();
+              setPasswordRevealed((revealed) => !revealed);
+            }}
+            className={clsx(
+              "absolute right-[3px] bottom-[22px] z-30 translate-y-1/2 transform p-2",
+              "text-gray-500 hover:text-black dark:text-gray-400 dark:hover:text-white",
+              "focus-visible:ring-primary-light-500 dark:focus-visible:ring-primary-dark-500 focus:outline-none focus-visible:ring-2",
+              actualRoundness.split(" ")[0],
+            )}
+          >
+            {passwordRevealed ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+          </button>
+        )}
 
         {suffix && (
           <span


### PR DESCRIPTION
## What

Adds an accessible show/hide ("eye") button to password fields in the Login UI. When a `TextInput` has `type="password"`, it renders a reveal button that toggles the field between `password` and `text`.

## Why

Users regularly want to see what they typed — especially on the set-password and change-password screens, to confirm the two password fields match. Login V2 currently has no way to reveal a password, and a visibility toggle is a common, expected affordance.

Because the toggle lives in the shared `TextInput` primitive, it applies to every password screen at once — login, set-password, change-password, register and LDAP — without changing those forms.

## Details

- The button is `type="button"` and calls `preventDefault`, so it never submits the surrounding form; `onMouseDown` preventDefault keeps focus and caret in the field.
- Accessible: translated `aria-label`, `aria-pressed`, and a visible `focus-visible` ring — works with keyboard and screen readers.
- Labels use the `common` i18n namespace (`showPassword` / `hidePassword`); all 14 locale files are updated.
- `pr-10` padding so long values don't run under the icon.
- Opt out per field via `showPasswordToggle={false}`.
- Reuses the existing `@heroicons/react` dependency (`EyeIcon` / `EyeSlashIcon`); no new deps.

## Tests

Added unit tests in `input.test.tsx`: the toggle switches the input `type` and `aria-pressed`; the button is absent for non-password inputs and when `showPasswordToggle={false}`; and clicking it does not submit the form. `pnpm --filter @zitadel/login test-unit` passes.

## Screenshots

<img width="286" height="421" alt="image" src="https://github.com/user-attachments/assets/b35da0bb-0354-43b7-9911-b1a1f8c6d42a" />