### PR TITLE
fix(login): forward login hint to external IdP on discovery redirects

### DIFF
--- a/apps/login/src/lib/server/flow-initiation.test.ts
+++ b/apps/login/src/lib/server/flow-initiation.test.ts
@@ -812,6 +812,36 @@ describe("handleOIDCFlowInitiation — idp scope (urn:zitadel:iam:org:idp:id)", 
     expect(res.headers.get("location")).toBe("https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize?client_id=xyz");
   });
 
+  test("should forward the auth request's loginHint to the scoped IdP flow", async () => {
+    const { IdentityProviderType } = await import("@zitadel/proto/zitadel/settings/v2/login_settings_pb");
+
+    mockGetAuthRequest.mockResolvedValue({
+      authRequest: {
+        id: "abc123",
+        uiLocales: [],
+        scope: ["urn:zitadel:iam:org:idp:id:idp-1"],
+        prompt: [],
+        loginHint: "user@example.com",
+      },
+    });
+
+    mockGetActiveIdentityProviders.mockResolvedValue({
+      identityProviders: [{ id: "idp-1", type: IdentityProviderType.AZURE_AD }],
+    });
+
+    mockStartIdentityProviderFlow.mockResolvedValue({
+      url: "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize?client_id=xyz",
+    });
+
+    await handleOIDCFlowInitiation(makeBaseParams({ sessions: [] }));
+
+    expect(mockStartIdentityProviderFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urls: expect.objectContaining({ loginHint: "user@example.com" }),
+      }),
+    );
+  });
+
   test("should block unsafe IdP URLs with a 400 instead of redirecting or rendering a form", async () => {
     const { IdentityProviderType } = await import("@zitadel/proto/zitadel/settings/v2/login_settings_pb");
 

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -318,6 +318,7 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
           urls: {
             successUrl: constructUrl(request, `/idp/${provider}/process?${params.toString()}`).toString(),
             failureUrl: constructUrl(request, `/idp/${provider}/failure?${params.toString()}`).toString(),
+            loginHint: authRequest.loginHint,
           },
         });
 

--- a/apps/login/src/lib/server/loginname.test.ts
+++ b/apps/login/src/lib/server/loginname.test.ts
@@ -453,6 +453,26 @@ describe("sendLoginname", () => {
         expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
       });
 
+      test("should forward the login name as the IDP loginHint when redirecting via a user-linked IDP", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.PASSWORD, AuthenticationMethodType.IDP],
+        });
+        mockListIDPLinks.mockResolvedValue({
+          result: [{ idpId: "idp123" }],
+        });
+        mockStartIdentityProviderFlow.mockResolvedValue({ url: "https://idp.example.com/auth" });
+
+        await sendLoginname({
+          loginName: "user@example.com",
+        });
+
+        expect(mockStartIdentityProviderFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            urls: expect.objectContaining({ loginHint: "user@example.com" }),
+          }),
+        );
+      });
+
       test("should redirect to password when no passkey or IDP, only password available and allowed", async () => {
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
@@ -649,6 +669,30 @@ describe("sendLoginname", () => {
       });
 
       expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
+    });
+
+    test("should forward the login name as the IDP loginHint on single active IDP discovery", async () => {
+      // Regression test: the typed login hint must be forwarded to the
+      // external IdP (via RedirectURLs.loginHint) so it can prefill the
+      // username there, instead of being dropped on discovery-based redirects.
+      mockGetLoginSettings.mockResolvedValue({
+        allowRegister: false,
+        allowLocalAuthentication: false,
+      });
+      mockGetActiveIdentityProviders.mockResolvedValue({
+        identityProviders: [{ id: "idp123", type: "OIDC", options: { isAutoCreation: true } }],
+      });
+      mockStartIdentityProviderFlow.mockResolvedValue({ url: "https://idp.example.com/auth" });
+
+      await sendLoginname({
+        loginName: "user@example.com",
+      });
+
+      expect(mockStartIdentityProviderFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          urls: expect.objectContaining({ loginHint: "user@example.com" }),
+        }),
+      );
     });
 
     test("should not redirect to IDP when single active IDP does not allow creation", async () => {

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -165,6 +165,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
             failureUrl:
               `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +
               new URLSearchParams(params),
+            loginHint: command.loginName,
           },
         });
 
@@ -224,6 +225,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
           failureUrl:
             `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +
             new URLSearchParams(params),
+          loginHint: command.loginName,
         },
       });
 


### PR DESCRIPTION
When domain/user discovery auto-redirects to a single external IdP, or an OIDC auth request scopes a specific IdP, the login hint the user typed (or the client's OIDC login_hint) was dropped instead of being forwarded via RedirectURLs.loginHint, forcing users to retype their username at the external IdP's login page.

<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

# Which Problems Are Solved
When a user typed the email address in the Zitadel login form and the domain was discovered as part of a specific organisation, the already typed ed in email addresses was not included in the "login_hint" parameter for the external IDP. This caused the user to retyping the email in the external IDP e.g. Microsoft Entra ID.

# How the Problems Are Solved

Added the loginHint parameter during OIDC flow initiation. 

# Additional Changes

No specific other changes. 

# Additional Context

Discovered based on own Zitadel usage.
