### PR TITLE
fix(oidc): honor TrustRemoteSpans for the OIDC HTTP server

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -683,6 +683,7 @@ func startAPIs(
 		config.SystemDefaults.SecretHasher,
 		federatedLogoutsCache,
 		httpClient,
+		config.Instrumentation.Trace.TrustRemoteSpans,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start oidc provider: %w", err)

--- a/internal/api/http/middleware/trace_interceptor.go
+++ b/internal/api/http/middleware/trace_interceptor.go
@@ -11,16 +11,27 @@ import (
 )
 
 func DefaultTraceHandler(handler http.Handler) http.Handler {
-	return TraceHandler(http_utils.Probes...)(handler)
+	return TraceHandler(false, http_utils.Probes...)(handler)
 }
 
-func TraceHandler(ignoredPrefix ...string) func(http.Handler) http.Handler {
+// TraceHandler wraps handler with otelhttp instrumentation.
+//
+// When trustRemoteSpans is false (the default), every request is treated as
+// a [otelhttp.WithPublicEndpointFn] endpoint: an incoming traceparent header
+// is never used to continue the caller's trace, it is at most recorded as a
+// span link. Set trustRemoteSpans to true for handlers where the caller is
+// known and trusted (mirroring the behavior already available for the
+// gRPC/Connect API via ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS, see
+// otelconnect.WithTrustRemote in internal/api/api.go) so that spans emitted
+// by this handler are correctly parented under the caller's trace instead of
+// starting a disconnected trace.
+func TraceHandler(trustRemoteSpans bool, ignoredPrefix ...string) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return otelhttp.NewHandler(handler,
 			"zitadel",
 			otelhttp.WithFilter(instrumentation.RequestFilter(ignoredPrefix...)),
 			otelhttp.WithPublicEndpointFn(func(_ *http.Request) bool {
-				return true
+				return !trustRemoteSpans
 			}),
 			otelhttp.WithSpanNameFormatter(spanNameFormatter),
 			otelhttp.WithMeterProvider(otel.GetMeterProvider()),

--- a/internal/api/oidc/op.go
+++ b/internal/api/oidc/op.go
@@ -128,6 +128,7 @@ func NewServer(
 	hashConfig crypto.HashConfig,
 	federatedLogoutCache cache.Cache[federatedlogout.Index, string, *federatedlogout.FederatedLogout],
 	httpClient *http.Client,
+	trustRemoteSpans bool,
 ) (*Server, error) {
 	opConfig, err := createOPConfig(config, defaultLogoutRedirectURI, cryptoKey)
 	if err != nil {
@@ -200,7 +201,7 @@ func NewServer(
 			middleware.CallDurationHandler,
 			middleware.RequestDetailsHandler(),
 			middleware.MetricsHandler(metricTypes),
-			middleware.TraceHandler(),
+			middleware.TraceHandler(trustRemoteSpans),
 			middleware.LogHandler("oidc"),
 			middleware.RecoverHandler(writeRecoverError),
 			middleware.NoCacheInterceptor().Handler,

--- a/internal/api/saml/provider.go
+++ b/internal/api/saml/provider.go
@@ -75,7 +75,7 @@ func NewProvider(
 			middleware.CallDurationHandler,
 			middleware.RequestDetailsHandler(),
 			middleware.MetricsHandler(metricTypes),
-			middleware.TraceHandler(),
+			middleware.TraceHandler(false),
 			middleware.LogHandler("saml"),
 			middleware.NoCacheInterceptor().Handler,
 			instanceHandler,

--- a/internal/api/ui/console/console.go
+++ b/internal/api/ui/console/console.go
@@ -117,7 +117,7 @@ func Start(config Config, externalSecure bool, issuer op.IssuerFromRequest, call
 	env.Use(
 		callDurationInterceptor,
 		middleware.RequestDetailsHandler(),
-		middleware.TraceHandler(),
+		middleware.TraceHandler(false),
 		middleware.LogHandler("console"),
 		instanceHandler,
 	)

--- a/internal/api/ui/login/login.go
+++ b/internal/api/ui/login/login.go
@@ -221,7 +221,7 @@ func CreateLogin(
 	login.router = CreateRouter(login,
 		middleware.CallDurationHandler,
 		middleware.RequestDetailsHandler(),
-		middleware.TraceHandler(IgnoreInstanceEndpoints...),
+		middleware.TraceHandler(false, IgnoreInstanceEndpoints...),
 		middleware.LogHandler("login_v1", IgnoreInstanceEndpoints...),
 		oidcInstanceHandler,
 		samlInstanceHandler,


### PR DESCRIPTION
## Summary

`ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS` is currently only wired into the gRPC/Connect API, via `otelconnect.WithTrustRemote()` in `internal/api/api.go`:

```go
if trustRemoteSpans {
    otelOpts = append(otelOpts, otelconnect.WithTrustRemote())
}
```

The legacy OIDC HTTP server (`internal/api/oidc/op.go`), which serves `/oauth/v2/token`, `/oauth/v2/introspect`, etc., uses a separate `otelhttp`-based `middleware.TraceHandler()` that unconditionally sets `WithPublicEndpointFn` to `true`:

```go
otelhttp.WithPublicEndpointFn(func(_ *http.Request) bool {
    return true
}),
```

This means an incoming `traceparent` header is never used to continue the caller's trace for these endpoints, regardless of `TrustRemoteSpans` — spans for OIDC HTTP requests always start a new, disconnected trace, even though the exact same setting already works correctly for the Connect API.

In practice this makes it impossible to get a single linked trace across a reverse-proxy/gateway (e.g. an API gateway plugin doing token introspection) and Zitadel's own handling of that introspection call — confirmed by testing: a `traceparent` sent to `/oauth/v2/introspect` is ignored, and Zitadel logs a fresh, unrelated `TraceID` for the request.

## Change

`middleware.TraceHandler` now accepts a `trustRemoteSpans bool` parameter, threaded through from `config.Instrumentation.Trace.TrustRemoteSpans` into the OIDC server (`oidc.NewServer`), so `WithPublicEndpointFn` honors the same setting already used for the Connect API.

Other `TraceHandler` call sites (console, login, saml) explicitly pass `false` to keep their current behavior unchanged — extending this to those surfaces felt like a separate discussion/PR.

## Test plan

- [x] `gofmt -l` clean on all touched files
- [ ] I don't have the full `buf generate` toolchain set up locally to run a complete `go build ./...` (the repo's generated `pkg/grpc/**` connect stubs are gitignored) — would appreciate CI confirming compilation
- [ ] Manual verification: with this change and `ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS=true`, an introspect call carrying a `traceparent` header should produce a span parented under the caller's trace instead of a disconnected one

Happy to add a regression test for `TraceHandler`'s `WithPublicEndpointFn` behavior if useful — let me know the preferred location/pattern.