### PR TITLE
fix(database): skip CREATE USER when role exists to avoid password in Postgres logs

### DIFF
--- a/cmd/initialise/verify_user.go
+++ b/cmd/initialise/verify_user.go
@@ -58,11 +58,28 @@ func VerifyUser(username, password string) func(context.Context, *database.DB) e
 			logging.Info(ctx, "config.database.postgres.user.username is same as config.database.postgres.admin.username, skipping create user", "username", username)
 			return nil
 		}
-		logging.Info(ctx, "verify user", "username", username)
-		if password != "" {
-			createUserStmt += " WITH PASSWORD '" + password + "'"
+
+		// Check if the role already exists in the catalog before attempting CREATE USER.
+		// This avoids PostgreSQL logging the full CREATE USER statement (including the
+		// plaintext password) when the role already exists on re-deploy / re-init.
+		var exists bool
+		err = db.QueryRowContext(ctx, func(r *sql.Row) error {
+			return r.Scan(&exists)
+		}, "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", username)
+		if err != nil {
+			return fmt.Errorf("unable to check if user exists: %w", err)
+		}
+		if exists {
+			logging.Info(ctx, "user already exists, skipping creation", "username", username)
+			return nil
 		}
 
-		return exec(ctx, db, fmt.Sprintf(createUserStmt, username), []string{roleAlreadyExistsCode})
+		logging.Info(ctx, "verify user", "username", username)
+		stmt := createUserStmt
+		if password != "" {
+			stmt += " WITH PASSWORD '" + password + "'"
+		}
+
+		return exec(ctx, db, fmt.Sprintf(stmt, username), []string{roleAlreadyExistsCode})
 	}
 }

--- a/cmd/initialise/verify_user.go
+++ b/cmd/initialise/verify_user.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -75,11 +76,19 @@ func VerifyUser(username, password string) func(context.Context, *database.DB) e
 		}
 
 		logging.Info(ctx, "verify user", "username", username)
-		stmt := createUserStmt
+		// Format the username first so the password is never part of a fmt format string
+		// (passwords may contain '%' which would be interpreted as format verbs).
+		stmt := fmt.Sprintf(createUserStmt, username)
 		if password != "" {
-			stmt += " WITH PASSWORD '" + password + "'"
+			stmt += " WITH PASSWORD " + quotePostgresLiteral(password)
 		}
 
-		return exec(ctx, db, fmt.Sprintf(stmt, username), []string{roleAlreadyExistsCode})
+		return exec(ctx, db, stmt, []string{roleAlreadyExistsCode})
 	}
+}
+
+// quotePostgresLiteral returns s as a single-quoted PostgreSQL string literal,
+// escaping embedded single quotes by doubling them.
+func quotePostgresLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/cmd/initialise/verify_user_test.go
+++ b/cmd/initialise/verify_user_test.go
@@ -32,6 +32,9 @@ func Test_verifyUser(t *testing.T) {
 					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
 						{"postgres"},
 					}),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", nil, []string{"exists"}, [][]driver.Value{
+						{false},
+					}, "zitadel-user"),
 					expectExec("-- replace zitadel-user with the name of the user\nCREATE USER \"zitadel-user\"", sql.ErrTxDone),
 				),
 				username: "zitadel-user",
@@ -46,6 +49,9 @@ func Test_verifyUser(t *testing.T) {
 					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
 						{"postgres"},
 					}),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", nil, []string{"exists"}, [][]driver.Value{
+						{false},
+					}, "zitadel-user"),
 					expectExec("-- replace zitadel-user with the name of the user\nCREATE USER \"zitadel-user\"", nil),
 				),
 				username: "zitadel-user",
@@ -60,6 +66,9 @@ func Test_verifyUser(t *testing.T) {
 					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
 						{"postgres"},
 					}),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", nil, []string{"exists"}, [][]driver.Value{
+						{false},
+					}, "zitadel-user"),
 					expectExec("-- replace zitadel-user with the name of the user\nCREATE USER \"zitadel-user\" WITH PASSWORD 'password'", nil),
 				),
 				username: "zitadel-user",
@@ -68,18 +77,34 @@ func Test_verifyUser(t *testing.T) {
 			targetErr: nil,
 		},
 		{
-			name: "already exists",
+			name: "already exists in catalog, skip creation",
 			args: args{
 				db: prepareDB(t,
 					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
 						{"postgres"},
 					}),
-					expectExec("-- replace zitadel-user with the name of the user\nCREATE USER \"zitadel-user\" WITH PASSWORD 'password'", nil),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", nil, []string{"exists"}, [][]driver.Value{
+						{true},
+					}, "zitadel-user"),
 				),
 				username: "zitadel-user",
-				password: "",
+				password: "password",
 			},
 			targetErr: nil,
+		},
+		{
+			name: "catalog check fails",
+			args: args{
+				db: prepareDB(t,
+					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
+						{"postgres"},
+					}),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", sql.ErrConnDone, []string{"exists"}, [][]driver.Value{}, "zitadel-user"),
+				),
+				username: "zitadel-user",
+				password: "password",
+			},
+			targetErr: sql.ErrConnDone,
 		},
 		{
 			name: "same user, skip create",

--- a/cmd/initialise/verify_user_test.go
+++ b/cmd/initialise/verify_user_test.go
@@ -77,6 +77,23 @@ func Test_verifyUser(t *testing.T) {
 			targetErr: nil,
 		},
 		{
+			name: "correct with password containing percent and quote",
+			args: args{
+				db: prepareDB(t,
+					expectQuery("SELECT current_user", nil, []string{"current_user"}, [][]driver.Value{
+						{"postgres"},
+					}),
+					expectQuery("SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)", nil, []string{"exists"}, [][]driver.Value{
+						{false},
+					}, "zitadel-user"),
+					expectExec("-- replace zitadel-user with the name of the user\nCREATE USER \"zitadel-user\" WITH PASSWORD 'p%''ass'", nil),
+				),
+				username: "zitadel-user",
+				password: "p%'ass",
+			},
+			targetErr: nil,
+		},
+		{
 			name: "already exists in catalog, skip creation",
 			args: args{
 				db: prepareDB(t,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `zitadel init` runs on every Helm upgrade/re-deploy, `VerifyUser` always executed `CREATE USER ... WITH PASSWORD '...'`. If the role already existed, PostgreSQL returned `42710` and logged the full statement—including the plaintext password—even though ZITADEL swallowed that error.

This mirrors the existing `VerifyDatabase` catalog check: query `pg_roles` first and skip creation when the role exists. Also stops mutating the package-level `createUserStmt` when appending `WITH PASSWORD`.

Password clause construction now formats the username first, then appends a Postgres-escaped literal, so passwords containing `%` or `'` cannot break the SQL (review feedback).

Fixes #12178

## Changes

- `cmd/initialise/verify_user.go`: check `SELECT EXISTS(... FROM pg_roles ...)` before `CREATE USER`; build password clause with `quotePostgresLiteral` after username formatting
- `cmd/initialise/verify_user_test.go`: cover catalog skip, catalog-check failure, create paths, and passwords with `%` / `'`

## Test plan

- [x] `go test ./cmd/initialise/...` (passed)
- [ ] Re-run init against an existing role and confirm Postgres logs no longer contain `CREATE USER ... WITH PASSWORD`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc514793-d275-4d91-a71b-1b7566668b65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc514793-d275-4d91-a71b-1b7566668b65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

closes #12178