### PR TITLE
fix(login): show account selection after RP-initiated logout #12252

### DIFF
--- a/apps/login/src/app/(login)/accounts/page.tsx
+++ b/apps/login/src/app/(login)/accounts/page.tsx
@@ -4,10 +4,10 @@ import { Translated } from "@/components/translated";
 import { getAllSessions } from "@/lib/cookies";
 import { getServiceConfig } from "@/lib/service-url";
 import { getBrandingSettings, getDefaultOrg, listSessions, ServiceConfig } from "@/lib/zitadel";
-import { create } from "@zitadel/client";
-import { Session, SessionSchema } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { UserPlusIcon } from "@heroicons/react/24/outline";
+import { create } from "@zitadel/client";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
+import { Session, SessionSchema } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 // import { getLocale } from "next-intl/server";
@@ -35,17 +35,12 @@ async function loadSessions({ serviceConfig, organization }: { serviceConfig: Se
       liveSessions = response?.sessions ?? [];
     } catch (error) {
       // listSessions can fail for stale/expired session IDs still in cookies,
-      // API errors, etc. Fall back to cookie-derived accounts below instead of
-      // rendering an empty / broken accounts page (see #12252).
       console.error("Failed to load sessions from API, falling back to cookie", error);
-      liveSessions = [];
     }
   }
 
-  // For cookie entries whose server-side session no longer exists (e.g. after
-  // RP-initiated logout terminated the session, see #12252 / #12209),
-  // synthesize an invalid Session so the account stays selectable. The existing
-  // SessionItem re-login path continues the flow when the user picks it.
+  // For cookie entries whose server-side session no longer exists
+  // synthesize an invalid Session so the account stays selectable
   const liveIds = new Set(liveSessions.map((s) => s.id));
   const synthesized: Session[] = sessionCookies
     .filter((c) => !!c.id && !!c.loginName && !liveIds.has(c.id))

--- a/apps/login/src/app/(login)/accounts/page.tsx
+++ b/apps/login/src/app/(login)/accounts/page.tsx
@@ -1,9 +1,11 @@
 import { DynamicTheme } from "@/components/dynamic-theme";
 import { SessionsList } from "@/components/sessions-list";
 import { Translated } from "@/components/translated";
-import { getAllSessionCookieIds } from "@/lib/cookies";
+import { getAllSessions } from "@/lib/cookies";
 import { getServiceConfig } from "@/lib/service-url";
 import { getBrandingSettings, getDefaultOrg, listSessions, ServiceConfig } from "@/lib/zitadel";
+import { create } from "@zitadel/client";
+import { Session, SessionSchema } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { UserPlusIcon } from "@heroicons/react/24/outline";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import { Metadata } from "next";
@@ -18,24 +20,54 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 async function loadSessions({ serviceConfig, organization }: { serviceConfig: ServiceConfig; organization?: string }) {
-  const cookieIds = await getAllSessionCookieIds();
+  const sessionCookies = await getAllSessions();
 
-  if (cookieIds && cookieIds.length) {
-    const response = await listSessions({
-      serviceConfig,
-      ids: cookieIds.filter((id) => !!id) as string[],
-    });
-
-    let sessions = response?.sessions ?? [];
-    if (organization) {
-      sessions = sessions.filter((s) => s.factors?.user?.organizationId === organization);
-    }
-
-    return sessions;
-  } else {
+  if (!sessionCookies || !sessionCookies.length) {
     console.info("No session cookie found.");
     return [];
   }
+
+  const ids = sessionCookies.map((s) => s.id).filter((id) => !!id) as string[];
+  let liveSessions: Session[] = [];
+  if (ids.length) {
+    try {
+      const response = await listSessions({ serviceConfig, ids });
+      liveSessions = response?.sessions ?? [];
+    } catch (error) {
+      // listSessions can fail for stale/expired session IDs still in cookies,
+      // API errors, etc. Fall back to cookie-derived accounts below instead of
+      // rendering an empty / broken accounts page (see #12252).
+      console.error("Failed to load sessions from API, falling back to cookie", error);
+      liveSessions = [];
+    }
+  }
+
+  // For cookie entries whose server-side session no longer exists (e.g. after
+  // RP-initiated logout terminated the session, see #12252 / #12209),
+  // synthesize an invalid Session so the account stays selectable. The existing
+  // SessionItem re-login path continues the flow when the user picks it.
+  const liveIds = new Set(liveSessions.map((s) => s.id));
+  const synthesized: Session[] = sessionCookies
+    .filter((c) => !!c.id && !!c.loginName && !liveIds.has(c.id))
+    .map((c) =>
+      create(SessionSchema, {
+        id: c.id,
+        factors: {
+          user: {
+            loginName: c.loginName,
+            displayName: c.loginName,
+            organizationId: c.organization ?? "",
+          },
+        },
+      }),
+    );
+
+  let sessions = [...liveSessions, ...synthesized];
+  if (organization) {
+    sessions = sessions.filter((s) => s.factors?.user?.organizationId === organization);
+  }
+
+  return sessions;
 }
 
 export default async function Page(props: { searchParams: Promise<Record<string | number | symbol, string | undefined>> }) {

--- a/apps/login/src/lib/cookies.ts
+++ b/apps/login/src/lib/cookies.ts
@@ -235,25 +235,8 @@ export async function getSessionCookieByLoginName<T>({
  * @returns Session Cookies
  */
 export async function getAllSessionCookieIds<T>(cleanup: boolean = false): Promise<string[]> {
-  const cookiesList = await cookies();
-  const stringifiedCookie = cookiesList.get("sessions");
-
-  if (!stringifiedCookie?.value) {
-    return [];
-  }
-
-  const sessions: SessionCookie<T>[] = JSON.parse(stringifiedCookie.value);
-
-  if (cleanup) {
-    const now = new Date();
-    return sessions
-      .filter((session) =>
-        session.expirationTs ? timestampDate(timestampFromMs(Number(session.expirationTs))) > now : true,
-      )
-      .map((session) => session.id);
-  }
-
-  return sessions.map((session) => session.id);
+  const sessions = await getAllSessions<T>(cleanup);
+  return sessions.map(({ id }) => id);
 }
 
 /**

--- a/apps/login/src/lib/server/flow-initiation.test.ts
+++ b/apps/login/src/lib/server/flow-initiation.test.ts
@@ -233,7 +233,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const res = await handleOIDCFlowInitiation(
       makeBaseParams({
         sessions: [otherOrgSession] as any,
-        sessionCookies: [{ id: "session-other", token: "tok" }],
+        sessionCookies: [{ id: "session-other", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -256,7 +256,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const res = await handleOIDCFlowInitiation(
       makeBaseParams({
         sessions: [otherOrgSession] as any,
-        sessionCookies: [{ id: "session-other", token: "tok" }],
+        sessionCookies: [{ id: "session-other", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -281,7 +281,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const res = await handleOIDCFlowInitiation(
       makeBaseParams({
         sessions: [orgSession] as any,
-        sessionCookies: [{ id: "session-org", token: "tok" }],
+        sessionCookies: [{ id: "session-org", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -305,7 +305,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const res = await handleOIDCFlowInitiation(
       makeBaseParams({
         sessions: [otherOrgSession] as any,
-        sessionCookies: [{ id: "session-other", token: "tok" }],
+        sessionCookies: [{ id: "session-other", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -330,7 +330,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const res = await handleOIDCFlowInitiation(
       makeBaseParams({
         sessions: [orgSession] as any,
-        sessionCookies: [{ id: "session-org", token: "tok" }],
+        sessionCookies: [{ id: "session-org", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -410,7 +410,7 @@ describe("handleOIDCFlowInitiation — Prompt.LOGIN + loginHint requestId prefix
       makeBaseParams({
         requestId: "oidc_abc123",
         sessions: [existingSession] as any,
-        sessionCookies: [{ id: "session-1", token: "tok" }],
+        sessionCookies: [{ id: "session-1", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 
@@ -443,7 +443,7 @@ describe("handleOIDCFlowInitiation — Prompt.LOGIN + loginHint requestId prefix
       makeBaseParams({
         requestId: "oidc_abc123",
         sessions: [existingSession] as any,
-        sessionCookies: [{ id: "session-1", token: "tok" }],
+        sessionCookies: [{ id: "session-1", token: "tok", loginName: "", creationTs: "", expirationTs: "", changeTs: "" }],
       }),
     );
 

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -123,19 +123,12 @@ function getEligibleSessions(sessions: Session[], organization?: string): Sessio
 /**
  * Whether the `sessions` cookie references any previous account for the given
  * organization (or for any org when `organization` is unset).
- *
- * After RP-initiated logout the server-side sessions are terminated but the
- * `sessions` cookie still lists the previously signed-in accounts (see #12209).
- * Login V1 keeps these selectable; Login V2 must do the same by rendering
- * account selection from the cookie when there are no live sessions (#12252).
  */
 function hasCookieAccount(sessionCookies: Cookie[], organization?: string): boolean {
   if (!sessionCookies || sessionCookies.length === 0) {
     return false;
   }
-  return sessionCookies.some(
-    (c) => !!c.loginName && (!organization || c.organization === organization),
-  );
+  return sessionCookies.some((c) => !!c.loginName && (!organization || c.organization === organization));
 }
 
 export interface FlowInitiationParams {
@@ -293,10 +286,8 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
 
     if (authRequest.prompt.includes(Prompt.SELECT_ACCOUNT)) {
       if (eligibleSessions.length === 0) {
-        // No live session is eligible. If the sessions cookie still references
-        // a previous account (e.g. after RP-initiated logout, #12252), keep
-        // account selection so the user can pick it instead of landing on the
-        // loginname screen.
+        // No live session is eligible. If the session cookie still references
+        // a previous account, keep account selection so the user can pick it
         if (!hasCookieAccount(sessionCookies, organization)) {
           return gotoLoginname({
             request,
@@ -400,10 +391,6 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       let selectedSession = await findValidSession({ serviceConfig, sessions, authRequest, organization });
 
       if (!selectedSession || !selectedSession.id) {
-        // No live session is eligible. If the sessions cookie still references a
-        // previous account (e.g. after RP-initiated logout, #12252), show
-        // account selection from the cookie instead of sending the user to the
-        // loginname screen.
         if (eligibleSessions.length === 0 && !hasCookieAccount(sessionCookies, organization)) {
           return gotoLoginname({
             request,

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -1,6 +1,6 @@
 import { getValidLocaleFromUILocales } from "@/lib/auth-utils";
 import { isSafeRedirectUri } from "@/lib/client-utils";
-import { getLanguageCookie, setLanguageCookie } from "@/lib/cookies";
+import { getLanguageCookie, setLanguageCookie, type Cookie } from "@/lib/cookies";
 
 import { shouldUILocalesOverrideCookie } from "@/lib/i18n";
 import { idpTypeToSlug } from "@/lib/idp";
@@ -120,11 +120,29 @@ function getEligibleSessions(sessions: Session[], organization?: string): Sessio
   return sessions.filter((s) => s.factors?.user?.organizationId === organization);
 }
 
+/**
+ * Whether the `sessions` cookie references any previous account for the given
+ * organization (or for any org when `organization` is unset).
+ *
+ * After RP-initiated logout the server-side sessions are terminated but the
+ * `sessions` cookie still lists the previously signed-in accounts (see #12209).
+ * Login V1 keeps these selectable; Login V2 must do the same by rendering
+ * account selection from the cookie when there are no live sessions (#12252).
+ */
+function hasCookieAccount(sessionCookies: Cookie[], organization?: string): boolean {
+  if (!sessionCookies || sessionCookies.length === 0) {
+    return false;
+  }
+  return sessionCookies.some(
+    (c) => !!c.loginName && (!organization || c.organization === organization),
+  );
+}
+
 export interface FlowInitiationParams {
   serviceConfig: ServiceConfig;
   requestId: string;
   sessions: Session[];
-  sessionCookies: any[];
+  sessionCookies: Cookie[];
   request: NextRequest;
 }
 
@@ -275,13 +293,19 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
 
     if (authRequest.prompt.includes(Prompt.SELECT_ACCOUNT)) {
       if (eligibleSessions.length === 0) {
-        return gotoLoginname({
-          request,
-          requestId,
-          loginHint: authRequest.loginHint,
-          organization,
-          orgDomain,
-        });
+        // No live session is eligible. If the sessions cookie still references
+        // a previous account (e.g. after RP-initiated logout, #12252), keep
+        // account selection so the user can pick it instead of landing on the
+        // loginname screen.
+        if (!hasCookieAccount(sessionCookies, organization)) {
+          return gotoLoginname({
+            request,
+            requestId,
+            loginHint: authRequest.loginHint,
+            organization,
+            orgDomain,
+          });
+        }
       }
       return gotoAccounts({
         request,
@@ -376,9 +400,11 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       let selectedSession = await findValidSession({ serviceConfig, sessions, authRequest, organization });
 
       if (!selectedSession || !selectedSession.id) {
-        // If no sessions are eligible for this organization, go directly to
-        // loginname instead of showing an empty accounts page.
-        if (eligibleSessions.length === 0) {
+        // No live session is eligible. If the sessions cookie still references a
+        // previous account (e.g. after RP-initiated logout, #12252), show
+        // account selection from the cookie instead of sending the user to the
+        // loginname screen.
+        if (eligibleSessions.length === 0 && !hasCookieAccount(sessionCookies, organization)) {
           return gotoLoginname({
             request,
             requestId,
@@ -448,6 +474,18 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       }
     }
   } else {
+    // No live sessions were resolved. If the sessions cookie still references a
+    // previous account and the RP did not pass a login_hint, show account
+    // selection (mirrors Login V1 behavior after RP-initiated logout, #12252).
+    if (!authRequest?.loginHint && hasCookieAccount(sessionCookies, organization)) {
+      return gotoAccounts({
+        request,
+        requestId,
+        organization,
+        orgDomain,
+      });
+    }
+
     const loginNameUrl = constructUrl(request, "/loginname");
     loginNameUrl.searchParams.set("requestId", requestId);
 

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -300,14 +300,26 @@ export async function clearSession(options: ClearSessionOptions) {
     return;
   }
 
-  const deleteResponse = await deleteSession({
-    serviceConfig,
-    sessionId: sessionCookie.id,
-    sessionToken: sessionCookie.token,
-  });
-
   const securitySettings = await getSecuritySettings({ serviceConfig });
   const iFrameEnabled = !!securitySettings?.embeddedIframe?.enabled;
+
+  let deleteResponse;
+  try {
+    deleteResponse = await deleteSession({
+      serviceConfig,
+      sessionId: sessionCookie.id,
+      sessionToken: sessionCookie.token,
+    });
+  } catch (error) {
+    // The server-side session may already be gone (e.g. RP-initiated logout
+    // terminated it, see #12252). Prune the cookie entry anyway so the account
+    // card is removed from the selection screen.
+    logger.warn("clearSession: deleteSession failed, pruning cookie entry anyway", {
+      sessionId: sessionCookie.id,
+      error,
+    });
+    return removeSessionFromCookie({ session: sessionCookie, iFrameEnabled });
+  }
 
   if (!deleteResponse) {
     throw new Error("Could not delete session");

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -311,9 +311,8 @@ export async function clearSession(options: ClearSessionOptions) {
       sessionToken: sessionCookie.token,
     });
   } catch (error) {
-    // The server-side session may already be gone (e.g. RP-initiated logout
-    // terminated it, see #12252). Prune the cookie entry anyway so the account
-    // card is removed from the selection screen.
+    // The server-side session may already be gone.
+    // Prune the cookie entry anyway so the account card is removed from the selection screen.
     logger.warn("clearSession: deleteSession failed, pruning cookie entry anyway", {
       sessionId: sessionCookie.id,
       error,


### PR DESCRIPTION
# Which Problems Are Solved
 - After RP-initiated logout, a new /oauth/v2/authorize flow in Login V2 redirects to /loginname instead of showing the previous account selection, even when the sessions cookie still lists previously signed-in accounts.

 # How the Problems Are Solved
 - flow-initiation: when no live session is eligible but the sessions cookie still references a previous account, route to accounts instead of /loginname.
 - accounts page: synthesize an invalid Session from cookie entries whose server-side session no longer exists, so the existing SessionItem re-login path renders and continues the flow on click.

 # Additional Changes
 - Reuse getAllSessions in getAllSessionCookieIds
 - Updated flow-initiation test fixtures to match the tightened sessionCookies: Cookie[] type.

 # Additional Context
 - Closes #12252
