### PR TITLE
feat(actions): add request scope to preuserinfo and preaccesstoken context

### DIFF
--- a/apps/docs/content/guides/integrate/actions/testing-function.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-function.mdx
@@ -166,6 +166,13 @@ Your server should now print out something like the following. Check out the [Se
   },
   "application" : {
     "client_id" : "312909075212534168"
+  },
+  "request" : {
+    "scope" : [
+      "openid",
+      "profile",
+      "email"
+    ]
   }
 }
 ```

--- a/apps/docs/content/guides/integrate/actions/usage.mdx
+++ b/apps/docs/content/guides/integrate/actions/usage.mdx
@@ -142,6 +142,13 @@ The information sent to the Endpoint is structured as JSON:
   "application": {
     "client_id": "The client_id of the application the token was requested for"
   },
+  "request": {
+    "scope": [
+      "openid",
+      "profile",
+      "email"
+    ]
+  },
   "actor": {
     "user_id": "The ID of the user acting on behalf of the token subject",
     "issuer": "The issuer of the token the actor was authenticated with",
@@ -249,6 +256,13 @@ The information sent to the Endpoint is structured as JSON:
   ],
   "application": {
     "client_id": "The client_id of the application the token was requested for"
+  },
+  "request": {
+    "scope": [
+      "openid",
+      "profile",
+      "email"
+    ]
   },
   "actor": {
     "user_id": "The ID of the user acting on behalf of the token subject",

--- a/internal/api/grpc/action/v2/integration_test/execution_target_test.go
+++ b/internal/api/grpc/action/v2/integration_test/execution_target_test.go
@@ -904,8 +904,11 @@ func contextInfoForUserOIDC(instance *integration.Instance, function string, cli
 			PrimaryDomain: instance.DefaultOrg.GetPrimaryDomain(),
 		},
 		UserGrants: nil,
-		Actor:      actor,
-		Response:   nil,
+		Request: &oidc_api.ContextInfoRequest{
+			Scope: []string{oidc.ScopeOpenID},
+		},
+		Actor:    actor,
+		Response: nil,
 	}
 }
 

--- a/internal/api/grpc/action/v2beta/integration_test/execution_target_test.go
+++ b/internal/api/grpc/action/v2beta/integration_test/execution_target_test.go
@@ -943,7 +943,10 @@ func contextInfoForUserOIDC(instance *integration.Instance, function string, cli
 			PrimaryDomain: instance.DefaultOrg.GetPrimaryDomain(),
 		},
 		UserGrants: nil,
-		Response:   nil,
+		Request: &oidc_api.ContextInfoRequest{
+			Scope: []string{oidc.ScopeOpenID},
+		},
+		Response: nil,
 	}
 }
 

--- a/internal/api/oidc/userinfo.go
+++ b/internal/api/oidc/userinfo.go
@@ -124,7 +124,7 @@ func (s *Server) userInfo(
 			Claims:          maps.Clone(rawUserInfo.Claims),
 		}
 		assertRoles(projectID, qu, roleAudience, requestedRoles, roleAssertion, userInfo)
-		return userInfo, s.userinfoFlows(ctx, qu, userInfo, triggerType, clientID, actor)
+		return userInfo, s.userinfoFlows(ctx, qu, userInfo, triggerType, clientID, scope, actor)
 	}
 }
 
@@ -317,6 +317,7 @@ func (s *Server) userinfoFlows(
 	userInfo *oidc.UserInfo,
 	triggerType domain.TriggerType,
 	clientID string,
+	scope []string,
 	actor *domain.TokenActor,
 ) (err error) {
 	ctx, span := tracing.NewSpan(ctx)
@@ -542,6 +543,7 @@ func (s *Server) runUserinfoExecutionTargets(ctx context.Context, qu *query.OIDC
 		Org:          qu.Org,
 		Application:  &ContextInfoApplication{ClientID: clientID},
 		UserGrants:   qu.UserGrants,
+		Request:      &ContextInfoRequest{Scope: scope},
 		Actor:        actor,
 	}
 
@@ -583,12 +585,17 @@ type ContextInfo struct {
 	Org          *query.UserInfoOrg      `json:"org,omitempty"`
 	UserGrants   []query.UserGrant       `json:"user_grants,omitempty"`
 	Application  *ContextInfoApplication `json:"application,omitempty"`
+	Request      *ContextInfoRequest     `json:"request,omitempty"`
 	// Actor is only set when the token was obtained through token exchange / impersonation.
 	Actor    *domain.TokenActor   `json:"actor,omitempty"`
 	Response *ContextInfoResponse `json:"response,omitempty"`
 }
 type ContextInfoApplication struct {
 	ClientID string `json:"client_id,omitempty"`
+}
+
+type ContextInfoRequest struct {
+	Scope []string `json:"scope,omitempty"`
 }
 
 type ContextInfoResponse struct {


### PR DESCRIPTION
# Which Problems Are Solved

The context information sent to Actions v2 targets for the `preuserinfo` and `preaccesstoken` functions does not contain the scopes of the underlying request.

A target therefore cannot tell which scopes a token is being issued for, which makes it impossible to customize access token or ID token claims based on the requested scope.

# How the Problems Are Solved

- Add a `request` object containing a `scope` array to the context information sent for the `preuserinfo` and `preaccesstoken` functions. The scope is already available for the code that prepares the context information. So no additional lookup is needed, just include it in the context. The scopes are nested under `request` rather than added as a top-level field, so further request attributes can be added later without reshaping the payload again.
- Extend the `preuserinfo` and `preaccesstoken` integration tests in both `action/v2` and `action/v2beta` to assert the new field.
- Document the new object in the `PreUserinfo` and `PreAccessToken` payload examples.

# Additional Changes

- Document the `application` object in the `PreUserinfo` and `PreAccessToken` payload examples. It has been part of the payload since #10339 but was never documented.
- Add `application` and `request` to the example payload in the "Testing a function" guide.

# Additional Context

- Actions v1 is not extended, as it is superseded by Actions v2.
- `presamlresponse` is unchanged, as SAML requests have no scopes.
- Closes #12524