### PR TITLE
fix(login): preserve user theme preference when branding theme is auto

### DIFF
--- a/apps/login/src/components/theme-wrapper.tsx
+++ b/apps/login/src/components/theme-wrapper.tsx
@@ -111,8 +111,14 @@ export const ThemeWrapper = ({ children, branding }: Props) => {
         case ThemeMode.UNSPECIFIED:
         default:
           // Do not forcibly override the user's theme preference.
-          // Let next-themes read from localStorage and fall back to system
-          // default only if no saved preference exists.
+          // Let next-themes read from localStorage and fall back to
+          // system default only if no saved preference exists.
+          //
+          // branding.themeMode is a static setting from the org's
+          // branding policy and does not change at runtime. If the
+          // branding ever changes, the component will re-render and
+          // either enforce a new forced theme (LIGHT/DARK) or
+          // continue respecting the user's stored preference (AUTO).
           break;
       }
     }

--- a/apps/login/src/components/theme-wrapper.tsx
+++ b/apps/login/src/components/theme-wrapper.tsx
@@ -110,7 +110,9 @@ export const ThemeWrapper = ({ children, branding }: Props) => {
         case ThemeMode.AUTO:
         case ThemeMode.UNSPECIFIED:
         default:
-          setNextTheme("system");
+          // Do not forcibly override the user's theme preference.
+          // Let next-themes read from localStorage and fall back to system
+          // default only if no saved preference exists.
           break;
       }
     }


### PR DESCRIPTION
When branding themeMode is AUTO or UNSPECIFIED, the component was calling setNextTheme("system") on every render, overwriting the user's saved preference from localStorage.

This caused the theme picker to reset to "system" every time the login page was reloaded, ignoring the user's choice of dark or light mode.

Fix: skip forcing the theme when no explicit LIGHT/DARK is set by branding, letting next-themes respect the user's stored preference.

Fixes https://github.com/zitadel/zitadel/issues/12534

# Which Problems Are Solved
 - When no branding theme is set (AUTO/UNSPECIFIED), the login page resets the user's theme preference to "system"
   on every page reload, ignoring their previously selected dark or light mode.
 - The setNextTheme("system") call overwrites the cp-theme value in localStorage, making it impossible for users to
   persist their theme choice across sessions.

# How the Problems Are Solved
- Removed the setNextTheme("system") call in the AUTO/UNSPECIFIED/default case of the theme switch statement in
   theme-wrapper.tsx.
 - When branding does not enforce a specific theme (LIGHT/DARK), next-themes now reads from localStorage and
   preserves the user's saved preference, falling back to system default only if no preference exists.
 - Explicit LIGHT and DARK branding settings continue to override user preference as intended.

# Additional Changes
- None. This is a focused fix with no side effects.

# Additional Context
 - Closes #12534
 - Reported by @melbaa (Lazar Lazarov)
