### PR TITLE
docs: add video walkthrough link to quickstart guide

### DIFF
--- a/apps/docs/content/guides/start/quickstart.mdx
+++ b/apps/docs/content/guides/start/quickstart.mdx
@@ -1081,3 +1081,5 @@ You’ve successfully integrated ZITADEL into an application.
 - [**Explore the API**](/apis/introduction): Check out the ZITADEL API Reference for advanced integrations.
 
 Need help? Join our [Discord community](https://zitadel.com/chat) or explore the full Documentation. Happy coding!
+
+Prefer watching over reading? Check out our [video walkthrough of this quickstart](https://www.youtube.com/watch?v=POxkxGdDJyo).


### PR DESCRIPTION
Link the YouTube walkthrough at the end of the quickstart page for users who prefer watching over reading.

