### PR TITLE
fix(login): set the document language on the login pages

### DIFF
--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -11,7 +11,7 @@ import { getServiceConfig } from "@/lib/service-url";
 import { getAllowedLanguages } from "@/lib/zitadel";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Lato } from "next/font/google";
 import { headers } from "next/headers";
 import React, { Suspense } from "react";
@@ -30,6 +30,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const _headers = await headers();
   const { serviceConfig } = getServiceConfig(_headers);
 
+  // Same locale next-intl resolved for the messages, so the document language
+  // matches the text that is actually rendered.
+  const locale = await getLocale();
+
   let languages = LANGS;
   try {
     const settings = await getAllowedLanguages({ serviceConfig });
@@ -43,7 +47,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <html className={`${lato.className}`} suppressHydrationWarning>
+    <html lang={locale} className={`${lato.className}`} suppressHydrationWarning>
       <head />
       <body>
         <ThemeProvider>


### PR DESCRIPTION
# Which Problems Are Solved

The Login V2 pages render `<html>` with no `lang` attribute:

```tsx
// apps/login/src/app/(login)/layout.tsx
<html className={`${lato.className}`} suppressHydrationWarning>
```

Without a declared document language, screen readers fall back to the user agent locale and may pronounce the page with the wrong phonetics, browser translation cannot detect the source language reliably, and `:lang()` selectors and hyphenation rules never apply. The pages are fully localized into 15 languages, so the declared language and the rendered text can disagree in every one of them except the reader's default.

# How the Problems Are Solved

`next-intl` already resolves a locale for the messages in `src/i18n/request.ts` — from the instance default language, the `Accept-Language` header and the language cookie. The layout now reads that same locale with `getLocale()` and passes it to `<html lang>`, so the declared language always matches the text that is actually rendered, including when the user switches language.

Verified against a built standalone server:

```
<html lang="en" class="lato_a11ec650-module__twb6aa__className">
```

# Additional Changes

None.

# Additional Context

- Closes #12513
