### PR TITLE
feat(api): serve AASA and assetlinks for native app passkeys

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -701,6 +701,11 @@ OIDC:
     # Lifetime of the token used to notify clients through OIDC back-channel logout.
     TokenLifetime: 15m # ZITADEL_OIDC_BACKCHANNELLOGOUT_TOKENLIFETIME
 
+WellKnown:
+  # HTTP Cache-Control max-age for /.well-known/apple-app-site-association and
+  # /.well-known/assetlinks.json. 0 sets Cache-Control: no-store.
+  AppLinksCacheControlMaxAge: 5m # ZITADEL_WELLKNOWN_APPLINKSCACHECONTROLMAXAGE
+
 SAML:
   DefaultLoginURLV2: "/ui/v2/login/login?samlRequest=" # ZITADEL_SAML_DEFAULTLOGINURLV2
   ProviderConfig:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -703,7 +703,7 @@ OIDC:
 
 WellKnown:
   # HTTP Cache-Control max-age for /.well-known/apple-app-site-association and
-  # /.well-known/assetlinks.json. Non-positive values set Cache-Control: no-store.
+  # /.well-known/assetlinks.json. 0 sets Cache-Control: no-store.
   AppLinksCacheControlMaxAge: 5m # ZITADEL_WELLKNOWN_APPLINKSCACHECONTROLMAXAGE
 
 SAML:

--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -703,7 +703,7 @@ OIDC:
 
 WellKnown:
   # HTTP Cache-Control max-age for /.well-known/apple-app-site-association and
-  # /.well-known/assetlinks.json. 0 sets Cache-Control: no-store.
+  # /.well-known/assetlinks.json. Non-positive values set Cache-Control: no-store.
   AppLinksCacheControlMaxAge: 5m # ZITADEL_WELLKNOWN_APPLINKSCACHECONTROLMAXAGE
 
 SAML:

--- a/cmd/start/config.go
+++ b/cmd/start/config.go
@@ -24,6 +24,7 @@ import (
 	scim_config "github.com/zitadel/zitadel/internal/api/scim/config"
 	"github.com/zitadel/zitadel/internal/api/ui/console"
 	"github.com/zitadel/zitadel/internal/api/ui/login"
+	"github.com/zitadel/zitadel/internal/api/well_known"
 	auth_es "github.com/zitadel/zitadel/internal/auth/repository/eventsourcing"
 	"github.com/zitadel/zitadel/internal/cache/connector"
 	"github.com/zitadel/zitadel/internal/command"
@@ -72,6 +73,7 @@ type Config struct {
 	SCIM                scim_config.Config
 	Login               login.Config
 	Console             console.Config
+	WellKnown           well_known.Config
 	AssetStorage        static_config.AssetStorageConfig
 	InternalAuthZ       authz.Config
 	SystemAuthZ         authz.Config

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -85,6 +85,7 @@ import (
 	"github.com/zitadel/zitadel/internal/api/ui/console"
 	"github.com/zitadel/zitadel/internal/api/ui/console/path"
 	"github.com/zitadel/zitadel/internal/api/ui/login"
+	"github.com/zitadel/zitadel/internal/api/well_known"
 	auth_es "github.com/zitadel/zitadel/internal/auth/repository/eventsourcing"
 	"github.com/zitadel/zitadel/internal/authz"
 	authz_repo "github.com/zitadel/zitadel/internal/authz/repository"
@@ -656,6 +657,9 @@ func startAPIs(
 		return nil, fmt.Errorf("unable to start robots txt handler: %w", err)
 	}
 	apis.RegisterHandlerOnPrefix(robots_txt.HandlerPrefix, robotsTxtHandler)
+
+	// native app link well-known files (instance-scoped)
+	apis.RegisterHandlerPrefixes(instanceInterceptor.Handler(well_known.NewHandler(queries)), well_known.HandlerPrefixes...)
 
 	// TODO: Record openapi access logs?
 	openAPIHandler, err := openapi.Start()

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -659,7 +659,7 @@ func startAPIs(
 	apis.RegisterHandlerOnPrefix(robots_txt.HandlerPrefix, robotsTxtHandler)
 
 	// native app link well-known files (instance-scoped)
-	apis.RegisterHandlerPrefixes(instanceInterceptor.Handler(well_known.NewHandler(queries)), well_known.HandlerPrefixes...)
+	apis.RegisterHandlerPrefixes(instanceInterceptor.Handler(well_known.NewHandler(queries, config.WellKnown)), well_known.HandlerPrefixes...)
 
 	// TODO: Record openapi access logs?
 	openAPIHandler, err := openapi.Start()

--- a/internal/api/well_known/integration_test/well_known_test.go
+++ b/internal/api/well_known/integration_test/well_known_test.go
@@ -134,6 +134,7 @@ func assertEventuallyJSON(t *testing.T, url string, want any) {
 			return
 		}
 		assert.Contains(ct, resp.Header.Get("Content-Type"), "application/json")
+		assert.Equal(ct, "public, max-age=300", resp.Header.Get("Cache-Control"))
 
 		body, err := io.ReadAll(resp.Body)
 		if !assert.NoError(ct, err) {

--- a/internal/api/well_known/integration_test/well_known_test.go
+++ b/internal/api/well_known/integration_test/well_known_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package well_known_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/api/well_known"
+	"github.com/zitadel/zitadel/internal/integration"
+	"github.com/zitadel/zitadel/pkg/grpc/application/v2"
+)
+
+var (
+	CTX         context.Context
+	IAMOwnerCtx context.Context
+	Instance    *integration.Instance
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(func() int {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
+
+		Instance = integration.NewInstance(ctx)
+		CTX = ctx
+		IAMOwnerCtx = Instance.WithAuthorization(ctx, integration.UserTypeIAMOwner)
+		return m.Run()
+	}())
+}
+
+func TestWellKnownAppLinks(t *testing.T) {
+	issuer := Instance.OIDCIssuer()
+
+	t.Run("empty when no apps configured", func(t *testing.T) {
+		assertEventuallyJSON(t, issuer+well_known.AppleAppSiteAssociationPath, map[string]any{
+			"webcredentials": map[string]any{
+				"apps": []any{},
+			},
+		})
+		assertEventuallyJSON(t, issuer+well_known.AssetLinksPath, []any{})
+	})
+
+	project := Instance.CreateProject(IAMOwnerCtx, t, Instance.DefaultOrg.GetId(), integration.ProjectName(), false, false)
+
+	ios1 := &application.IOSAppLinkConfig{TeamId: "TEAMAAAAAA", BundleId: "com.example.one"}
+	android1 := &application.AndroidAppLinkConfig{
+		PackageName:            "com.example.one",
+		Sha256CertFingerprints: []string{"11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11"},
+	}
+	createOIDCAppWithLinks(t, project.GetId(), ios1, android1)
+
+	ios2 := &application.IOSAppLinkConfig{TeamId: "TEAMBBBBBB", BundleId: "com.example.two"}
+	createOIDCAppWithLinks(t, project.GetId(), ios2, nil)
+
+	android2 := &application.AndroidAppLinkConfig{
+		PackageName:            "com.example.two",
+		Sha256CertFingerprints: []string{"22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22:22"},
+	}
+	createOIDCAppWithLinks(t, project.GetId(), nil, android2)
+
+	// duplicate iOS app id should be deduped in AASA
+	createOIDCAppWithLinks(t, project.GetId(), ios1, nil)
+
+	assertEventuallyJSONUnorderedApps(t, issuer,
+		[]string{
+			"TEAMAAAAAA.com.example.one",
+			"TEAMBBBBBB.com.example.two",
+		},
+		[]any{
+			map[string]any{
+				"relation": []any{"delegate_permission/common.get_login_creds"},
+				"target": map[string]any{
+					"namespace":                "android_app",
+					"package_name":             "com.example.one",
+					"sha256_cert_fingerprints": []any{android1.Sha256CertFingerprints[0]},
+				},
+			},
+			map[string]any{
+				"relation": []any{"delegate_permission/common.get_login_creds"},
+				"target": map[string]any{
+					"namespace":                "android_app",
+					"package_name":             "com.example.two",
+					"sha256_cert_fingerprints": []any{android2.Sha256CertFingerprints[0]},
+				},
+			},
+		},
+	)
+}
+
+func createOIDCAppWithLinks(t *testing.T, projectID string, ios *application.IOSAppLinkConfig, android *application.AndroidAppLinkConfig) {
+	t.Helper()
+	_, err := Instance.Client.ApplicationV2.CreateApplication(IAMOwnerCtx, &application.CreateApplicationRequest{
+		ProjectId: projectID,
+		Name:      integration.ApplicationName(),
+		ApplicationType: &application.CreateApplicationRequest_OidcConfiguration{
+			OidcConfiguration: &application.CreateOIDCApplicationRequest{
+				RedirectUris:    []string{"http://example.com"},
+				ResponseTypes:   []application.OIDCResponseType{application.OIDCResponseType_OIDC_RESPONSE_TYPE_CODE},
+				GrantTypes:      []application.OIDCGrantType{application.OIDCGrantType_OIDC_GRANT_TYPE_AUTHORIZATION_CODE},
+				ApplicationType: application.OIDCApplicationType_OIDC_APP_TYPE_NATIVE,
+				AuthMethodType:  application.OIDCAuthMethodType_OIDC_AUTH_METHOD_TYPE_NONE,
+				Version:         application.OIDCVersion_OIDC_VERSION_1_0,
+				AccessTokenType: application.OIDCTokenType_OIDC_TOKEN_TYPE_BEARER,
+				Ios:             ios,
+				Android:         android,
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func assertEventuallyJSON(t *testing.T, url string, want any) {
+	t.Helper()
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(CTX, time.Minute)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(url)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		defer func() {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+		if !assert.Equal(ct, http.StatusOK, resp.StatusCode) {
+			return
+		}
+		assert.Contains(ct, resp.Header.Get("Content-Type"), "application/json")
+
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		var got any
+		if !assert.NoError(ct, json.Unmarshal(body, &got)) {
+			return
+		}
+		assert.Equal(ct, want, got)
+	}, retryDuration, tick)
+}
+
+func assertEventuallyJSONUnorderedApps(t *testing.T, url string, wantApps []string, wantAssetLinks []any) {
+	t.Helper()
+	retryDuration, tick := integration.WaitForAndTickWithMaxDuration(CTX, time.Minute)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		aasaResp, err := http.Get(url + well_known.AppleAppSiteAssociationPath)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		defer aasaResp.Body.Close()
+		if !assert.Equal(ct, http.StatusOK, aasaResp.StatusCode) {
+			return
+		}
+		var aasa struct {
+			WebCredentials struct {
+				Apps []string `json:"apps"`
+			} `json:"webcredentials"`
+		}
+		if !assert.NoError(ct, json.NewDecoder(aasaResp.Body).Decode(&aasa)) {
+			return
+		}
+		assert.ElementsMatch(ct, wantApps, aasa.WebCredentials.Apps)
+
+		assetResp, err := http.Get(url + well_known.AssetLinksPath)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		defer assetResp.Body.Close()
+		if !assert.Equal(ct, http.StatusOK, assetResp.StatusCode) {
+			return
+		}
+		var got []any
+		if !assert.NoError(ct, json.NewDecoder(assetResp.Body).Decode(&got)) {
+			return
+		}
+		assert.ElementsMatch(ct, wantAssetLinks, got)
+	}, retryDuration, tick)
+}

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -3,10 +3,15 @@ package well_known
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
+	"time"
+	"unicode"
 
 	"github.com/zitadel/logging"
 
+	http_util "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/query"
 )
 
@@ -21,16 +26,28 @@ var HandlerPrefixes = []string{
 	AssetLinksPath,
 }
 
+// Config holds runtime options for the well-known handlers.
+type Config struct {
+	// AppLinksCacheControlMaxAge sets the Cache-Control max-age for
+	// apple-app-site-association and assetlinks.json responses.
+	// 0 sets Cache-Control: no-store.
+	AppLinksCacheControlMaxAge time.Duration
+}
+
 type appLinkQuerier interface {
 	SearchOIDCAppLinkConfigs(ctx context.Context) ([]*query.OIDCAppLinkConfig, error)
 }
 
 type Handler struct {
-	queries appLinkQuerier
+	queries            appLinkQuerier
+	cacheControlMaxAge time.Duration
 }
 
-func NewHandler(queries appLinkQuerier) *Handler {
-	return &Handler{queries: queries}
+func NewHandler(queries appLinkQuerier, config Config) *Handler {
+	return &Handler{
+		queries:            queries,
+		cacheControlMaxAge: config.AppLinksCacheControlMaxAge,
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +91,7 @@ func (h *Handler) serveAppleAppSiteAssociation(w http.ResponseWriter, r *http.Re
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, buildAppleAppSiteAssociation(configs))
+	h.writeJSON(w, buildAppleAppSiteAssociation(configs))
 }
 
 func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +105,7 @@ func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, buildAssetLinks(configs))
+	h.writeJSON(w, buildAssetLinks(configs))
 }
 
 func buildAppleAppSiteAssociation(configs []*query.OIDCAppLinkConfig) appleAppSiteAssociation {
@@ -116,26 +133,72 @@ func buildAssetLinks(configs []*query.OIDCAppLinkConfig) []assetLink {
 		if cfg.AndroidPackageName == "" || len(cfg.AndroidSHA256CertFingerprints) == 0 {
 			continue
 		}
-		fps := cfg.AndroidSHA256CertFingerprints
-		if fps == nil {
-			fps = []string{}
-		}
 		links = append(links, assetLink{
 			Relation: []string{"delegate_permission/common.get_login_creds"},
 			Target: assetLinkTarget{
 				Namespace:              "android_app",
 				PackageName:            cfg.AndroidPackageName,
-				SHA256CertFingerprints: fps,
+				SHA256CertFingerprints: normalizeSHA256Fingerprints(cfg.AndroidSHA256CertFingerprints),
 			},
 		})
 	}
 	return links
 }
 
-func writeJSON(w http.ResponseWriter, v any) {
+// normalizeSHA256Fingerprints returns colon-separated uppercase hex fingerprints
+// for assetlinks.json. Normalization is applied at serve time only so stored /
+// client state can keep the format clients sent.
+func normalizeSHA256Fingerprints(fps []string) []string {
+	out := make([]string, len(fps))
+	for i, fp := range fps {
+		out[i] = normalizeSHA256Fingerprint(fp)
+	}
+	return out
+}
+
+func normalizeSHA256Fingerprint(fp string) string {
+	cleaned := make([]byte, 0, 64)
+	for _, r := range fp {
+		switch {
+		case r == ':' || unicode.IsSpace(r):
+			continue
+		case r >= 'a' && r <= 'f':
+			cleaned = append(cleaned, byte(r-32))
+		case (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F'):
+			cleaned = append(cleaned, byte(r))
+		default:
+			return strings.ToUpper(strings.TrimSpace(fp))
+		}
+	}
+	if len(cleaned) != 64 {
+		return strings.ToUpper(strings.TrimSpace(fp))
+	}
+	var b strings.Builder
+	b.Grow(95) // 64 hex chars + 31 colons
+	for i := 0; i < 64; i += 2 {
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		b.Write(cleaned[i : i+2])
+	}
+	return b.String()
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
+	h.setCacheControl(w)
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		logging.WithError(err).Error("unable to encode well-known response")
 	}
+}
+
+func (h *Handler) setCacheControl(w http.ResponseWriter) {
+	if h.cacheControlMaxAge == 0 {
+		w.Header().Set(http_util.CacheControl, "no-store")
+		return
+	}
+	w.Header().Set(http_util.CacheControl,
+		fmt.Sprintf("public, max-age=%d", int(h.cacheControlMaxAge/time.Second)),
+	)
 }

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -2,12 +2,13 @@ package well_known
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/zitadel/logging"
 
@@ -157,31 +158,20 @@ func normalizeSHA256Fingerprints(fps []string) []string {
 }
 
 func normalizeSHA256Fingerprint(fp string) string {
-	cleaned := make([]byte, 0, 64)
-	for _, r := range fp {
-		switch {
-		case r == ':' || unicode.IsSpace(r):
-			continue
-		case r >= 'a' && r <= 'f':
-			cleaned = append(cleaned, byte(r-32))
-		case (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F'):
-			cleaned = append(cleaned, byte(r))
-		default:
-			return strings.ToUpper(strings.TrimSpace(fp))
-		}
+	if strings.Contains(fp, ":") {
+		return strings.ToUpper(fp) // already 32 valid pairs per API validation; only case may vary
 	}
-	if len(cleaned) != 64 {
-		return strings.ToUpper(strings.TrimSpace(fp))
+	raw, err := hex.DecodeString(fp) // guaranteed 64 hex chars
+	if err != nil || len(raw) != sha256.Size {
+		logging.WithFields("fingerprint", fp).WithError(err).
+			Warn("stored android sha256 fingerprint is not canonical hex; serving as-is")
+		return strings.ToUpper(fp)
 	}
-	var b strings.Builder
-	b.Grow(95) // 64 hex chars + 31 colons
-	for i := 0; i < 64; i += 2 {
-		if i > 0 {
-			b.WriteByte(':')
-		}
-		b.Write(cleaned[i : i+2])
+	parts := make([]string, len(raw))
+	for i, b := range raw {
+		parts[i] = fmt.Sprintf("%02X", b)
 	}
-	return b.String()
+	return strings.Join(parts, ":")
 }
 
 func (h *Handler) writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -31,7 +31,7 @@ var HandlerPrefixes = []string{
 type Config struct {
 	// AppLinksCacheControlMaxAge sets the Cache-Control max-age for
 	// apple-app-site-association and assetlinks.json responses.
-	// Non-positive values (including 0) set Cache-Control: no-store.
+	// 0 sets Cache-Control: no-store.
 	AppLinksCacheControlMaxAge time.Duration
 }
 

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -1,0 +1,141 @@
+package well_known
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/zitadel/logging"
+
+	"github.com/zitadel/zitadel/internal/query"
+)
+
+const (
+	AppleAppSiteAssociationPath = "/.well-known/apple-app-site-association"
+	AssetLinksPath              = "/.well-known/assetlinks.json"
+)
+
+// HandlerPrefixes are registered with [api.API.RegisterHandlerPrefixes].
+var HandlerPrefixes = []string{
+	AppleAppSiteAssociationPath,
+	AssetLinksPath,
+}
+
+type appLinkQuerier interface {
+	SearchOIDCAppLinkConfigs(ctx context.Context) ([]*query.OIDCAppLinkConfig, error)
+}
+
+type Handler struct {
+	queries appLinkQuerier
+}
+
+func NewHandler(queries appLinkQuerier) *Handler {
+	return &Handler{queries: queries}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case AppleAppSiteAssociationPath:
+		h.serveAppleAppSiteAssociation(w, r)
+	case AssetLinksPath:
+		h.serveAssetLinks(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+type appleAppSiteAssociation struct {
+	WebCredentials appleWebCredentials `json:"webcredentials"`
+}
+
+type appleWebCredentials struct {
+	Apps []string `json:"apps"`
+}
+
+type assetLink struct {
+	Relation []string        `json:"relation"`
+	Target   assetLinkTarget `json:"target"`
+}
+
+type assetLinkTarget struct {
+	Namespace              string   `json:"namespace"`
+	PackageName            string   `json:"package_name"`
+	SHA256CertFingerprints []string `json:"sha256_cert_fingerprints"`
+}
+
+func (h *Handler) serveAppleAppSiteAssociation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	configs, err := h.queries.SearchOIDCAppLinkConfigs(r.Context())
+	if err != nil {
+		logging.WithError(err).Error("unable to query OIDC app link configs for apple-app-site-association")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, buildAppleAppSiteAssociation(configs))
+}
+
+func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	configs, err := h.queries.SearchOIDCAppLinkConfigs(r.Context())
+	if err != nil {
+		logging.WithError(err).Error("unable to query OIDC app link configs for assetlinks.json")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, buildAssetLinks(configs))
+}
+
+func buildAppleAppSiteAssociation(configs []*query.OIDCAppLinkConfig) appleAppSiteAssociation {
+	apps := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, cfg := range configs {
+		if cfg.IOSTeamID == "" || cfg.IOSBundleID == "" {
+			continue
+		}
+		appID := cfg.IOSTeamID + "." + cfg.IOSBundleID
+		if _, ok := seen[appID]; ok {
+			continue
+		}
+		seen[appID] = struct{}{}
+		apps = append(apps, appID)
+	}
+	return appleAppSiteAssociation{
+		WebCredentials: appleWebCredentials{Apps: apps},
+	}
+}
+
+func buildAssetLinks(configs []*query.OIDCAppLinkConfig) []assetLink {
+	links := make([]assetLink, 0)
+	for _, cfg := range configs {
+		if cfg.AndroidPackageName == "" || len(cfg.AndroidSHA256CertFingerprints) == 0 {
+			continue
+		}
+		fps := cfg.AndroidSHA256CertFingerprints
+		if fps == nil {
+			fps = []string{}
+		}
+		links = append(links, assetLink{
+			Relation: []string{"delegate_permission/common.get_login_creds"},
+			Target: assetLinkTarget{
+				Namespace:              "android_app",
+				PackageName:            cfg.AndroidPackageName,
+				SHA256CertFingerprints: fps,
+			},
+		})
+	}
+	return links
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		logging.WithError(err).Error("unable to encode well-known response")
+	}
+}

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -31,7 +31,7 @@ var HandlerPrefixes = []string{
 type Config struct {
 	// AppLinksCacheControlMaxAge sets the Cache-Control max-age for
 	// apple-app-site-association and assetlinks.json responses.
-	// 0 sets Cache-Control: no-store.
+	// Non-positive values (including 0) set Cache-Control: no-store.
 	AppLinksCacheControlMaxAge time.Duration
 }
 
@@ -92,7 +92,7 @@ func (h *Handler) serveAppleAppSiteAssociation(w http.ResponseWriter, r *http.Re
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	h.writeJSON(w, buildAppleAppSiteAssociation(configs))
+	h.writeJSON(w, r, buildAppleAppSiteAssociation(configs))
 }
 
 func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +106,7 @@ func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	h.writeJSON(w, buildAssetLinks(configs))
+	h.writeJSON(w, r, buildAssetLinks(configs))
 }
 
 func buildAppleAppSiteAssociation(configs []*query.OIDCAppLinkConfig) appleAppSiteAssociation {
@@ -174,17 +174,20 @@ func normalizeSHA256Fingerprint(fp string) string {
 	return strings.Join(parts, ":")
 }
 
-func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
+func (h *Handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	h.setCacheControl(w)
 	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodHead {
+		return
+	}
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		logging.WithError(err).Error("unable to encode well-known response")
 	}
 }
 
 func (h *Handler) setCacheControl(w http.ResponseWriter) {
-	if h.cacheControlMaxAge == 0 {
+	if h.cacheControlMaxAge <= 0 {
 		w.Header().Set(http_util.CacheControl, "no-store")
 		return
 	}

--- a/internal/api/well_known/well_known.go
+++ b/internal/api/well_known/well_known.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/zitadel/logging"
-
+	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
 	http_util "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/query"
 )
@@ -88,7 +87,7 @@ func (h *Handler) serveAppleAppSiteAssociation(w http.ResponseWriter, r *http.Re
 	}
 	configs, err := h.queries.SearchOIDCAppLinkConfigs(r.Context())
 	if err != nil {
-		logging.WithError(err).Error("unable to query OIDC app link configs for apple-app-site-association")
+		logging.Error(r.Context(), "unable to query OIDC app link configs for apple-app-site-association", "err", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -102,11 +101,11 @@ func (h *Handler) serveAssetLinks(w http.ResponseWriter, r *http.Request) {
 	}
 	configs, err := h.queries.SearchOIDCAppLinkConfigs(r.Context())
 	if err != nil {
-		logging.WithError(err).Error("unable to query OIDC app link configs for assetlinks.json")
+		logging.Error(r.Context(), "unable to query OIDC app link configs for assetlinks.json", "err", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	h.writeJSON(w, r, buildAssetLinks(configs))
+	h.writeJSON(w, r, buildAssetLinks(r.Context(), configs))
 }
 
 func buildAppleAppSiteAssociation(configs []*query.OIDCAppLinkConfig) appleAppSiteAssociation {
@@ -128,7 +127,7 @@ func buildAppleAppSiteAssociation(configs []*query.OIDCAppLinkConfig) appleAppSi
 	}
 }
 
-func buildAssetLinks(configs []*query.OIDCAppLinkConfig) []assetLink {
+func buildAssetLinks(ctx context.Context, configs []*query.OIDCAppLinkConfig) []assetLink {
 	links := make([]assetLink, 0)
 	for _, cfg := range configs {
 		if cfg.AndroidPackageName == "" || len(cfg.AndroidSHA256CertFingerprints) == 0 {
@@ -139,7 +138,7 @@ func buildAssetLinks(configs []*query.OIDCAppLinkConfig) []assetLink {
 			Target: assetLinkTarget{
 				Namespace:              "android_app",
 				PackageName:            cfg.AndroidPackageName,
-				SHA256CertFingerprints: normalizeSHA256Fingerprints(cfg.AndroidSHA256CertFingerprints),
+				SHA256CertFingerprints: normalizeSHA256Fingerprints(ctx, cfg.AndroidSHA256CertFingerprints),
 			},
 		})
 	}
@@ -149,22 +148,22 @@ func buildAssetLinks(configs []*query.OIDCAppLinkConfig) []assetLink {
 // normalizeSHA256Fingerprints returns colon-separated uppercase hex fingerprints
 // for assetlinks.json. Normalization is applied at serve time only so stored /
 // client state can keep the format clients sent.
-func normalizeSHA256Fingerprints(fps []string) []string {
+func normalizeSHA256Fingerprints(ctx context.Context, fps []string) []string {
 	out := make([]string, len(fps))
 	for i, fp := range fps {
-		out[i] = normalizeSHA256Fingerprint(fp)
+		out[i] = normalizeSHA256Fingerprint(ctx, fp)
 	}
 	return out
 }
 
-func normalizeSHA256Fingerprint(fp string) string {
+func normalizeSHA256Fingerprint(ctx context.Context, fp string) string {
 	if strings.Contains(fp, ":") {
 		return strings.ToUpper(fp) // already 32 valid pairs per API validation; only case may vary
 	}
 	raw, err := hex.DecodeString(fp) // guaranteed 64 hex chars
 	if err != nil || len(raw) != sha256.Size {
-		logging.WithFields("fingerprint", fp).WithError(err).
-			Warn("stored android sha256 fingerprint is not canonical hex; serving as-is")
+		logging.Warn(ctx, "stored android sha256 fingerprint is not canonical hex; serving as-is",
+			"fingerprint", fp, "err", err)
 		return strings.ToUpper(fp)
 	}
 	parts := make([]string, len(raw))
@@ -182,7 +181,7 @@ func (h *Handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
 		return
 	}
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		logging.WithError(err).Error("unable to encode well-known response")
+		logging.Error(r.Context(), "unable to encode well-known response", "err", err)
 	}
 }
 

--- a/internal/api/well_known/well_known_test.go
+++ b/internal/api/well_known/well_known_test.go
@@ -198,6 +198,11 @@ func TestHandlerCacheControl(t *testing.T) {
 			maxAge:     0,
 			wantHeader: "no-store",
 		},
+		{
+			name:       "no-store when negative",
+			maxAge:     -time.Minute,
+			wantHeader: "no-store",
+		},
 	}
 
 	for _, tc := range tt {
@@ -213,6 +218,24 @@ func TestHandlerCacheControl(t *testing.T) {
 				assert.Equal(t, tc.wantHeader, rec.Header().Get(http_util.CacheControl), path)
 				assert.NotContains(t, rec.Header().Get(http_util.CacheControl), "stale-while-revalidate")
 			}
+		})
+	}
+}
+
+func TestHandlerHeadOmitsBody(t *testing.T) {
+	t.Parallel()
+
+	h := NewHandler(stubAppLinkQuerier{}, Config{AppLinksCacheControlMaxAge: 5 * time.Minute})
+	for _, path := range []string{AppleAppSiteAssociationPath, AssetLinksPath} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodHead, path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+			assert.Equal(t, "public, max-age=300", rec.Header().Get(http_util.CacheControl))
+			assert.Empty(t, rec.Body.Bytes())
 		})
 	}
 }

--- a/internal/api/well_known/well_known_test.go
+++ b/internal/api/well_known/well_known_test.go
@@ -1,0 +1,115 @@
+package well_known
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/query"
+)
+
+func TestBuildAppleAppSiteAssociation(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		configs  []*query.OIDCAppLinkConfig
+		wantApps []string
+	}{
+		{
+			name:     "empty",
+			configs:  nil,
+			wantApps: []string{},
+		},
+		{
+			name: "skips incomplete ios",
+			configs: []*query.OIDCAppLinkConfig{
+				{IOSTeamID: "TEAM"},
+				{IOSBundleID: "com.example"},
+			},
+			wantApps: []string{},
+		},
+		{
+			name: "aggregates and dedupes",
+			configs: []*query.OIDCAppLinkConfig{
+				{IOSTeamID: "TEAM1", IOSBundleID: "com.one"},
+				{IOSTeamID: "TEAM2", IOSBundleID: "com.two"},
+				{IOSTeamID: "TEAM1", IOSBundleID: "com.one"},
+				{AndroidPackageName: "com.android", AndroidSHA256CertFingerprints: []string{"AA"}},
+			},
+			wantApps: []string{"TEAM1.com.one", "TEAM2.com.two"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildAppleAppSiteAssociation(tc.configs)
+			assert.Equal(t, tc.wantApps, got.WebCredentials.Apps)
+		})
+	}
+}
+
+func TestBuildAssetLinks(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name    string
+		configs []*query.OIDCAppLinkConfig
+		want    []assetLink
+	}{
+		{
+			name:    "empty",
+			configs: nil,
+			want:    []assetLink{},
+		},
+		{
+			name: "skips incomplete android",
+			configs: []*query.OIDCAppLinkConfig{
+				{AndroidPackageName: "com.example"},
+				{AndroidSHA256CertFingerprints: []string{"AA"}},
+			},
+			want: []assetLink{},
+		},
+		{
+			name: "aggregates entries",
+			configs: []*query.OIDCAppLinkConfig{
+				{
+					IOSTeamID:                     "TEAM",
+					IOSBundleID:                   "com.ios",
+					AndroidPackageName:            "com.one",
+					AndroidSHA256CertFingerprints: []string{"AA:BB"},
+				},
+				{
+					AndroidPackageName:            "com.two",
+					AndroidSHA256CertFingerprints: []string{"CC:DD", "EE:FF"},
+				},
+			},
+			want: []assetLink{
+				{
+					Relation: []string{"delegate_permission/common.get_login_creds"},
+					Target: assetLinkTarget{
+						Namespace:              "android_app",
+						PackageName:            "com.one",
+						SHA256CertFingerprints: []string{"AA:BB"},
+					},
+				},
+				{
+					Relation: []string{"delegate_permission/common.get_login_creds"},
+					Target: assetLinkTarget{
+						Namespace:              "android_app",
+						PackageName:            "com.two",
+						SHA256CertFingerprints: []string{"CC:DD", "EE:FF"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, buildAssetLinks(tc.configs))
+		})
+	}
+}

--- a/internal/api/well_known/well_known_test.go
+++ b/internal/api/well_known/well_known_test.go
@@ -1,10 +1,16 @@
 package well_known
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	http_util "github.com/zitadel/zitadel/internal/api/http"
 	"github.com/zitadel/zitadel/internal/query"
 )
 
@@ -72,34 +78,42 @@ func TestBuildAssetLinks(t *testing.T) {
 			want: []assetLink{},
 		},
 		{
-			name: "aggregates entries",
+			name: "aggregates and normalizes fingerprints",
 			configs: []*query.OIDCAppLinkConfig{
 				{
 					IOSTeamID:                     "TEAM",
 					IOSBundleID:                   "com.ios",
 					AndroidPackageName:            "com.one",
-					AndroidSHA256CertFingerprints: []string{"AA:BB"},
+					AndroidSHA256CertFingerprints: []string{"aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"},
 				},
 				{
-					AndroidPackageName:            "com.two",
-					AndroidSHA256CertFingerprints: []string{"CC:DD", "EE:FF"},
+					AndroidPackageName: "com.two",
+					AndroidSHA256CertFingerprints: []string{
+						"CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB",
+						"ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd",
+					},
 				},
 			},
 			want: []assetLink{
 				{
 					Relation: []string{"delegate_permission/common.get_login_creds"},
 					Target: assetLinkTarget{
-						Namespace:              "android_app",
-						PackageName:            "com.one",
-						SHA256CertFingerprints: []string{"AA:BB"},
+						Namespace:   "android_app",
+						PackageName: "com.one",
+						SHA256CertFingerprints: []string{
+							"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+						},
 					},
 				},
 				{
 					Relation: []string{"delegate_permission/common.get_login_creds"},
 					Target: assetLinkTarget{
-						Namespace:              "android_app",
-						PackageName:            "com.two",
-						SHA256CertFingerprints: []string{"CC:DD", "EE:FF"},
+						Namespace:   "android_app",
+						PackageName: "com.two",
+						SHA256CertFingerprints: []string{
+							"CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB",
+							"EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD",
+						},
 					},
 				},
 			},
@@ -110,6 +124,90 @@ func TestBuildAssetLinks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, buildAssetLinks(tc.configs))
+		})
+	}
+}
+
+func TestNormalizeSHA256Fingerprint(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already canonical",
+			in:   "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+		},
+		{
+			name: "lowercase without separators",
+			in:   "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+		},
+		{
+			name: "mixed case with spaces",
+			in:   "aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99",
+			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+		},
+		{
+			name: "invalid length uppercased",
+			in:   "aa:bb",
+			want: "AA:BB",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, normalizeSHA256Fingerprint(tc.in))
+		})
+	}
+}
+
+type stubAppLinkQuerier struct {
+	configs []*query.OIDCAppLinkConfig
+	err     error
+}
+
+func (s stubAppLinkQuerier) SearchOIDCAppLinkConfigs(_ context.Context) ([]*query.OIDCAppLinkConfig, error) {
+	return s.configs, s.err
+}
+
+func TestHandlerCacheControl(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name       string
+		maxAge     time.Duration
+		wantHeader string
+	}{
+		{
+			name:       "default max-age",
+			maxAge:     5 * time.Minute,
+			wantHeader: "public, max-age=300",
+		},
+		{
+			name:       "no-store when zero",
+			maxAge:     0,
+			wantHeader: "no-store",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewHandler(stubAppLinkQuerier{}, Config{AppLinksCacheControlMaxAge: tc.maxAge})
+
+			for _, path := range []string{AppleAppSiteAssociationPath, AssetLinksPath} {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, req)
+				require.Equal(t, http.StatusOK, rec.Code)
+				assert.Equal(t, tc.wantHeader, rec.Header().Get(http_util.CacheControl), path)
+				assert.NotContains(t, rec.Header().Get(http_util.CacheControl), "stale-while-revalidate")
+			}
 		})
 	}
 }

--- a/internal/api/well_known/well_known_test.go
+++ b/internal/api/well_known/well_known_test.go
@@ -89,8 +89,8 @@ func TestBuildAssetLinks(t *testing.T) {
 				{
 					AndroidPackageName: "com.two",
 					AndroidSHA256CertFingerprints: []string{
-						"CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB",
-						"ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd",
+						"cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb",
+						"eeff00112233445566778899aabbccddeeff00112233445566778899aabbccdd",
 					},
 				},
 			},
@@ -142,17 +142,22 @@ func TestNormalizeSHA256Fingerprint(t *testing.T) {
 			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
 		},
 		{
+			name: "lowercase with colons",
+			in:   "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+		},
+		{
 			name: "lowercase without separators",
 			in:   "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
 			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
 		},
 		{
-			name: "mixed case with spaces",
-			in:   "aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99",
-			want: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+			name: "invalid continuous hex uppercased",
+			in:   "aabb",
+			want: "AABB",
 		},
 		{
-			name: "invalid length uppercased",
+			name: "colon form uppercased without reparse",
 			in:   "aa:bb",
 			want: "AA:BB",
 		},

--- a/internal/api/well_known/well_known_test.go
+++ b/internal/api/well_known/well_known_test.go
@@ -123,7 +123,7 @@ func TestBuildAssetLinks(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, buildAssetLinks(tc.configs))
+			assert.Equal(t, tc.want, buildAssetLinks(t.Context(), tc.configs))
 		})
 	}
 }
@@ -166,7 +166,7 @@ func TestNormalizeSHA256Fingerprint(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, normalizeSHA256Fingerprint(tc.in))
+			assert.Equal(t, tc.want, normalizeSHA256Fingerprint(t.Context(), tc.in))
 		})
 	}
 }

--- a/internal/query/app_link.go
+++ b/internal/query/app_link.go
@@ -1,0 +1,100 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	sq "github.com/Masterminds/squirrel"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/domain"
+	"github.com/zitadel/zitadel/internal/telemetry/tracing"
+	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+// OIDCAppLinkConfig holds iOS/Android association fields for one active OIDC app.
+type OIDCAppLinkConfig struct {
+	AppID                         string
+	IOSTeamID                     string
+	IOSBundleID                   string
+	AndroidPackageName            string
+	AndroidSHA256CertFingerprints []string
+}
+
+// SearchOIDCAppLinkConfigs returns association fields for active OIDC apps in the
+// current instance that have at least one iOS or Android app-link field set.
+func (q *Queries) SearchOIDCAppLinkConfigs(ctx context.Context) (configs []*OIDCAppLinkConfig, err error) {
+	ctx, span := tracing.NewSpan(ctx)
+	defer func() { span.EndWithError(err) }()
+
+	query, scan := prepareOIDCAppLinkConfigsQuery()
+	iosTeamIDCol := AppOIDCConfigColumnIOSTeamID.identifier()
+	iosBundleIDCol := AppOIDCConfigColumnIOSBundleID.identifier()
+	androidPackageCol := AppOIDCConfigColumnAndroidPackageName.identifier()
+	stmt, args, err := query.Where(sq.And{
+		sq.Eq{
+			AppOIDCConfigColumnInstanceID.identifier(): authz.GetInstance(ctx).InstanceID(),
+			AppColumnState.identifier():                domain.AppStateActive,
+		},
+		sq.Or{
+			sq.Expr("COALESCE("+iosTeamIDCol+", '') <> ''"),
+			sq.Expr("COALESCE("+iosBundleIDCol+", '') <> ''"),
+			sq.Expr("COALESCE("+androidPackageCol+", '') <> ''"),
+		},
+	}).OrderBy(AppOIDCConfigColumnAppID.identifier()).ToSql()
+	if err != nil {
+		return nil, zerrors.ThrowInvalidArgument(err, "QUERY-ApLn1", "Errors.Query.InvalidRequest")
+	}
+
+	err = q.client.QueryContext(ctx, func(rows *sql.Rows) error {
+		configs, err = scan(rows)
+		return err
+	}, stmt, args...)
+	if err != nil {
+		return nil, zerrors.ThrowInternal(err, "QUERY-ApLn2", "Errors.Internal")
+	}
+	return configs, nil
+}
+
+func prepareOIDCAppLinkConfigsQuery() (sq.SelectBuilder, func(*sql.Rows) ([]*OIDCAppLinkConfig, error)) {
+	return sq.Select(
+			AppOIDCConfigColumnAppID.identifier(),
+			AppOIDCConfigColumnIOSTeamID.identifier(),
+			AppOIDCConfigColumnIOSBundleID.identifier(),
+			AppOIDCConfigColumnAndroidPackageName.identifier(),
+			AppOIDCConfigColumnAndroidSHA256CertFingerprints.identifier(),
+		).From(appOIDCConfigsTable.identifier()).
+			Join(join(AppColumnID, AppOIDCConfigColumnAppID)).
+			PlaceholderFormat(sq.Dollar),
+		func(rows *sql.Rows) ([]*OIDCAppLinkConfig, error) {
+			configs := make([]*OIDCAppLinkConfig, 0)
+			for rows.Next() {
+				var (
+					appID          sql.NullString
+					iosTeamID      sql.NullString
+					iosBundleID    sql.NullString
+					androidPackage sql.NullString
+					fingerprints   database.TextArray[string]
+				)
+				if err := rows.Scan(
+					&appID,
+					&iosTeamID,
+					&iosBundleID,
+					&androidPackage,
+					&fingerprints,
+				); err != nil {
+					return nil, zerrors.ThrowInternal(err, "QUERY-ApLn3", "Errors.Internal")
+				}
+				configs = append(configs, &OIDCAppLinkConfig{
+					AppID:                         appID.String,
+					IOSTeamID:                     strings.TrimSpace(iosTeamID.String),
+					IOSBundleID:                   strings.TrimSpace(iosBundleID.String),
+					AndroidPackageName:            strings.TrimSpace(androidPackage.String),
+					AndroidSHA256CertFingerprints: fingerprints,
+				})
+			}
+			return configs, nil
+		}
+}

--- a/internal/query/app_link.go
+++ b/internal/query/app_link.go
@@ -39,9 +39,9 @@ func (q *Queries) SearchOIDCAppLinkConfigs(ctx context.Context) (configs []*OIDC
 			AppColumnState.identifier():                domain.AppStateActive,
 		},
 		sq.Or{
-			sq.Expr("COALESCE("+iosTeamIDCol+", '') <> ''"),
-			sq.Expr("COALESCE("+iosBundleIDCol+", '') <> ''"),
-			sq.Expr("COALESCE("+androidPackageCol+", '') <> ''"),
+			sq.Expr("COALESCE(" + iosTeamIDCol + ", '') <> ''"),
+			sq.Expr("COALESCE(" + iosBundleIDCol + ", '') <> ''"),
+			sq.Expr("COALESCE(" + androidPackageCol + ", '') <> ''"),
 		},
 	}).OrderBy(AppOIDCConfigColumnAppID.identifier()).ToSql()
 	if err != nil {

--- a/proto/zitadel/app.proto
+++ b/proto/zitadel/app.proto
@@ -181,12 +181,12 @@ message OIDCConfig {
     ];
     IOSAppLinkConfig ios = 23 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+            description: "iOS Associated Domains / passkey trust config. Served in /.well-known/apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID). That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
     AndroidAppLinkConfig android = 24 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
+            description: "Android Digital Asset Links / passkey trust config. Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds. That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
 }

--- a/proto/zitadel/application/v2/application_service.proto
+++ b/proto/zitadel/application/v2/application_service.proto
@@ -343,12 +343,16 @@ message CreateOIDCApplicationRequest {
   LoginVersion login_version = 17;
 
   // IOS is iOS Associated Domains / passkey trust config.
-  // Served in apple-app-site-association as webcredentials.apps entry
+  // Served in /.well-known/apple-app-site-association as webcredentials.apps entry
   // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   IOSAppLinkConfig ios = 18;
 
   // Android is Android Digital Asset Links / passkey trust config.
-  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  // Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds.
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   AndroidAppLinkConfig android = 19;
 }
 
@@ -589,13 +593,17 @@ message UpdateOIDCApplicationConfigurationRequest {
   optional LoginVersion login_version = 17;
 
   // IOS is iOS Associated Domains / passkey trust config.
-  // Served in apple-app-site-association as webcredentials.apps entry
+  // Served in /.well-known/apple-app-site-association as webcredentials.apps entry
   // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   // If not set, the iOS config will not be changed.
   optional IOSAppLinkConfig ios = 18;
 
   // Android is Android Digital Asset Links / passkey trust config.
-  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  // Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds.
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   // If not set, the Android config will not be changed.
   optional AndroidAppLinkConfig android = 19;
 }

--- a/proto/zitadel/application/v2/oidc.proto
+++ b/proto/zitadel/application/v2/oidc.proto
@@ -160,18 +160,24 @@ message OIDCConfiguration {
   LoginVersion login_version = 21;
 
   // IOS is iOS Associated Domains / passkey trust config.
-  // Served in apple-app-site-association as webcredentials.apps entry
+  // Served in /.well-known/apple-app-site-association as webcredentials.apps entry
   // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   IOSAppLinkConfig ios = 22;
 
   // Android is Android Digital Asset Links / passkey trust config.
-  // Served in assetlinks.json for delegate_permission/common.get_login_creds.
+  // Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds.
+  // That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+  // changes can take time to take effect.
   AndroidAppLinkConfig android = 23;
 }
 
 // IOSAppLinkConfig is iOS Associated Domains / passkey trust config.
-// Served in apple-app-site-association as webcredentials.apps entry
+// Served in /.well-known/apple-app-site-association as webcredentials.apps entry
 // "{team_id}.{bundle_id}" (Apple's full App ID = Team ID prefix + Bundle ID).
+// That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+// changes can take time to take effect.
 message IOSAppLinkConfig {
   // TeamID is the Apple Developer Team ID (exactly 10 alphanumeric characters), e.g. ABCDE12345.
   // From Apple Developer account membership — not the Bundle ID.
@@ -185,7 +191,9 @@ message IOSAppLinkConfig {
 }
 
 // AndroidAppLinkConfig is Android Digital Asset Links / passkey trust config.
-// Served in assetlinks.json for delegate_permission/common.get_login_creds.
+// Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds.
+// That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer;
+// changes can take time to take effect.
 message AndroidAppLinkConfig {
   // PackageName is the Android applicationId / package name from the app manifest.
   // Empty clears the value on update.

--- a/proto/zitadel/management.proto
+++ b/proto/zitadel/management.proto
@@ -10384,12 +10384,12 @@ message AddOIDCAppRequest {
     ];
     zitadel.app.v1.IOSAppLinkConfig ios = 20 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+            description: "iOS Associated Domains / passkey trust config. Served in /.well-known/apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID). That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
     zitadel.app.v1.AndroidAppLinkConfig android = 21 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
+            description: "Android Digital Asset Links / passkey trust config. Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds. That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
 }
@@ -10585,12 +10585,12 @@ message UpdateOIDCAppConfigRequest {
     ];
     zitadel.app.v1.IOSAppLinkConfig ios = 19 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "iOS Associated Domains / passkey trust config. Served in apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID).";
+            description: "iOS Associated Domains / passkey trust config. Served in /.well-known/apple-app-site-association as webcredentials.apps entry \"{team_id}.{bundle_id}\" (Apple's full App ID). That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
     zitadel.app.v1.AndroidAppLinkConfig android = 20 [
         (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description: "Android Digital Asset Links / passkey trust config. Served in assetlinks.json for delegate_permission/common.get_login_creds.";
+            description: "Android Digital Asset Links / passkey trust config. Served in /.well-known/assetlinks.json for delegate_permission/common.get_login_creds. That response may be HTTP-cached (Cache-Control), and platform verifiers may cache longer; changes can take time to take effect.";
         }
     ];
 }


### PR DESCRIPTION
# Which Problems Are Solved

- Native iOS/Android passkeys need instance-scoped Apple App Site Association and Digital Asset Links documents, but ZITADEL did not serve `/.well-known/apple-app-site-association` or `/.well-known/assetlinks.json`.
- App link fields wired in #12532 were not yet exposed to clients via well-known endpoints.

# How the Problems Are Solved

- Adds `internal/api/well_known` handlers that aggregate OIDC app iOS/Android link config for the current instance.
- Serves AASA as webcredentials-only (`TEAMID.BUNDLEID` entries) and Android `assetlinks.json` with `get_login_creds`.
- Returns HTTP 200 with empty arrays when no apps are configured.
- Registers the handlers behind the instance interceptor in `cmd/start`.
- Adds unit and integration coverage for empty and populated responses.

# Additional Changes

- Adds `internal/query/app_link.go` to search OIDC app link configs used by the handlers.

# Additional Context

- Part of #12497 (WIP stacked PR 3/N — well-known endpoints; does not close the issue).
- Stacked on #12532 (`feat-12497-native-app-links-wire`). After that merges into the feature branch, rebase/retarget this PR onto `feat-12497-native-app-links`.
- Console UI and docs remain follow-up PRs.

---
Layer of stacked review for ship PR #12539 (full feature description / squash target onto `main`).