### PR TITLE
fix(login): match root background to theme

### DIFF
--- a/apps/login/src/styles/globals.scss
+++ b/apps/login/src/styles/globals.scss
@@ -16,6 +16,12 @@
 html {
   --background-color: #ffffff;
   --dark-background-color: #000000;
+
+  background-color: var(--theme-light-background-600, var(--background-color));
+}
+
+html.dark {
+  background-color: var(--theme-dark-background-600, var(--dark-background-color));
 }
 
 .form-checkbox {


### PR DESCRIPTION
# Which Problems Are Solved

- Firefox paints the overscroll area white instead of using the selected login theme background.

# How the Problems Are Solved

- Applies the generated light theme background color to the root `html` element.
- Applies the generated dark theme background when `html` has the `dark` class.
- Uses the existing static background variables as pre-hydration fallbacks.

# Additional Changes

- None.

# Additional Context

- Closes #7387
- Validation: `pnpm nx run @zitadel/login:lint --tui=false`
- Validation: `pnpm --filter @zitadel/login exec prettier --check src/styles/globals.scss`