### PR TITLE
docs(telemetry): document the unified Instrumentation config and structured log fields

### DIFF
--- a/apps/docs/content/apis/observability/metrics.mdx
+++ b/apps/docs/content/apis/observability/metrics.mdx
@@ -12,5 +12,5 @@ The metrics endpoint can be scrubbed by any tool of choice that supports the `ot
 
 For our [Kubernetes/Helm](/self-hosting/deploy/kubernetes) users, we provide an out-of-the-box support for the [ServiceMonitor](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/templates/servicemonitor.yaml) custom resource.
 
-By default, metrics are enabled but can be turned off through ZITADEL's [settings](/self-hosting/manage/configure).
+Metrics exposure is controlled by `Instrumentation.Metric.Exporter.Type` (`ZITADEL_INSTRUMENTATION_METRIC_EXPORTER_TYPE`), which must be set to `prometheus` to expose this endpoint. Metrics are one of four observability pillars — tracing, metrics, logging, and profiling — that all share the same `Instrumentation` configuration and `Exporter` concept; see [Instrumentation](/self-hosting/manage/instrumentation/overview) for the full picture.
 The (default) settings are located in the [defaults.yaml](https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml).

--- a/apps/docs/content/self-hosting/deploy/kubernetes/observability.mdx
+++ b/apps/docs/content/self-hosting/deploy/kubernetes/observability.mdx
@@ -12,25 +12,27 @@ This guide covers how to collect traces, metrics, and logs from the Zitadel and 
 
 ### Traces
 
-Zitadel can push traces to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) using the [OTLP protocol](https://opentelemetry.io/docs/specs/otlp/) over gRPC:
+Zitadel can push traces to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) using the [OTLP protocol](https://opentelemetry.io/docs/specs/otlp/) over gRPC, configured through the [`Instrumentation`](/self-hosting/manage/instrumentation/overview) section:
 
 ```yaml
 env:
-  - name: ZITADEL_TRACING_TYPE
-    value: "otel"
-  - name: ZITADEL_TRACING_ENDPOINT
+  - name: ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_TYPE
+    value: "grpc"
+  - name: ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT
     value: "otelcol-opentelemetry-collector.monitoring.svc.cluster.local:4317"
-  - name: ZITADEL_TRACING_SERVICENAME
+  - name: ZITADEL_INSTRUMENTATION_SERVICENAME
     value: "zitadel"
 ```
 
-The `ZITADEL_TRACING_ENDPOINT` should point to your OpenTelemetry Collector's gRPC receiver, typically listening on port 4317. The collector can then forward traces to your preferred backend such as [Jaeger](https://www.jaegertracing.io/), [Grafana Tempo](https://grafana.com/oss/tempo/), or [OpenObserve](https://openobserve.ai/).
+Note that `ZITADEL_INSTRUMENTATION_SERVICENAME` is shared across all instrumentation pillars (tracing, metrics, logging), so it's set at the top level rather than nested under trace-specific settings.
+
+The `ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT` should point to your OpenTelemetry Collector's gRPC receiver, typically listening on port 4317. The collector can then forward traces to your preferred backend such as [Jaeger](https://www.jaegertracing.io/), [Grafana Tempo](https://grafana.com/oss/tempo/), or [OpenObserve](https://openobserve.ai/).
 
 You can deploy an OpenTelemetry Collector in your cluster using the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) or the [OpenTelemetry Collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector).
 
 ### Metrics
 
-Zitadel exposes [Prometheus](https://prometheus.io/) metrics at `/debug/metrics`. Metrics must be scraped by Prometheus. Pushing metrics is not supported.
+Zitadel exposes [Prometheus](https://prometheus.io/) metrics at `/debug/metrics`, when `Instrumentation.Metric.Exporter.Type: prometheus` (`ZITADEL_INSTRUMENTATION_METRIC_EXPORTER_TYPE=prometheus`) is set — see [Instrumentation](/self-hosting/manage/instrumentation/overview#metrics). Metrics must be scraped by Prometheus. Pushing metrics is not supported.
 
 Enable the metrics endpoint:
 
@@ -56,7 +58,15 @@ Your Prometheus configuration must include a [scrape job](https://prometheus.io/
 
 ### Logs
 
-Zitadel writes structured JSON logs to stdout. Logs must be collected by a log collector running in your cluster. Pushing logs is not supported.
+By default, Zitadel writes plain text logs to stderr. To get structured JSON logs suitable for a log collector, set `Instrumentation.Log.Format: json` explicitly:
+
+```yaml
+env:
+  - name: ZITADEL_INSTRUMENTATION_LOG_FORMAT
+    value: "json"
+```
+
+See [Instrumentation](/self-hosting/manage/instrumentation/overview#logging) for all supported formats, and [Structured Log Fields](/self-hosting/manage/instrumentation/log-fields) for the resulting JSON schema. Logs must be collected by a log collector running in your cluster. Pushing logs is not supported.
 
 Common log collectors include:
 - [Fluent Bit](https://fluentbit.io/) — Lightweight log processor and forwarder

--- a/apps/docs/content/self-hosting/deploy/troubleshooting/troubleshooting.mdx
+++ b/apps/docs/content/self-hosting/deploy/troubleshooting/troubleshooting.mdx
@@ -46,6 +46,6 @@ Existing instances keep Login V1 until you opt in. To adopt Login V2 on an exist
 
 If the `zitadel` container shows as `unhealthy` but the log output does not reveal an obvious error:
 
-1. Increase log verbosity by setting `ZITADEL_LOG_LEVEL: debug` and `ZITADEL_LOGSTORE_ACCESS_STDOUT_ENABLED: true`.
+1. Increase log verbosity by setting `ZITADEL_INSTRUMENTATION_LOG_LEVEL: debug` and `ZITADEL_LOGSTORE_ACCESS_STDOUT_ENABLED: true`.
 2. Check that the healthcheck command can reach ZITADEL. The built-in `zitadel ready` command uses HTTP when `ZITADEL_TLS_ENABLED=false` and HTTPS otherwise. Ensure that this variable matches your TLS settings.
 3. If ZITADEL is running behind a reverse proxy, make sure the proxy forwards traffic correctly before the first healthcheck succeeds. See [Run and configure a reverse proxy](/self-hosting/manage/reverseproxy/reverse_proxy).

--- a/apps/docs/content/self-hosting/manage/instrumentation/log-fields.mdx
+++ b/apps/docs/content/self-hosting/manage/instrumentation/log-fields.mdx
@@ -1,0 +1,155 @@
+---
+title: Structured Log Fields
+description: "Reference of the structured JSON log fields ZITADEL emits, including request context, trace correlation, and error details."
+sidebar_label: Log Fields
+---
+
+This page describes the fields that appear in ZITADEL's structured log output, once [`Instrumentation.Log.Format`](/self-hosting/manage/instrumentation/overview#logging) is set to `json`, `gcp`, or `gcp_error_reporting`. The examples below are real log lines, captured from a local instance by calling the API with [grpcurl](https://github.com/fullstorydev/grpcurl) while running with `Instrumentation.Log.Format: json` and `Instrumentation.Log.Level: debug`.
+
+## Common fields
+
+Every log line contains these fields:
+
+| Field | Description |
+|---|---|
+| `time` | RFC3339 timestamp. |
+| `level` | `DEBUG`, `INFO`, `WARN`, or `ERROR` (plus GCP-specific alert/emergency levels used by [`logging.ErrorContextLogger`](#error-fields-err-group) for panics and fatal errors). |
+| `msg` | Human-readable log message. |
+| `source.function` / `source.file` / `source.line` | Where the log line was emitted, present when `AddSource: true`. |
+| `stream` | Which [stream](/self-hosting/manage/instrumentation/overview#logging) the line belongs to: `runtime`, `ready`, `request`, `event_handler`, `queue`, or `event_pusher`. |
+| `version` | The running ZITADEL build version. |
+| `TraceID` / `SpanID` | Present when the log line was emitted inside an active trace span, allowing correlation with [tracing](/self-hosting/manage/instrumentation/overview#tracing) data. |
+
+## Request context fields
+
+Once a request starts being handled, every subsequent log line on that request also carries a `request` group:
+
+| Field | Description |
+|---|---|
+| `request.id` | Unique ID for this request. Also returned to the client (as a response header for HTTP/gRPC, or header/trailer for connect RPC depending on success/failure). |
+| `request.instance_host` | The host used to resolve the ZITADEL instance for this request. |
+| `request.public_host` | The public-facing host, if different from `instance_host`. |
+| `request.instance_id` | The resolved instance ID, once authorization has resolved it. |
+| `request.user_id` | The authenticated user or service account ID, once resolved. |
+
+## Request-served fields
+
+A `"request served"` line is logged for every API call, in the `request` stream, once the call completes. The exact fields depend on which protocol handler served the request:
+
+| Field | grpc / connect | http |
+|---|---|---|
+| `protocol` | `"grpc"` or `"connect"` | `"http"` |
+| `service` | ✅ | ✅ |
+| `http_method` | ✅ | ✅ |
+| `path` | ✅ | ✅ |
+| `code` | ✅ (gRPC status code) | ❌ |
+| `status` | ❌ | ✅ (HTTP status code) |
+| `duration` | ✅ (nanoseconds) | ✅ (nanoseconds) |
+
+<Callout>
+`protocol` reflects the server-side handler stack that processed the request, not the wire protocol a client happened to use. ZITADEL's v2/v2beta services (like `zitadel.user.v2.UserService`) are all served through a [Connect](https://connectrpc.com) handler, which transparently accepts gRPC, gRPC-Web, and Connect wire formats — so calls to those services always log `protocol: "connect"`, even when made with a plain gRPC client like `grpcurl`. The legacy v1 services (`AdminService`, `ManagementService`, `AuthService`, `SystemService`) are still served by a classic gRPC server and log `protocol: "grpc"`. Non-gRPC endpoints (OIDC, SAML, Console, the legacy Login UI) log `protocol: "http"`.
+</Callout>
+
+### Example: successful request
+
+Captured from `grpcurl -plaintext -H "Authorization: Bearer $(cat admin.pat)" localhost:8080 zitadel.user.v2.UserService.ListUsers`:
+
+```json
+{
+  "time": "2026-07-20T14:04:35.984512809Z",
+  "level": "INFO",
+  "source": {
+    "function": "github.com/zitadel/zitadel/internal/api.(*API).registerConnectServer.LogHandler.func4.1",
+    "file": "/workspaces/zitadel/internal/api/grpc/server/connect_middleware/log_interceptor.go",
+    "line": 34
+  },
+  "msg": "request served",
+  "request": {
+    "id": "d9f2lsvhdckqk9sg9nf0",
+    "instance_host": "localhost:8080",
+    "instance_id": "382621618297372675",
+    "user_id": "382621618297962499"
+  },
+  "TraceID": "6d509f22d2f334570d1905960a05c523",
+  "SpanID": "bf80407e7f354922",
+  "stream": "request",
+  "version": "2026-07-20T14:04:16Z",
+  "protocol": "connect",
+  "service": "zitadel.user.v2.UserService",
+  "http_method": "POST",
+  "path": "/zitadel.user.v2.UserService/ListUsers",
+  "code": "code_0",
+  "duration": 11302933
+}
+```
+
+## Error fields (`err` group)
+
+When a request fails, ZITADEL logs a `WARN` (client errors, e.g. `NotFound`, `InvalidArgument`) or `ERROR` (server errors, e.g. `Internal`) line in addition to the `"request served"` line, carrying an `err` group:
+
+| Field | Description |
+|---|---|
+| `err.kind` | One of ZITADEL's error kinds: `Canceled`, `Unknown`, `InvalidArgument`, `DeadlineExceeded`, `NotFound`, `AlreadyExists`, `PermissionDenied`, `ResourceExhausted`, `PreconditionFailed`, `Aborted`, `OutOfRange`, `Unimplemented`, `Internal`, `Unavailable`, `DataLoss`, `Unauthenticated`. |
+| `err.message` | Human-readable error message. |
+| `err.id` | ZITADEL's error code, in `<PACKAGE>-<shortcode>` form (e.g. `QUERY-Dfbg2`), useful for searching source/support material. |
+| `err.parent` | The wrapped underlying error, if any (e.g. a driver-level error). |
+| `err.reportLocation.filePath` / `.lineNumber` / `.functionName` | Where the error was created, present when `Instrumentation.Log.Errors.ReportLocation: true` (the default). |
+| `err.stackTrace` | A full stack trace, present only when `Instrumentation.Log.Errors.StackTrace: true` (disabled by default — verbose). |
+
+When `Format: gcp_error_reporting` is set, the `err` attribute is renamed to `error`, `reportLocation`/`stackTrace` move to top-level fields, and the whole line is reshaped to match the [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages) JSON schema (adding a top-level `@type` field).
+
+### Example: NotFound error
+
+Captured from `grpcurl -plaintext -H "Authorization: Bearer $(cat admin.pat)" -d '{"user_id":"does-not-exist"}' localhost:8080 zitadel.user.v2.UserService.GetUserByID`:
+
+```json
+{
+  "time": "2026-07-20T14:04:44.595817096Z",
+  "level": "WARN",
+  "source": {
+    "function": "github.com/zitadel/zitadel/internal/api/grpc/gerrors.ZITADELToConnectError",
+    "file": "/workspaces/zitadel/internal/api/grpc/gerrors/zitadel_errors.go",
+    "line": 65
+  },
+  "msg": "User could not be found (QUERY-Dfbg2)",
+  "request": {
+    "id": "d9f2lv7hdckqk9sg9njg",
+    "instance_host": "localhost:8080",
+    "instance_id": "382621618297372675",
+    "user_id": "382621618297962499"
+  },
+  "TraceID": "9f5bd938f3ab20c43b271a1667fb0394",
+  "SpanID": "5f879d60abe74692",
+  "stream": "request",
+  "version": "2026-07-20T14:04:16Z",
+  "err": {
+    "kind": "NotFound",
+    "message": "User could not be found",
+    "id": "QUERY-Dfbg2",
+    "parent": "sql: no rows in result set",
+    "reportLocation": {
+      "filePath": "/workspaces/zitadel/internal/query/user.go",
+      "lineNumber": 890,
+      "functionName": "github.com/zitadel/zitadel/internal/query.scanUser"
+    }
+  }
+}
+```
+
+Note this is the same request (`request.id: d9f2lv7hdckqk9sg9njg`) that also produced a `"request served"` line with `code: "not_found"` — the two lines can be correlated by `request.id` or by `TraceID`/`SpanID`.
+
+## Masking
+
+`Instrumentation.Log.Mask.Keys` redacts attribute values by key name, matching the key at any nesting depth (both a leaf attribute and an entire group), and replaces the value with `Mask.Value` while preserving structure. For example, with `Mask.Keys: ["message"]` and `Mask.Value: "****"`, the error example above would log `"message": "****"` instead of `"message": "User could not be found"`, while every other field stays intact.
+
+## Format differences
+
+`Instrumentation.Log.Format` controls how the fields above are rendered to standard error:
+
+| Format | Output |
+|---|---|
+| `disabled` | No output on stderr (falls back to the legacy `Log` config if set, see [Legacy configuration](/self-hosting/manage/instrumentation/overview#legacy-configuration)). |
+| `text` | Human-readable `key=value` text, one line per log entry. |
+| `json` | The JSON shown in the examples above. |
+| `gcp` | JSON, with `level` renamed to `severity`, `msg` renamed to `message`, and `source` renamed to `logging.googleapis.com/sourceLocation`, matching [Google Cloud Logging](https://cloud.google.com/logging/docs/structured-logging)'s expected field names. |
+| `gcp_error_reporting` | Same as `gcp`, plus: whenever an `err`/`error` attribute is present, the line is additionally reshaped to match the [GCP Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages) schema (`@type`, `message` containing the stack trace when available, top-level `reportLocation`). |

--- a/apps/docs/content/self-hosting/manage/instrumentation/overview.mdx
+++ b/apps/docs/content/self-hosting/manage/instrumentation/overview.mdx
@@ -1,0 +1,150 @@
+---
+title: Instrumentation
+description: "Configure ZITADEL's unified Instrumentation section to collect traces, metrics, logs, and profiles using OpenTelemetry-compatible exporters."
+sidebar_label: Instrumentation
+---
+
+ZITADEL emits telemetry for four pillars of observability: **tracing**, **metrics**, **logging**, and **profiling**.
+All four are configured under a single `Instrumentation` section in the [runtime configuration](/self-hosting/manage/configure), which replaces several older, inconsistent configuration sections (`Log`, `Tracing`, `Metrics`, `Profiler`).
+
+<Callout>
+The examples on this page show a subset of the available options. The full, always up-to-date list of fields and their defaults is in [`cmd/defaults.yaml`](https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml).
+</Callout>
+
+## Exporters
+
+Every pillar sends its data through an **Exporter**, configured the same way everywhere:
+
+```yaml
+Exporter:
+  Type: "none" # which exporter implementation to use
+  Endpoint: "" # collector endpoint, for grpc/http exporters
+  Insecure: false # disable TLS for grpc/http exporters
+  BatchDuration: 1s # interval for batching before export
+  GoogleProjectID: "" # project ID for the google exporter
+```
+
+Not every `Type` is supported by every pillar:
+
+| Type | Trace | Metric | Log | Profile | Description |
+|---|---|---|---|---|---|
+| `none` | ✅ | ✅ | ✅ | ✅ | Disables exporting for this pillar. |
+| `auto` | ✅ | ✅ | ✅ | ❌ | Delegates to standard OTEL environment variables (`OTEL_TRACES_EXPORTER`, `OTEL_EXPORTER_OTLP_ENDPOINT`, etc.). Only takes effect if one of the recognized OTEL env vars is actually set. |
+| `stdOut` / `stdErr` | ✅ | ✅ | ✅ | ❌ | Writes OTEL-formatted output to standard output/error. |
+| `grpc` / `http` | ✅ | ✅ | ✅ | ❌ | Sends data to an OTEL collector via OTLP over gRPC or HTTP (recommended for production). |
+| `google` | ✅ | ✅ | ❌ | ✅ | Sends data to Google Cloud (Trace, Monitoring, or Profiler). Requires `GoogleProjectID`. |
+| `prometheus` | ❌ | ✅ | ❌ | ❌ | Exposes metrics for Prometheus to scrape, see [Metrics](/self-hosting/manage/metrics/overview). |
+
+Profiling only supports `none` and `google`, because there is currently no OTEL-upstream exporter for profiles.
+
+## Service name
+
+`Instrumentation.ServiceName` sets the service name attached to traces, metrics, and logs (default `"zitadel"`):
+
+```yaml
+Instrumentation:
+  ServiceName: "zitadel" # ZITADEL_INSTRUMENTATION_SERVICENAME
+```
+
+## Tracing
+
+ZITADEL creates a trace span for every request and propagates trace context so calls can be correlated across your infrastructure. Each log line written while a span is active also carries the same `TraceID`/`SpanID`, so traces and logs can be cross-referenced.
+
+```yaml
+Instrumentation:
+  Trace:
+    Fraction: 1.0 # ZITADEL_INSTRUMENTATION_TRACE_FRACTION
+    # Trust incoming trace context from remote services for distributed tracing.
+    # Enable only in controlled environments; defaults to false for security.
+    TrustRemoteSpans: false # ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS
+    Exporter:
+      Type: "none" # none|auto|stdOut|stdErr|grpc|http|google
+      Endpoint: "" # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT
+```
+
+`TrustRemoteSpans` defaults to `false`: incoming trace context from clients is not trusted by default, since a client could otherwise inject an arbitrary trace ID. Only enable it in environments where you control everything upstream of ZITADEL (for example behind your own OTEL-aware ingress).
+
+See the [Kubernetes observability guide](/self-hosting/deploy/kubernetes/observability) for an example of shipping traces to an OpenTelemetry Collector.
+
+## Metrics
+
+Metrics use the same `Exporter` shape, plus the `prometheus` type for pull-based scraping:
+
+```yaml
+Instrumentation:
+  Metric:
+    Exporter:
+      Type: "none" # none|auto|stdOut|stdErr|grpc|http|google|prometheus
+```
+
+Metrics have their own dedicated pages with more detail: [Metrics overview](/self-hosting/manage/metrics/overview) and [Prometheus setup](/self-hosting/manage/metrics/prometheus).
+
+## Logging
+
+ZITADEL emits structured logs through Go's standard `log/slog`. Logging has two independent knobs:
+
+<Callout title="Format vs. Exporter">
+`Instrumentation.Log.Format` controls what gets printed to standard error (for a human, a log collector tailing stdout/stderr, etc.).
+`Instrumentation.Log.Exporter` controls whether logs are **also** pushed to an OTEL collector.
+These are independent — for example you can print JSON to stderr **and** export the same log records via OTLP gRPC at the same time.
+</Callout>
+
+```yaml
+Instrumentation:
+  Log:
+    # Log lines lower than this level are not emitted.
+    Level: "INFO" # ZITADEL_INSTRUMENTATION_LOG_LEVEL
+    # Streams enable logging for specific parts of the application.
+    Streams: # ZITADEL_INSTRUMENTATION_LOG_STREAMS (comma separated list)
+      - runtime # General runtime logs, such as startup and shutdown messages.
+      - ready # Logs related to readiness and health checks.
+      - request # Logs for incoming API and HTTP requests.
+      - event_handler # Logs for event handling in projections.
+      - queue # Logs for the job queue processing.
+      #- event_pusher # Logs for event pushing to the database. Warning: contains sensitive information.
+    Mask:
+      Keys: # ZITADEL_INSTRUMENTATION_LOG_MASK_KEYS (comma separated list)
+        # - "first_name"
+      Value: "****" # ZITADEL_INSTRUMENTATION_LOG_MASK_VALUE
+    # "disabled" | "text" | "json" | "gcp" | "gcp_error_reporting"
+    Format: "disabled" # ZITADEL_INSTRUMENTATION_LOG_STDERR
+    AddSource: true # ZITADEL_INSTRUMENTATION_LOG_ADDSOURCE
+    Errors:
+      ReportLocation: true # ZITADEL_INSTRUMENTATION_LOG_ERRORS_REPORTLOCATION
+      StackTrace: false # ZITADEL_INSTRUMENTATION_LOG_ERRORS_STACKTRACE
+    Exporter:
+      Type: "none" # none|auto|stdOut|stdErr|grpc|http
+```
+
+A `Stream` is a coarse category of logs (application runtime, readiness checks, API requests, event projections, the job queue, and event pushes to the database). Each stream can be turned on or off independently — a disabled stream produces no output at all. `event_pusher` is disabled by default because it can contain sensitive event payload data.
+
+`Mask.Keys` redacts attribute values by key name, at any nesting depth, replacing the value with `Mask.Value` while preserving the surrounding structure — useful for keeping personal data (like `first_name`) out of your log sink.
+
+For the exact shape of a log line — which fields appear, and real example output — see [Structured Log Fields](/self-hosting/manage/instrumentation/log-fields).
+
+## Profiling
+
+Profiling data (CPU, memory, …) can be sent to Google Cloud Profiler:
+
+```yaml
+Instrumentation:
+  Profile:
+    Exporter:
+      Type: "none" # none|google
+      GoogleProjectID: "" # ZITADEL_INSTRUMENTATION_PROFILE_EXPORTER_GOOGLEPROJECTID
+```
+
+## Legacy configuration
+
+The older, top-level `Log`, `Metrics`, `Tracing`, and `Profiler` sections still exist in `defaults.yaml` for backward compatibility, but each only takes effect while the corresponding `Instrumentation.*` field is left at its default (unset). They are deprecated and scheduled for removal in ZITADEL v5 — new deployments should configure `Instrumentation` directly rather than relying on the legacy fallback.
+
+<Callout>
+Don't confuse this with the separate, still-current `Telemetry` section: that section pushes anonymized usage milestones to external endpoints and has nothing to do with tracing, metrics, or logging. See [Production Setup](/self-hosting/manage/production#telemetry) and [Service Ping](/self-hosting/manage/service_ping).
+</Callout>
+
+## What's next
+
+- [Structured Log Fields](/self-hosting/manage/instrumentation/log-fields) — the JSON schema of ZITADEL's log output, with real example log lines.
+- [Metrics overview](/self-hosting/manage/metrics/overview) and [Prometheus setup](/self-hosting/manage/metrics/prometheus).
+- [Kubernetes observability guide](/self-hosting/deploy/kubernetes/observability) for collecting traces, metrics, and logs in a cluster.
+- Check out all possible [runtime configuration properties and their defaults in the source code](https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml).

--- a/apps/docs/content/self-hosting/manage/metrics/overview.mdx
+++ b/apps/docs/content/self-hosting/manage/metrics/overview.mdx
@@ -47,13 +47,11 @@ ZITADEL does **not** require a specific metrics backend. Any system capable of s
 
 ## Settings
 
-Metrics are enabled by default in standard ZITADEL deployments.
-
-If metrics were explicitly disabled in your configuration, re-enable them before proceeding. The default configuration is defined in the project's `defaults.yaml` file:
+Metrics are configured through `Instrumentation.Metric.Exporter.Type` (`ZITADEL_INSTRUMENTATION_METRIC_EXPORTER_TYPE`), which defaults to `none`. The `/debug/metrics` endpoint is only live today because a deprecated, legacy `Metrics.Type: otel` setting is still enabled in `defaults.yaml` and automatically promotes the new field to `prometheus` when it's left unset. Since this legacy fallback is scheduled for removal in ZITADEL v5, set `Instrumentation.Metric.Exporter.Type: prometheus` explicitly rather than relying on it. The default configuration is defined in the project's `defaults.yaml` file:
 
 - https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml
 
-Refer to the configuration documentation for details on enabling or adjusting metrics behavior.
+See [Instrumentation](/self-hosting/manage/instrumentation/overview) for details on the shared `Exporter` concept used by metrics, tracing, logging, and profiling.
 
 ## Next steps
 

--- a/apps/docs/content/self-hosting/manage/production.mdx
+++ b/apps/docs/content/self-hosting/manage/production.mdx
@@ -39,15 +39,20 @@ Also, not all configuration options are available as environment variables.
 
 By default, [**metrics**](/apis/observability/metrics) are exposed at /debug/metrics in OpenTelemetry (otel) format.
 
-Also, you can enable **tracing** in the ZITADEL configuration.
+You can also enable **tracing** and control both metrics and tracing exporters through the unified [`Instrumentation`](/self-hosting/manage/instrumentation/overview) configuration section, which replaces the older `Tracing`/`Metrics` sections:
 
 ```yaml
-Tracing:
-  # Choose one in "otel", "google", "log" and "none"
-  Type: google
-  Fraction: 1
-  MetricPrefix: zitadel
+Instrumentation:
+  Trace:
+    Fraction: 1.0 # ZITADEL_INSTRUMENTATION_TRACE_FRACTION
+    Exporter:
+      Type: "google" # none|auto|stdOut|stdErr|grpc|http|google
+  Metric:
+    Exporter:
+      Type: "prometheus" # none|auto|stdOut|stdErr|grpc|http|google|prometheus
 ```
+
+See [Instrumentation](/self-hosting/manage/instrumentation/overview) for the full set of options, and how tracing/metric exporters share a common `Exporter` shape.
 
 ## Logging
 
@@ -56,17 +61,21 @@ Logs are a stream of time-ordered events collected from all running processes.
 
 [ZITADEL is configurable](#default-zitadel-logging-config) to write the following events to the standard output:
 
-- Runtime Logs: Define the log level and record format in the `Log` configuration section.
+- Runtime Logs: Define the log level and output format in the `Instrumentation.Log` configuration section. See [Instrumentation](/self-hosting/manage/instrumentation/overview#logging) for all options, and [Structured Log Fields](/self-hosting/manage/instrumentation/log-fields) for the JSON schema and real example output.
 - Access Logs: Enable logging all HTTP and gRPC responses from the ZITADEL binary by setting `LogStore.Access.Stdout.Enabled` to true.
 - Actions Execution Logs: Actions can emit custom logs at different levels. For example, a log record can be emitted each time a user is created or authenticated. If you don't want to have these logs in STDOUT, you can disable this by setting `LogStore.Execution.Stdout.Enabled` to true.
+
+<Callout>
+`LogStore` (below) is a separate feature from `Instrumentation.Log` — it controls whether ZITADEL persists/prints dedicated access and Actions execution logs, independent of the general structured application logging described in [Instrumentation](/self-hosting/manage/instrumentation/overview#logging).
+</Callout>
 
 ### Default ZITADEL Logging Config
 
 ```yaml
-Log:
-  Level: info # ZITADEL_LOG_LEVEL
-  Formatter:
-    Format: text # ZITADEL_LOG_FORMATTER_FORMAT
+Instrumentation:
+  Log:
+    Level: "INFO" # ZITADEL_INSTRUMENTATION_LOG_LEVEL
+    Format: "disabled" # disabled|text|json|gcp|gcp_error_reporting, ZITADEL_INSTRUMENTATION_LOG_STDERR
 
 LogStore:
   Access:
@@ -80,6 +89,10 @@ LogStore:
 
 ```
 
+<Callout type="warn">
+`Instrumentation.Log.Format` defaults to `disabled`, which falls back to the legacy `Log.Formatter.Format` default of `text`. To get structured JSON output (recommended for log collectors), set `Instrumentation.Log.Format: json` explicitly — see [Instrumentation](/self-hosting/manage/instrumentation/overview#logging).
+</Callout>
+
 ### Why ZITADEL does not write logs to files
 
 Log file management should not be in each business apps responsibility.
@@ -88,6 +101,10 @@ This includes tasks like rotating files, routing, collecting, archiving and clea
 For example, systemd has journald and kubernetes has fluentd and fluentbit.
 
 ## Telemetry
+
+<Callout>
+This `Telemetry` section is unrelated to the `Instrumentation` section described under [Monitoring](#monitoring) and [Logging](#logging) above — it only pushes anonymized usage-milestone data, not traces, metrics, or logs.
+</Callout>
 
 If you want to have some data about reached usage milestones pushed to external systems, enable telemetry in the ZITADEL configuration.
 

--- a/apps/docs/lib/sidebar-data.ts
+++ b/apps/docs/lib/sidebar-data.ts
@@ -774,6 +774,16 @@ export const guidesSidebar: readonly SidebarItem[] = [
                   "self-hosting/manage/service_ping",
                   {
                     type: "category",
+                    label: "Instrumentation",
+                    collapsed: true,
+                    link: {
+                      type: "doc",
+                      id: "self-hosting/manage/instrumentation/overview",
+                    },
+                    items: ["self-hosting/manage/instrumentation/log-fields"],
+                  },
+                  {
+                    type: "category",
                     label: "Metrics",
                     collapsed: true,
                     link: {


### PR DESCRIPTION
## Summary

Documents the unified `Instrumentation` runtime config (tracing, metrics, logging, profiling, and the shared `Exporter` concept) that replaced the legacy `Log`/`Tracing`/`Metrics`/`Profiler` sections, per the observability refactor landed in #11159, #11355, #11509, #11606, #11623, #11842.

- New page [`self-hosting/manage/instrumentation/overview`](https://github.com/zitadel/zitadel/blob/main/apps/docs/content/self-hosting/manage/instrumentation/overview.mdx): explains `Instrumentation`, the shared `Exporter` concept and valid types per pillar, and each of Tracing/Metrics/Logging/Profiling.
- New page [`self-hosting/manage/instrumentation/log-fields`](https://github.com/zitadel/zitadel/blob/main/apps/docs/content/self-hosting/manage/instrumentation/log-fields.mdx): reference for the structured JSON log schema (common fields, request context, request-served fields per protocol, the `err` group, masking, format differences). Includes **real log lines captured from a locally running instance** via `grpcurl` (a successful `ListUsers` call and a `NotFound` error from `GetUserByID`), not fabricated examples.
- Updated `production.mdx`, `deploy/kubernetes/observability.mdx`, `deploy/troubleshooting/troubleshooting.mdx`, `apis/observability/metrics.mdx`, and `manage/metrics/overview.mdx` to replace references to the deprecated `Tracing`/`Log`/`Metrics` config and env vars with the new `Instrumentation.*` equivalents, and cross-link to the new pages.
- Added an "Instrumentation" entry to the sidebar under Self-Hosted → Manage → Observability.

Closes #11335

Replaces #11885 (closing that PR separately with a pointer to this one).

## Test plan

- [x] `pnpm nx run @zitadel/docs:generate`
- [x] `pnpm nx run @zitadel/docs:lint`
- [x] `pnpm nx run @zitadel/docs:check-links` — 0 errors
- [x] `pnpm nx run @zitadel/docs:build` — succeeds
- [x] Every config key/env var referenced was cross-checked against `cmd/defaults.yaml` and the `backend/v3/instrumentation` source
- [x] Log examples are real output captured from a local instance, not hand-written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
