### PR TITLE
fix(oidc): bind v1 refresh token to requesting client

### DIFF
--- a/internal/api/oidc/token_refresh.go
+++ b/internal/api/oidc/token_refresh.go
@@ -46,6 +46,9 @@ func (s *Server) refreshTokenV1(ctx context.Context, client *Client, r *op.Clien
 	if err != nil {
 		return nil, err
 	}
+	if refreshToken.ClientID != client.client.ClientID {
+		return nil, oidc.ErrInvalidClient().WithDescription("client_id does not correspond to the client_id in the refresh token")
+	}
 	scope, err := validateRefreshTokenScopes(refreshToken.Scopes, r.Data.Scopes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The v1 refresh token path did not check that the token belongs to the requesting client, unlike the other refresh and auth code paths, which lets one client redeem another client's refresh token. This binds the refresh token to the requesting client.