### PR TITLE
fix(login): add missing registerNotAllowed translation to all locales

### DIFF
--- a/apps/login/locales/ar.json
+++ b/apps/login/locales/ar.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "تعذر إنشاء الجلسة",
       "userNotFound": "المستخدم غير موجود في النظام",
       "couldNotLinkIDP": "تعذر ربط IDP بالمستخدم",
-      "couldNotRegisterUser": "تعذر تسجيل المستخدم"
+      "couldNotRegisterUser": "تعذر تسجيل المستخدم",
+      "registerNotAllowed": "التسجيل غير مسموح به"
     }
   },
   "invite": {

--- a/apps/login/locales/de.json
+++ b/apps/login/locales/de.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Sitzung konnte nicht erstellt werden",
       "userNotFound": "Benutzer nicht im System gefunden",
       "couldNotLinkIDP": "IDP konnte nicht mit dem Benutzer verknüpft werden",
-      "couldNotRegisterUser": "Benutzer konnte nicht registriert werden"
+      "couldNotRegisterUser": "Benutzer konnte nicht registriert werden",
+      "registerNotAllowed": "Registrierung ist nicht erlaubt"
     }
   },
   "invite": {

--- a/apps/login/locales/en.json
+++ b/apps/login/locales/en.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Could not create session",
       "userNotFound": "User not found in the system",
       "couldNotLinkIDP": "Could not link IDP to user",
-      "couldNotRegisterUser": "Could not register user"
+      "couldNotRegisterUser": "Could not register user",
+      "registerNotAllowed": "Registration is not allowed"
     }
   },
   "invite": {

--- a/apps/login/locales/es.json
+++ b/apps/login/locales/es.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "No se pudo crear la sesión",
       "userNotFound": "Usuario no encontrado en el sistema",
       "couldNotLinkIDP": "No se pudo vincular el IdP al usuario",
-      "couldNotRegisterUser": "No se pudo registrar el usuario"
+      "couldNotRegisterUser": "No se pudo registrar el usuario",
+      "registerNotAllowed": "El registro no está permitido"
     }
   },
   "invite": {

--- a/apps/login/locales/fr.json
+++ b/apps/login/locales/fr.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Impossible de créer la session",
       "userNotFound": "Utilisateur non trouvé dans le système",
       "couldNotLinkIDP": "Impossible de lier le fournisseur d'identité à l'utilisateur",
-      "couldNotRegisterUser": "Impossible d'inscrire l'utilisateur"
+      "couldNotRegisterUser": "Impossible d'inscrire l'utilisateur",
+      "registerNotAllowed": "L'enregistrement n'est pas autorisé"
     }
   },
   "invite": {

--- a/apps/login/locales/hu.json
+++ b/apps/login/locales/hu.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Nem sikerült létrehozni a munkamenetet",
       "userNotFound": "A felhasználó nem található a rendszerben",
       "couldNotLinkIDP": "Nem sikerült összekapcsolni az azonosítószolgáltatót a felhasználóval",
-      "couldNotRegisterUser": "Nem sikerült regisztrálni a felhasználót"
+      "couldNotRegisterUser": "Nem sikerült regisztrálni a felhasználót",
+      "registerNotAllowed": "A regisztráció nem engedélyezett"
     }
   },
   "invite": {

--- a/apps/login/locales/it.json
+++ b/apps/login/locales/it.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Impossibile creare la sessione",
       "userNotFound": "Utente non trovato nel sistema",
       "couldNotLinkIDP": "Impossibile collegare l'IDP all'utente",
-      "couldNotRegisterUser": "Impossibile registrare l'utente"
+      "couldNotRegisterUser": "Impossibile registrare l'utente",
+      "registerNotAllowed": "La registrazione non è consentita"
     }
   },
   "invite": {

--- a/apps/login/locales/ja.json
+++ b/apps/login/locales/ja.json
@@ -347,7 +347,8 @@
       "couldNotCreateSession": "セッションを作成できませんでした",
       "userNotFound": "ユーザーがシステムに見つかりません",
       "couldNotLinkIDP": "IDPをユーザーにリンクできませんでした",
-      "couldNotRegisterUser": "ユーザーを登録できませんでした"
+      "couldNotRegisterUser": "ユーザーを登録できませんでした",
+      "registerNotAllowed": "新規登録は許可されていません"
     }
   },
   "invite": {

--- a/apps/login/locales/nl.json
+++ b/apps/login/locales/nl.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Kon sessie niet aanmaken",
       "userNotFound": "Gebruiker niet in het systeem gevonden",
       "couldNotLinkIDP": "Kon IDP niet aan gebruiker koppelen",
-      "couldNotRegisterUser": "Kon gebruiker niet registreren"
+      "couldNotRegisterUser": "Kon gebruiker niet registreren",
+      "registerNotAllowed": "Registratie is niet toegestaan"
     }
   },
   "invite": {

--- a/apps/login/locales/pl.json
+++ b/apps/login/locales/pl.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Nie udało się utworzyć sesji",
       "userNotFound": "Nie znaleziono użytkownika w systemie",
       "couldNotLinkIDP": "Nie udało się powiązać IDP z użytkownikiem",
-      "couldNotRegisterUser": "Nie udało się zarejestrować użytkownika"
+      "couldNotRegisterUser": "Nie udało się zarejestrować użytkownika",
+      "registerNotAllowed": "Rejestracja nie jest dozwolona"
     }
   },
   "invite": {

--- a/apps/login/locales/pt.json
+++ b/apps/login/locales/pt.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Não foi possível criar a sessão",
       "userNotFound": "Usuário não encontrado no sistema",
       "couldNotLinkIDP": "Não foi possível vincular o provedor de identidade ao usuário",
-      "couldNotRegisterUser": "Não foi possível cadastrar o usuário"
+      "couldNotRegisterUser": "Não foi possível cadastrar o usuário",
+      "registerNotAllowed": "O registro não é permitido"
     }
   },
   "invite": {

--- a/apps/login/locales/ru.json
+++ b/apps/login/locales/ru.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Не удалось создать сессию",
       "userNotFound": "Пользователь не найден в системе",
       "couldNotLinkIDP": "Не удалось привязать IDP к пользователю",
-      "couldNotRegisterUser": "Не удалось зарегистрировать пользователя"
+      "couldNotRegisterUser": "Не удалось зарегистрировать пользователя",
+      "registerNotAllowed": "Регистрация запрещена"
     }
   },
   "invite": {

--- a/apps/login/locales/tr.json
+++ b/apps/login/locales/tr.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Oturum oluşturulamadı",
       "userNotFound": "Kullanıcı sistemde bulunamadı",
       "couldNotLinkIDP": "IDP kullanıcıya bağlanamadı",
-      "couldNotRegisterUser": "Kullanıcı kayıt edilemedi"
+      "couldNotRegisterUser": "Kullanıcı kayıt edilemedi",
+      "registerNotAllowed": "Kayıt olmasına izin verilmiyor"
     }
   },
   "invite": {

--- a/apps/login/locales/uk.json
+++ b/apps/login/locales/uk.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "Не вдалося створити сеанс",
       "userNotFound": "Користувача не знайдено в системі",
       "couldNotLinkIDP": "Не вдалося прив'язати IDP до користувача",
-      "couldNotRegisterUser": "Не вдалося зареєструвати користувача"
+      "couldNotRegisterUser": "Не вдалося зареєструвати користувача",
+      "registerNotAllowed": "Реєстрація не дозволена"
     }
   },
   "invite": {

--- a/apps/login/locales/zh.json
+++ b/apps/login/locales/zh.json
@@ -354,7 +354,8 @@
       "couldNotCreateSession": "无法创建会话",
       "userNotFound": "系统中未找到用户",
       "couldNotLinkIDP": "无法将 IDP 关联到用户",
-      "couldNotRegisterUser": "无法注册用户"
+      "couldNotRegisterUser": "无法注册用户",
+      "registerNotAllowed": "不允许注册"
     }
   },
   "invite": {


### PR DESCRIPTION
# Which Problems Are Solved

`apps/login/src/lib/server/register.ts` returns `t("errors.registerNotAllowed")` when the login policy disallows registration, but the key `register.errors.registerNotAllowed` is missing from every file in `apps/login/locales`.

- next-intl throws `MISSING_MESSAGE` instead of returning the error message, so the user sees a raw key or an internal error rather than "Registration is not allowed".
- The thrown error replaces the real cause in the server logs. An operator debugging a failed registration sees only a next-intl stack trace with no indication that the login policy rejected the request:

  ```
  Error: MISSING_MESSAGE: register.errors.registerNotAllowed (en)
      at q (.next/server/chunks/ssr/_03a7vmb._.js:3:5664)
      code: 'MISSING_MESSAGE',
      originalMessage: 'register.errors.registerNotAllowed (en)'
  ```

- This affects every language, including English, and is reachable through both call sites in `register.ts` (`registerUser` and `registerUserAndLinkToIDP`) — the latter being the IdP auto-creation path, where it is easily hit by an external user whose organization has registration disabled.

# How the Problems Are Solved

- Adds `register.errors.registerNotAllowed` to all 15 locale files in `apps/login/locales`.
- Reuses the translations the legacy login already ships for the equivalent message (`RegistrationNotAllowed` in `internal/api/ui/login/static/i18n/*.yaml`) instead of introducing new wording, so the phrasing stays consistent with Login V1 and no machine translation is involved.
- The Italian string is normalised to sentence case without a trailing period, to match its sibling entries in `register.errors`.

# Additional Changes

None. The change is limited to the locale files; no code or behaviour is modified.

All locales remain at key parity with `en.json` (296 keys each) after the change.

# Additional Context

- Closes #12415
- The issue reports the key as absent from v4.13.1 through v4.16.0; it is still absent on `main`.
- While verifying this, ten further keys referenced by server actions were found to be missing from all locales, producing the same `MISSING_MESSAGE` failure: `idp.errors.unknown`, `passkey.verify.errors.couldNotGetUser`, `password.errors.passwordResetNotAllowed`, `password.errors.localAuthenticationNotAllowed`, `register.errors.couldNotGetLoginSettings`, `register.errors.localAuthenticationNotAllowed`, and the session errors used in `lib/server/session.ts`. They are left out of this PR because the legacy login has no equivalent strings to reuse, so they need wording decisions rather than a mechanical port. Happy to open a follow-up issue or PR, ideally together with a test that asserts every key referenced by `t()` exists in the locales, which would prevent this class of bug from recurring.
