### PR TITLE
fix(login): sign user verification check with server secret

### DIFF
--- a/apps/login/src/lib/server/register.ts
+++ b/apps/login/src/lib/server/register.ts
@@ -5,13 +5,13 @@ import { addHumanUser, addIDPLink, getLoginSettings, getUserByID, listAuthentica
 import { Code, ConnectError, Duration, create } from "@zitadel/client";
 import { Factors } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { Checks, ChecksJson, ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import crypto from "crypto";
 import { getTranslations } from "next-intl/server";
 import { cookies, headers } from "next/headers";
 import { completeFlowOrGetUrl } from "../client";
 import { getOrSetFingerprintId } from "../fingerprint";
 import { createLogger } from "../logger";
 import { getServiceConfig } from "../service-url";
+import { computeUserVerificationCheck } from "../verification-check";
 import { checkEmailVerification, checkMFAFactors } from "../verify-helper";
 
 const logger = createLogger("register");
@@ -139,7 +139,7 @@ export async function registerUser(
     const cookiesList = await cookies();
     const userAgentId = await getOrSetFingerprintId();
 
-    const verificationCheck = crypto.createHash("sha256").update(`${session.factors.user.id}:${userAgentId}`).digest("hex");
+    const verificationCheck = computeUserVerificationCheck(session.factors.user.id, userAgentId);
 
     await cookiesList.set({
       name: "verificationCheck",

--- a/apps/login/src/lib/server/verify.ts
+++ b/apps/login/src/lib/server/verify.ts
@@ -12,7 +12,6 @@ import {
   verifyTOTPRegistration,
   sendEmailCode as zitadelSendEmailCode,
 } from "@/lib/zitadel";
-import crypto from "crypto";
 
 import { create } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
@@ -26,6 +25,7 @@ import { getOrSetFingerprintId } from "../fingerprint";
 import { checkMFAFactors } from "../mfa-helper";
 import { getServiceConfig } from "../service-url";
 import { loadMostRecentSession } from "../session";
+import { computeUserVerificationCheck } from "../verification-check";
 import { createSessionAndUpdateCookie } from "./cookie";
 import { getEnrollmentAuthorizationError } from "./enrollment-guard";
 import { getPublicHostWithProtocol } from "./host";
@@ -176,7 +176,7 @@ export async function sendVerification(command: VerifyUserByEmailCommand) {
     const cookiesList = await cookies();
     const userAgentId = await getOrSetFingerprintId();
 
-    const verificationCheck = crypto.createHash("sha256").update(`${user.userId}:${userAgentId}`).digest("hex");
+    const verificationCheck = computeUserVerificationCheck(user.userId, userAgentId);
 
     await cookiesList.set({
       name: "verificationCheck",

--- a/apps/login/src/lib/verification-check.ts
+++ b/apps/login/src/lib/verification-check.ts
@@ -1,0 +1,29 @@
+import crypto from "crypto";
+
+/**
+ * Returns a server-side secret used to key the user-verification cookie.
+ * It is derived from the deployment credentials that are already required to run the login app
+ * (see service.ts), so the value is never exposed to the client.
+ */
+function getServerSecret(): string {
+  const secret =
+    process.env.SYSTEM_USER_PRIVATE_KEY ||
+    process.env.ZITADEL_SERVICE_USER_TOKEN ||
+    process.env.ZITADEL_LOGINCLIENT_KEYFILE ||
+    process.env.SYSTEM_USER_PRIVATE_KEY_FILE;
+
+  if (!secret) {
+    throw new Error("No server secret available to sign the user verification check");
+  }
+
+  return secret;
+}
+
+/**
+ * Computes the keyed hash bound to a user and browser fingerprint for the verificationCheck cookie.
+ * Uses HMAC with a server-side secret so the value cannot be forged from the userId and fingerprint
+ * alone, which are both known to the client.
+ */
+export function computeUserVerificationCheck(userId: string, fingerprintId: string): string {
+  return crypto.createHmac("sha256", getServerSecret()).update(`${userId}:${fingerprintId}`).digest("hex");
+}

--- a/apps/login/src/lib/verify-helper.ts
+++ b/apps/login/src/lib/verify-helper.ts
@@ -2,11 +2,11 @@ import { timestampDate } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { PasswordExpirySettings } from "@zitadel/proto/zitadel/settings/v2/password_settings_pb";
 import { HumanUser } from "@zitadel/proto/zitadel/user/v2/user_pb";
-import crypto from "crypto";
 import moment from "moment";
 import { cookies } from "next/headers";
 import { getFingerprintIdCookie } from "./fingerprint";
 import { trySendVerification } from "./server/verify";
+import { computeUserVerificationCheck } from "./verification-check";
 
 export function checkPasswordChangeRequired(
   expirySettings: PasswordExpirySettings | undefined,
@@ -121,7 +121,7 @@ export async function checkUserVerification(userId: string): Promise<boolean> {
     return false;
   }
 
-  const verificationCheck = crypto.createHash("sha256").update(`${userId}:${fingerPrintCookie.value}`).digest("hex");
+  const verificationCheck = computeUserVerificationCheck(userId, fingerPrintCookie.value);
 
   const cookieValue = await cookiesList.get("verificationCheck")?.value;
 


### PR DESCRIPTION
The user verification check cookie was a plain sha256 of values the client controls, so it could be forged to pass the enrollment verification gate on accounts without an auth method. This signs the check with a server side secret using HMAC across the sites that set and read it.