### PR TITLE
fix: default docs selector to latest release

### DIFF
--- a/apps/docs/app/[[...slug]]/layout.tsx
+++ b/apps/docs/app/[[...slug]]/layout.tsx
@@ -5,6 +5,9 @@ import { baseOptions } from '@/lib/layout.shared';
 import { buildCustomTree } from '@/lib/custom-tree';
 import rawVersions from '@/content/versions.json';
 import { VersionSelector } from '@/components/version-selector';
+import { LATEST_VERSION, resolveVersion, VERSION_PREFERENCE_COOKIE } from '@/lib/version-preference.mjs';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 type DocVersion = { param: string };
 type PageTree = typeof source.pageTree;
@@ -54,8 +57,19 @@ export default async function Layout(props: { children: ReactNode; params: Promi
   const params = await props.params;
   const slug = params.slug || [];
 
-  const currentVersion = slug[0] && versionParams.has(slug[0]) ? slug[0] : 'latest';
-  const tree = currentVersion === 'latest' ? latestTree : getVersionTree(currentVersion);
+  const requestedVersion = slug[0] && versionParams.has(slug[0]) ? slug[0] : undefined;
+  const cookieStore = await cookies();
+  const currentVersion = resolveVersion({
+    requestedVersion,
+    storedVersion: cookieStore.get(VERSION_PREFERENCE_COOKIE)?.value,
+    versions,
+  });
+
+  if (!requestedVersion && currentVersion !== LATEST_VERSION) {
+    redirect(`/${[currentVersion, ...slug].join('/')}`);
+  }
+
+  const tree = currentVersion === LATEST_VERSION ? latestTree : getVersionTree(currentVersion);
 
   return (
     <DocsLayout

--- a/apps/docs/components/version-selector.tsx
+++ b/apps/docs/components/version-selector.tsx
@@ -12,6 +12,7 @@ interface DocVersion {
 }
 
 import rawVersions from '../content/versions.json';
+import { getVersionPreferenceCookie } from '../lib/version-preference.mjs';
 const versions = rawVersions as DocVersion[];
 
 export function VersionSelector() {
@@ -46,6 +47,8 @@ export function VersionSelector() {
         if (!version) return;
 
         if (!version.param) return;
+
+        document.cookie = getVersionPreferenceCookie(version.param);
 
         // Calculate the 'tail' of the path (content path)
         let tail = normalizedPath;

--- a/apps/docs/lib/version-preference.mjs
+++ b/apps/docs/lib/version-preference.mjs
@@ -1,0 +1,25 @@
+export const VERSION_PREFERENCE_COOKIE = 'zitadel-docs-version';
+export const LATEST_VERSION = 'latest';
+export const LATEST_VERSION_LABEL = 'Latest (unreleased)';
+
+export function getVersionPreferenceCookie(version) {
+  return `${VERSION_PREFERENCE_COOKIE}=${encodeURIComponent(version)}; Path=/docs; Max-Age=31536000; SameSite=Lax`;
+}
+
+export function getLatestReleasedVersion(versions) {
+  return versions.find((version) => version.param !== LATEST_VERSION)?.param;
+}
+
+export function resolveVersion({ requestedVersion, storedVersion, versions }) {
+  const availableVersions = new Set(versions.map((version) => version.param));
+
+  if (requestedVersion && availableVersions.has(requestedVersion)) {
+    return requestedVersion;
+  }
+
+  if (storedVersion && availableVersions.has(storedVersion)) {
+    return storedVersion;
+  }
+
+  return getLatestReleasedVersion(versions) ?? LATEST_VERSION;
+}

--- a/apps/docs/scripts/fetch-remote-content.mjs
+++ b/apps/docs/scripts/fetch-remote-content.mjs
@@ -3,6 +3,7 @@ import path, { join, dirname, resolve } from 'path';
 import { spawn, execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import semver from 'semver';
+import { LATEST_VERSION_LABEL } from '../lib/version-preference.mjs';
 import { Readable } from 'stream';
 
 const FALLBACK_VERSION = 'v4.10.0';
@@ -520,7 +521,7 @@ async function run() {
   const versionsJson = [
     {
       param: 'latest',
-      label: localVer.isUnreleased ? `${localVer.label} (Unreleased)` : `${localVer.label} (Latest)`,
+      label: LATEST_VERSION_LABEL,
       url: '/docs',
       ref: 'local',
       refType: 'local'

--- a/apps/docs/scripts/version-preference.test.mjs
+++ b/apps/docs/scripts/version-preference.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  getVersionPreferenceCookie,
+  LATEST_VERSION_LABEL,
+  resolveVersion,
+} from '../lib/version-preference.mjs';
+
+const versions = [
+  { param: 'latest' },
+  { param: 'newest-release' },
+  { param: 'older-release' },
+];
+
+describe('API docs version preference', () => {
+  test('labels the unreleased docs consistently', () => {
+    assert.equal(LATEST_VERSION_LABEL, 'Latest (unreleased)');
+  });
+
+  test('creates a preference cookie for an explicit selection', () => {
+    assert.equal(
+      getVersionPreferenceCookie('latest'),
+      'zitadel-docs-version=latest; Path=/docs; Max-Age=31536000; SameSite=Lax',
+    );
+  });
+
+  test('defaults a new visitor to the latest released version', () => {
+    assert.equal(resolveVersion({ versions }), 'newest-release');
+  });
+
+  test('preserves an explicitly selected released version', () => {
+    assert.equal(resolveVersion({ storedVersion: 'older-release', versions }), 'older-release');
+  });
+
+  test('preserves an explicitly selected unreleased version', () => {
+    assert.equal(resolveVersion({ storedVersion: 'latest', versions }), 'latest');
+  });
+
+  test('falls back from a stale preference to the latest released version', () => {
+    assert.equal(resolveVersion({ storedVersion: 'removed-release', versions }), 'newest-release');
+  });
+
+  test('gives a URL version precedence over the stored preference', () => {
+    assert.equal(
+      resolveVersion({
+        requestedVersion: 'older-release',
+        storedVersion: 'latest',
+        versions,
+      }),
+      'older-release',
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- rename the unreleased API docs option to `Latest (unreleased)`
- default visitors without a URL version or stored preference to the latest released version from the generated version manifest
- preserve valid versions explicitly selected in the selector, including `Latest (unreleased)`
- fall back to the latest released version when a stored preference is no longer available
- keep an explicit URL version authoritative over any stored preference
- write the preference cookie only when the user changes the selector

## Why

The selector previously had no preference persistence and treated unversioned visits as the unreleased docs. This made new visitors land on unreleased documentation and prevented returning visitors from retaining an explicit choice.

The latest released version is derived dynamically from the existing generated version data; no release number is hardcoded.

## Validation

- `pnpm --dir apps/docs test:scripts` — 20 tests passed
- focused ESLint for the five changed files — passed
- `git diff --check` — passed

The Nx lint target was also attempted with `NX_DAEMON=false`, but Nx project graph calculation hung before producing target output. A full direct TypeScript check remains blocked by the absent generated `.source/server` module and an unrelated existing implicit-`any` error in `scripts/inspect-toc-endpoints.ts`.