### PR TITLE
fix(login): show account selection when multiple sessions are valid

### DIFF
--- a/apps/login/src/lib/server/flow-initiation.test.ts
+++ b/apps/login/src/lib/server/flow-initiation.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { FlowInitiationParams, handleOIDCFlowInitiation } from "./flow-initiation";
+import { FlowInitiationParams, handleOIDCFlowInitiation, handleSAMLFlowInitiation } from "./flow-initiation";
 
 vi.mock("@/lib/cookies", () => ({
   getLanguageCookie: vi.fn(),
@@ -25,6 +25,7 @@ vi.mock("@/lib/service-url", () => ({
 
 vi.mock("@/lib/session", () => ({
   findValidSession: vi.fn(),
+  findValidSessions: vi.fn(),
 }));
 
 vi.mock("@/lib/zitadel", () => ({
@@ -69,6 +70,7 @@ describe("handleOIDCFlowInitiation — locale / cookie handling", () => {
   let mockGetAuthRequest: ReturnType<typeof vi.fn>;
   let mockConstructUrl: ReturnType<typeof vi.fn>;
   let mockFindValidSession: ReturnType<typeof vi.fn>;
+  let mockFindValidSessions: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -86,6 +88,7 @@ describe("handleOIDCFlowInitiation — locale / cookie handling", () => {
     mockGetAuthRequest = vi.mocked(zitadel.getAuthRequest);
     mockConstructUrl = vi.mocked(serviceUrl.constructUrl);
     mockFindValidSession = vi.mocked(session.findValidSession);
+    mockFindValidSessions = vi.mocked(session.findValidSessions);
 
     // Default auth request: no prompts, no special scopes
     mockGetAuthRequest.mockResolvedValue({
@@ -104,6 +107,7 @@ describe("handleOIDCFlowInitiation — locale / cookie handling", () => {
     });
 
     mockFindValidSession.mockResolvedValue(null);
+    mockFindValidSessions.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -185,6 +189,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
   let mockGetAuthRequest: ReturnType<typeof vi.fn>;
   let mockConstructUrl: ReturnType<typeof vi.fn>;
   let mockFindValidSession: ReturnType<typeof vi.fn>;
+  let mockFindValidSessions: ReturnType<typeof vi.fn>;
   let mockSendLoginname: ReturnType<typeof vi.fn>;
   let mockGetLoginSettings: ReturnType<typeof vi.fn>;
 
@@ -210,6 +215,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     mockGetAuthRequest = vi.mocked(zitadel.getAuthRequest);
     mockConstructUrl = vi.mocked(serviceUrl.constructUrl);
     mockFindValidSession = vi.mocked(session.findValidSession);
+    mockFindValidSessions = vi.mocked(session.findValidSessions);
     mockSendLoginname = vi.mocked(loginname.sendLoginname);
     mockGetLoginSettings = vi.mocked(zitadel.getLoginSettings);
     mockGetLoginSettings.mockResolvedValue(undefined);
@@ -220,6 +226,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     });
 
     mockFindValidSession.mockResolvedValue(null);
+    mockFindValidSessions.mockResolvedValue([]);
     // Default: hint cannot be resolved to a redirect, exercising the prefilled
     // /loginname fallback. Individual tests override this to assert the happy path.
     mockSendLoginname.mockResolvedValue(undefined);
@@ -341,8 +348,8 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     });
 
     // An unrelated session is present (so eligibleSessions is non-empty), but
-    // findValidSession filtered by the hint returns nothing.
-    mockFindValidSession.mockResolvedValue(null);
+    // filtering by the hint leaves no valid session.
+    mockFindValidSessions.mockResolvedValue([]);
 
     mockSendLoginname.mockResolvedValue({
       redirect: "/password?loginName=user%40example.com",
@@ -372,7 +379,7 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
       },
     });
 
-    mockFindValidSession.mockResolvedValue(null);
+    mockFindValidSessions.mockResolvedValue([]);
     // mockSendLoginname resolves to undefined (default) → fallback path.
 
     const res = await handleOIDCFlowInitiation(
@@ -532,6 +539,166 @@ describe("handleOIDCFlowInitiation — org-scoped session filtering", () => {
     const location = res.headers.get("location") ?? "";
     expect(location).toContain("/password");
     expect(location).not.toContain("/loginname");
+  });
+});
+
+describe("flow initiation — ambiguous session selection", () => {
+  let mockGetAuthRequest: ReturnType<typeof vi.fn>;
+  let mockGetSAMLRequest: ReturnType<typeof vi.fn>;
+  let mockConstructUrl: ReturnType<typeof vi.fn>;
+  let mockFindValidSession: ReturnType<typeof vi.fn>;
+  let mockFindValidSessions: ReturnType<typeof vi.fn>;
+  let mockCreateCallback: ReturnType<typeof vi.fn>;
+  let mockCreateResponse: ReturnType<typeof vi.fn>;
+
+  const sessionA = {
+    id: "session-a",
+    factors: { user: { id: "user-a", organizationId: "111111", loginName: "a@org.com" } },
+  };
+  const sessionB = {
+    id: "session-b",
+    factors: { user: { id: "user-b", organizationId: "111111", loginName: "b@org.com" } },
+  };
+
+  const bothCookies = [
+    { id: "session-a", token: "tok-a" },
+    { id: "session-b", token: "tok-b" },
+  ];
+
+  // Both sessions belong to the org named by the scope, so neither is filtered out.
+  const orgScopedAuthRequest = (overrides?: Record<string, unknown>) => ({
+    authRequest: {
+      id: "abc123",
+      uiLocales: [],
+      scope: ["urn:zitadel:iam:org:id:111111"],
+      prompt: [],
+      loginHint: undefined,
+      ...overrides,
+    },
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+
+    const zitadel = await import("@/lib/zitadel");
+    const serviceUrl = await import("@/lib/service-url");
+    const session = await import("@/lib/session");
+    const authUtils = await import("@/lib/auth-utils");
+
+    mockGetAuthRequest = vi.mocked(zitadel.getAuthRequest);
+    mockGetSAMLRequest = vi.mocked(zitadel.getSAMLRequest);
+    mockConstructUrl = vi.mocked(serviceUrl.constructUrl);
+    mockFindValidSession = vi.mocked(session.findValidSession);
+    mockFindValidSessions = vi.mocked(session.findValidSessions);
+    mockCreateCallback = vi.mocked(zitadel.createCallback);
+    mockCreateResponse = vi.mocked(zitadel.createResponse);
+
+    vi.mocked(authUtils.getValidLocaleFromUILocales).mockReturnValue(null);
+    mockConstructUrl.mockImplementation((_req: any, path: string) => new URL(`https://example.com${path}`));
+
+    mockGetAuthRequest.mockResolvedValue(orgScopedAuthRequest());
+    mockCreateCallback.mockResolvedValue({ callbackUrl: "https://app.example.com/callback?code=xyz" });
+    mockCreateResponse.mockResolvedValue({
+      url: "https://app.example.com/saml/acs",
+      binding: { case: "redirect" },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("should show account selection when several sessions are valid and no prompt disambiguates them", async () => {
+    mockFindValidSessions.mockResolvedValue([sessionB, sessionA]);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({ sessions: [sessionA, sessionB] as any, sessionCookies: bothCookies }),
+    );
+
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/accounts");
+    expect(location).toContain("organization=111111");
+    // The user picks: no session may be handed to the callback on their behalf.
+    expect(mockCreateCallback).not.toHaveBeenCalled();
+  });
+
+  test("should complete silently when exactly one session is valid (default prompt)", async () => {
+    mockFindValidSessions.mockResolvedValue([sessionA]);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({ sessions: [sessionA, sessionB] as any, sessionCookies: bothCookies }),
+    );
+
+    expect(res.headers.get("location")).toBe("https://app.example.com/callback?code=xyz");
+    expect(mockCreateCallback).toHaveBeenCalled();
+  });
+
+  test("should keep completing silently with several valid sessions when login_hint names the user", async () => {
+    mockGetAuthRequest.mockResolvedValue(orgScopedAuthRequest({ loginHint: "a@org.com" }));
+    // The hint has already narrowed findValidSessions' own filtering; a caller that still
+    // sees several matches asked for this user, so the most recent one is the answer.
+    mockFindValidSessions.mockResolvedValue([sessionA, sessionB]);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({ sessions: [sessionA, sessionB] as any, sessionCookies: bothCookies }),
+    );
+
+    expect(res.headers.get("location")).toBe("https://app.example.com/callback?code=xyz");
+  });
+
+  test("should keep completing silently with several valid sessions when hintUserId names the user", async () => {
+    mockGetAuthRequest.mockResolvedValue(orgScopedAuthRequest({ hintUserId: "user-a" }));
+    mockFindValidSessions.mockResolvedValue([sessionA, sessionB]);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({ sessions: [sessionA, sessionB] as any, sessionCookies: bothCookies }),
+    );
+
+    expect(res.headers.get("location")).toBe("https://app.example.com/callback?code=xyz");
+  });
+
+  test("should not show account selection for prompt=none, which may not render UI", async () => {
+    const { Prompt } = await import("@zitadel/proto/zitadel/oidc/v2/authorization_pb");
+    mockGetAuthRequest.mockResolvedValue(orgScopedAuthRequest({ prompt: [Prompt.NONE] }));
+    mockFindValidSession.mockResolvedValue(sessionA);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({ sessions: [sessionA, sessionB] as any, sessionCookies: bothCookies }),
+    );
+
+    expect(res.headers.get("location")).toBe("https://app.example.com/callback?code=xyz");
+  });
+
+  test("should show account selection for SAML when several sessions are valid", async () => {
+    mockGetSAMLRequest.mockResolvedValue({ samlRequest: { id: "saml123" } });
+    mockFindValidSessions.mockResolvedValue([sessionB, sessionA]);
+
+    const res = await handleSAMLFlowInitiation(
+      makeBaseParams({
+        requestId: "saml_saml123",
+        sessions: [sessionA, sessionB] as any,
+        sessionCookies: bothCookies,
+      }),
+    );
+
+    expect(res.headers.get("location") ?? "").toContain("/accounts");
+    expect(mockCreateResponse).not.toHaveBeenCalled();
+  });
+
+  test("should complete the SAML flow when exactly one session is valid", async () => {
+    mockGetSAMLRequest.mockResolvedValue({ samlRequest: { id: "saml123" } });
+    mockFindValidSessions.mockResolvedValue([sessionA]);
+
+    const res = await handleSAMLFlowInitiation(
+      makeBaseParams({
+        requestId: "saml_saml123",
+        sessions: [sessionA, sessionB] as any,
+        sessionCookies: bothCookies,
+      }),
+    );
+
+    expect(res.headers.get("location")).toBe("https://app.example.com/saml/acs");
   });
 });
 

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -7,7 +7,7 @@ import { idpTypeToSlug } from "@/lib/idp";
 import { createLogger } from "@/lib/logger";
 import { sendLoginname } from "@/lib/server/loginname";
 import { constructUrl } from "@/lib/service-url";
-import { findValidSession } from "@/lib/session";
+import { findValidSession, findValidSessions } from "@/lib/session";
 import {
   createCallback,
   createResponse,
@@ -20,7 +20,7 @@ import {
   startIdentityProviderFlow,
 } from "@/lib/zitadel";
 import { create } from "@zitadel/client";
-import { Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
+import { AuthRequest, Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
 import { CreateCallbackRequestSchema, SessionSchema } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
 import { CreateResponseRequestSchema } from "@zitadel/proto/zitadel/saml/v2/saml_service_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
@@ -164,6 +164,14 @@ function getEligibleSessions(sessions: Session[], organization?: string): Sessio
     return sessions;
   }
   return sessions.filter((s) => s.factors?.user?.organizationId === organization);
+}
+
+/**
+ * Whether the request names the user it wants, so picking a session for it is the
+ * requested behaviour rather than a guess.
+ */
+function hasUserHint(authRequest: AuthRequest): boolean {
+  return !!(authRequest.hintUserId || authRequest.loginHint);
 }
 
 export interface FlowInitiationParams {
@@ -402,7 +410,22 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       setCSPHeaders(callbackResponse, serviceConfig, securitySettings);
       return callbackResponse;
     } else {
-      let selectedSession = await findValidSession({ serviceConfig, sessions, authRequest, organization });
+      const validSessions = await findValidSessions({ serviceConfig, sessions, authRequest, organization });
+
+      // More than one session could serve this request and nothing in it says which one:
+      // ask instead of silently continuing as whoever authenticated most recently. Per
+      // Technical Advisory 10000 the no-prompt shortcut only covers a single active session.
+      // A user hint (hintUserId / login_hint) already narrows the choice, so it stays silent.
+      if (validSessions.length > 1 && !hasUserHint(authRequest)) {
+        return gotoAccounts({
+          request,
+          requestId,
+          organization,
+          orgDomain,
+        });
+      }
+
+      let selectedSession = validSessions[0];
 
       if (!selectedSession || !selectedSession.id) {
         // login_hint matches no session: resolve it straight to the next step.
@@ -530,8 +553,18 @@ export async function handleSAMLFlowInitiation(params: FlowInitiationParams): Pr
     return NextResponse.redirect(loginNameUrl);
   }
 
-  // Try to find a valid session
-  let selectedSession = await findValidSession({ serviceConfig, sessions, samlRequest });
+  // Try to find a valid session. SAML requests carry no user hint (see findValidSession),
+  // so several valid sessions always mean the choice is the user's to make.
+  const validSessions = await findValidSessions({ serviceConfig, sessions, samlRequest });
+
+  if (validSessions.length > 1) {
+    return gotoAccounts({
+      request,
+      requestId,
+    });
+  }
+
+  let selectedSession = validSessions[0];
 
   // Early return: No valid session found - show account selection
   if (!selectedSession || !selectedSession.id) {

--- a/apps/login/src/lib/session.ts
+++ b/apps/login/src/lib/session.ts
@@ -182,19 +182,26 @@ export async function isSessionValid({
   return true;
 }
 
-export async function findValidSession({
-  serviceConfig,
-  sessions,
-  authRequest,
-  samlRequest,
-  organization,
-}: {
+type FindSessionParams = {
   serviceConfig: ServiceConfig;
   sessions: Session[];
   authRequest?: AuthRequest;
   samlRequest?: SAMLRequest;
   organization?: string;
-}): Promise<Session | undefined> {
+};
+
+/**
+ * Narrow the browser's sessions to the ones this request could legitimately continue with:
+ * filtered by the request's user hint and by the organization scope, then sorted by change
+ * date descending (most recently used first). Validity is NOT checked here — callers decide
+ * how many candidates they need to validate.
+ */
+function getCandidateSessions({
+  sessions,
+  authRequest,
+  samlRequest,
+  organization,
+}: Omit<FindSessionParams, "serviceConfig">): Session[] {
   let sessionsWithHint = sessions.filter((s) => {
     if (authRequest && authRequest.hintUserId) {
       return s.factors?.user?.id === authRequest.hintUserId;
@@ -214,10 +221,6 @@ export async function findValidSession({
     sessionsWithHint = sessionsWithHint.filter((s) => s.factors?.user?.organizationId === organization);
   }
 
-  if (sessionsWithHint.length === 0) {
-    return undefined;
-  }
-
   // sort by change date descending
   sessionsWithHint.sort((a, b) => {
     const dateA = a.changeDate ? timestampDate(a.changeDate).getTime() : 0;
@@ -225,12 +228,42 @@ export async function findValidSession({
     return dateB - dateA;
   });
 
-  // return the first valid session according to settings
-  for (const session of sessionsWithHint) {
+  return sessionsWithHint;
+}
+
+/**
+ * The most recently changed session that is valid according to settings, or undefined.
+ * Short-circuits on the first valid candidate: use this when the caller only needs *a*
+ * session and does not care whether others would also have qualified.
+ */
+export async function findValidSession({ serviceConfig, ...params }: FindSessionParams): Promise<Session | undefined> {
+  for (const session of getCandidateSessions(params)) {
     if (await isSessionValid({ serviceConfig, session })) {
       return session;
     }
   }
 
   return undefined;
+}
+
+/**
+ * Every session that is valid according to settings, most recently changed first.
+ *
+ * Unlike findValidSession this validates all candidates, so the caller can tell an
+ * unambiguous single session apart from several equally valid ones and prompt the user
+ * to choose instead of silently picking for them. Validation can cost an API call per
+ * session (see isSessionValid), which is why the short-circuiting variant above still
+ * exists for callers that cannot act on the difference.
+ */
+export async function findValidSessions({ serviceConfig, ...params }: FindSessionParams): Promise<Session[]> {
+  const candidates = getCandidateSessions(params);
+  const valid: Session[] = [];
+
+  for (const session of candidates) {
+    if (await isSessionValid({ serviceConfig, session })) {
+      valid.push(session);
+    }
+  }
+
+  return valid;
 }


### PR DESCRIPTION
# Which Problems Are Solved

- With more than one active session in the browser and no `prompt` parameter, the login app shows no account selection at all. It silently completes the authorization request using whichever session authenticated most recently and redirects straight to the app's callback, so the user never gets to choose — or even notice that an account was picked for them.
- [Technical Advisory 10000](https://zitadel.com/docs/support/advisory/a10000) scoped the automatic session reuse to users who "only have one active session", so the shortcut should stop applying once a second session exists.
- `select_account` already renders the picker correctly with both sessions listed in the identical setup, so the two paths disagree today.
- The SAML flow has the same behaviour, and additionally never filters sessions by organization.

# How the Problems Are Solved

- Add `findValidSessions` in `apps/login/src/lib/session.ts`. Unlike `findValidSession` it validates every candidate rather than short-circuiting on the first match, so callers can tell one unambiguous session apart from several equally valid ones.
- In the default (no prompt) branch of `handleOIDCFlowInitiation`, redirect to account selection when more than one session is valid and the request carries no `hintUserId` or `login_hint`. A user hint means the request already named the account it wants, so those flows stay silent.
- Apply the same check to `handleSAMLFlowInitiation`. SAML requests carry no user hint, so several valid sessions always mean the choice belongs to the user.
- `prompt=none` is deliberately left unchanged — it must not render UI. See the open question below.

The check is gated on *valid* sessions rather than the already-available `eligibleSessions` count on purpose: an expired or MFA-incomplete second session would otherwise trigger a picker offering one usable and one dead account.

# Additional Changes

- `findValidSession` is refactored onto a shared `getCandidateSessions` helper that does the hint/organization filtering and the change-date sort. Its behaviour and short-circuiting are unchanged, and it remains in use for the `prompt=none` branch.
- 7 new tests in `flow-initiation.test.ts` covering: the multi-session picker, single-session silent completion, the `login_hint` and `hintUserId` carve-outs, the `prompt=none` carve-out, and both SAML paths.

# Additional Context

- Closes #12543
- Distinct from #11914, which renders the Account Selection screen but empty; here no selection screen appears at all.

Two things I'd like maintainer input on:

1. **`prompt=none` has the same ambiguity** and currently picks a session silently. The spec-correct response is arguably the OIDC `account_selection_required` error rather than the current generic 400 or a silent pick, but that changes what relying parties receive, so I left it out of this PR rather than deciding it here.
2. **This is a user-visible behaviour change.** Anyone with two valid sessions who gets a seamless redirect today will start seeing the account picker. That matches the stated intent of Advisory 10000, but it is worth an explicit sign-off. It also is not specific to the org-scoped case in the issue — the org scope just makes it easy to reproduce.
