### PR TITLE
docs(deps): upgrade image versions in env examples

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -28,11 +28,11 @@ LOGIN_CLIENT_PAT_EXPIRATION=2099-01-01T00:00:00Z
 #   docker compose --env-file .env -f docker-compose.yml pull
 #   docker compose --env-file .env -f docker-compose.yml up -d --wait
 # -----------------------------
-ZITADEL_VERSION=v4.13.0
-TRAEFIK_IMAGE=traefik:v3.6.8
-POSTGRES_IMAGE=postgres:17.2-alpine
-REDIS_IMAGE=redis:7.4.2-alpine
-OTEL_COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib:0.114.0
+ZITADEL_VERSION=v4.16.0
+TRAEFIK_IMAGE=traefik:v3.7.7
+POSTGRES_IMAGE=postgres:17.10-alpine
+REDIS_IMAGE=redis:7.4.9-alpine
+OTEL_COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib:0.156.0
 
 # -----------------------------
 # Proxy settings

--- a/deploy/compose/.env.test
+++ b/deploy/compose/.env.test
@@ -17,10 +17,10 @@ LOGIN_CLIENT_PAT_EXPIRATION=2099-01-01T00:00:00Z
 ZITADEL_VERSION=local
 
 # Images for services not overridden by docker-compose.test.yml
-TRAEFIK_IMAGE=traefik:v3.6.8
-POSTGRES_IMAGE=postgres:17.2-alpine
-REDIS_IMAGE=redis:7.4.2-alpine
-OTEL_COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib:0.114.0
+TRAEFIK_IMAGE=traefik:v3.7.7
+POSTGRES_IMAGE=postgres:17.10-alpine
+REDIS_IMAGE=redis:7.4.9-alpine
+OTEL_COLLECTOR_IMAGE=otel/opentelemetry-collector-contrib:0.156.0
 
 # Traefik
 TRAEFIK_DASHBOARD_ENABLED=false


### PR DESCRIPTION
# Which Problems Are Solved

Image versions in the example env, used in the docker quickstart, were outdated.

# How the Problems Are Solved

Update all image versions.
