### PR TITLE
fix(login): size branding logo by aspect ratio instead of a fixed square

### DIFF
--- a/apps/login/.env.theme.example
+++ b/apps/login/.env.theme.example
@@ -44,6 +44,15 @@ NEXT_PUBLIC_THEME_APPEARANCE=flat
 # Example: NEXT_PUBLIC_THEME_BACKGROUND_IMAGE=/images/login-bg.jpg
 # NEXT_PUBLIC_THEME_BACKGROUND_IMAGE=
 
+# Logo Max Height
+# ---------------
+# Upper bound in px for the rendered height of the branding logo.
+# The logo keeps its own aspect ratio and is additionally capped at the width
+# of its container, so wordmarks, square marks and portrait marks all fit.
+# Raise this if a wide wordmark renders too small, lower it if a tall logo
+# takes up too much vertical space. Default: 80
+# NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT=80
+
 # ==============================================
 # EXAMPLE COMBINATIONS
 # ==============================================

--- a/apps/login/src/components/dynamic-theme.tsx
+++ b/apps/login/src/components/dynamic-theme.tsx
@@ -56,14 +56,7 @@ export function DynamicTheme({
                     <div className="from-primary-50 to-primary-100 dark:from-primary-900/20 dark:to-primary-800/20 flex w-1/2 flex-col justify-center bg-gradient-to-br p-4 lg:p-8">
                       <div className="mx-auto max-w-[440px] space-y-8">
                         {/* Logo and branding */}
-                        {branding && (
-                          <Logo
-                            lightSrc={branding.lightTheme?.logoUrl}
-                            darkSrc={branding.darkTheme?.logoUrl}
-                            height={150}
-                            width={150}
-                          />
-                        )}
+                        {branding && <Logo lightSrc={branding.lightTheme?.logoUrl} darkSrc={branding.darkTheme?.logoUrl} />}
 
                         {/* First child content (title, description) - only if we have left/right structure */}
                         {hasLeftRightStructure && (
@@ -100,14 +93,7 @@ export function DynamicTheme({
                 <Card>
                   <div className="mx-auto flex flex-col items-center space-y-8">
                     <div className="relative flex flex-row items-center justify-center">
-                      {branding && (
-                        <Logo
-                          lightSrc={branding.lightTheme?.logoUrl}
-                          darkSrc={branding.darkTheme?.logoUrl}
-                          height={150}
-                          width={150}
-                        />
-                      )}
+                      {branding && <Logo lightSrc={branding.lightTheme?.logoUrl} darkSrc={branding.darkTheme?.logoUrl} />}
                     </div>
 
                     {hasMultipleChildren ? (

--- a/apps/login/src/components/logo.test.tsx
+++ b/apps/login/src/components/logo.test.tsx
@@ -1,0 +1,94 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_THEME } from "../lib/theme";
+import { Logo } from "./logo";
+
+const LIGHT = "https://example.com/logo-light.png";
+const DARK = "https://example.com/logo-dark.png";
+
+// Queries are scoped to each render's container because the shared test setup
+// does not register React Testing Library's automatic cleanup.
+function renderLogo(props: Parameters<typeof Logo>[0]) {
+  const { container } = render(<Logo {...props} />);
+  return Array.from(container.querySelectorAll<HTMLImageElement>('img[alt="logo"]'));
+}
+
+describe("Logo", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("rendering", () => {
+    it("should render both the light and dark variant when both are provided", () => {
+      const imgs = renderLogo({ lightSrc: LIGHT, darkSrc: DARK });
+
+      expect(imgs.map((img) => img.getAttribute("src"))).toEqual([DARK, LIGHT]);
+    });
+
+    it("should render nothing when no source is provided", () => {
+      expect(renderLogo({})).toHaveLength(0);
+    });
+
+    it.each([
+      ["light only", { lightSrc: LIGHT }],
+      ["dark only", { darkSrc: DARK }],
+    ])("should render a single image for %s", (_label, props) => {
+      expect(renderLogo(props)).toHaveLength(1);
+    });
+  });
+
+  describe("sizing", () => {
+    it("should constrain both axes instead of pinning fixed dimensions", () => {
+      const [img] = renderLogo({ lightSrc: LIGHT });
+
+      // Without width/height attributes the asset keeps its intrinsic ratio.
+      expect(img.getAttribute("width")).toBeNull();
+      expect(img.getAttribute("height")).toBeNull();
+      expect(img.style.maxHeight).toBe(`${DEFAULT_THEME.logoMaxHeight}px`);
+      expect(img.style.maxWidth).toBe("100%");
+      expect(img.className).toContain("object-contain");
+    });
+
+    it("should use the maxHeight prop when it is a positive number", () => {
+      const [img] = renderLogo({ lightSrc: LIGHT, maxHeight: 140 });
+
+      expect(img.style.maxHeight).toBe("140px");
+    });
+
+    it("should read the cap from the theme environment variable", () => {
+      process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT = "120";
+
+      const [img] = renderLogo({ lightSrc: LIGHT });
+
+      expect(img.style.maxHeight).toBe("120px");
+    });
+
+    it("should prefer the prop over the environment variable", () => {
+      process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT = "120";
+
+      const [img] = renderLogo({ lightSrc: LIGHT, maxHeight: 64 });
+
+      expect(img.style.maxHeight).toBe("64px");
+    });
+
+    // A non-finite or non-positive cap would emit something like "NaNpx", which
+    // browsers discard, leaving the logo with no height constraint at all.
+    it.each([
+      ["NaN", Number.NaN],
+      ["Infinity", Number.POSITIVE_INFINITY],
+      ["zero", 0],
+      ["a negative number", -40],
+    ])("should fall back to the theme cap when maxHeight is %s", (_label, value) => {
+      const [img] = renderLogo({ lightSrc: LIGHT, maxHeight: value });
+
+      expect(img.style.maxHeight).toBe(`${DEFAULT_THEME.logoMaxHeight}px`);
+    });
+  });
+});

--- a/apps/login/src/components/logo.tsx
+++ b/apps/login/src/components/logo.tsx
@@ -1,21 +1,37 @@
+import { getThemeConfig } from "@/lib/theme";
+
 type Props = {
   darkSrc?: string;
   lightSrc?: string;
-  height?: number;
-  width?: number;
+  /**
+   * Upper bound in px for the rendered height. Defaults to the theme config
+   * value (NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT).
+   */
+  maxHeight?: number;
 };
 
-export function Logo({ lightSrc, darkSrc, height = 40, width = 147.5 }: Props) {
+export function Logo({ lightSrc, darkSrc, maxHeight }: Props) {
+  const { logoMaxHeight } = getThemeConfig();
+  const cap = maxHeight ?? logoMaxHeight;
+
+  // Constrain both axes instead of forcing fixed dimensions: the intrinsic
+  // aspect ratio of the uploaded asset is preserved, so wide wordmarks use the
+  // available width while tall marks stay within the height budget. Uploaded
+  // logos have no guaranteed aspect ratio, so anything that pins one axis to a
+  // constant either distorts the mark or shrinks it to illegibility.
+  const style = { maxHeight: `${cap}px`, maxWidth: "100%" };
+  const className = "h-auto w-auto object-contain";
+
   return (
     <>
       {darkSrc && (
-        <div className="hidden dark:flex">
-          <img height={height} width={width} src={darkSrc} alt="logo" />
+        <div className="hidden items-center dark:flex">
+          <img className={className} style={style} src={darkSrc} alt="logo" />
         </div>
       )}
       {lightSrc && (
-        <div className="flex dark:hidden">
-          <img height={height} width={width} src={lightSrc} alt="logo" />
+        <div className="flex items-center dark:hidden">
+          <img className={className} style={style} src={lightSrc} alt="logo" />
         </div>
       )}
     </>

--- a/apps/login/src/components/logo.tsx
+++ b/apps/login/src/components/logo.tsx
@@ -12,8 +12,7 @@ type Props = {
 
 export function Logo({ lightSrc, darkSrc, maxHeight }: Props) {
   const { logoMaxHeight } = getThemeConfig();
-  const cap = maxHeight ?? logoMaxHeight;
-
+  const cap = Number.isFinite(maxHeight) && maxHeight > 0 ? maxHeight : logoMaxHeight;
   // Constrain both axes instead of forcing fixed dimensions: the intrinsic
   // aspect ratio of the uploaded asset is preserved, so wide wordmarks use the
   // available width while tall marks stay within the height budget. Uploaded

--- a/apps/login/src/components/logo.tsx
+++ b/apps/login/src/components/logo.tsx
@@ -1,4 +1,4 @@
-import { getThemeConfig } from "@/lib/theme";
+import { getThemeConfig, parsePixelValue } from "@/lib/theme";
 
 type Props = {
   darkSrc?: string;
@@ -12,7 +12,11 @@ type Props = {
 
 export function Logo({ lightSrc, darkSrc, maxHeight }: Props) {
   const { logoMaxHeight } = getThemeConfig();
-  const cap = Number.isFinite(maxHeight) && maxHeight > 0 ? maxHeight : logoMaxHeight;
+  // Validate the override the same way as the env-derived value: a non-finite or
+  // non-positive cap would otherwise emit an invalid max-height that the browser
+  // drops, leaving the logo unconstrained.
+  const cap = parsePixelValue(maxHeight, logoMaxHeight);
+
   // Constrain both axes instead of forcing fixed dimensions: the intrinsic
   // aspect ratio of the uploaded asset is preserved, so wide wordmarks use the
   // available width while tall marks stay within the height budget. Uploaded

--- a/apps/login/src/lib/theme.test.ts
+++ b/apps/login/src/lib/theme.test.ts
@@ -65,6 +65,7 @@ describe("Theme Configuration", () => {
         layout: "top-to-bottom",
         appearance: "flat",
         spacing: "regular",
+        logoMaxHeight: 80,
       });
     });
 
@@ -73,6 +74,7 @@ describe("Theme Configuration", () => {
       expect(DEFAULT_THEME.layout).toBe("top-to-bottom");
       expect(DEFAULT_THEME.appearance).toBe("flat");
       expect(DEFAULT_THEME.spacing).toBe("regular");
+      expect(DEFAULT_THEME.logoMaxHeight).toBe(80);
     });
   });
 
@@ -83,6 +85,7 @@ describe("Theme Configuration", () => {
       delete process.env.NEXT_PUBLIC_THEME_APPEARANCE;
       delete process.env.NEXT_PUBLIC_THEME_SPACING;
       delete process.env.NEXT_PUBLIC_THEME_BACKGROUND_IMAGE;
+      delete process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT;
 
       const config = getThemeConfig();
 
@@ -91,6 +94,31 @@ describe("Theme Configuration", () => {
       expect(config.appearance).toBe(DEFAULT_THEME.appearance);
       expect(config.spacing).toBe(DEFAULT_THEME.spacing);
       expect(config.componentRoundness).toEqual(DEFAULT_COMPONENT_ROUNDNESS);
+      expect(config.logoMaxHeight).toBe(DEFAULT_THEME.logoMaxHeight);
+    });
+
+    describe("logoMaxHeight", () => {
+      afterEach(() => {
+        delete process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT;
+      });
+
+      it("should read a positive value from the environment variable", () => {
+        process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT = "120";
+
+        expect(getThemeConfig().logoMaxHeight).toBe(120);
+      });
+
+      it("should accept fractional values", () => {
+        process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT = "62.5";
+
+        expect(getThemeConfig().logoMaxHeight).toBe(62.5);
+      });
+
+      it.each(["0", "-40", "abc", ""])("should fall back to the default for invalid value %j", (value) => {
+        process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT = value;
+
+        expect(getThemeConfig().logoMaxHeight).toBe(DEFAULT_THEME.logoMaxHeight);
+      });
     });
 
     it("should use global roundness from environment variable", () => {

--- a/apps/login/src/lib/theme.ts
+++ b/apps/login/src/lib/theme.ts
@@ -22,6 +22,7 @@ export interface ThemeConfig {
   backgroundImage?: string;
   appearance: ThemeAppearance;
   spacing: ThemeSpacing;
+  logoMaxHeight: number; // Upper bound in px for the branding logo's rendered height
 }
 
 // Default component-specific roundness configuration
@@ -42,7 +43,19 @@ export const DEFAULT_THEME: ThemeConfig = {
   layout: "top-to-bottom",
   appearance: "flat",
   spacing: "regular",
+  logoMaxHeight: 80,
 };
+
+// Parse a positive pixel value from an environment variable, ignoring
+// anything that isn't a finite number greater than zero.
+function parsePixelValue(raw: string | undefined, fallback: number): number {
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // Get theme configuration from environment variables
 export function getThemeConfig(): ThemeConfig {
@@ -69,6 +82,7 @@ export function getThemeConfig(): ThemeConfig {
     backgroundImage: process.env.NEXT_PUBLIC_THEME_BACKGROUND_IMAGE || undefined,
     appearance: (process.env.NEXT_PUBLIC_THEME_APPEARANCE as ThemeAppearance) || DEFAULT_THEME.appearance,
     spacing: (process.env.NEXT_PUBLIC_THEME_SPACING as ThemeSpacing) || DEFAULT_THEME.spacing,
+    logoMaxHeight: parsePixelValue(process.env.NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT, DEFAULT_THEME.logoMaxHeight),
   };
 }
 

--- a/apps/login/src/lib/theme.ts
+++ b/apps/login/src/lib/theme.ts
@@ -46,9 +46,11 @@ export const DEFAULT_THEME: ThemeConfig = {
   logoMaxHeight: 80,
 };
 
-// Parse a positive pixel value from an environment variable, ignoring
-// anything that isn't a finite number greater than zero.
-function parsePixelValue(raw: string | undefined, fallback: number): number {
+// Parse a positive pixel value from an environment variable or a caller-supplied
+// override, ignoring anything that isn't a finite number greater than zero.
+// Falsy input (undefined, empty string, 0, NaN) falls back, as do Infinity and
+// negative numbers.
+export function parsePixelValue(raw: string | number | undefined, fallback: number): number {
   if (!raw) {
     return fallback;
   }


### PR DESCRIPTION
# Which Problems Are Solved

Login v2 renders the branding logo with hardcoded `width=150 height=150` attributes, so the rendered size is dictated entirely by the uploaded asset's aspect ratio. Uploaded logos have no guaranteed ratio, so the result is wrong for most real assets:

- A wide wordmark (e.g. 1200×150, 8:1) is capped at 150px wide and renders about 19px tall — effectively illegible, with roughly two thirds of the card width unused.
- A portrait mark (e.g. 400×1200, 1:3) renders 150×450 and dominates the card.
- When the asset fails to load, the `width`/`height` attributes reserve a 150×150 square that corresponds to no real logo.
- Nothing documents that a specific aspect ratio or pixel size is expected, and the size cannot be adjusted by a deployment.
- `Logo` contradicted itself: its own defaults (`height = 40`, `width = 147.5`) assume roughly 3.7:1, while both call sites overrode them with `150`/`150`.

# How the Problems Are Solved

- `Logo` constrains both axes instead of pinning either one: a configurable `max-height` plus `max-width: 100%`, with `h-auto w-auto object-contain`. The asset keeps its intrinsic aspect ratio, wide wordmarks use the available container width, and tall marks stay within the height budget.
- The cap is configurable through the existing env-var theme config as `NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT` (default `80`), alongside the other `NEXT_PUBLIC_THEME_*` options, and can still be overridden per call site through the `maxHeight` prop.
- Invalid values (`0`, negative, non-numeric, empty) fall back to the default instead of producing a broken layout.
- Both `DynamicTheme` call sites drop their `height={150} width={150}` overrides.

Measured on a local instance with real uploaded assets, in light and dark mode and in both the top-to-bottom and side-by-side layouts:

| Logo | Before | After |
| --- | --- | --- |
| 1200×150 (8:1) | 150 × 18.8 | 358 × 44.8 |
| 1063×446 (2.38:1) | 150 × 62.9 | 190.7 × 80 |
| 400×1200 (1:3) | 150 × 450 | 26.7 × 80 |

Every case preserves the asset's aspect ratio.

# Additional Changes

- `ThemeConfig` gains a `logoMaxHeight` field, read via a small `parsePixelValue` helper that validates pixel-valued environment variables.
- `.env.theme.example` documents `NEXT_PUBLIC_THEME_LOGO_MAX_HEIGHT`, including when to raise or lower it.
- `theme.test.ts`: updated the strict `DEFAULT_THEME` shape assertion for the new field, and added coverage for reading the environment variable, accepting fractional values, and falling back to the default on invalid input.
- The logo wrappers get `items-center`, so the image is not stretched should the slot ever be taller than the logo itself.

# Additional Context

- No existing issue tracks the logo sizing behaviour; it surfaced while investigating how Login v2 renders branding assets.
- Related but deliberately out of scope: #12111 (custom logo overlapping the text below it). That was caused by `-mb-4` on the logo slot interacting with Tailwind v4's `space-y-*`, which applies `margin-bottom` to the same element from inside a zero-specificity `:where()` rule, so the negative margin replaced the spacing instead of adjusting it. It was already resolved by removing `-mb-4` — present up to v4.14.0, gone from v4.15.0 onward. This PR does not touch that spacing and does not change overlap behaviour.
- Related: #4256 covered restricting asset MIME types and maximum upload size; this PR concerns rendered dimensions rather than upload constraints.
- Verified with `pnpm nx run-many --projects @zitadel/login --targets lint build` (both pass) and the `theme.test.ts` suite (44 tests). Note that `src/lib/api.test.ts` cannot run on stock macOS, before or after this change, because it shells out to `openssl rsa -traditional`, which LibreSSL does not support.