### PR TITLE
ci: replace project-board workflow with shared kanban workflow

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,4 +1,4 @@
-name: Add new issues to product management project
+name: Add new issues and PRs to kanban project
 
 on:
   issues:
@@ -8,36 +8,17 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
-  add-to-project:
-    name: Add issue and community pr to project
-    runs-on: ubuntu-latest
-    steps:
-      - name: add issue
-        uses: actions/add-to-project@v1.0.1
-        if: ${{ github.event_name == 'issues' }}
-        with:
-          # You can target a repository in a different organization
-          # to the issue
-          project-url: https://github.com/orgs/zitadel/projects/2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: tspascoal/get-user-teams-membership@v3
-        id: checkUserMember
-        if: github.actor != 'dependabot[bot]'
-        with:
-         username: ${{ github.actor }}
-         GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - name: add pr
-        uses: actions/add-to-project@v1.0.1
-        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'engineers')}}
-        with:
-          # You can target a repository in a different organization
-          # to the issue
-          project-url: https://github.com/orgs/zitadel/projects/2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
-        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff')}}
-        with:
-          github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labels: |
-            os-contribution
+  add-to-kanban:
+    name: Add issue/PR to kanban
+    if: github.actor != 'dependabot[bot]'
+    uses: zitadel/.github/.github/workflows/kanban.yml@main
+    secrets:
+      PROJECT_APP_ID: ${{ secrets.PROJECT_APP_ID }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+    with:
+      issue_url: ${{ github.event_name == 'issues' && github.event.issue.html_url || '' }}
+      pr_url: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.html_url || '' }}


### PR DESCRIPTION
## Summary
- Replaces the legacy `actions/add-to-project` based workflow (targeting project 2 with `ADD_TO_PROJECT_PAT`) with the shared `zitadel/.github/.github/workflows/kanban.yml` reusable workflow, matching the pattern used in `zitadel/nextgen`.
- New issues and PRs (opened by non-dependabot actors) are now added to the org kanban project (project 15) instead of the old product management project.

## Test plan
- [ ] Merge and open a test issue/PR to confirm it gets added to the kanban project.
- [ ] Confirm `PROJECT_APP_ID` / `PROJECT_APP_PRIVATE_KEY` secrets are available to this repo (org-level secrets used by other repos already running this workflow).