### PR TITLE
fix(login): return an invalid-code error instead of a 500 on a wrong OTP code

### DIFF
--- a/apps/login/locales/ar.json
+++ b/apps/login/locales/ar.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "تعذر التحقق من الدعوة",
       "couldNotVerifyEmail": "تعذر التحقق من البريد الإلكتروني",
       "couldNotVerify": "تعذر التحقق",
+      "invalidCode": "الرمز غير صالح. يرجى المحاولة مرة أخرى.",
       "couldNotLoadUser": "تعذر تحميل المستخدم",
       "couldNotLoadAuthenticators": "تعذر تحميل المصادقين المحتملين",
       "couldNotCreateSession": "تعذر إنشاء الجلسة",

--- a/apps/login/locales/de.json
+++ b/apps/login/locales/de.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Einladung konnte nicht verifiziert werden",
       "couldNotVerifyEmail": "E-Mail konnte nicht verifiziert werden",
       "couldNotVerify": "Konnte nicht verifizieren",
+      "invalidCode": "Der Code ist ungültig. Bitte versuchen Sie es erneut.",
       "couldNotLoadUser": "Benutzer konnte nicht geladen werden",
       "couldNotLoadAuthenticators": "Mögliche Authentifikatoren konnten nicht geladen werden",
       "couldNotCreateSession": "Sitzung konnte nicht erstellt werden",

--- a/apps/login/locales/en.json
+++ b/apps/login/locales/en.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Could not verify invite",
       "couldNotVerifyEmail": "Could not verify email",
       "couldNotVerify": "Could not verify",
+      "invalidCode": "The code is invalid. Please try again.",
       "couldNotLoadUser": "Could not load user",
       "couldNotLoadAuthenticators": "Could not load possible authenticators",
       "couldNotCreateSession": "Could not create session",

--- a/apps/login/locales/es.json
+++ b/apps/login/locales/es.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "No se pudo verificar la invitación",
       "couldNotVerifyEmail": "No se pudo verificar el correo electrónico",
       "couldNotVerify": "No se pudo verificar",
+      "invalidCode": "El código no es válido. Inténtelo de nuevo.",
       "couldNotLoadUser": "No se pudo cargar al usuario",
       "couldNotLoadAuthenticators": "No se pudieron cargar los autenticadores posibles",
       "couldNotCreateSession": "No se pudo crear la sesión",

--- a/apps/login/locales/fr.json
+++ b/apps/login/locales/fr.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Impossible de vérifier l'invitation",
       "couldNotVerifyEmail": "Impossible de vérifier l'e-mail",
       "couldNotVerify": "Impossible de vérifier",
+      "invalidCode": "Le code est invalide. Veuillez réessayer.",
       "couldNotLoadUser": "Impossible de charger l'utilisateur",
       "couldNotLoadAuthenticators": "Impossible de charger les authentificateurs disponibles",
       "couldNotCreateSession": "Impossible de créer la session",

--- a/apps/login/locales/hu.json
+++ b/apps/login/locales/hu.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Nem sikerült ellenőrizni a meghívást",
       "couldNotVerifyEmail": "Nem sikerült ellenőrizni az e-mail címet",
       "couldNotVerify": "Nem sikerült ellenőrizni",
+      "invalidCode": "A kód érvénytelen. Kérjük, próbálja újra.",
       "couldNotLoadUser": "Nem sikerült betölteni a felhasználót",
       "couldNotLoadAuthenticators": "Nem sikerült betölteni a lehetséges hitelesítőket",
       "couldNotCreateSession": "Nem sikerült létrehozni a munkamenetet",

--- a/apps/login/locales/it.json
+++ b/apps/login/locales/it.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Impossibile verificare l'invito",
       "couldNotVerifyEmail": "Impossibile verificare l'email",
       "couldNotVerify": "Impossibile verificare",
+      "invalidCode": "Il codice non è valido. Riprova.",
       "couldNotLoadUser": "Impossibile caricare l'utente",
       "couldNotLoadAuthenticators": "Impossibile caricare gli autenticatori possibili",
       "couldNotCreateSession": "Impossibile creare la sessione",

--- a/apps/login/locales/ja.json
+++ b/apps/login/locales/ja.json
@@ -398,6 +398,7 @@
       "couldNotVerifyInvite": "招待を確認できませんでした",
       "couldNotVerifyEmail": "メールアドレスを確認できませんでした",
       "couldNotVerify": "確認できませんでした",
+      "invalidCode": "コードが無効です。もう一度お試しください。",
       "couldNotLoadUser": "ユーザーを読み込めませんでした",
       "couldNotLoadAuthenticators": "認証方法を読み込めませんでした",
       "couldNotCreateSession": "セッションを作成できませんでした",

--- a/apps/login/locales/nl.json
+++ b/apps/login/locales/nl.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Kon uitnodiging niet verifiëren",
       "couldNotVerifyEmail": "Kon e-mail niet verifiëren",
       "couldNotVerify": "Kon niet verifiëren",
+      "invalidCode": "De code is ongeldig. Probeer het opnieuw.",
       "couldNotLoadUser": "Kon gebruiker niet laden",
       "couldNotLoadAuthenticators": "Kon mogelijke authenticators niet laden",
       "couldNotCreateSession": "Kon sessie niet aanmaken",

--- a/apps/login/locales/pl.json
+++ b/apps/login/locales/pl.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Nie udało się zweryfikować zaproszenia",
       "couldNotVerifyEmail": "Nie udało się zweryfikować adresu e-mail",
       "couldNotVerify": "Nie udało się zweryfikować",
+      "invalidCode": "Kod jest nieprawidłowy. Spróbuj ponownie.",
       "couldNotLoadUser": "Nie udało się załadować użytkownika",
       "couldNotLoadAuthenticators": "Nie udało się wczytać dostępnych metod uwierzytelniania",
       "couldNotCreateSession": "Nie udało się utworzyć sesji",

--- a/apps/login/locales/pt.json
+++ b/apps/login/locales/pt.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Não foi possível verificar o convite",
       "couldNotVerifyEmail": "Não foi possível verificar o e-mail",
       "couldNotVerify": "Não foi possível verificar",
+      "invalidCode": "O código é inválido. Tente novamente.",
       "couldNotLoadUser": "Não foi possível carregar o usuário",
       "couldNotLoadAuthenticators": "Não foi possível carregar os autenticadores disponíveis",
       "couldNotCreateSession": "Não foi possível criar a sessão",

--- a/apps/login/locales/ru.json
+++ b/apps/login/locales/ru.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Не удалось подтвердить приглашение",
       "couldNotVerifyEmail": "Не удалось подтвердить электронную почту",
       "couldNotVerify": "Не удалось подтвердить",
+      "invalidCode": "Неверный код. Пожалуйста, попробуйте снова.",
       "couldNotLoadUser": "Не удалось загрузить пользователя",
       "couldNotLoadAuthenticators": "Не удалось загрузить доступные средства аутентификации",
       "couldNotCreateSession": "Не удалось создать сеанс",

--- a/apps/login/locales/tr.json
+++ b/apps/login/locales/tr.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Davet doğrulanamadı",
       "couldNotVerifyEmail": "E-posta doğrulanamadı",
       "couldNotVerify": "Doğrulanamadı",
+      "invalidCode": "Kod geçersiz. Lütfen tekrar deneyin.",
       "couldNotLoadUser": "Kullanıcı yüklenemedi",
       "couldNotLoadAuthenticators": "Olası kimlik doğrulayıcılar yüklenemedi",
       "couldNotCreateSession": "Oturum oluşturulamadı",

--- a/apps/login/locales/uk.json
+++ b/apps/login/locales/uk.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "Не вдалося підтвердити запрошення",
       "couldNotVerifyEmail": "Не вдалося підтвердити електронну пошту",
       "couldNotVerify": "Не вдалося підтвердити",
+      "invalidCode": "Невірний код. Будь ласка, спробуйте ще раз.",
       "couldNotLoadUser": "Не вдалося завантажити користувача",
       "couldNotLoadAuthenticators": "Не вдалося завантажити можливі автентифікатори",
       "couldNotCreateSession": "Не вдалося створити сеанс",

--- a/apps/login/locales/zh.json
+++ b/apps/login/locales/zh.json
@@ -405,6 +405,7 @@
       "couldNotVerifyInvite": "无法验证邀请",
       "couldNotVerifyEmail": "无法验证邮箱",
       "couldNotVerify": "无法验证",
+      "invalidCode": "验证码无效。请重试。",
       "couldNotLoadUser": "无法加载用户",
       "couldNotLoadAuthenticators": "无法加载可用的身份验证器",
       "couldNotCreateSession": "无法创建会话",

--- a/apps/login/src/lib/server/session.test.ts
+++ b/apps/login/src/lib/server/session.test.ts
@@ -1,0 +1,138 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create, toJson } from "@zitadel/client";
+import { Checks, ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ClassifiedConnectError } from "../grpc/interceptors/error-classification";
+import { updateOrCreateSession } from "./session";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/server/cookie", () => ({
+  createSessionAndUpdateCookie: vi.fn(),
+  setSessionAndUpdateCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/zitadel", () => ({
+  deleteSession: vi.fn(),
+  getLoginSettings: vi.fn(),
+  getSecuritySettings: vi.fn(),
+  humanMFAInitSkipped: vi.fn(),
+  listAuthenticationMethodTypes: vi.fn(),
+  listUsers: vi.fn(),
+}));
+
+vi.mock("../cookies", () => ({
+  getMostRecentSessionCookie: vi.fn(),
+  getSessionCookieById: vi.fn(),
+  getSessionCookieByLoginName: vi.fn(),
+  removeSessionFromCookie: vi.fn(),
+}));
+
+vi.mock("../client", () => ({
+  completeFlowOrGetUrl: vi.fn(),
+}));
+
+vi.mock("../service-url", () => ({
+  getServiceConfig: vi.fn(),
+}));
+
+vi.mock("./host", () => ({
+  getPublicHost: vi.fn(),
+}));
+
+// Mock translations - returns the key itself for testing
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(() => (key: string) => key),
+}));
+
+const USER_ID = "1416cf78-43e0-423d-9691-49fd4f4df776";
+const LOGIN_NAME = "user@example.com";
+
+describe("updateOrCreateSession", () => {
+  let mockCreateSessionAndUpdateCookie: any;
+  let mockSetSessionAndUpdateCookie: any;
+  let mockListUsers: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { headers } = await import("next/headers");
+    const { getServiceConfig } = await import("../service-url");
+    const { getPublicHost } = await import("./host");
+    const { getSessionCookieByLoginName } = await import("../cookies");
+    const { getLoginSettings, listUsers } = await import("@/lib/zitadel");
+    const { createSessionAndUpdateCookie, setSessionAndUpdateCookie } = await import("@/lib/server/cookie");
+
+    vi.mocked(headers).mockResolvedValue(new Headers() as any);
+    vi.mocked(getServiceConfig).mockReturnValue({ serviceConfig: {} } as any);
+    vi.mocked(getPublicHost).mockReturnValue("localhost:3000");
+    vi.mocked(getSessionCookieByLoginName).mockResolvedValue({
+      id: "session-id",
+      token: "session-token",
+      loginName: LOGIN_NAME,
+      organization: "org-id",
+    } as any);
+    vi.mocked(getLoginSettings).mockResolvedValue({} as any);
+    vi.mocked(listUsers).mockResolvedValue({
+      details: { totalResult: BigInt(1) },
+      result: [{ userId: USER_ID }],
+    } as any);
+    vi.mocked(createSessionAndUpdateCookie).mockResolvedValue({
+      session: { id: "new-session-id", factors: { user: { id: USER_ID, loginName: LOGIN_NAME } } },
+    } as any);
+
+    mockCreateSessionAndUpdateCookie = vi.mocked(createSessionAndUpdateCookie);
+    mockSetSessionAndUpdateCookie = vi.mocked(setSessionAndUpdateCookie);
+    mockListUsers = vi.mocked(listUsers);
+  });
+
+  test("returns an invalid code error instead of re-creating the session when the code check is rejected", async () => {
+    // ZITADEL answers a wrong TOTP/OTP code with invalid_argument (Errors.User.MFA.OTP.InvalidCode).
+    mockSetSessionAndUpdateCookie.mockRejectedValue(
+      new ClassifiedConnectError(new ConnectError("Code is invalid (EVENT-8isk2)", Code.InvalidArgument)),
+    );
+
+    const result = await updateOrCreateSession({
+      loginName: LOGIN_NAME,
+      organization: "org-id",
+      checks: create(ChecksSchema, { totp: { code: "000000" } }),
+    });
+
+    expect(result).toEqual({ error: "invalidCode" });
+    // The session is fine - re-creating it would only replay the same rejected code.
+    expect(mockListUsers).not.toHaveBeenCalled();
+    expect(mockCreateSessionAndUpdateCookie).not.toHaveBeenCalled();
+  });
+
+  test("re-creates the session with a serializable Checks message when the session is gone", async () => {
+    // A terminated/expired session answers with failed_precondition, which is what the
+    // fallback below is meant to recover from.
+    mockSetSessionAndUpdateCookie.mockRejectedValue(
+      new ClassifiedConnectError(new ConnectError("Errors.Session.Terminated", Code.FailedPrecondition)),
+    );
+
+    const result = await updateOrCreateSession({
+      loginName: LOGIN_NAME,
+      organization: "org-id",
+      checks: create(ChecksSchema, { totp: { code: "123456" } }),
+    });
+
+    expect(mockCreateSessionAndUpdateCookie).toHaveBeenCalledOnce();
+    const newChecks: Checks = mockCreateSessionAndUpdateCookie.mock.calls[0][0].checks;
+
+    // Regression guard: a plain object literal for `user` survives `create()` unconverted
+    // (protobuf-es returns an init value that already is a message of the target type as-is),
+    // which made serialization fail with "cannot use field
+    // zitadel.session.v2.CheckUser.user_id with message undefined" and turned a wrong code
+    // into an HTTP 500.
+    expect(() => toJson(ChecksSchema, newChecks)).not.toThrow();
+    expect(toJson(ChecksSchema, newChecks)).toEqual({
+      user: { userId: USER_ID },
+      totp: { code: "123456" },
+    });
+
+    expect(result).toEqual(expect.objectContaining({ sessionId: "new-session-id" }));
+  });
+});

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -11,10 +11,10 @@ import {
   listAuthenticationMethodTypes,
   listUsers,
 } from "@/lib/zitadel";
-import { create, Duration } from "@zitadel/client";
+import { Code, create, Duration } from "@zitadel/client";
 import { RequestChallenges } from "@zitadel/proto/zitadel/session/v2/challenge_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
-import { Checks, ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
+import { Checks, ChecksSchema, CheckUserSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 import { completeFlowOrGetUrl } from "../client";
@@ -229,6 +229,19 @@ export async function updateOrCreateSession(options: UpdateSessionCommand) {
       lifetime,
     });
   } catch (error) {
+    // A rejected check (e.g. a wrong OTP code) means the request was invalid, not that the
+    // session is gone. Re-creating the session below would only replay the same rejected
+    // check and hide the actual reason from the user, so surface it instead.
+    if (isClassifiedError(error) && error.code === Code.InvalidArgument) {
+      logger.warn("Session check was rejected", { grpcCode: error.code, httpStatus: error.httpStatus });
+
+      if (checks?.totp || checks?.otpEmail || checks?.otpSms) {
+        return { error: t("invalidCode") };
+      }
+
+      throw error;
+    }
+
     const loginNameForCreation = options.loginName || recentSession?.loginName;
     const orgForCreation = options.organization || recentSession?.organization;
 
@@ -246,7 +259,12 @@ export async function updateOrCreateSession(options: UpdateSessionCommand) {
       const user = users.result[0];
       const newChecks = create(ChecksSchema, {
         ...(checks || {}),
-        user: { search: { case: "userId", value: user.userId } } as any,
+        // `create()` returns an init value that already is a message of the target type
+        // unchanged, so the spread above short-circuits the conversion of nested fields.
+        // A plain object literal here would therefore stay unconverted and break
+        // serialization with "cannot use field zitadel.session.v2.CheckUser.user_id with
+        // message undefined" - build the message explicitly.
+        user: create(CheckUserSchema, { search: { case: "userId", value: user.userId } }),
       });
 
       const result = await createSessionAndUpdateCookie({


### PR DESCRIPTION
# Which Problems Are Solved

When a user submits a **wrong OTP/TOTP code at login** (`/otp/time-based`, `/otp/sms`, `/otp/email`), the login app answers with an HTTP 500 and a generic message instead of telling the user the code is invalid. The server log shows:

```
⨯ Error [ConnectError]: [internal] serialize binary: cannot use field
  zitadel.session.v2.CheckUser.user_id with message undefined
  code: 13, httpStatus: 500, isUserError: false
```

Observed in production on v4.15.1; the code path is unchanged on `main`. In the affected session the user hit this five times in a row (five `user.human.mfa.otp.check.failed` events, each followed ~85 ms later by the 500) before a correct code got them in — without ever being told that the code was simply wrong.

There are two defects behind it, both in `updateOrCreateSession` (`apps/login/src/lib/server/session.ts`):

1. **The session re-creation fallback runs for rejected checks.** ZITADEL answers a wrong code with `invalid_argument` (`Errors.User.MFA.OTP.InvalidCode`, `EVENT-8isk2`). The `catch` around `setSessionAndUpdateCookie` treats *every* failure as a possibly expired session and rebuilds it — replaying the very check the backend just rejected, and hiding the actual reason from the user.

2. **That fallback cannot build a serializable `Checks` message.** `create()` returns an init value that already is a message of the target type *as-is* ([`create.ts#L46`](https://github.com/bufbuild/protobuf-es/blob/main/packages/protobuf/src/create.ts)). Because `checks` is a `Checks` message, spreading it into `create(ChecksSchema, { ...checks, user: {...} as any })` short-circuits the conversion, and the plain `user` object literal stays unconverted — it never becomes a `CheckUser`. Serialization then fails in `assertOwn` with `cannot use field zitadel.session.v2.CheckUser.user_id with message undefined`, because the object has no `$typeName`. The `as any` is what masked this at compile time.

Defect 2 makes the fallback dead code whenever `checks` is present, so it also breaks the genuine expired-session recovery it was written for — not just the wrong-code case.

# How the Problems Are Solved

- `updateOrCreateSession` no longer runs the session re-creation fallback when the backend rejected the check (`Code.InvalidArgument`, detected via the existing error-classification interceptor). For a submitted code (`totp` / `otpEmail` / `otpSms`) it returns `{ error: t("invalidCode") }`, which `LoginOTP` already renders in its existing `<Alert>`; other checks keep re-throwing as before.
- The `CheckUser` is now built explicitly with `create(CheckUserSchema, ...)` instead of a plain object literal, and the `as any` is gone. The re-created `Checks` message serializes again, so the expired-session recovery works.

# Additional Changes

- One new translation key `verify.errors.invalidCode` in all 15 locale files.
- New unit test `apps/login/src/lib/server/session.test.ts` covering both branches: a rejected code returns the error without touching `listUsers`/`createSessionAndUpdateCookie`, and a `failed_precondition` (terminated session) produces a `Checks` message that serializes to `{ user: { userId }, totp: { code } }`. Without the fix the second test fails with the exact production error string.

# Additional Context

- Same error family as #12306 and #12370 (wrong code during TOTP *registration*): a user error escaping as a server error and reaching the user redacted. This PR is the *login* counterpart. The two touch the same `verify.errors` block of the locale files but are otherwise independent.
- Verified locally on `main`: `@zitadel/login` unit tests 826/826 pass, `prettier --check .` clean, `eslint` clean on the changed files, and `tsc --noEmit` is byte-identical to the `main` baseline (64 pre-existing errors, 0 introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
