### PR TITLE
fix(i18n): add missing Turkish error translations

### DIFF
--- a/internal/static/i18n/tr.yaml
+++ b/internal/static/i18n/tr.yaml
@@ -1,5 +1,6 @@
 Errors:
   Internal: "Dahili bir hata oluştu"
+  PermissionDenied: "İzin reddedildi"
   NoChangesFound: "Değişiklik bulunamadı"
   OriginNotAllowed: "Bu \"Origin\" izin verilmiyor"
   IDMissing: "ID eksik"
@@ -182,6 +183,7 @@ Errors:
       Passwordless:
         NotExisting: "Şifresiz giriş mevcut değil"
       RecoveryCodes:
+        Empty: "Kurtarma kodu boş"
         InvalidCode: "Geçersiz kurtarma kodu sağlandı"
         MaxCountExceeded: "Maksimum kurtarma kodu sayısı aşıldı"
         NotReady: "Kurtarma kodları kullanıma hazır değil"
@@ -514,6 +516,8 @@ Errors:
       StorageFailed: "Eylem yürütme günlüğünü veritabanına kaydetme başarısız"
       ScanFailed: "Eylem yürütme saniyeleri için kullanım sorgulama başarısız"
   Session:
+    IDMissing: "Oturum ID'si eksik"
+    NotFound: "Oturum bulunamadı"
     NotExisting: "Oturum mevcut değil"
     Terminated: "Oturum zaten sonlandırılmış"
     Expired: "Oturumun süresi dolmuş"


### PR DESCRIPTION
# Which Problems Are Solved

- The Turkish common translations were missing four error-message keys available in the English reference file.
- Affected errors could fall back to English or expose an untranslated localization key.

# How the Problems Are Solved

- Adds natural Turkish translations for:
  - `Errors.PermissionDenied`
  - `Errors.User.MFA.RecoveryCodes.Empty`
  - `Errors.Session.IDMissing`
  - `Errors.Session.NotFound`
- Compares all common locale files against `en.yaml`.
- Leaves other languages unchanged because they require native-speaker review.

# Additional Changes

None.

# Additional Context

- All 22 YAML locale files parse successfully after the change.
- The Turkish locale has no missing `Errors.*` keys compared with `en.yaml`.
- `git diff --check` passes.
- Go tests were not run because the Go toolchain is unavailable in the local environment.
- `ro.yaml` has a pre-existing hierarchy/indentation problem and was intentionally left unchanged to keep this change minimal.
- Closes #11841