### PR TITLE
fix(server): map client cancellations to 499 and drain before shutdown

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -773,6 +773,17 @@ func startAPIs(
 	return apis, nil
 }
 
+const (
+	// shutdownDrainDelay keeps the server serving after receiving SIGTERM, giving the
+	// upstream load balancer / serverless NEG time to stop routing new requests to this
+	// instance before we close the listener. Without it, requests still routed during
+	// teardown are reset and recorded as 5xx on every deploy and scale-down.
+	// shutdownDrainDelay + shutdownGracePeriod must stay within the platform's
+	// SIGTERM->SIGKILL grace period (Cloud Run default is ~10s). Tune per platform.
+	shutdownDrainDelay  = 3 * time.Second
+	shutdownGracePeriod = 5 * time.Second
+)
+
 func listen(ctx context.Context, router *mux.Router, port uint16, tlsConfig *tls.Config, shutdown <-chan os.Signal) error {
 	http2Server := &http2.Server{}
 	http1Server := &http.Server{Handler: h2c.NewHandler(router, http2Server), TLSConfig: tlsConfig}
@@ -799,7 +810,10 @@ func listen(ctx context.Context, router *mux.Router, port uint16, tlsConfig *tls
 	case err := <-errCh:
 		return fmt.Errorf("error starting server: %w", err)
 	case <-shutdown:
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// Lame-duck: keep serving during the drain window so the load balancer
+		// deregisters this instance before we stop accepting connections.
+		time.Sleep(shutdownDrainDelay)
+		ctx, cancel := context.WithTimeout(ctx, shutdownGracePeriod)
 		defer cancel()
 		return shutdownServer(ctx, http1Server)
 	case <-ctx.Done():

--- a/internal/api/grpc/gerrors/zitadel_errors.go
+++ b/internal/api/grpc/gerrors/zitadel_errors.go
@@ -82,6 +82,13 @@ func ExtractZITADELError(err error) (code codes.Code, msg, id string) {
 }
 
 func extractError(err error) (c codes.Code, msg, id string, lvl slog.Level) {
+	// A cancelled request context (client disconnect, browser navigation away, LB idle
+	// timeout) is not a server fault. Map it to codes.Canceled so the grpc-gateway
+	// returns 499 instead of falling through to codes.Unknown => 500. This keeps benign
+	// client cancellations out of the 5xx availability SLI.
+	if errors.Is(err, context.Canceled) {
+		return codes.Canceled, "context canceled", "", slog.LevelWarn
+	}
 	connErr := new(pgconn.ConnectError)
 	if ok := errors.As(err, &connErr); ok {
 		return codes.Internal, "db connection error", "", slog.LevelError


### PR DESCRIPTION
# Which Problems Are Solved

- **Benign client cancellations are recorded as 500.** When a client disconnects mid-request (browser navigates away, load balancer idle timeout), the cancelled request context falls through error mapping to `codes.Unknown`, which the gateway translates to HTTP 500. Nothing failed server-side, but the request still counts against the 5xx availability SLI. On low-traffic services this is enough to trip SLO alerting: at ~18 req/min, a single such 500 drags the minute's SLO health to ~0.95 against a 0.9995 goal and can page on-call.
- **Deploys and scale-downs cause 5xx bursts.** On SIGTERM the listener closes immediately, so requests the load balancer routes to the instance during teardown are reset and logged as 5xx on every rollout and scale-down.

# How the Problems Are Solved

- Map `context.Canceled` to `codes.Canceled` in `gerrors.extractError` (before the generic fallthrough), so the gateway returns 499 instead of 500 and the event is logged at warn level. Client cancellations no longer pollute the 5xx SLI.
- Add a lame-duck window to shutdown: after SIGTERM the server keeps serving for `shutdownDrainDelay` (3s) so the load balancer / serverless NEG can deregister the instance, then shuts down gracefully within `shutdownGracePeriod` (5s). Both are documented constants; their sum stays within Cloud Run's ~10s SIGTERM→SIGKILL grace period.

# Additional Changes

None.

# Additional Context

- Found while investigating recurring SLO fast-burn pages that were dominated by single-request "bad minutes" and deploy-time 5xx bursts, not real outages. The alerting side is addressed separately in our infra module; this PR reduces the underlying transient 5xx.
- Review notes:
  - The `context.Canceled` mapping is verified against production request logs (the observed 500s were fast client-side aborts, not timeouts).
  - The shutdown drain targets teardown connection resets, which surface in LB logs rather than instance logs; log-based confirmation around a deploy window is still pending, so extra scrutiny on this commit is welcome.
  - The drain also applies to signal-triggered stops in local development (Ctrl+C now takes ~3s longer). If that is unwanted, it could be gated behind config.
