### PR TITLE
fix(queue): avoid panic when debug-logging InsertManyFast results

### DIFF
--- a/internal/execution/ctx.go
+++ b/internal/execution/ctx.go
@@ -15,5 +15,6 @@ func HandlerContext(parent context.Context, event *eventstore.Aggregate) context
 }
 
 func ContextWithExecuter(ctx context.Context, aggregate *eventstore.Aggregate) context.Context {
+	ctx = authz.WithInstanceID(ctx, aggregate.InstanceID)
 	return authz.SetCtxData(ctx, authz.CtxData{UserID: ExecutionUserID, OrgID: aggregate.ResourceOwner})
 }

--- a/internal/queue/log.go
+++ b/internal/queue/log.go
@@ -40,9 +40,13 @@ func (m *logMiddleware) InsertMany(
 		slog.Duration("duration", time.Since(start)),
 	)
 
-	// Only do expensive operations if debug is enabled
+	// Only do expensive operations if debug is enabled.
+	// Skip nil results: InsertManyFast returns empty slots with no job rows (#12225).
 	if m.logger.Enabled(ctx, slog.LevelDebug) {
 		for _, result := range results {
+			if result == nil || result.Job == nil {
+				continue
+			}
 			logging.Debug(ctx, "inserted job details", attributesFromJobInsertResult(result)...)
 		}
 	}

--- a/internal/queue/log_test.go
+++ b/internal/queue/log_test.go
@@ -1,0 +1,78 @@
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #12225: River InsertManyFast / InsertManyFastTx return a
+// count-sized slice of nil *JobInsertResult (no job rows). The queue log
+// middleware must not panic when detailing inserts under debug.
+func TestLogMiddleware_InsertMany_NilFastResultsDoNotPanic(t *testing.T) {
+	fastShapedNils := func(context.Context) ([]*rivertype.JobInsertResult, error) {
+		return make([]*rivertype.JobInsertResult, 3), nil
+	}
+	mixedResults := func(context.Context) ([]*rivertype.JobInsertResult, error) {
+		return []*rivertype.JobInsertResult{
+			nil,
+			{Job: nil},
+			{Job: &rivertype.JobRow{
+				ID:          1,
+				Kind:        "test",
+				Queue:       "default",
+				State:       rivertype.JobStateAvailable,
+				CreatedAt:   time.Now(),
+				ScheduledAt: time.Now(),
+			}},
+		}, nil
+	}
+
+	tests := []struct {
+		name     string
+		level    slog.Level
+		doInner  func(context.Context) ([]*rivertype.JobInsertResult, error)
+		wantLen  int
+	}{
+		{
+			name:    "debug, InsertManyFast-shaped nils",
+			level:   slog.LevelDebug,
+			doInner: fastShapedNils,
+			wantLen: 3,
+		},
+		{
+			name:    "info, InsertManyFast-shaped nils",
+			level:   slog.LevelInfo,
+			doInner: fastShapedNils,
+			wantLen: 3,
+		},
+		{
+			name:    "debug, mixed nil and populated results",
+			level:   slog.LevelDebug,
+			doInner: mixedResults,
+			wantLen: 3,
+		},
+		{
+			name:    "info, mixed nil and populated results",
+			level:   slog.LevelInfo,
+			doInner: mixedResults,
+			wantLen: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &logMiddleware{
+				logger: slog.New(slog.NewTextHandler(t.Output(), &slog.HandlerOptions{Level: tt.level})),
+			}
+			require.NotPanics(t, func() {
+				results, err := m.InsertMany(context.Background(), nil, tt.doInner)
+				require.NoError(t, err)
+				require.Len(t, results, tt.wantLen)
+			})
+		})
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -128,7 +128,7 @@ func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOp
 //
 // Opts are applied to each job before sending them to river.
 func (q *Queue) InsertManyFastTx(ctx context.Context, tx *sql.Tx, args []river.JobArgs, opts ...InsertOpt) error {
-	if q == nil {
+	if q == nil || q.client == nil {
 		logging.Info(ctx, "skip inserting many jobs because queue is not set")
 		return nil
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -116,6 +116,7 @@ func WithQueueName(name string) InsertOpt {
 
 func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOpt) error {
 	if q == nil || q.client == nil {
+		logging.Info(ctx, "skip inserting job because queue is not set")
 		return nil
 	}
 	_, err := q.client.Insert(ctx, args, applyInsertOpts(opts))
@@ -127,7 +128,8 @@ func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOp
 //
 // Opts are applied to each job before sending them to river.
 func (q *Queue) InsertManyFastTx(ctx context.Context, tx *sql.Tx, args []river.JobArgs, opts ...InsertOpt) error {
-	if q == nil || q.client == nil {
+	if q == nil {
+		logging.Info(ctx, "skip inserting many jobs because queue is not set")
 		return nil
 	}
 	params := make([]river.InsertManyParams, len(args))

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -115,6 +115,9 @@ func WithQueueName(name string) InsertOpt {
 }
 
 func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOpt) error {
+	if q == nil || q.client == nil {
+		return nil
+	}
 	_, err := q.client.Insert(ctx, args, applyInsertOpts(opts))
 	return err
 }
@@ -124,6 +127,9 @@ func (q *Queue) Insert(ctx context.Context, args river.JobArgs, opts ...InsertOp
 //
 // Opts are applied to each job before sending them to river.
 func (q *Queue) InsertManyFastTx(ctx context.Context, tx *sql.Tx, args []river.JobArgs, opts ...InsertOpt) error {
+	if q == nil || q.client == nil {
+		return nil
+	}
 	params := make([]river.InsertManyParams, len(args))
 	for i, arg := range args {
 		params[i] = river.InsertManyParams{


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved

- Actions V2 **Event** executions can fail the originating API with `Errors.Internal (RECOVER)` / a nil-pointer panic when `Log.Level` is `debug`, even though the domain operation and target side effects may already have succeeded (for example Create User / Create Session while a webhook still fires). Relates to #12225.
- Root cause: River `InsertManyFast` / `InsertManyFastTx` returns a count-sized slice of nil `*JobInsertResult` (no job rows). The queue log middleware logged each result under debug and dereferenced `result.Job`.

# How the Problems Are Solved

- Skip `nil` results and results with a `nil` `Job` before debug detail logging in the queue insert middleware.
- Add a regression test that exercises InsertManyFast-shaped nil results (and mixed nil/populated results) under debug and info log levels and asserts the middleware does not panic.

# Additional Changes

- Set the instance ID on the execution worker context via `authz.WithInstanceID` in `ContextWithExecuter` so workers have a non-empty instance for follow-up work.
- Make `Queue.Insert` / `InsertManyFastTx` nil-safe when the queue or River client is unset (defensive no-op).

# Additional Context

- Closes #12225
- A full API E2E with debug logging is not covered by the shared integration suite (`apps/api/test-integration-api.yaml` uses `Log.Level: info`); the package-level middleware test is the practical regression for the panic path.