### PR TITLE
feat(api): add native app link config fields for passkeys

### DIFF
--- a/proto/zitadel/app.proto
+++ b/proto/zitadel/app.proto
@@ -218,6 +218,7 @@ message AndroidAppLinkConfig {
     ];
     repeated string sha256_cert_fingerprints = 2 [
         (validate.rules).repeated = {
+            max_items: 20,
             items: {
                 string: {
                     pattern: "^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){31}|[0-9A-Fa-f]{64})$";
@@ -226,7 +227,7 @@ message AndroidAppLinkConfig {
         },
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99\"]";
-            description: "SHA-256 signing certificate fingerprints for Digital Asset Links (passkey / get_login_creds). 64 hex chars, optionally colon-separated pairs. Include debug and release as needed.";
+            description: "SHA-256 signing certificate fingerprints for Digital Asset Links (passkey / get_login_creds). 64 hex chars, optionally colon-separated pairs. At most 20 entries. Include debug and release as needed.";
         }
     ];
 }

--- a/proto/zitadel/app.proto
+++ b/proto/zitadel/app.proto
@@ -193,30 +193,40 @@ message OIDCConfig {
 
 message IOSAppLinkConfig {
     string team_id = 1 [
+        (validate.rules).string = {ignore_empty: true, len: 10, pattern: "^[A-Z0-9]+$"},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "\"ABCDE12345\"";
-            description: "Apple Team ID (App ID prefix), e.g. ABCDE12345. Combined with bundle_id as TEAMID.BUNDLEID in AASA webcredentials.apps. Not the full Apple App ID by itself.";
+            description: "Apple Team ID (App ID prefix), exactly 10 alphanumeric characters, e.g. ABCDE12345. Combined with bundle_id as TEAMID.BUNDLEID in AASA webcredentials.apps. Not the full Apple App ID by itself. Empty clears the value on update.";
         }
     ];
     string bundle_id = 2 [
+        (validate.rules).string = {ignore_empty: true, min_len: 1, max_len: 200},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "\"com.example.app\"";
-            description: "iOS Bundle ID (CFBundleIdentifier), e.g. com.example.app. Combined with team_id for AASA webcredentials.apps. Do not paste TEAMID.bundle.id here.";
+            description: "iOS Bundle ID (CFBundleIdentifier), e.g. com.example.app. Combined with team_id for AASA webcredentials.apps. Do not paste TEAMID.bundle.id here. Empty clears the value on update.";
         }
     ];
 }
 
 message AndroidAppLinkConfig {
     string package_name = 1 [
+        (validate.rules).string = {ignore_empty: true, min_len: 1, max_len: 200},
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "\"com.example.app\"";
-            description: "Android package name (applicationId). Used in assetlinks.json target.package_name.";
+            description: "Android package name (applicationId). Used in assetlinks.json target.package_name. Empty clears the value on update.";
         }
     ];
     repeated string sha256_cert_fingerprints = 2 [
+        (validate.rules).repeated = {
+            items: {
+                string: {
+                    pattern: "^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){31}|[0-9A-Fa-f]{64})$";
+                }
+            }
+        },
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             example: "[\"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99\"]";
-            description: "SHA-256 signing certificate fingerprints for Digital Asset Links (passkey / get_login_creds). Include debug and release as needed. Colons optional.";
+            description: "SHA-256 signing certificate fingerprints for Digital Asset Links (passkey / get_login_creds). 64 hex chars, optionally colon-separated pairs. Include debug and release as needed.";
         }
     ];
 }

--- a/proto/zitadel/app.proto
+++ b/proto/zitadel/app.proto
@@ -179,6 +179,46 @@ message OIDCConfig {
             description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
         }
     ];
+    IOSAppLinkConfig ios = 23 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+        }
+    ];
+    AndroidAppLinkConfig android = 24 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
+        }
+    ];
+}
+
+message IOSAppLinkConfig {
+    string team_id = 1 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"ABCDE12345\"";
+            description: "Apple Team ID (App ID prefix), e.g. ABCDE12345. Combined with bundle_id as TEAMID.BUNDLEID in AASA webcredentials.apps. Not the full Apple App ID by itself.";
+        }
+    ];
+    string bundle_id = 2 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"com.example.app\"";
+            description: "iOS Bundle ID (CFBundleIdentifier), e.g. com.example.app. Combined with team_id for AASA webcredentials.apps. Do not paste TEAMID.bundle.id here.";
+        }
+    ];
+}
+
+message AndroidAppLinkConfig {
+    string package_name = 1 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "\"com.example.app\"";
+            description: "Android package name (applicationId). Used in assetlinks.json target.package_name.";
+        }
+    ];
+    repeated string sha256_cert_fingerprints = 2 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            example: "[\"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99\"]";
+            description: "SHA-256 signing certificate fingerprints for Digital Asset Links (passkey / get_login_creds). Include debug and release as needed. Colons optional.";
+        }
+    ];
 }
 
 enum OIDCResponseType {

--- a/proto/zitadel/application/v2/application_service.proto
+++ b/proto/zitadel/application/v2/application_service.proto
@@ -341,6 +341,15 @@ message CreateOIDCApplicationRequest {
   // hosted on any other domain.
   // If unset, the login UI is chosen by the instance default.
   LoginVersion login_version = 17;
+
+  // IOS is iOS Associated Domains / passkey trust config.
+  // Served in apple-app-site-association as webcredentials.apps entry
+  // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  IOSAppLinkConfig ios = 18;
+
+  // Android is Android Digital Asset Links / passkey trust config.
+  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  AndroidAppLinkConfig android = 19;
 }
 
 message CreateOIDCApplicationResponse {
@@ -578,6 +587,17 @@ message UpdateOIDCApplicationConfigurationRequest {
   // hosted on any other domain.
   // If unset, the login UI is chosen by the instance default.
   optional LoginVersion login_version = 17;
+
+  // IOS is iOS Associated Domains / passkey trust config.
+  // Served in apple-app-site-association as webcredentials.apps entry
+  // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  // If not set, the iOS config will not be changed.
+  optional IOSAppLinkConfig ios = 18;
+
+  // Android is Android Digital Asset Links / passkey trust config.
+  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  // If not set, the Android config will not be changed.
+  optional AndroidAppLinkConfig android = 19;
 }
 
 message UpdateAPIApplicationConfigurationRequest {

--- a/proto/zitadel/application/v2/oidc.proto
+++ b/proto/zitadel/application/v2/oidc.proto
@@ -4,6 +4,7 @@ package zitadel.application.v2;
 
 import "google/protobuf/duration.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
+import "validate/validate.proto";
 import "zitadel/application/v2/login.proto";
 
 option go_package = "github.com/zitadel/zitadel/pkg/grpc/application/v2;application";
@@ -172,22 +173,31 @@ message OIDCConfiguration {
 // Served in apple-app-site-association as webcredentials.apps entry
 // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
 message IOSAppLinkConfig {
-  // TeamID is the Apple Developer Team ID (10-character alphanumeric), e.g. ABCDE12345.
+  // TeamID is the Apple Developer Team ID (exactly 10 alphanumeric characters), e.g. ABCDE12345.
   // From Apple Developer account membership — not the Bundle ID.
-  string team_id = 1;
+  // Empty clears the value on update.
+  string team_id = 1 [(validate.rules).string = {ignore_empty: true, len: 10, pattern: "^[A-Z0-9]+$"}];
 
   // BundleID is the Xcode / CFBundleIdentifier, e.g. com.example.app.
   // Not the full Apple App ID; do not include the Team ID prefix here.
-  string bundle_id = 2;
+  // Empty clears the value on update.
+  string bundle_id = 2 [(validate.rules).string = {ignore_empty: true, min_len: 1, max_len: 200}];
 }
 
 // AndroidAppLinkConfig is Android Digital Asset Links / passkey trust config.
 // Served in assetlinks.json for delegate_permission/common.get_login_creds.
 message AndroidAppLinkConfig {
   // PackageName is the Android applicationId / package name from the app manifest.
-  string package_name = 1;
+  // Empty clears the value on update.
+  string package_name = 1 [(validate.rules).string = {ignore_empty: true, min_len: 1, max_len: 200}];
 
-  // SHA256CertFingerprints are signing certificate fingerprints (with or without colons).
+  // SHA256CertFingerprints are signing certificate fingerprints (64 hex chars, optional colons).
   // Include debug and release fingerprints as needed.
-  repeated string sha256_cert_fingerprints = 2;
+  repeated string sha256_cert_fingerprints = 2 [(validate.rules).repeated = {
+    items: {
+      string: {
+        pattern: "^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){31}|[0-9A-Fa-f]{64})$";
+      }
+    }
+  }];
 }

--- a/proto/zitadel/application/v2/oidc.proto
+++ b/proto/zitadel/application/v2/oidc.proto
@@ -192,8 +192,9 @@ message AndroidAppLinkConfig {
   string package_name = 1 [(validate.rules).string = {ignore_empty: true, min_len: 1, max_len: 200}];
 
   // SHA256CertFingerprints are signing certificate fingerprints (64 hex chars, optional colons).
-  // Include debug and release fingerprints as needed.
+  // Include debug and release fingerprints as needed. At most 20 entries.
   repeated string sha256_cert_fingerprints = 2 [(validate.rules).repeated = {
+    max_items: 20,
     items: {
       string: {
         pattern: "^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){31}|[0-9A-Fa-f]{64})$";

--- a/proto/zitadel/application/v2/oidc.proto
+++ b/proto/zitadel/application/v2/oidc.proto
@@ -157,4 +157,37 @@ message OIDCConfiguration {
   // hosted on any other domain.
   // If unset, the login UI is chosen by the instance default.
   LoginVersion login_version = 21;
+
+  // IOS is iOS Associated Domains / passkey trust config.
+  // Served in apple-app-site-association as webcredentials.apps entry
+  // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  IOSAppLinkConfig ios = 22;
+
+  // Android is Android Digital Asset Links / passkey trust config.
+  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  AndroidAppLinkConfig android = 23;
+}
+
+// IOSAppLinkConfig is iOS Associated Domains / passkey trust config.
+// Served in apple-app-site-association as webcredentials.apps entry
+// "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+message IOSAppLinkConfig {
+  // TeamID is the Apple Developer Team ID (10-character alphanumeric), e.g. ABCDE12345.
+  // From Apple Developer account membership — not the Bundle ID.
+  string team_id = 1;
+
+  // BundleID is the Xcode / CFBundleIdentifier, e.g. com.example.app.
+  // Not the full Apple App ID; do not include the Team ID prefix here.
+  string bundle_id = 2;
+}
+
+// AndroidAppLinkConfig is Android Digital Asset Links / passkey trust config.
+// Served in assetlinks.json for delegate_permission/common.get_login_creds.
+message AndroidAppLinkConfig {
+  // PackageName is the Android applicationId / package name from the app manifest.
+  string package_name = 1;
+
+  // SHA256CertFingerprints are signing certificate fingerprints (with or without colons).
+  // Include debug and release fingerprints as needed.
+  repeated string sha256_cert_fingerprints = 2;
 }

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -10382,6 +10382,16 @@ message AddOIDCAppRequest {
             description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
         }
     ];
+    zitadel.app.v1.IOSAppLinkConfig ios = 20 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+        }
+    ];
+    zitadel.app.v1.AndroidAppLinkConfig android = 21 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
+        }
+    ];
 }
 
 message AddOIDCAppResponse {
@@ -10571,6 +10581,16 @@ message UpdateOIDCAppConfigRequest {
     zitadel.app.v1.LoginVersion login_version = 18 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
             description: "Specify the preferred login UI, where the user is redirected to for authentication. If unset, the login UI is chosen by the instance default.";
+        }
+    ];
+    zitadel.app.v1.IOSAppLinkConfig ios = 19 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+        }
+    ];
+    zitadel.app.v1.AndroidAppLinkConfig android = 20 [
+        (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
         }
     ];
 }


### PR DESCRIPTION
# Which Problems Are Solved

- Native iOS/Android passkeys need OS trust association metadata (Team ID, Bundle ID, package name, cert fingerprints) configured on OIDC apps before ZITADEL can serve `apple-app-site-association` / `assetlinks.json` (#12497).
- There is no API surface yet for that configuration.

# How the Problems Are Solved

- Adds nested `ios` / `android` messages (`IOSAppLinkConfig`, `AndroidAppLinkConfig`) on Management and Application v2 OIDC app create/get/update contracts.
- Documents Team ID vs Bundle ID (composed Apple App ID) using each proto file’s existing style (OpenAPI descriptions in `app.proto` / Management; `//` comments in Application v2).

# Additional Changes

- None in this PR: persistence, converters, and well-known handlers are follow-up stacked PRs on `feat-12497-native-app-links`.
- Update semantics (omit = keep, empty message = clear, populated = replace) will be implemented when wiring commands.

# Additional Context

- Part of #12497 (WIP stacked PR 1/N — API contract only; does not close the issue).
- Targets integration branch `feat-12497-native-app-links` (not `main`).

---
Layer of stacked review for ship PR #12539 (full feature description / squash target onto `main`).