### PR TITLE
fix: add the dropped idpTemplate argument 

### DIFF
--- a/internal/api/ui/login/external_provider_handler.go
+++ b/internal/api/ui/login/external_provider_handler.go
@@ -852,11 +852,11 @@ func (l *Login) handleExternalNotFoundOptionCheck(w http.ResponseWriter, r *http
 	}
 	linkingUser := authReq.LinkingUsers[len(authReq.LinkingUsers)-1]
 	externalUser := mapExternalNotFoundOptionFormDataToLoginUser(data, linkingUser)
-  // the form only carries the editable profile fields, so preserve the ZITADEL project
+	// the form only carries the editable profile fields, so preserve the ZITADEL project
 	// roles captured at authentication (stored on the linking user) to keep the
 	// support-user instance membership grant working on the manual creation path.
 	preserveProjectRoles(externalUser, authReq.LinkingUsers)
-  l.registerExternalUser(w, r, authReq, externalUser)
+	l.registerExternalUser(w, r, idpTemplate, authReq, externalUser)
 }
 
 // registerExternalUser creates an externalUser with the provided data


### PR DESCRIPTION
# Which Problems Are Solved

This PR fixes a Go compilation error in the Login V1 caused by a previously dropped `idpTemplate` argument when calling `registerExternalUser`.

# How the Problems Are Solved

- Pass `idpTemplate` into `registerExternalUser` from `handleExternalNotFoundOptionCheck` to match the function signature.

# Additional Changes

N/A

# Additional Context

introduced in https://github.com/zitadel/zitadel/commit/a17af0fe934ff94fcbf6c38d56aee308e1694962#diff-ec5370dd3f47f190c01e8dee4fd027b334a523cf31e5557422dd14c6e6c90339R859
