### PR TITLE
fix(login): gate mfa init and username change on completed primary factor

### DIFF
--- a/internal/api/ui/login/mfa_init_sms.go
+++ b/internal/api/ui/login/mfa_init_sms.go
@@ -79,6 +79,10 @@ func (l *Login) handleRegisterSMSCheck(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+	if _, ok := authReq.PossibleSteps[0].(*domain.MFAPromptStep); !ok {
+		l.renderError(w, r, authReq, err)
+		return
+	}
 
 	ctx := setUserContext(r.Context(), authReq.UserID, authReq.UserOrgID)
 	// save the current state

--- a/internal/api/ui/login/mfa_init_u2f.go
+++ b/internal/api/ui/login/mfa_init_u2f.go
@@ -44,6 +44,10 @@ func (l *Login) handleRegisterU2F(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+	if _, ok := authReq.PossibleSteps[0].(*domain.MFAPromptStep); !ok {
+		l.renderError(w, r, authReq, err)
+		return
+	}
 	credData, err := base64.URLEncoding.DecodeString(data.CredentialData)
 	if err != nil {
 		l.renderRegisterU2F(w, r, authReq, err)

--- a/internal/api/ui/login/mfa_init_verify_handler.go
+++ b/internal/api/ui/login/mfa_init_verify_handler.go
@@ -31,6 +31,10 @@ func (l *Login) handleMFAInitVerify(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+	if _, ok := authReq.PossibleSteps[0].(*domain.MFAPromptStep); !ok {
+		l.renderError(w, r, authReq, err)
+		return
+	}
 	var verifyData *mfaVerifyData
 	switch data.MFAType {
 	case domain.MFATypeTOTP:

--- a/internal/api/ui/login/mfa_prompt_handler.go
+++ b/internal/api/ui/login/mfa_prompt_handler.go
@@ -23,6 +23,10 @@ func (l *Login) handleMFAPrompt(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+	if _, ok := authReq.PossibleSteps[0].(*domain.MFAPromptStep); !ok {
+		l.renderError(w, r, authReq, err)
+		return
+	}
 	if !data.Skip {
 		mfaVerifyData := new(mfaVerifyData)
 		mfaVerifyData.MFAType = data.MFAProvider

--- a/internal/api/ui/login/username_change_handler.go
+++ b/internal/api/ui/login/username_change_handler.go
@@ -28,6 +28,10 @@ func (l *Login) handleChangeUsername(w http.ResponseWriter, r *http.Request) {
 		l.renderError(w, r, authReq, err)
 		return
 	}
+	if _, ok := authReq.PossibleSteps[0].(*domain.ChangeUsernameStep); !ok {
+		l.renderError(w, r, authReq, err)
+		return
+	}
 	_, err = l.command.ChangeUsername(setContext(r.Context(), authReq.UserOrgID), authReq.UserOrgID, authReq.UserID, data.Username)
 	if err != nil {
 		l.renderChangeUsername(w, r, authReq, err)


### PR DESCRIPTION
Several login handlers acted on the auth request without checking the current step, so an identify only request could drive MFA initialization or a username change before the primary factor was verified. This gates those handlers on the expected step, matching the existing MFA verify handlers.