### PR TITLE
fix(login): hide language switcher when only one language is available

### DIFF
--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                   <div className="relative mx-auto w-full max-w-[1100px] py-8">
                     <div>{children}</div>
                     <div className="mx-auto flex max-w-[440px] flex-row items-center justify-end space-x-4 px-4 py-4 md:max-w-full md:px-8">
-                      <LanguageSwitcher languages={languages} />
+                      {languages.length > 1 && <LanguageSwitcher languages={languages} />}
                       <ThemeSwitch />
                     </div>
                   </div>


### PR DESCRIPTION
# Which Problems Are Solved

We are only using one language for the Zitadel login and it would be great if the login switcher wouldn't be shown in that case

- Login v2 renders a language switcher even when the instance allows only one language, presenting a control with no alternative choice.

# How the Problems Are Solved

- Render the language switcher only when more than one allowed language is available.

# Additional Changes

- None.

# Additional Context

- This keeps the theme switch available regardless of the number of allowed languages.

## Validation

- `pnpm nx --tui false run @zitadel/login:lint`
- `pnpm --dir apps/login test-unit` (54 files, 846 tests)
- The Login production build compiled and passed TypeScript checks; its standalone packaging step could not complete locally because Next.js detected a parent workspace lockfile and emitted a different standalone path.