### PR TITLE
fix(login): prevent overlapping passkey ceremonies failing the first attempt

### DIFF
--- a/apps/login/src/components/login-passkey.test.tsx
+++ b/apps/login/src/components/login-passkey.test.tsx
@@ -533,5 +533,45 @@ describe("LoginPasskey Component", () => {
         expect(screen.getByText("An error occurred during passkey verification")).toBeInTheDocument();
       });
     });
+
+    test("does not submit an assertion when the request resolves after being aborted", async () => {
+      mockUpdateSession.mockResolvedValue(challengeResponse());
+      let resolveGet: (value: unknown) => void = () => {};
+      let capturedSignal: AbortSignal | undefined;
+      mockCredentialsGet.mockImplementation((options: any) => {
+        capturedSignal = options?.signal;
+        return new Promise((resolve) => {
+          resolveGet = resolve;
+        });
+      });
+      mockSendPasskey.mockResolvedValue({ redirect: "/success" });
+
+      const { unmount } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+      await waitFor(() => {
+        expect(mockCredentialsGet).toHaveBeenCalled();
+      });
+
+      // Unmount aborts the ceremony...
+      unmount();
+      expect(capturedSignal?.aborted).toBe(true);
+
+      // ...and only then does the authenticator result arrive. An aborted get() can still
+      // resolve, but the abandoned ceremony must not submit its assertion.
+      await act(async () => {
+        resolveGet({
+          id: "credential-id",
+          rawId: new ArrayBuffer(8),
+          type: "public-key",
+          response: {
+            authenticatorData: new ArrayBuffer(8),
+            clientDataJSON: new ArrayBuffer(8),
+            signature: new ArrayBuffer(8),
+            userHandle: new ArrayBuffer(8),
+          },
+        });
+      });
+
+      expect(mockSendPasskey).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/login/src/components/login-passkey.test.tsx
+++ b/apps/login/src/components/login-passkey.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { LoginPasskey } from "./login-passkey";
 
 // Mock next/navigation
@@ -71,6 +71,10 @@ describe("LoginPasskey Component", () => {
 
     mockSendPasskey = vi.mocked(sendPasskey);
     mockUpdateSession = vi.mocked(updateOrCreateSession);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   describe("Initialization and Challenge Request", () => {
@@ -458,7 +462,7 @@ describe("LoginPasskey Component", () => {
       // Never resolve the WebAuthn request: the ceremony stays in flight.
       mockCredentialsGet.mockReturnValue(new Promise(() => {}));
 
-      const { container } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
 
       await waitFor(() => {
         expect(mockCredentialsGet).toHaveBeenCalled();
@@ -467,7 +471,7 @@ describe("LoginPasskey Component", () => {
       // While the authenticator prompt is open the button must stay disabled, so a
       // click cannot start a second, overlapping ceremony — the root cause of #12495.
       await waitFor(() => {
-        expect(within(container).getByTestId("submit-button")).toBeDisabled();
+        expect(screen.getByTestId("submit-button")).toBeDisabled();
       });
     });
 
@@ -482,36 +486,52 @@ describe("LoginPasskey Component", () => {
       });
     });
 
-    test("does not surface a verification error when the ceremony is aborted", async () => {
-      let resolveChallenge: (value: unknown) => void = () => {};
-      mockUpdateSession.mockReturnValue(
-        new Promise((resolve) => {
-          resolveChallenge = resolve;
-        }),
+    test("aborts the in-flight WebAuthn request when the component unmounts", async () => {
+      mockUpdateSession.mockResolvedValue(challengeResponse());
+      let capturedSignal: AbortSignal | undefined;
+      // Reject with AbortError when the signal fires, mirroring a real credentials.get().
+      mockCredentialsGet.mockImplementation(
+        (options: any) =>
+          new Promise((_resolve, reject) => {
+            capturedSignal = options?.signal;
+            options?.signal?.addEventListener("abort", () => {
+              const abortError = new Error("The operation was aborted.");
+              (abortError as any).name = "AbortError";
+              reject(abortError);
+            });
+          }),
       );
+
+      const { unmount } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+
+      await waitFor(() => {
+        expect(mockCredentialsGet).toHaveBeenCalled();
+      });
+      expect(capturedSignal?.aborted).toBe(false);
+
+      await act(async () => {
+        unmount();
+      });
+
+      // The effect cleanup aborts the ceremony's controller, cancelling the open request
+      // so it can never resolve against a challenge a later navigation replaced; the
+      // resulting AbortError is swallowed (no unhandled rejection).
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    test("surfaces an unexpected AbortError as a verification error", async () => {
+      mockUpdateSession.mockResolvedValue(challengeResponse());
+      // An AbortError raised without us aborting the signal is unexpected and must be
+      // shown, not silently swallowed — only aborts we initiate are swallowed.
       const abortError = new Error("The operation was aborted.");
       (abortError as any).name = "AbortError";
       mockCredentialsGet.mockRejectedValue(abortError);
 
-      const { container } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
 
-      // Ceremony started: the button is disabled while the challenge request is in flight.
       await waitFor(() => {
-        expect(within(container).getByTestId("submit-button")).toBeDisabled();
+        expect(screen.getByText("An error occurred during passkey verification")).toBeInTheDocument();
       });
-
-      await act(async () => {
-        resolveChallenge(challengeResponse());
-      });
-
-      // Ceremony settled (get() rejected with AbortError): the button is re-enabled...
-      await waitFor(() => {
-        expect(within(container).getByTestId("submit-button")).not.toBeDisabled();
-      });
-
-      // ...and the abort is swallowed, not shown as the Firefox "verificationFailed"
-      // that the overlapping-request race used to produce.
-      expect(within(container).queryByText("An error occurred during passkey verification")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/login/src/components/login-passkey.test.tsx
+++ b/apps/login/src/components/login-passkey.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { LoginPasskey } from "./login-passkey";
@@ -458,7 +458,7 @@ describe("LoginPasskey Component", () => {
       // Never resolve the WebAuthn request: the ceremony stays in flight.
       mockCredentialsGet.mockReturnValue(new Promise(() => {}));
 
-      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+      const { container } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
 
       await waitFor(() => {
         expect(mockCredentialsGet).toHaveBeenCalled();
@@ -467,7 +467,7 @@ describe("LoginPasskey Component", () => {
       // While the authenticator prompt is open the button must stay disabled, so a
       // click cannot start a second, overlapping ceremony — the root cause of #12495.
       await waitFor(() => {
-        expect(screen.getByTestId("submit-button")).toBeDisabled();
+        expect(within(container).getByTestId("submit-button")).toBeDisabled();
       });
     });
 
@@ -493,11 +493,11 @@ describe("LoginPasskey Component", () => {
       (abortError as any).name = "AbortError";
       mockCredentialsGet.mockRejectedValue(abortError);
 
-      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+      const { container } = renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
 
       // Ceremony started: the button is disabled while the challenge request is in flight.
       await waitFor(() => {
-        expect(screen.getByTestId("submit-button")).toBeDisabled();
+        expect(within(container).getByTestId("submit-button")).toBeDisabled();
       });
 
       await act(async () => {
@@ -506,12 +506,12 @@ describe("LoginPasskey Component", () => {
 
       // Ceremony settled (get() rejected with AbortError): the button is re-enabled...
       await waitFor(() => {
-        expect(screen.getByTestId("submit-button")).not.toBeDisabled();
+        expect(within(container).getByTestId("submit-button")).not.toBeDisabled();
       });
 
       // ...and the abort is swallowed, not shown as the Firefox "verificationFailed"
       // that the overlapping-request race used to produce.
-      expect(screen.queryByText("An error occurred during passkey verification")).not.toBeInTheDocument();
+      expect(within(container).queryByText("An error occurred during passkey verification")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/login/src/components/login-passkey.test.tsx
+++ b/apps/login/src/components/login-passkey.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { LoginPasskey } from "./login-passkey";
@@ -436,6 +436,82 @@ describe("LoginPasskey Component", () => {
 
       // Should still only be called once
       expect(mockUpdateSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Overlapping ceremony prevention (#12495)", () => {
+    const challengeResponse = () => ({
+      challenges: {
+        webAuthN: {
+          publicKeyCredentialRequestOptions: {
+            publicKey: {
+              challenge: new Uint8Array([1, 2, 3]),
+              allowCredentials: [{ id: new Uint8Array([4, 5, 6]), type: "public-key" }],
+            },
+          },
+        },
+      },
+    });
+
+    test("keeps the submit button disabled while a passkey ceremony is in flight", async () => {
+      mockUpdateSession.mockResolvedValue(challengeResponse());
+      // Never resolve the WebAuthn request: the ceremony stays in flight.
+      mockCredentialsGet.mockReturnValue(new Promise(() => {}));
+
+      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+
+      await waitFor(() => {
+        expect(mockCredentialsGet).toHaveBeenCalled();
+      });
+
+      // While the authenticator prompt is open the button must stay disabled, so a
+      // click cannot start a second, overlapping ceremony — the root cause of #12495.
+      await waitFor(() => {
+        expect(screen.getByTestId("submit-button")).toBeDisabled();
+      });
+    });
+
+    test("passes an AbortSignal to navigator.credentials.get", async () => {
+      mockUpdateSession.mockResolvedValue(challengeResponse());
+      mockCredentialsGet.mockResolvedValue(null);
+
+      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+
+      await waitFor(() => {
+        expect(mockCredentialsGet).toHaveBeenCalledWith(expect.objectContaining({ signal: expect.any(AbortSignal) }));
+      });
+    });
+
+    test("does not surface a verification error when the ceremony is aborted", async () => {
+      let resolveChallenge: (value: unknown) => void = () => {};
+      mockUpdateSession.mockReturnValue(
+        new Promise((resolve) => {
+          resolveChallenge = resolve;
+        }),
+      );
+      const abortError = new Error("The operation was aborted.");
+      (abortError as any).name = "AbortError";
+      mockCredentialsGet.mockRejectedValue(abortError);
+
+      renderWithIntl(<LoginPasskey loginName="test@example.com" altPassword={false} />);
+
+      // Ceremony started: the button is disabled while the challenge request is in flight.
+      await waitFor(() => {
+        expect(screen.getByTestId("submit-button")).toBeDisabled();
+      });
+
+      await act(async () => {
+        resolveChallenge(challengeResponse());
+      });
+
+      // Ceremony settled (get() rejected with AbortError): the button is re-enabled...
+      await waitFor(() => {
+        expect(screen.getByTestId("submit-button")).not.toBeDisabled();
+      });
+
+      // ...and the abort is swallowed, not shown as the Firefox "verificationFailed"
+      // that the overlapping-request race used to produce.
+      expect(screen.queryByText("An error occurred during passkey verification")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/login/src/components/login-passkey.tsx
+++ b/apps/login/src/components/login-passkey.tsx
@@ -29,7 +29,9 @@ type Props = {
 
 export function LoginPasskey({ loginName, sessionId, requestId, altPassword, organization, login = true }: Props) {
   const [error, setError] = useState<string>("");
-  const [loading, setLoading] = useState<boolean>(false);
+  // Start busy: the ceremony is auto-started in the mount effect below, so the submit
+  // button must be disabled from first paint — a click cannot precede that effect.
+  const [loading, setLoading] = useState<boolean>(true);
   const [samlData, setSamlData] = useState<{ url: string; fields: Record<string, string> } | null>(null);
 
   const t = useTranslations("passkey");

--- a/apps/login/src/components/login-passkey.tsx
+++ b/apps/login/src/components/login-passkey.tsx
@@ -35,39 +35,53 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
   const t = useTranslations("passkey");
   const router = useRouter();
 
-  const initialized = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // Runs the full passkey ceremony: request a challenge, get the assertion from the
+  // authenticator, then verify it. A single AbortController guards against overlapping
+  // ceremonies — starting a new one aborts the WebAuthn request still in flight — so we
+  // never sign an assertion against a challenge that a second, overlapping request has
+  // already overwritten on the session. See https://github.com/zitadel/zitadel/issues/12495.
+  async function startPasskeyLogin() {
+    abortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    setError("");
+    setLoading(true);
+    try {
+      const response = await updateOrCreateSessionForChallenge();
+      if (abortController.signal.aborted) {
+        return;
+      }
+
+      const pK = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
+      if (!pK) {
+        setError(t("verify.errors.couldNotRequestChallenge"));
+        return;
+      }
+
+      await submitLoginAndContinue(pK, abortController.signal);
+    } catch (error) {
+      if (!abortController.signal.aborted) {
+        setError(error instanceof Error ? error.message : String(error));
+      }
+    } finally {
+      // Only the most recent ceremony owns the shared loading state.
+      if (abortControllerRef.current === abortController) {
+        setLoading(false);
+      }
+    }
+  }
 
   useEffect(() => {
-    if (!initialized.current) {
-      initialized.current = true;
-      setLoading(true);
-      updateOrCreateSessionForChallenge()
-        .then((response) => {
-          const pK = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
+    startPasskeyLogin();
 
-          if (!pK) {
-            setError(t("verify.errors.couldNotRequestChallenge"));
-            setLoading(false);
-            return;
-          }
-
-          return submitLoginAndContinue(pK)
-            .catch((error) => {
-              setError(error instanceof Error ? error.message : String(error));
-              return;
-            })
-            .finally(() => {
-              setLoading(false);
-            });
-        })
-        .catch((error) => {
-          setError(error instanceof Error ? error.message : String(error));
-          return;
-        })
-        .finally(() => {
-          setLoading(false);
-        });
-    }
+    // Abort an in-flight WebAuthn request if the component unmounts (e.g. an RSC
+    // navigation remounts the page) so it cannot resolve against a stale challenge.
+    return () => {
+      abortControllerRef.current?.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -76,8 +90,6 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
       ? UserVerificationRequirement.REQUIRED
       : UserVerificationRequirement.DISCOURAGED,
   ) {
-    setError("");
-    setLoading(true);
     const sessionResponse = await updateOrCreateSession({
       loginName,
       sessionId,
@@ -89,15 +101,11 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
         },
       }),
       requestId,
-    })
-      .catch((error) => {
-        console.error(error);
-        setError(t("verify.errors.couldNotRequestChallenge"));
-        return;
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    }).catch((error) => {
+      console.error(error);
+      setError(t("verify.errors.couldNotRequestChallenge"));
+      return;
+    });
 
     if (sessionResponse && "error" in sessionResponse && sessionResponse.error) {
       setError(sessionResponse.error);
@@ -136,7 +144,7 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
     }
   }
 
-  async function submitLoginAndContinue(publicKey: any): Promise<boolean | void> {
+  async function submitLoginAndContinue(publicKey: any, signal?: AbortSignal): Promise<boolean | void> {
     publicKey.challenge = coerceToArrayBuffer(publicKey.challenge, "publicKey.challenge");
     publicKey.allowCredentials.map((listItem: any) => {
       listItem.id = coerceToArrayBuffer(listItem.id, "publicKey.allowCredentials.id");
@@ -145,6 +153,7 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
     return navigator.credentials
       .get({
         publicKey,
+        signal,
       })
       .then((assertedCredential: any) => {
         if (!assertedCredential) {
@@ -172,6 +181,11 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
         return submitLogin(data);
       })
       .catch((error) => {
+        // A superseded or unmounted ceremony rejects with AbortError — that is
+        // expected (we aborted it), not a verification failure to surface.
+        if (error?.name === "AbortError") {
+          return;
+        }
         // Handle passkey cancellation or errors
         if (error?.name === "NotAllowedError") {
           setError(t("verify.errors.verificationCancelled"));
@@ -179,9 +193,6 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
           setError(t("verify.errors.verificationFailed"));
         }
         console.error("Passkey verification error:", error);
-      })
-      .finally(() => {
-        setLoading(false);
       });
   }
 
@@ -235,29 +246,7 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
           className="self-end"
           variant={ButtonVariants.Primary}
           disabled={loading}
-          onClick={async () => {
-            const response = await updateOrCreateSessionForChallenge().finally(() => {
-              setLoading(false);
-            });
-
-            const pK = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
-
-            if (!pK) {
-              setError(t("verify.errors.couldNotRequestChallenge"));
-              return;
-            }
-
-            setLoading(true);
-
-            return submitLoginAndContinue(pK)
-              .catch((error) => {
-                setError(error instanceof Error ? error.message : String(error));
-                return;
-              })
-              .finally(() => {
-                setLoading(false);
-              });
-          }}
+          onClick={() => startPasskeyLogin()}
           data-testid="submit-button"
         >
           {loading && <Spinner className="mr-2 h-5 w-5" />} <Translated i18nKey="verify.submit" namespace="passkey" />

--- a/apps/login/src/components/login-passkey.tsx
+++ b/apps/login/src/components/login-passkey.tsx
@@ -158,6 +158,13 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
         signal,
       })
       .then((assertedCredential: any) => {
+        // Ignore a result that resolved after this ceremony was superseded or unmounted:
+        // an aborted get() can still resolve if the authenticator already completed, and
+        // we must not submit an assertion for a ceremony we abandoned (mirrors the
+        // post-challenge guard in startPasskeyLogin).
+        if (signal?.aborted) {
+          return;
+        }
         if (!assertedCredential) {
           setError(t("verify.errors.couldNotRetrievePasskey"));
           return;

--- a/apps/login/src/components/login-passkey.tsx
+++ b/apps/login/src/components/login-passkey.tsx
@@ -181,9 +181,10 @@ export function LoginPasskey({ loginName, sessionId, requestId, altPassword, org
         return submitLogin(data);
       })
       .catch((error) => {
-        // A superseded or unmounted ceremony rejects with AbortError — that is
-        // expected (we aborted it), not a verification failure to surface.
-        if (error?.name === "AbortError") {
+        // A superseded or unmounted ceremony rejects with AbortError once we abort its
+        // signal — that is expected, not a verification failure. An AbortError that we
+        // did not cause is unexpected, so let it fall through and surface an error.
+        if (error?.name === "AbortError" && signal?.aborted) {
           return;
         }
         // Handle passkey cancellation or errors


### PR DESCRIPTION
# Which Problems Are Solved

The Login v2 passkey page fails the first authentication attempt and only
succeeds on retry (#12495). In Firefox the user sees "An error occurred during
passkey verification"; the API logs `WEBAU-3M9si` immediately followed by
`COMMAND-Ioqu5`.

The page starts a WebAuthn ceremony automatically on mount, but
`updateOrCreateSessionForChallenge` cleared `loading` as soon as the challenge
was minted — before `navigator.credentials.get()` resolved — re-enabling the
submit button while the OS prompt was still open. Clicking "Continue" then
minted a second challenge (overwriting the first on the session) and opened a
second `navigator.credentials.get()`, so the browser aborts one request and the
assertion is verified against a challenge the second mint already overwrote.

# How the Problems Are Solved

- Consolidate the mount effect and the submit handler into a single
  `startPasskeyLogin` that owns `loading` for the whole ceremony, so the submit
  button stays disabled until it settles and a click can no longer start a
  second, overlapping ceremony.
- Hold one `AbortController` that supersedes any in-flight
  `navigator.credentials.get()` and is aborted on unmount, so a superseded or
  torn-down ceremony can never resolve against a stale challenge.
- Swallow the resulting `AbortError` only when we initiated the abort
  (`signal.aborted`); an unexpected `AbortError` still surfaces as an error.

# Additional Changes

- The mount effect no longer uses an `initialized` ref; it relies on the
  `AbortController` (aborted on cleanup), the correct pattern for an abortable
  effect. As a side effect, React StrictMode in `next dev` issues two challenge
  requests on mount — the first is immediately superseded via `signal.aborted`,
  so only one prompt opens and it signs against the latest challenge. Production
  mounts once.
- Add unit tests (button disabled during a ceremony, `AbortSignal` passed to
  `get()`, in-flight request aborted on unmount, unexpected `AbortError`
  surfaces) and register `afterEach(cleanup)` so renders no longer accumulate.

# Additional Context

- Closes #12495
- Reproducible in Firefox by clicking "Continue" before completing the OS
  prompt; high latency (e.g. a remote authenticator) widens the race window.
