### PR TITLE
fix(command): check permission when adding user passkey code

### DIFF
--- a/internal/command/user_v2_passkey.go
+++ b/internal/command/user_v2_passkey.go
@@ -141,6 +141,9 @@ func (c *Commands) addUserPasskeyCode(ctx context.Context, userID, resourceOwner
 	if err != nil {
 		return nil, err
 	}
+	if err := c.checkPermissionUpdateUserCredentials(ctx, wm.ResourceOwner, userID); err != nil {
+		return nil, err
+	}
 	agg := UserAggregateFromWriteModel(&wm.WriteModel)
 
 	if urlTmpl == "" {


### PR DESCRIPTION
Adding a passkey registration code goes through a coarse permission check that is not bound to the target user, so a caller holding the passkey write permission in any organization can mint a passkey code for another user and take over the account. This adds the fine grained permission check the sibling passkey registration already uses, bound to the target user.