### PR TITLE
fix(oidc): keep expiry gate when token events cannot be loaded

### DIFF
--- a/internal/auth/repository/eventsourcing/eventstore/refresh_token.go
+++ b/internal/auth/repository/eventsourcing/eventstore/refresh_token.go
@@ -71,6 +71,9 @@ func (r *RefreshTokenRepo) RefreshTokenByID(ctx context.Context, tokenID, userID
 
 	if esErr != nil {
 		logging.Log("EVENT-AE462").WithError(viewErr).WithField("traceID", tracing.TraceIDFromCtx(ctx)).Debug("error retrieving new events")
+		if !tokenView.Expiration.After(time.Now()) {
+			return nil, zerrors.ThrowNotFound(nil, "EVENT-5Bm9s", "Errors.User.RefreshToken.Invalid")
+		}
 		return model.RefreshTokenViewToModel(tokenView), nil
 	}
 	viewToken := *tokenView

--- a/internal/auth/repository/eventsourcing/eventstore/token.go
+++ b/internal/auth/repository/eventsourcing/eventstore/token.go
@@ -56,6 +56,9 @@ func (repo *TokenRepo) TokenByIDs(ctx context.Context, userID, tokenID string) (
 
 	if esErr != nil {
 		logging.Log("EVENT-5Nm9s").WithError(viewErr).WithField("traceID", tracing.TraceIDFromCtx(ctx)).Debug("error retrieving new events")
+		if !token.Expiration.After(time.Now().UTC()) || token.Deactivated {
+			return nil, zerrors.ThrowNotFound(nil, "EVENT-5Bm9s", "Errors.Token.NotFound")
+		}
 		return model.TokenViewToModel(token), nil
 	}
 	viewToken := *token


### PR DESCRIPTION
When token events cannot be loaded from the eventstore the code returned the view token without applying the expiry and deactivation gate that the normal path applies, so an already expired or deactivated token could be accepted during an eventstore error. This keeps the same gate on the error path.