### PR TITLE
docs: prefix legacy V1 API paths in generated OpenAPI

### DIFF
--- a/apps/docs/scripts/generate-api-reference.ts
+++ b/apps/docs/scripts/generate-api-reference.ts
@@ -76,8 +76,8 @@ async function generateVersionApiDocs(version: string) {
     const hasBeenRenamed = !!newTitle;
     const title = newTitle ?? originalTitle;
     const renameNote = hasBeenRenamed
-      ? `\n> **Terminology Update:** We have streamlined our naming conventions to improve clarity. The term **${originalTitle}** has been replaced with **${title}**. To avoid breaking changes the APIs still make use of the old term. Both terms refer to the same underlying functionality.\n`
-      : '';
+        ? `\n> **Terminology Update:** We have streamlined our naming conventions to improve clarity. The term **${originalTitle}** has been replaced with **${title}**. To avoid breaking changes the APIs still make use of the old term. Both terms refer to the same underlying functionality.\n`
+        : '';
 
     const indexContent = `---
 title: ${title} API
@@ -237,7 +237,7 @@ async function fixAllGeneratedLinks() {
             .map(line => line.trim())
             .filter(line => line.length > 0 && !line.startsWith('- ') && !line.startsWith('---'))
             .join(' ');
-
+          
           if (description.length > 200) {
             description = description.slice(0, 197) + '...';
           }
@@ -250,44 +250,44 @@ async function fixAllGeneratedLinks() {
         // Clean up title for description use
         const cleanTitle = title.replace(/\n\s+/g, ' ').trim();
         if (!description.includes(cleanTitle)) {
-          description = `${cleanTitle}: ${description}`;
+           description = `${cleanTitle}: ${description}`;
         }
-
+        
         // Final sanitization for YAML double-quoted string
         description = description
-          .replace(/\\/g, '\\\\') // Escape backslashes first to avoid double-processing
-          .replace(/\n/g, ' ')
-          .replace(/"/g, "'") // Use single quotes internally
-          .replace(/\s+/g, ' ')
-          .trim();
+            .replace(/\\/g, '\\\\') // Escape backslashes first to avoid double-processing
+            .replace(/\n/g, ' ')
+            .replace(/"/g, "'") // Use single quotes internally
+            .replace(/\s+/g, ' ')
+            .trim();
 
         const newDescLine = `description: "${description}"`;
 
         // Clean existing descriptions to avoid duplicates or corrupted ones
         const oldContent = newContent;
-
+        
         // Split frontmatter and body
         const parts = newContent.split('---');
         if (parts.length >= 3) {
-          let frontmatter = parts[1];
-          // Remove any existing description keys and their potential multiline values
-          // This regex matches "description:" and then everything until it sees a new key (word followed by colon) 
-          // or the end of the frontmatter section.
-          frontmatter = frontmatter.replace(/description:\s*[\s\S]*?(?=\n\w+:|$)/g, '');
-
-          // Also explicitly fix the "iam.member.read" type corruption by looking for lines that start with quotes 
-          // but have no colon, which follow a description line.
-          // Actually the regex above should have caught it if it matched until the next key.
-
-          // Clean up any double newlines and trim
-          frontmatter = frontmatter.split('\n').filter(line => line.trim().length > 0).join('\n');
-
-          parts[1] = `\n${newDescLine}\n${frontmatter}\n`;
-          newContent = parts.join('---');
+            let frontmatter = parts[1];
+            // Remove any existing description keys and their potential multiline values
+            // This regex matches "description:" and then everything until it sees a new key (word followed by colon) 
+            // or the end of the frontmatter section.
+            frontmatter = frontmatter.replace(/description:\s*[\s\S]*?(?=\n\w+:|$)/g, '');
+            
+            // Also explicitly fix the "iam.member.read" type corruption by looking for lines that start with quotes 
+            // but have no colon, which follow a description line.
+            // Actually the regex above should have caught it if it matched until the next key.
+            
+            // Clean up any double newlines and trim
+            frontmatter = frontmatter.split('\n').filter(line => line.trim().length > 0).join('\n');
+            
+            parts[1] = `\n${newDescLine}\n${frontmatter}\n`;
+            newContent = parts.join('---');
         }
 
         if (newContent !== oldContent) {
-          modified = true;
+            modified = true;
         }
       }
     }

--- a/apps/docs/scripts/generate-api-reference.ts
+++ b/apps/docs/scripts/generate-api-reference.ts
@@ -34,18 +34,6 @@ async function generateVersionApiDocs(version: string) {
   console.log(`Generating API docs for version: ${version} -> ${outputRoot}`);
   mkdirSync(outputRoot, { recursive: true });
 
-  // --- START: READ DYNAMIC BASE PATHS ---
-  const basePathsPath = join(sourceRoot, 'base_paths.json');
-  let basePaths: Record<string, string> = {};
-  if (existsSync(basePathsPath)) {
-    try {
-      basePaths = JSON.parse(readFileSync(basePathsPath, 'utf8'));
-    } catch (e) {
-      console.warn(`Failed to parse base_paths.json for ${version}`);
-    }
-  }
-  // --- END: READ DYNAMIC BASE PATHS ---
-
   const specs = await glob('**/*.openapi.json', { cwd: sourceRoot });
   const services: string[] = [];
 
@@ -55,26 +43,6 @@ async function generateVersionApiDocs(version: string) {
     const doc = JSON.parse(content) as any;
 
     if (!doc.paths || Object.keys(doc.paths).length === 0) continue;
-
-    // --- START: DYNAMICALLY APPLY BASE PATH ---
-    let modified = false;
-    const fileBaseName = basename(specPath, '.openapi.json');
-    const prefix = basePaths[fileBaseName];
-
-    if (prefix) {
-      const newPaths: Record<string, any> = {};
-      for (const [route, operations] of Object.entries(doc.paths)) {
-        const newRoute = route.startsWith(prefix) ? route : `${prefix}${route}`;
-        newPaths[newRoute] = operations;
-      }
-      doc.paths = newPaths;
-      modified = true;
-    }
-
-    if (modified) {
-      writeFileSync(fullPath, JSON.stringify(doc, null, 2), 'utf8');
-    }
-    // --- END: DYNAMICALLY APPLY BASE PATH ---
 
     let service = basename(specPath, '.openapi.json');
     if (service.endsWith('_service')) {

--- a/apps/docs/scripts/generate-api-reference.ts
+++ b/apps/docs/scripts/generate-api-reference.ts
@@ -34,6 +34,18 @@ async function generateVersionApiDocs(version: string) {
   console.log(`Generating API docs for version: ${version} -> ${outputRoot}`);
   mkdirSync(outputRoot, { recursive: true });
 
+  // --- START: READ DYNAMIC BASE PATHS ---
+  const basePathsPath = join(sourceRoot, 'base_paths.json');
+  let basePaths: Record<string, string> = {};
+  if (existsSync(basePathsPath)) {
+    try {
+      basePaths = JSON.parse(readFileSync(basePathsPath, 'utf8'));
+    } catch (e) {
+      console.warn(`Failed to parse base_paths.json for ${version}`);
+    }
+  }
+  // --- END: READ DYNAMIC BASE PATHS ---
+
   const specs = await glob('**/*.openapi.json', { cwd: sourceRoot });
   const services: string[] = [];
 
@@ -43,6 +55,26 @@ async function generateVersionApiDocs(version: string) {
     const doc = JSON.parse(content) as any;
 
     if (!doc.paths || Object.keys(doc.paths).length === 0) continue;
+
+    // --- START: DYNAMICALLY APPLY BASE PATH ---
+    let modified = false;
+    const fileBaseName = basename(specPath, '.openapi.json');
+    const prefix = basePaths[fileBaseName];
+
+    if (prefix) {
+      const newPaths: Record<string, any> = {};
+      for (const [route, operations] of Object.entries(doc.paths)) {
+        const newRoute = route.startsWith(prefix) ? route : `${prefix}${route}`;
+        newPaths[newRoute] = operations;
+      }
+      doc.paths = newPaths;
+      modified = true;
+    }
+
+    if (modified) {
+      writeFileSync(fullPath, JSON.stringify(doc, null, 2), 'utf8');
+    }
+    // --- END: DYNAMICALLY APPLY BASE PATH ---
 
     let service = basename(specPath, '.openapi.json');
     if (service.endsWith('_service')) {
@@ -76,8 +108,8 @@ async function generateVersionApiDocs(version: string) {
     const hasBeenRenamed = !!newTitle;
     const title = newTitle ?? originalTitle;
     const renameNote = hasBeenRenamed
-        ? `\n> **Terminology Update:** We have streamlined our naming conventions to improve clarity. The term **${originalTitle}** has been replaced with **${title}**. To avoid breaking changes the APIs still make use of the old term. Both terms refer to the same underlying functionality.\n`
-        : '';
+      ? `\n> **Terminology Update:** We have streamlined our naming conventions to improve clarity. The term **${originalTitle}** has been replaced with **${title}**. To avoid breaking changes the APIs still make use of the old term. Both terms refer to the same underlying functionality.\n`
+      : '';
 
     const indexContent = `---
 title: ${title} API
@@ -237,7 +269,7 @@ async function fixAllGeneratedLinks() {
             .map(line => line.trim())
             .filter(line => line.length > 0 && !line.startsWith('- ') && !line.startsWith('---'))
             .join(' ');
-          
+
           if (description.length > 200) {
             description = description.slice(0, 197) + '...';
           }
@@ -250,44 +282,44 @@ async function fixAllGeneratedLinks() {
         // Clean up title for description use
         const cleanTitle = title.replace(/\n\s+/g, ' ').trim();
         if (!description.includes(cleanTitle)) {
-           description = `${cleanTitle}: ${description}`;
+          description = `${cleanTitle}: ${description}`;
         }
-        
+
         // Final sanitization for YAML double-quoted string
         description = description
-            .replace(/\\/g, '\\\\') // Escape backslashes first to avoid double-processing
-            .replace(/\n/g, ' ')
-            .replace(/"/g, "'") // Use single quotes internally
-            .replace(/\s+/g, ' ')
-            .trim();
+          .replace(/\\/g, '\\\\') // Escape backslashes first to avoid double-processing
+          .replace(/\n/g, ' ')
+          .replace(/"/g, "'") // Use single quotes internally
+          .replace(/\s+/g, ' ')
+          .trim();
 
         const newDescLine = `description: "${description}"`;
 
         // Clean existing descriptions to avoid duplicates or corrupted ones
         const oldContent = newContent;
-        
+
         // Split frontmatter and body
         const parts = newContent.split('---');
         if (parts.length >= 3) {
-            let frontmatter = parts[1];
-            // Remove any existing description keys and their potential multiline values
-            // This regex matches "description:" and then everything until it sees a new key (word followed by colon) 
-            // or the end of the frontmatter section.
-            frontmatter = frontmatter.replace(/description:\s*[\s\S]*?(?=\n\w+:|$)/g, '');
-            
-            // Also explicitly fix the "iam.member.read" type corruption by looking for lines that start with quotes 
-            // but have no colon, which follow a description line.
-            // Actually the regex above should have caught it if it matched until the next key.
-            
-            // Clean up any double newlines and trim
-            frontmatter = frontmatter.split('\n').filter(line => line.trim().length > 0).join('\n');
-            
-            parts[1] = `\n${newDescLine}\n${frontmatter}\n`;
-            newContent = parts.join('---');
+          let frontmatter = parts[1];
+          // Remove any existing description keys and their potential multiline values
+          // This regex matches "description:" and then everything until it sees a new key (word followed by colon) 
+          // or the end of the frontmatter section.
+          frontmatter = frontmatter.replace(/description:\s*[\s\S]*?(?=\n\w+:|$)/g, '');
+
+          // Also explicitly fix the "iam.member.read" type corruption by looking for lines that start with quotes 
+          // but have no colon, which follow a description line.
+          // Actually the regex above should have caught it if it matched until the next key.
+
+          // Clean up any double newlines and trim
+          frontmatter = frontmatter.split('\n').filter(line => line.trim().length > 0).join('\n');
+
+          parts[1] = `\n${newDescLine}\n${frontmatter}\n`;
+          newContent = parts.join('---');
         }
 
         if (newContent !== oldContent) {
-            modified = true;
+          modified = true;
         }
       }
     }

--- a/apps/docs/scripts/generate-proto-docs.mjs
+++ b/apps/docs/scripts/generate-proto-docs.mjs
@@ -26,21 +26,25 @@ function applyV1PathPrefixes(outputPath) {
   for (const [service, prefix] of Object.entries(V1_PATH_PREFIXES)) {
     const files = glob.sync(`**/${service}.openapi.json`, { cwd: outputPath, absolute: true, nodir: true });
     for (const file of files) {
-      const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
-      if (!doc.paths || Object.keys(doc.paths).length === 0) continue;
+      try {
+        const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+        if (!doc.paths || Object.keys(doc.paths).length === 0) continue;
 
-      const newPaths = {};
-      let changed = false;
-      for (const [route, operations] of Object.entries(doc.paths)) {
-        const newRoute = route.startsWith(prefix) ? route : `${prefix}${route}`;
-        if (newRoute !== route) changed = true;
-        newPaths[newRoute] = operations;
+        const newPaths = {};
+        let changed = false;
+        for (const [route, operations] of Object.entries(doc.paths)) {
+          const newRoute = route.startsWith(prefix) ? route : `${prefix}${route}`;
+          if (newRoute !== route) changed = true;
+          newPaths[newRoute] = operations;
+        }
+        if (!changed) continue;
+
+        doc.paths = newPaths;
+        fs.writeFileSync(file, JSON.stringify(doc, null, 2));
+        console.log(`Applied ${prefix} to ${basename(file)}`);
+      } catch (e) {
+        console.warn(`Failed to apply ${prefix} to ${basename(file)}`, e);
       }
-      if (!changed) continue;
-
-      doc.paths = newPaths;
-      fs.writeFileSync(file, JSON.stringify(doc, null, 2));
-      console.log(`Applied ${prefix} to ${basename(file)}`);
     }
   }
 }

--- a/apps/docs/scripts/generate-proto-docs.mjs
+++ b/apps/docs/scripts/generate-proto-docs.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { glob } from 'glob';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, basename } from 'path';
 import { spawn, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
@@ -15,8 +15,8 @@ const PNPM_COMMAND = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
 async function run() {
   if (!fs.existsSync(VERSIONS_FILE)) {
-      console.error('versions.json not found. Run fetch-docs.mjs first.');
-      process.exit(1);
+    console.error('versions.json not found. Run fetch-docs.mjs first.');
+    process.exit(1);
   }
 
   const versions = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf8'));
@@ -50,7 +50,7 @@ async function run() {
 
     return run;
   };
-  
+
   const limit = pLimit(2);
 
   await Promise.all(versions.map(v => limit(async () => {
@@ -58,138 +58,171 @@ async function run() {
 
     const label = v.param;
     const outputPath = resolve(join(OPENAPI_DIR, label));
-      
+
     console.log(`\n--- Generating OpenAPI specs for ${label} ---`);
-      
+
     fs.rmSync(outputPath, { recursive: true, force: true });
     fs.mkdirSync(outputPath, { recursive: true });
 
     // Determine buf input based on refType
     let bufInput;
     if (v.refType === 'local') {
-        // Point to local proto directory (repo root/proto)
-        bufInput = PROTO_DIR; 
+      // Point to local proto directory (repo root/proto)
+      bufInput = PROTO_DIR;
     } else {
-        const refPart = v.refType === 'branch' ? `branch=${v.ref}` : `tag=${v.ref}`;
-        bufInput = `${REPO_URL}#${refPart},subdir=proto`;
+      const refPart = v.refType === 'branch' ? `branch=${v.ref}` : `tag=${v.ref}`;
+      bufInput = `${REPO_URL}#${refPart},subdir=proto`;
     }
-      
+
     console.log(`Using input for ${label}: ${bufInput}`);
 
 
     // Use spawn (async) instead of spawnSync to avoid blocking the event loop
     // eslint-disable-next-line no-async-promise-executor
     await new Promise(async (resolvePromise, rejectPromise) => {
-        // Dynamic discovery of excluded paths
-        const getExcludedPaths = async () => {
-             const patterns = ['**/v3alpha', '**/v2beta'];
-             const excluded = new Set();
-             
-             if (v.refType === 'local') {
-                 // For local, use glob against PROTO_DIR
-                 // patterns are relative to PROTO_DIR, but glob needs to search inside PROTO_DIR
-                 // The result of glob will be paths relative to PROTO_DIR if cwd is PROTO_DIR
-                 try {
-                    const files = await glob(patterns, { cwd: PROTO_DIR, nodir: false });
-                    // We only want directories that contain v3alpha, or files?
-                    // buf --exclude-path expects directories or files.
-                    // If we found directories ending in v3alpha, usage is fine.
-                    // glob '**/v3alpha' matches directories or files ending in v3alpha.
-                    // Ensure we pass absolute paths for local input to avoid CWD resolution issues
-                    files.forEach(f => excluded.add(resolve(PROTO_DIR, f)));
-                 } catch (e) {
-                     console.warn('Failed to glob excluded paths locally', e);
-                 }
-             } else {
-                 // For remote (tag/branch), use git ls-tree
-                 // We need to run git ls-tree -r <ref> --name-only
-                 // and filter for lines matching /v3alpha/
-                 // We run this in ROOT_DIR (where .git presumably is available via parent)
-                 // The paths returned by git ls-tree are relative to repo root.
-                 // buf input is relative to 'proto' subdir.
-                 // So we need to strip 'proto/' prefix.
-                 try {
-                     const ref = v.ref;
-                     const gitCmd = spawnSync('git', ['ls-tree', '-r', '--name-only', ref], { cwd: ROOT_DIR, encoding: 'utf-8' });
-                     if (gitCmd.error) throw gitCmd.error;
-                     const files = gitCmd.stdout.split('\n');
-                     files.forEach(f => {
-                         if ((f.includes('v3alpha') || f.includes('v2beta')) && f.startsWith('proto/')) {
-                             // strip 'proto/' (6 chars) and take the directory
-                             const relPath = f.substring(6);
-                             const dirPath = dirname(relPath);
-                             if (dirPath.includes('v3alpha') || dirPath.includes('v2beta')) {
-                                excluded.add(dirPath);
-                             } else {
-                                excluded.add(relPath);
-                             }
-                         }
-                     });
-                 } catch (e) {
-                     console.warn(`Failed to list tree for ${v.param}`, e);
-                 }
-             }
-             return Array.from(excluded);
-        };
+      // Dynamic discovery of excluded paths
+      const getExcludedPaths = async () => {
+        const patterns = ['**/v3alpha', '**/v2beta'];
+        const excluded = new Set();
 
-        const excludedPaths = await getExcludedPaths();
-        if (excludedPaths.length > 0) {
-            console.log(`Excluding ${excludedPaths.length} paths matching v3alpha or v2beta`);
-        }
-
-        const args = [
-          'exec', 'buf', 'generate',
-          bufInput,
-          '--template', templatePath,
-          '--output', outputPath
-        ];
-
-        // Add excluded paths
-        for (const excludedPath of excludedPaths) {
-          args.push('--exclude-path', excludedPath);
-        }
-
-        // Run from the workspace root so pnpm resolves the repo-pinned Buf binary.
-        const child = spawn(PNPM_COMMAND, args, {
-          cwd: WORKSPACE_ROOT,
-          stdio: 'inherit',
-          env: process.env
-        });
-
-        child.on('close', (code, signal) => {
-          if (code !== 0) {
-            let reason;
-            if (code === null && signal) {
-              reason = `terminated by signal ${signal}`;
-            } else if (typeof code === 'number') {
-              reason = `exit code ${code}`;
-            } else {
-              reason = 'process terminated for an unknown reason';
-            }
-
-            rejectPromise(new Error(`Failed to generate OpenAPI for ${label} (${reason})`));
-          } else {
-            console.log(`Successfully generated OpenAPI for ${label}`);
-                
-            // Post-generation cleanup: delete any missed v2beta/v3alpha files
-            try {
-              const generatedFiles = glob.sync('**/*', { cwd: outputPath, absolute: true, nodir: false });
-              generatedFiles.forEach(f => {
-                if (f.includes('v2beta') || f.includes('v3alpha')) {
-                  fs.rmSync(f, { recursive: true, force: true });
-                }
-              });
-            } catch (e) {
-              console.warn(`Failed to clean up OpenAPI specs for ${label}`, e);
-            }
-                
-            resolvePromise();
+        if (v.refType === 'local') {
+          // For local, use glob against PROTO_DIR
+          // patterns are relative to PROTO_DIR, but glob needs to search inside PROTO_DIR
+          // The result of glob will be paths relative to PROTO_DIR if cwd is PROTO_DIR
+          try {
+            const files = await glob(patterns, { cwd: PROTO_DIR, nodir: false });
+            // We only want directories that contain v3alpha, or files?
+            // buf --exclude-path expects directories or files.
+            // If we found directories ending in v3alpha, usage is fine.
+            // glob '**/v3alpha' matches directories or files ending in v3alpha.
+            // Ensure we pass absolute paths for local input to avoid CWD resolution issues
+            files.forEach(f => excluded.add(resolve(PROTO_DIR, f)));
+          } catch (e) {
+            console.warn('Failed to glob excluded paths locally', e);
           }
-        });
-          
-        child.on('error', (err) => {
-          rejectPromise(err);
-        });
+        } else {
+          // For remote (tag/branch), use git ls-tree
+          // We need to run git ls-tree -r <ref> --name-only
+          // and filter for lines matching /v3alpha/
+          // We run this in ROOT_DIR (where .git presumably is available via parent)
+          // The paths returned by git ls-tree are relative to repo root.
+          // buf input is relative to 'proto' subdir.
+          // So we need to strip 'proto/' prefix.
+          try {
+            const ref = v.ref;
+            const gitCmd = spawnSync('git', ['ls-tree', '-r', '--name-only', ref], { cwd: ROOT_DIR, encoding: 'utf-8' });
+            if (gitCmd.error) throw gitCmd.error;
+            const files = gitCmd.stdout.split('\n');
+            files.forEach(f => {
+              if ((f.includes('v3alpha') || f.includes('v2beta')) && f.startsWith('proto/')) {
+                // strip 'proto/' (6 chars) and take the directory
+                const relPath = f.substring(6);
+                const dirPath = dirname(relPath);
+                if (dirPath.includes('v3alpha') || dirPath.includes('v2beta')) {
+                  excluded.add(dirPath);
+                } else {
+                  excluded.add(relPath);
+                }
+              }
+            });
+          } catch (e) {
+            console.warn(`Failed to list tree for ${v.param}`, e);
+          }
+        }
+        return Array.from(excluded);
+      };
+
+      const excludedPaths = await getExcludedPaths();
+      if (excludedPaths.length > 0) {
+        console.log(`Excluding ${excludedPaths.length} paths matching v3alpha or v2beta`);
+      }
+
+      const args = [
+        'exec', 'buf', 'generate',
+        bufInput,
+        '--template', templatePath,
+        '--output', outputPath
+      ];
+
+      // Add excluded paths
+      for (const excludedPath of excludedPaths) {
+        args.push('--exclude-path', excludedPath);
+      }
+
+      // Run from the workspace root so pnpm resolves the repo-pinned Buf binary.
+      const child = spawn(PNPM_COMMAND, args, {
+        cwd: WORKSPACE_ROOT,
+        stdio: 'inherit',
+        env: process.env
+      });
+
+      child.on('close', (code, signal) => {
+        if (code !== 0) {
+          let reason;
+          if (code === null && signal) {
+            reason = `terminated by signal ${signal}`;
+          } else if (typeof code === 'number') {
+            reason = `exit code ${code}`;
+          } else {
+            reason = 'process terminated for an unknown reason';
+          }
+
+          rejectPromise(new Error(`Failed to generate OpenAPI for ${label} (${reason})`));
+        } else {
+          console.log(`Successfully generated OpenAPI for ${label}`);
+
+          // Post-generation cleanup: delete any missed v2beta/v3alpha files
+          try {
+            const generatedFiles = glob.sync('**/*', { cwd: outputPath, absolute: true, nodir: false });
+            generatedFiles.forEach(f => {
+              if (f.includes('v2beta') || f.includes('v3alpha')) {
+                fs.rmSync(f, { recursive: true, force: true });
+              }
+            });
+          } catch (e) {
+            console.warn(`Failed to clean up OpenAPI specs for ${label}`, e);
+          }
+
+          // --- START: EXTRACT BASE PATHS FROM .PROTO FILES ---
+          try {
+            const basePaths = {};
+            if (v.refType === 'local') {
+              const protoFiles = glob.sync('**/*.proto', { cwd: PROTO_DIR, nodir: true });
+              for (const file of protoFiles) {
+                const content = fs.readFileSync(join(PROTO_DIR, file), 'utf8');
+                const match = content.match(/base_path:\s*"([^"]+)"/);
+                if (match) {
+                  basePaths[basename(file, '.proto')] = match[1];
+                }
+              }
+            } else {
+              // Extremely fast extraction directly from the git tree
+              const gitGrep = spawnSync('git', ['grep', '-E', 'base_path:', v.ref, '--', 'proto/'], { cwd: ROOT_DIR, encoding: 'utf-8' });
+              if (!gitGrep.error && gitGrep.stdout) {
+                const lines = gitGrep.stdout.split('\n');
+                for (const line of lines) {
+                  // Match format: ref:proto/.../admin.proto: base_path: "/admin/v1";
+                  const match = line.match(/\/([^/]+)\.proto:.*base_path:\s*"([^"]+)"/);
+                  if (match) {
+                    basePaths[match[1]] = match[2];
+                  }
+                }
+              }
+            }
+            // Save the map so the next script can apply it
+            fs.writeFileSync(join(outputPath, 'base_paths.json'), JSON.stringify(basePaths, null, 2));
+            console.log(`Extracted base paths from .proto files for ${label}`);
+          } catch (e) {
+            console.warn(`Failed to extract base paths for ${label}`, e);
+          }
+
+          resolvePromise();
+        }
+      });
+
+      child.on('error', (err) => {
+        rejectPromise(err);
+      });
     });
   })));
 }

--- a/apps/docs/scripts/generate-proto-docs.mjs
+++ b/apps/docs/scripts/generate-proto-docs.mjs
@@ -13,10 +13,42 @@ const VERSIONS_FILE = join(ROOT_DIR, 'content/versions.json');
 const REPO_URL = 'https://github.com/zitadel/zitadel.git';
 const PNPM_COMMAND = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
+// Legacy V1 APIs declare base_path via OpenAPI v2 swagger options that
+// protoc-gen-connect-openapi ignores. Prefix paths so fumadocs shows the real URLs.
+const V1_PATH_PREFIXES = {
+  admin: '/admin/v1',
+  auth: '/auth/v1',
+  management: '/management/v1',
+  system: '/system/v1',
+};
+
+function applyV1PathPrefixes(outputPath) {
+  for (const [service, prefix] of Object.entries(V1_PATH_PREFIXES)) {
+    const files = glob.sync(`**/${service}.openapi.json`, { cwd: outputPath, absolute: true, nodir: true });
+    for (const file of files) {
+      const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (!doc.paths || Object.keys(doc.paths).length === 0) continue;
+
+      const newPaths = {};
+      let changed = false;
+      for (const [route, operations] of Object.entries(doc.paths)) {
+        const newRoute = route.startsWith(prefix) ? route : `${prefix}${route}`;
+        if (newRoute !== route) changed = true;
+        newPaths[newRoute] = operations;
+      }
+      if (!changed) continue;
+
+      doc.paths = newPaths;
+      fs.writeFileSync(file, JSON.stringify(doc, null, 2));
+      console.log(`Applied ${prefix} to ${basename(file)}`);
+    }
+  }
+}
+
 async function run() {
   if (!fs.existsSync(VERSIONS_FILE)) {
-    console.error('versions.json not found. Run fetch-docs.mjs first.');
-    process.exit(1);
+      console.error('versions.json not found. Run fetch-docs.mjs first.');
+      process.exit(1);
   }
 
   const versions = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf8'));
@@ -50,7 +82,7 @@ async function run() {
 
     return run;
   };
-
+  
   const limit = pLimit(2);
 
   await Promise.all(versions.map(v => limit(async () => {
@@ -58,171 +90,144 @@ async function run() {
 
     const label = v.param;
     const outputPath = resolve(join(OPENAPI_DIR, label));
-
+      
     console.log(`\n--- Generating OpenAPI specs for ${label} ---`);
-
+      
     fs.rmSync(outputPath, { recursive: true, force: true });
     fs.mkdirSync(outputPath, { recursive: true });
 
     // Determine buf input based on refType
     let bufInput;
     if (v.refType === 'local') {
-      // Point to local proto directory (repo root/proto)
-      bufInput = PROTO_DIR;
+        // Point to local proto directory (repo root/proto)
+        bufInput = PROTO_DIR; 
     } else {
-      const refPart = v.refType === 'branch' ? `branch=${v.ref}` : `tag=${v.ref}`;
-      bufInput = `${REPO_URL}#${refPart},subdir=proto`;
+        const refPart = v.refType === 'branch' ? `branch=${v.ref}` : `tag=${v.ref}`;
+        bufInput = `${REPO_URL}#${refPart},subdir=proto`;
     }
-
+      
     console.log(`Using input for ${label}: ${bufInput}`);
 
 
     // Use spawn (async) instead of spawnSync to avoid blocking the event loop
     // eslint-disable-next-line no-async-promise-executor
     await new Promise(async (resolvePromise, rejectPromise) => {
-      // Dynamic discovery of excluded paths
-      const getExcludedPaths = async () => {
-        const patterns = ['**/v3alpha', '**/v2beta'];
-        const excluded = new Set();
+        // Dynamic discovery of excluded paths
+        const getExcludedPaths = async () => {
+             const patterns = ['**/v3alpha', '**/v2beta'];
+             const excluded = new Set();
+             
+             if (v.refType === 'local') {
+                 // For local, use glob against PROTO_DIR
+                 // patterns are relative to PROTO_DIR, but glob needs to search inside PROTO_DIR
+                 // The result of glob will be paths relative to PROTO_DIR if cwd is PROTO_DIR
+                 try {
+                    const files = await glob(patterns, { cwd: PROTO_DIR, nodir: false });
+                    // We only want directories that contain v3alpha, or files?
+                    // buf --exclude-path expects directories or files.
+                    // If we found directories ending in v3alpha, usage is fine.
+                    // glob '**/v3alpha' matches directories or files ending in v3alpha.
+                    // Ensure we pass absolute paths for local input to avoid CWD resolution issues
+                    files.forEach(f => excluded.add(resolve(PROTO_DIR, f)));
+                 } catch (e) {
+                     console.warn('Failed to glob excluded paths locally', e);
+                 }
+             } else {
+                 // For remote (tag/branch), use git ls-tree
+                 // We need to run git ls-tree -r <ref> --name-only
+                 // and filter for lines matching /v3alpha/
+                 // We run this in ROOT_DIR (where .git presumably is available via parent)
+                 // The paths returned by git ls-tree are relative to repo root.
+                 // buf input is relative to 'proto' subdir.
+                 // So we need to strip 'proto/' prefix.
+                 try {
+                     const ref = v.ref;
+                     const gitCmd = spawnSync('git', ['ls-tree', '-r', '--name-only', ref], { cwd: ROOT_DIR, encoding: 'utf-8' });
+                     if (gitCmd.error) throw gitCmd.error;
+                     const files = gitCmd.stdout.split('\n');
+                     files.forEach(f => {
+                         if ((f.includes('v3alpha') || f.includes('v2beta')) && f.startsWith('proto/')) {
+                             // strip 'proto/' (6 chars) and take the directory
+                             const relPath = f.substring(6);
+                             const dirPath = dirname(relPath);
+                             if (dirPath.includes('v3alpha') || dirPath.includes('v2beta')) {
+                                excluded.add(dirPath);
+                             } else {
+                                excluded.add(relPath);
+                             }
+                         }
+                     });
+                 } catch (e) {
+                     console.warn(`Failed to list tree for ${v.param}`, e);
+                 }
+             }
+             return Array.from(excluded);
+        };
 
-        if (v.refType === 'local') {
-          // For local, use glob against PROTO_DIR
-          // patterns are relative to PROTO_DIR, but glob needs to search inside PROTO_DIR
-          // The result of glob will be paths relative to PROTO_DIR if cwd is PROTO_DIR
-          try {
-            const files = await glob(patterns, { cwd: PROTO_DIR, nodir: false });
-            // We only want directories that contain v3alpha, or files?
-            // buf --exclude-path expects directories or files.
-            // If we found directories ending in v3alpha, usage is fine.
-            // glob '**/v3alpha' matches directories or files ending in v3alpha.
-            // Ensure we pass absolute paths for local input to avoid CWD resolution issues
-            files.forEach(f => excluded.add(resolve(PROTO_DIR, f)));
-          } catch (e) {
-            console.warn('Failed to glob excluded paths locally', e);
-          }
-        } else {
-          // For remote (tag/branch), use git ls-tree
-          // We need to run git ls-tree -r <ref> --name-only
-          // and filter for lines matching /v3alpha/
-          // We run this in ROOT_DIR (where .git presumably is available via parent)
-          // The paths returned by git ls-tree are relative to repo root.
-          // buf input is relative to 'proto' subdir.
-          // So we need to strip 'proto/' prefix.
-          try {
-            const ref = v.ref;
-            const gitCmd = spawnSync('git', ['ls-tree', '-r', '--name-only', ref], { cwd: ROOT_DIR, encoding: 'utf-8' });
-            if (gitCmd.error) throw gitCmd.error;
-            const files = gitCmd.stdout.split('\n');
-            files.forEach(f => {
-              if ((f.includes('v3alpha') || f.includes('v2beta')) && f.startsWith('proto/')) {
-                // strip 'proto/' (6 chars) and take the directory
-                const relPath = f.substring(6);
-                const dirPath = dirname(relPath);
-                if (dirPath.includes('v3alpha') || dirPath.includes('v2beta')) {
-                  excluded.add(dirPath);
-                } else {
-                  excluded.add(relPath);
-                }
-              }
-            });
-          } catch (e) {
-            console.warn(`Failed to list tree for ${v.param}`, e);
-          }
+        const excludedPaths = await getExcludedPaths();
+        if (excludedPaths.length > 0) {
+            console.log(`Excluding ${excludedPaths.length} paths matching v3alpha or v2beta`);
         }
-        return Array.from(excluded);
-      };
 
-      const excludedPaths = await getExcludedPaths();
-      if (excludedPaths.length > 0) {
-        console.log(`Excluding ${excludedPaths.length} paths matching v3alpha or v2beta`);
-      }
+        const args = [
+          'exec', 'buf', 'generate',
+          bufInput,
+          '--template', templatePath,
+          '--output', outputPath
+        ];
 
-      const args = [
-        'exec', 'buf', 'generate',
-        bufInput,
-        '--template', templatePath,
-        '--output', outputPath
-      ];
+        // Add excluded paths
+        for (const excludedPath of excludedPaths) {
+          args.push('--exclude-path', excludedPath);
+        }
 
-      // Add excluded paths
-      for (const excludedPath of excludedPaths) {
-        args.push('--exclude-path', excludedPath);
-      }
+        // Run from the workspace root so pnpm resolves the repo-pinned Buf binary.
+        const child = spawn(PNPM_COMMAND, args, {
+          cwd: WORKSPACE_ROOT,
+          stdio: 'inherit',
+          env: process.env
+        });
 
-      // Run from the workspace root so pnpm resolves the repo-pinned Buf binary.
-      const child = spawn(PNPM_COMMAND, args, {
-        cwd: WORKSPACE_ROOT,
-        stdio: 'inherit',
-        env: process.env
-      });
-
-      child.on('close', (code, signal) => {
-        if (code !== 0) {
-          let reason;
-          if (code === null && signal) {
-            reason = `terminated by signal ${signal}`;
-          } else if (typeof code === 'number') {
-            reason = `exit code ${code}`;
-          } else {
-            reason = 'process terminated for an unknown reason';
-          }
-
-          rejectPromise(new Error(`Failed to generate OpenAPI for ${label} (${reason})`));
-        } else {
-          console.log(`Successfully generated OpenAPI for ${label}`);
-
-          // Post-generation cleanup: delete any missed v2beta/v3alpha files
-          try {
-            const generatedFiles = glob.sync('**/*', { cwd: outputPath, absolute: true, nodir: false });
-            generatedFiles.forEach(f => {
-              if (f.includes('v2beta') || f.includes('v3alpha')) {
-                fs.rmSync(f, { recursive: true, force: true });
-              }
-            });
-          } catch (e) {
-            console.warn(`Failed to clean up OpenAPI specs for ${label}`, e);
-          }
-
-          // --- START: EXTRACT BASE PATHS FROM .PROTO FILES ---
-          try {
-            const basePaths = {};
-            if (v.refType === 'local') {
-              const protoFiles = glob.sync('**/*.proto', { cwd: PROTO_DIR, nodir: true });
-              for (const file of protoFiles) {
-                const content = fs.readFileSync(join(PROTO_DIR, file), 'utf8');
-                const match = content.match(/base_path:\s*"([^"]+)"/);
-                if (match) {
-                  basePaths[basename(file, '.proto')] = match[1];
-                }
-              }
+        child.on('close', (code, signal) => {
+          if (code !== 0) {
+            let reason;
+            if (code === null && signal) {
+              reason = `terminated by signal ${signal}`;
+            } else if (typeof code === 'number') {
+              reason = `exit code ${code}`;
             } else {
-              // Extremely fast extraction directly from the git tree
-              const gitGrep = spawnSync('git', ['grep', '-E', 'base_path:', v.ref, '--', 'proto/'], { cwd: ROOT_DIR, encoding: 'utf-8' });
-              if (!gitGrep.error && gitGrep.stdout) {
-                const lines = gitGrep.stdout.split('\n');
-                for (const line of lines) {
-                  // Match format: ref:proto/.../admin.proto: base_path: "/admin/v1";
-                  const match = line.match(/\/([^/]+)\.proto:.*base_path:\s*"([^"]+)"/);
-                  if (match) {
-                    basePaths[match[1]] = match[2];
-                  }
-                }
-              }
+              reason = 'process terminated for an unknown reason';
             }
-            // Save the map so the next script can apply it
-            fs.writeFileSync(join(outputPath, 'base_paths.json'), JSON.stringify(basePaths, null, 2));
-            console.log(`Extracted base paths from .proto files for ${label}`);
-          } catch (e) {
-            console.warn(`Failed to extract base paths for ${label}`, e);
+
+            rejectPromise(new Error(`Failed to generate OpenAPI for ${label} (${reason})`));
+          } else {
+            console.log(`Successfully generated OpenAPI for ${label}`);
+                
+            // Post-generation cleanup: delete any missed v2beta/v3alpha files
+            try {
+              const generatedFiles = glob.sync('**/*', { cwd: outputPath, absolute: true, nodir: false });
+              generatedFiles.forEach(f => {
+                if (f.includes('v2beta') || f.includes('v3alpha')) {
+                  fs.rmSync(f, { recursive: true, force: true });
+                }
+              });
+            } catch (e) {
+              console.warn(`Failed to clean up OpenAPI specs for ${label}`, e);
+            }
+
+            try {
+              applyV1PathPrefixes(outputPath);
+            } catch (e) {
+              console.warn(`Failed to apply V1 path prefixes for ${label}`, e);
+            }
+
+            resolvePromise();
           }
-
-          resolvePromise();
-        }
-      });
-
-      child.on('error', (err) => {
-        rejectPromise(err);
-      });
+        });
+          
+        child.on('error', (err) => {
+          rejectPromise(err);
+        });
     });
   })));
 }


### PR DESCRIPTION
# Which Problems Are Solved

- Generated V1 API reference docs are missing their base path prefixes (e.g. `/admin/v1`, `/auth/v1`, `/management/v1`, `/system/v1`).
- Endpoint pages show routes like `/healthz` instead of `/admin/v1/healthz`.

This happens because V1 protos still define `base_path` via legacy OpenAPI v2 swagger annotations, while docs generation uses `protoc-gen-connect-openapi`, which ignores those annotations and emits the bare `google.api.http` paths.

# How the Problems Are Solved

- After OpenAPI generation in `apps/docs/scripts/generate-proto-docs.mjs`, apply a small hardcoded map of the four legacy V1 services and prepend the correct prefix to each path in the generated specs.
- The rewrite is idempotent (`startsWith(prefix)`), so already-prefixed paths are left alone.
- Because the prefixes are written into the generated OpenAPI files, Fumadocs MDX generation and runtime page rendering stay in sync.

# Additional Changes

- None.

# Additional Context

- V1 APIs are legacy and frozen; hardcoding the four known prefixes is simpler and more reliable than dynamically scraping `.proto` files.
- Changing the protos or dual-generating with `openapiv2` would be much more invasive for a docs-only issue.
- Verified locally for Admin, Auth, Management, and System pages (e.g. `/admin/v1/healthz`, `/management/v1/users/{id}`).