### PR TITLE
fix(telemetry): reduce otelgrpc RPC histogram bucket counts

### DIFF
--- a/backend/v3/instrumentation/metric.go
+++ b/backend/v3/instrumentation/metric.go
@@ -10,6 +10,7 @@ import (
 	google_metric "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -22,6 +23,13 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/zitadel/zitadel/internal/zerrors"
+)
+
+var (
+	rpcDurationSecondsBuckets = []float64{0.005, 0.025, 0.1, 0.5, 2.5, 10}
+	rpcDurationMillisBuckets  = []float64{5, 25, 100, 500, 2500, 10000}
+	rpcSizeBytesBuckets       = []float64{256, 1024, 4096, 65536, 1048576}
+	rpcMessagesPerRPCBuckets  = []float64{1, 2, 5, 10}
 )
 
 type MetricConfig struct {
@@ -205,25 +213,83 @@ func newMeterProvider(ctx context.Context, cfg MetricConfig, resource *resource.
 		return nil, fmt.Errorf("meter reader: %w", err)
 	}
 
-	// create a view to filter out unwanted attributes
-	view := sdk_metric.NewView(
-		sdk_metric.Instrument{
-			Scope: instrumentation.Scope{Name: otelhttp.ScopeName},
-		},
-		sdk_metric.Stream{
-			AttributeFilter: attribute.NewAllowKeysFilter("http.method", "http.status_code", "http.target"),
-		},
-	)
-
 	opts := []sdk_metric.Option{
 		sdk_metric.WithResource(resource),
-		sdk_metric.WithView(view),
+	}
+	for _, view := range metricViews() {
+		opts = append(opts, sdk_metric.WithView(view))
 	}
 	if readerOption != nil {
 		opts = append(opts, readerOption)
 	}
 	meterProvider := sdk_metric.NewMeterProvider(opts...)
 	return meterProvider, nil
+}
+
+func metricViews() []sdk_metric.View {
+	otelgrpcScope := instrumentation.Scope{Name: otelgrpc.ScopeName}
+	return []sdk_metric.View{
+		sdk_metric.NewView(
+			sdk_metric.Instrument{
+				Scope: instrumentation.Scope{Name: otelhttp.ScopeName},
+			},
+			sdk_metric.Stream{
+				AttributeFilter: attribute.NewAllowKeysFilter("http.method", "http.status_code", "http.target"),
+			},
+		),
+		sdk_metric.NewView(
+			sdk_metric.Instrument{
+				Scope: otelgrpcScope,
+				Kind:  sdk_metric.InstrumentKindHistogram,
+				Unit:  "s",
+			},
+			sdk_metric.Stream{
+				Aggregation: sdk_metric.AggregationExplicitBucketHistogram{
+					Boundaries: rpcDurationSecondsBuckets,
+					NoMinMax:   true,
+				},
+			},
+		),
+		sdk_metric.NewView(
+			sdk_metric.Instrument{
+				Scope: otelgrpcScope,
+				Kind:  sdk_metric.InstrumentKindHistogram,
+				Unit:  "ms",
+			},
+			sdk_metric.Stream{
+				Aggregation: sdk_metric.AggregationExplicitBucketHistogram{
+					Boundaries: rpcDurationMillisBuckets,
+					NoMinMax:   true,
+				},
+			},
+		),
+		sdk_metric.NewView(
+			sdk_metric.Instrument{
+				Scope: otelgrpcScope,
+				Kind:  sdk_metric.InstrumentKindHistogram,
+				Unit:  "By",
+			},
+			sdk_metric.Stream{
+				Aggregation: sdk_metric.AggregationExplicitBucketHistogram{
+					Boundaries: rpcSizeBytesBuckets,
+					NoMinMax:   true,
+				},
+			},
+		),
+		sdk_metric.NewView(
+			sdk_metric.Instrument{
+				Scope: otelgrpcScope,
+				Kind:  sdk_metric.InstrumentKindHistogram,
+				Unit:  "{count}",
+			},
+			sdk_metric.Stream{
+				Aggregation: sdk_metric.AggregationExplicitBucketHistogram{
+					Boundaries: rpcMessagesPerRPCBuckets,
+					NoMinMax:   true,
+				},
+			},
+		),
+	}
 }
 
 func metricStdOutOption(cfg ExporterConfig) (sdk_metric.Option, error) {

--- a/backend/v3/instrumentation/metric_test.go
+++ b/backend/v3/instrumentation/metric_test.go
@@ -5,6 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdk_metric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -360,4 +366,103 @@ func Test_newMeterProvider_autoexport(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_metricViews_reduceRPCHistogramBuckets(t *testing.T) {
+	reader := sdk_metric.NewManualReader()
+	res, err := resource.New(t.Context())
+	require.NoError(t, err)
+
+	opts := []sdk_metric.Option{
+		sdk_metric.WithResource(res),
+		sdk_metric.WithReader(reader),
+	}
+	for _, view := range metricViews() {
+		opts = append(opts, sdk_metric.WithView(view))
+	}
+	provider := sdk_metric.NewMeterProvider(opts...)
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(t.Context()))
+	})
+
+	meter := provider.Meter(
+		otelgrpc.ScopeName,
+		metric.WithInstrumentationVersion("test"),
+	)
+
+	tests := []struct {
+		name       string
+		instrument string
+		unit       string
+		want       []float64
+	}{
+		{
+			name:       "duration seconds",
+			instrument: "rpc.server.call.duration",
+			unit:       "s",
+			want:       rpcDurationSecondsBuckets,
+		},
+		{
+			name:       "duration milliseconds",
+			instrument: "rpc.server.duration",
+			unit:       "ms",
+			want:       rpcDurationMillisBuckets,
+		},
+		{
+			name:       "size bytes",
+			instrument: "rpc.server.request.size",
+			unit:       "By",
+			want:       rpcSizeBytesBuckets,
+		},
+		{
+			name:       "messages per rpc",
+			instrument: "rpc.server.requests_per_rpc",
+			unit:       "{count}",
+			want:       rpcMessagesPerRPCBuckets,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hist, err := meter.Float64Histogram(
+				tt.instrument,
+				metric.WithUnit(tt.unit),
+				metric.WithExplicitBucketBoundaries(0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000),
+			)
+			require.NoError(t, err)
+			hist.Record(t.Context(), 1, metric.WithAttributes(attribute.String("rpc.method", "Test")))
+		})
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	gotBounds := map[string][]float64{}
+	for _, sm := range rm.ScopeMetrics {
+		assert.Equal(t, otelgrpc.ScopeName, sm.Scope.Name)
+		for _, m := range sm.Metrics {
+			hist, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "expected histogram for %s", m.Name)
+			require.Len(t, hist.DataPoints, 1)
+			gotBounds[m.Name] = hist.DataPoints[0].Bounds
+		}
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, gotBounds[tt.instrument], tt.instrument)
+	}
+}
+
+func Test_metricViews_httpAttributeFilterUnchanged(t *testing.T) {
+	views := metricViews()
+	require.NotEmpty(t, views)
+
+	stream, match := views[0](sdk_metric.Instrument{
+		Scope: instrumentation.Scope{Name: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"},
+		Name:  "http.server.request.duration",
+	})
+	require.True(t, match)
+	require.NotNil(t, stream.AttributeFilter)
+	assert.True(t, stream.AttributeFilter(attribute.String("http.method", "GET")))
+	assert.False(t, stream.AttributeFilter(attribute.String("http.scheme", "https")))
 }

--- a/backend/v3/instrumentation/metric_test.go
+++ b/backend/v3/instrumentation/metric_test.go
@@ -457,11 +457,21 @@ func Test_metricViews_httpAttributeFilterUnchanged(t *testing.T) {
 	views := metricViews()
 	require.NotEmpty(t, views)
 
-	stream, match := views[0](sdk_metric.Instrument{
+	httpInstrument := sdk_metric.Instrument{
 		Scope: instrumentation.Scope{Name: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"},
 		Name:  "http.server.request.duration",
-	})
-	require.True(t, match)
+	}
+	var (
+		stream sdk_metric.Stream
+		match  bool
+	)
+	for _, view := range views {
+		stream, match = view(httpInstrument)
+		if match {
+			break
+		}
+	}
+	require.True(t, match, "expected an otelhttp attribute-filter view")
 	require.NotNil(t, stream.AttributeFilter)
 	assert.True(t, stream.AttributeFilter(attribute.String("http.method", "GET")))
 	assert.False(t, stream.AttributeFilter(attribute.String("http.scheme", "https")))


### PR DESCRIPTION
# Which Problems Are Solved

- After fixing HTTP `uri` cardinality (#12557), Prometheus scrapes of `/debug/metrics` are still dominated by `otelgrpc` histograms (`rpc.server.*` / `rpc.client.*`).
- Those histograms use the default 14–15 explicit buckets. Combined with labels for every RPC method and status code, a single production instance can exceed common scrape `sample_limit` values (e.g. 3000) even when HTTP metrics are healthy.
- On one v4.16.3 deployment, ~2.7k of ~3.5k series were `rpc_*` histogram time series; most of that weight is bucket cardinality, not distinct methods.

# How the Problems Are Solved

- Add MeterProvider views (alongside the existing `otelhttp` attribute filter) that override `otelgrpc` histogram aggregations with tighter, unit-specific boundaries:
  - duration (`s`): `0.005, 0.025, 0.1, 0.5, 2.5, 10` (6 vs 14)
  - duration (`ms`): `5, 25, 100, 500, 2500, 10000` (6 vs 15)
  - size (`By`): `256, 1024, 4096, 65536, 1048576` (5 vs 15)
  - messages (`{count}`): `1, 2, 5, 10` (4 vs 15)
- Keep method/status labels so per-RPC latency remains useful; only reduce bucket resolution.
- Rough impact: `rpc_*_bucket` series drop by ~60%, which brings scrapes that were ~3.5k series back under a 3000 sample limit (assuming similar method coverage).

# Additional Changes

- Regression tests for the reduced boundaries and that the existing HTTP attribute allow-list view is unchanged.

# Additional Context

- Follow-up for PR #12557
- Related: #9286, #9523
- Alternative considered: dropping `rpc.*` instruments entirely via `AggregationDrop`. This PR keeps the metrics and only shrinks buckets.
- Alternative considered: stripping `rpc.method` / `rpc.service` attributes. That would collapse per-method detail; out of scope here.