### PR TITLE
docs: update V2 end-of-support copy in roadmap

### DIFF
--- a/apps/docs/content/product/roadmap.mdx
+++ b/apps/docs/content/product/roadmap.mdx
@@ -118,7 +118,7 @@ The next iteration of Zitadel brings that visibility closer to the identity laye
 
 ## **Migration and Adoption**
 
-V2 has already reached end of support. Details on V3's end-of-support timeline and migration guidance will be published soon. During the transition, community contributions remain an important part of Zitadel. If you're maintaining a V4 deployment and would like to contribute fixes or improvements, we'll continue reviewing and working with contributors wherever those changes align with the long-term direction of the platform.
+V2 has already reached end-of-life (EOL). We'll be sharing V3's EOL timeline and upgrade guidance soon to help customers plan their upgrade with confidence. During the transition, community contributions remain an important part of Zitadel. If you're maintaining a V4 deployment and would like to contribute fixes or improvements, we'll continue reviewing and working with contributors wherever those changes align with the long-term direction of the platform.
 
 Before starting a larger contribution, we encourage you to open a GitHub issue first. This helps us validate the approach, share any relevant roadmap context, and ensure the work aligns with the direction of the platform.
 

--- a/apps/docs/content/product/roadmap.mdx
+++ b/apps/docs/content/product/roadmap.mdx
@@ -118,7 +118,7 @@ The next iteration of Zitadel brings that visibility closer to the identity laye
 
 ## **Migration and Adoption**
 
-We'll communicate end-of-support timelines for V2 and V3 well in advance, together with migration guidance, to help customers plan their adoption with confidence. During the transition, community contributions remain an important part of Zitadel. If you're maintaining a V4 deployment and would like to contribute fixes or improvements, we'll continue reviewing and working with contributors wherever those changes align with the long-term direction of the platform.
+V2 has already reached end of support. Details on V3's end-of-support timeline and migration guidance will be published soon. During the transition, community contributions remain an important part of Zitadel. If you're maintaining a V4 deployment and would like to contribute fixes or improvements, we'll continue reviewing and working with contributors wherever those changes align with the long-term direction of the platform.
 
 Before starting a larger contribution, we encourage you to open a GitHub issue first. This helps us validate the approach, share any relevant roadmap context, and ensure the work aligns with the direction of the platform.
 


### PR DESCRIPTION
## Summary
- V2 has already reached end of support; the roadmap page previously implied end-of-support timelines for V2 and V3 were both still forthcoming.
- Updated copy to state V2's end-of-support status plainly and note that V3's timeline and migration guidance will be published soon.

## Test plan
- [x] Verified the updated sentence renders correctly in `apps/docs/content/product/roadmap.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)