### PR TITLE
docs: fix redirect to WIP page

### DIFF
--- a/apps/docs/redirects.json
+++ b/apps/docs/redirects.json
@@ -3260,7 +3260,7 @@
     "permanent": true
   },
   {
-    "source": "/api/group/:path*",
+    "source": "/reference/api/group/:path*",
     "destination": "/api-under-development",
     "permanent": false
   }


### PR DESCRIPTION
Fixes the path for the temporary redirect for all /reference/api/group/* routes to a new "Under
Development" page while the API is being built.