### PR TITLE
fix(login): hide the language switcher when only one language is allowed

### DIFF
--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -71,7 +71,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                   <div className="relative mx-auto w-full max-w-[1100px] py-8">
                     <div>{children}</div>
                     <div className="mx-auto flex max-w-[440px] flex-row items-center justify-end space-x-4 px-4 py-4 md:max-w-full md:px-8">
-                      <LanguageSwitcher languages={languages} />
+                      {/* With a single allowed language there is nothing to switch to. */}
+                      {languages.length > 1 && <LanguageSwitcher languages={languages} />}
                       <ThemeSwitch />
                     </div>
                   </div>


### PR DESCRIPTION
# Which Problems Are Solved

The Login V2 language switcher is rendered unconditionally:

```tsx
// apps/login/src/app/(login)/layout.tsx
<LanguageSwitcher languages={languages} />
```

When an instance restricts the allowed languages to a single one, the control still appears and opens a menu with exactly one entry — the language already in use. It offers nothing to switch to, and it invites the user to look for a setting that does not exist.

# How the Problems Are Solved

The layout already narrows `LANGS` down to the instance's allowed set just above the render:

```tsx
languages = settings.allowedLanguages
  .filter((code) => LANGS.find((l) => l.code === code))
  .map((code) => getLanguage(code));
```

The switcher is now rendered only when that set holds more than one language. `ThemeSwitch` keeps its place in the same row, so the layout is unaffected in either case.

# Additional Changes

None.

# Additional Context

- Closes #12271
- The `Suspense` fallback in the same layout renders only `ThemeSwitch`, so it needed no change.
- The switcher is hidden rather than disabled: a disabled control still suggests a choice exists, and the row has no other affordance that would look broken without it.
