### PR TITLE
fix(login): set html background-color for Firefox overscroll

### DIFF
--- a/apps/login/src/styles/globals.scss
+++ b/apps/login/src/styles/globals.scss
@@ -16,6 +16,11 @@
 html {
   --background-color: #ffffff;
   --dark-background-color: #000000;
+  background-color: var(--theme-light-background-500, #fafafa);
+}
+
+html.dark {
+  background-color: var(--theme-dark-background-500, #252526);
 }
 
 .form-checkbox {


### PR DESCRIPTION
Fixes #7387

## Problem

When overscrolling in Firefox (), the background color of the selected theme is not respected and defaults to white. This happens because the root `html` element had no `background-color` applied — only CSS custom properties were defined.

## Fix

Apply the theme's background color directly to the `html` element using the existing CSS variables (`--theme-light-background-500` / `--theme-dark-background-500`) that are already set by the theme system in `helpers/colors.ts`.

This ensures Firefox's overscroll area uses the correct theme background color, and also improves the initial paint by avoiding a flash of white before JavaScript applies the theme.

## Changes

- `apps/login/src/styles/globals.scss`: Added `background-color` to `html` element with dark mode variant

## Testing

- Verified the CSS variables `--theme-light-background-500` and `--theme-dark-background-500` are set by `setTheme()` in `helpers/colors.ts`
- Fallback values match the defaults from `colors.ts` (`#fafafa` light, `#252526` dark)
- Both light and dark themes are covered via the `.dark` class selector