### PR TITLE
ci: harden pack/release image inputs before shell use

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -155,13 +155,13 @@ jobs:
           INPUTS_IMAGE_NAME_GITHUB_API: ${{ inputs.image_name_github_api }}
           INPUTS_IMAGE_NAME_GOOGLE_API: ${{ inputs.image_name_google_api }}
         run: |
-          if [ ""$MATRIX_PUSH_GHCR"" = "true" ]; then
+          if [ "$MATRIX_PUSH_GHCR" = "true" ]; then
             {
-              echo ""$INPUTS_IMAGE_NAME_GITHUB_API""
-              echo ""$INPUTS_IMAGE_NAME_GOOGLE_API""
+              echo "$INPUTS_IMAGE_NAME_GITHUB_API"
+              echo "$INPUTS_IMAGE_NAME_GOOGLE_API"
             } > api-images.txt
           else
-            echo ""$INPUTS_IMAGE_NAME_GOOGLE_API"" > api-images.txt
+            echo "$INPUTS_IMAGE_NAME_GOOGLE_API" > api-images.txt
           fi
           echo "list<<EOF" >> "$GITHUB_OUTPUT"
           cat api-images.txt >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -150,14 +150,18 @@ jobs:
           password: ${{ secrets.GCR_JSON_KEY_BASE64 }}
       - name: Set API image names
         id: api-images
+        env:
+          MATRIX_PUSH_GHCR: ${{ matrix.push_ghcr }}
+          INPUTS_IMAGE_NAME_GITHUB_API: ${{ inputs.image_name_github_api }}
+          INPUTS_IMAGE_NAME_GOOGLE_API: ${{ inputs.image_name_google_api }}
         run: |
-          if [ "${{ matrix.push_ghcr }}" = "true" ]; then
+          if [ ""$MATRIX_PUSH_GHCR"" = "true" ]; then
             {
-              echo "${{ inputs.image_name_github_api }}"
-              echo "${{ inputs.image_name_google_api }}"
+              echo ""$INPUTS_IMAGE_NAME_GITHUB_API""
+              echo ""$INPUTS_IMAGE_NAME_GOOGLE_API""
             } > api-images.txt
           else
-            echo "${{ inputs.image_name_google_api }}" > api-images.txt
+            echo ""$INPUTS_IMAGE_NAME_GOOGLE_API"" > api-images.txt
           fi
           echo "list<<EOF" >> "$GITHUB_OUTPUT"
           cat api-images.txt >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,53 +93,66 @@ jobs:
         password: ${{ secrets.GCR_JSON_KEY_BASE64 }}
     -
       name: Publish ${{ needs.version.outputs.version }}
+      env:
+        INPUTS_IMAGE_NAME_GITHUB_API: ${{ inputs.image_name_github_api }}
+        NEEDS_VERSION_OUTPUTS_VERSION: ${{ needs.version.outputs.version }}
+        INPUTS_IMAGE_NAME_GOOGLE_API: ${{ inputs.image_name_google_api }}
+        INPUTS_IMAGE_NAME_GITHUB_LOGIN: ${{ inputs.image_name_github_login }}
+        INPUTS_IMAGE_NAME_GOOGLE_LOGIN: ${{ inputs.image_name_google_login }}
+        GIT_SHA: ${{ github.sha }}
       run: |
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_api }}:${{ needs.version.outputs.version }} \
-          ${{ inputs.image_name_github_api }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_API":"$NEEDS_VERSION_OUTPUTS_VERSION" \
+          "$INPUTS_IMAGE_NAME_GITHUB_API":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_api }}:${{ needs.version.outputs.version }}-debug \
-          ${{ inputs.image_name_github_api }}:${{ github.sha }}-debug
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_API":"$NEEDS_VERSION_OUTPUTS_VERSION"-debug \
+          "$INPUTS_IMAGE_NAME_GITHUB_API":"$GIT_SHA"-debug
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_api }}:${{ needs.version.outputs.version }} \
-          ${{ inputs.image_name_google_api }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_API":"$NEEDS_VERSION_OUTPUTS_VERSION" \
+          "$INPUTS_IMAGE_NAME_GOOGLE_API":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_api }}:${{ needs.version.outputs.version }}-fips \
-          ${{ inputs.image_name_google_api }}:${{ github.sha }}-fips
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_API":"$NEEDS_VERSION_OUTPUTS_VERSION"-fips \
+          "$INPUTS_IMAGE_NAME_GOOGLE_API":"$GIT_SHA"-fips
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_api }}:${{ needs.version.outputs.version }}-fips-debug \
-          ${{ inputs.image_name_google_api }}:${{ github.sha }}-fips-debug
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_API":"$NEEDS_VERSION_OUTPUTS_VERSION"-fips-debug \
+          "$INPUTS_IMAGE_NAME_GOOGLE_API":"$GIT_SHA"-fips-debug
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_login }}:${{ needs.version.outputs.version }} \
-          ${{ inputs.image_name_github_login }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_LOGIN":"$NEEDS_VERSION_OUTPUTS_VERSION" \
+          "$INPUTS_IMAGE_NAME_GITHUB_LOGIN":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_login }}:${{ needs.version.outputs.version }} \
-          ${{ inputs.image_name_google_login }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":"$NEEDS_VERSION_OUTPUTS_VERSION" \
+          "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_login }}:${{ needs.version.outputs.version }}-fips \
-          ${{ inputs.image_name_google_login }}:${{ github.sha }}-fips
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":"$NEEDS_VERSION_OUTPUTS_VERSION"-fips \
+          "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":"$GIT_SHA"-fips
     -
       name: Publish latest
       if: ${{ github.ref_name == 'next' }}
+      env:
+        INPUTS_IMAGE_NAME_GITHUB_API: ${{ inputs.image_name_github_api }}
+        INPUTS_IMAGE_NAME_GITHUB_LOGIN: ${{ inputs.image_name_github_login }}
+        INPUTS_IMAGE_NAME_GOOGLE_API: ${{ inputs.image_name_google_api }}
+        INPUTS_IMAGE_NAME_GOOGLE_LOGIN: ${{ inputs.image_name_google_login }}
+        GIT_SHA: ${{ github.sha }}
       run: |
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_api }}:latest \
-          ${{ inputs.image_name_github_api }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_API":latest \
+          "$INPUTS_IMAGE_NAME_GITHUB_API":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_api }}:latest-debug \
-          ${{ inputs.image_name_github_api }}:${{ github.sha }}-debug
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_API":latest-debug \
+          "$INPUTS_IMAGE_NAME_GITHUB_API":"$GIT_SHA"-debug
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_github_login }}:latest \
-          ${{ inputs.image_name_github_login }}:${{ github.sha }}
+          --tag "$INPUTS_IMAGE_NAME_GITHUB_LOGIN":latest \
+          "$INPUTS_IMAGE_NAME_GITHUB_LOGIN":"$GIT_SHA"
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_api }}:latest-fips \
-          ${{ inputs.image_name_google_api }}:${{ github.sha }}-fips
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_API":latest-fips \
+          "$INPUTS_IMAGE_NAME_GOOGLE_API":"$GIT_SHA"-fips
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_api }}:latest-fips-debug \
-          ${{ inputs.image_name_google_api }}:${{ github.sha }}-fips-debug
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_API":latest-fips-debug \
+          "$INPUTS_IMAGE_NAME_GOOGLE_API":"$GIT_SHA"-fips-debug
         docker buildx imagetools create \
-          --tag ${{ inputs.image_name_google_login }}:latest-fips \
-          ${{ inputs.image_name_google_login }}:${{ github.sha }}-fips
+          --tag "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":latest-fips \
+          "$INPUTS_IMAGE_NAME_GOOGLE_LOGIN":"$GIT_SHA"-fips
 
   homebrew-tap:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/workflows/pack.yml` and `release.yml`.
- Bind free-string `inputs.*` / related values under `env:` before use in `run:` docker tag scripts (quoted shell vars).
- Defense-in-depth for privileged container publish workflows — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing pack/release callers still pass hardcoded image names as today


Made with [Cursor](https://cursor.com)
