### PR TITLE
docs: remove changelog link from sidebar

### DIFF
--- a/apps/docs/lib/sidebar-data.ts
+++ b/apps/docs/lib/sidebar-data.ts
@@ -872,17 +872,6 @@ export const guidesSidebar: readonly SidebarItem[] = [
       },
       {
         type: "category",
-        label: "Releases",
-        items: [
-          {
-            type: "link",
-            label: "Changelog",
-            href: "https://zitadel.com/changelog",
-          },
-        ],
-      },
-      {
-        type: "category",
         label: "Support Resources",
         items: [
           "support/troubleshooting",


### PR DESCRIPTION
The changelog page on zitadel.com was removed for being unmaintained, leaving the docs sidebar link 404ing.