### PR TITLE
fix(login): redirect with error=login_required for prompt=none

### DIFF
--- a/apps/login/src/lib/server/flow-initiation.test.ts
+++ b/apps/login/src/lib/server/flow-initiation.test.ts
@@ -872,3 +872,147 @@ describe("handleOIDCFlowInitiation — idp scope (urn:zitadel:iam:org:idp:id)", 
     expect(html).toContain('name="SAMLRequest"');
   });
 });
+
+describe("handleOIDCFlowInitiation — Prompt.NONE (OIDC prompt=none)", () => {
+  let mockGetAuthRequest: ReturnType<typeof vi.fn>;
+  let mockConstructUrl: ReturnType<typeof vi.fn>;
+  let mockFindValidSession: ReturnType<typeof vi.fn>;
+  let mockCreateCallback: ReturnType<typeof vi.fn>;
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  const existingSession = {
+    id: "session-1",
+    factors: { user: { id: "user1", organizationId: "org1", loginName: "user@example.com" } },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+
+    const zitadel = await import("@/lib/zitadel");
+    const serviceUrl = await import("@/lib/service-url");
+    const session = await import("@/lib/session");
+    const authUtils = await import("@/lib/auth-utils");
+    const client = await import("@zitadel/client");
+    const { Prompt } = await import("@zitadel/proto/zitadel/oidc/v2/authorization_pb");
+
+    mockGetAuthRequest = vi.mocked(zitadel.getAuthRequest);
+    mockConstructUrl = vi.mocked(serviceUrl.constructUrl);
+    mockFindValidSession = vi.mocked(session.findValidSession);
+    mockCreateCallback = vi.mocked(zitadel.createCallback);
+    mockCreate = vi.mocked(client.create);
+    vi.mocked(authUtils.getValidLocaleFromUILocales).mockReturnValue(null);
+    vi.mocked(zitadel.getSecuritySettings).mockResolvedValue(undefined as any);
+
+    mockConstructUrl.mockImplementation((_req: any, path: string) => {
+      return new URL(`https://example.com${path}`);
+    });
+
+    // Pass the message init through so assertions can inspect the callback request.
+    mockCreate.mockImplementation((_schema: any, value: any) => value);
+
+    mockCreateCallback.mockResolvedValue({
+      callbackUrl: "https://client.example.com/callback?error=login_required",
+    });
+
+    mockGetAuthRequest.mockResolvedValue({
+      authRequest: {
+        id: "abc123",
+        uiLocales: [],
+        scope: [],
+        prompt: [Prompt.NONE],
+        loginHint: undefined,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function expectLoginRequiredCallback(res: any) {
+    const { ErrorReason } = await import("@zitadel/proto/zitadel/oidc/v2/authorization_pb");
+
+    expect(mockCreateCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: expect.objectContaining({
+          authRequestId: "abc123",
+          callbackKind: expect.objectContaining({
+            case: "error",
+            value: expect.objectContaining({ error: ErrorReason.LOGIN_REQUIRED }),
+          }),
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://client.example.com/callback?error=login_required");
+  }
+
+  test("should redirect to the client with error=login_required when there is no session at all", async () => {
+    const res = await handleOIDCFlowInitiation(makeBaseParams({ sessions: [], sessionCookies: [] }));
+
+    await expectLoginRequiredCallback(res);
+    expect(res.headers.get("location")).not.toContain("/loginname");
+  });
+
+  test("should redirect to the client with error=login_required when no session is valid (stale session)", async () => {
+    mockFindValidSession.mockResolvedValue(null);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({
+        sessions: [existingSession] as any,
+        sessionCookies: [{ id: "session-1", token: "tok" }],
+      }),
+    );
+
+    await expectLoginRequiredCallback(res);
+    expect(res.status).not.toBe(400);
+  });
+
+  test("should redirect to the client with error=login_required when the session cookie is missing", async () => {
+    mockFindValidSession.mockResolvedValue(existingSession);
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({
+        sessions: [existingSession] as any,
+        sessionCookies: [{ id: "other-session", token: "tok" }],
+      }),
+    );
+
+    await expectLoginRequiredCallback(res);
+  });
+
+  test("should still complete the flow with the session callback when a valid session exists", async () => {
+    mockFindValidSession.mockResolvedValue(existingSession);
+    mockCreateCallback.mockResolvedValue({
+      callbackUrl: "https://client.example.com/callback?code=abc",
+    });
+
+    const res = await handleOIDCFlowInitiation(
+      makeBaseParams({
+        sessions: [existingSession] as any,
+        sessionCookies: [{ id: "session-1", token: "tok" }],
+      }),
+    );
+
+    expect(mockCreateCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: expect.objectContaining({
+          callbackKind: expect.objectContaining({ case: "session" }),
+        }),
+      }),
+    );
+    expect(res.headers.get("location")).toBe("https://client.example.com/callback?code=abc");
+  });
+
+  test("should fall back to a 400 when the error callback cannot be created", async () => {
+    mockFindValidSession.mockResolvedValue(null);
+    mockCreateCallback.mockRejectedValue(new Error("backend unavailable"));
+
+    const res = await handleOIDCFlowInitiation(makeBaseParams({ sessions: [], sessionCookies: [] }));
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("location")).toBeNull();
+  });
+});

--- a/apps/login/src/lib/server/flow-initiation.ts
+++ b/apps/login/src/lib/server/flow-initiation.ts
@@ -20,7 +20,7 @@ import {
   startIdentityProviderFlow,
 } from "@/lib/zitadel";
 import { create } from "@zitadel/client";
-import { Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
+import { AuthorizationErrorSchema, ErrorReason, Prompt } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
 import { CreateCallbackRequestSchema, SessionSchema } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
 import { CreateResponseRequestSchema } from "@zitadel/proto/zitadel/saml/v2/saml_service_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
@@ -222,6 +222,57 @@ function getEligibleSessions(sessions: Session[], organization?: string): Sessio
   return sessions.filter((s) => s.factors?.user?.organizationId === organization);
 }
 
+/**
+ * OIDC Core 3.1.2.6: with prompt=none the authorization server must not render
+ * interactive UI when it cannot authenticate the end-user. Send the relying
+ * party back to its redirect_uri with error=login_required instead.
+ */
+async function loginRequiredResponse({
+  serviceConfig,
+  requestId,
+}: {
+  serviceConfig: ServiceConfig;
+  requestId: string;
+}): Promise<NextResponse> {
+  try {
+    const { callbackUrl } = await createCallback({
+      serviceConfig,
+      req: create(CreateCallbackRequestSchema, {
+        authRequestId: requestId.replace("oidc_", ""),
+        callbackKind: {
+          case: "error",
+          value: create(AuthorizationErrorSchema, {
+            error: ErrorReason.LOGIN_REQUIRED,
+          }),
+        },
+      }),
+    });
+
+    if (!callbackUrl) {
+      logger.warn("Empty OIDC error callback URL (prompt=none)");
+    } else if (!isSafeRedirectUri(callbackUrl)) {
+      logger.warn("Blocked unsafe OIDC error callback URL (prompt=none)", { callbackUrl });
+    } else {
+      return NextResponse.redirect(callbackUrl);
+    }
+  } catch (error) {
+    logger.error("Error creating login_required callback (prompt=none):", { error });
+  }
+
+  // Fallback only: without a callback URL there is nowhere to send the client.
+  let securitySettings: SecuritySettings | undefined;
+  try {
+    securitySettings = await getSecuritySettings({ serviceConfig });
+  } catch (err) {
+    logger.error("Failed to load security settings for CSP in prompt=none flow", {
+      error: err,
+    });
+  }
+  const noSessionResponse = NextResponse.json({ error: "No active session found" }, { status: 400 });
+  setCSPHeaders(noSessionResponse, serviceConfig, securitySettings);
+  return noSessionResponse;
+}
+
 export interface FlowInitiationParams {
   serviceConfig: ServiceConfig;
   requestId: string;
@@ -400,6 +451,18 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
         orgDomain,
       });
     } else if (authRequest.prompt.includes(Prompt.NONE)) {
+      const selectedSession = await findValidSession({ serviceConfig, sessions, authRequest, organization });
+
+      if (!selectedSession || !selectedSession.id) {
+        return loginRequiredResponse({ serviceConfig, requestId });
+      }
+
+      const cookie = sessionCookies.find((cookie) => cookie.id === selectedSession.id);
+
+      if (!cookie || !cookie.id || !cookie.token) {
+        return loginRequiredResponse({ serviceConfig, requestId });
+      }
+
       let securitySettings: SecuritySettings | undefined;
       try {
         securitySettings = await getSecuritySettings({ serviceConfig });
@@ -407,20 +470,6 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
         logger.error("Failed to load security settings for CSP in prompt=none flow", {
           error: err,
         });
-      }
-      const selectedSession = await findValidSession({ serviceConfig, sessions, authRequest, organization });
-
-      const noSessionResponse = NextResponse.json({ error: "No active session found" }, { status: 400 });
-      setCSPHeaders(noSessionResponse, serviceConfig, securitySettings);
-
-      if (!selectedSession || !selectedSession.id) {
-        return noSessionResponse;
-      }
-
-      const cookie = sessionCookies.find((cookie) => cookie.id === selectedSession.id);
-
-      if (!cookie || !cookie.id || !cookie.token) {
-        return noSessionResponse;
       }
 
       const session = {
@@ -534,6 +583,12 @@ export async function handleOIDCFlowInitiation(params: FlowInitiationParams): Pr
       }
     }
   } else {
+    // prompt=none with no session at all: same rule as the branch above, the
+    // relying party gets the error callback instead of the /loginname screen.
+    if (authRequest?.prompt.includes(Prompt.NONE)) {
+      return loginRequiredResponse({ serviceConfig, requestId });
+    }
+
     // No session: resolve a login_hint straight to the next step if we can.
     const hintResponse = await resolveLoginHint({
       request,


### PR DESCRIPTION
# Which Problems Are Solved

OIDC Core [3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) requires the authorization server to redirect back to the client's redirect_uri with error=login_required when prompt=none is requested and the end-user cannot be authenticated without interaction. Login V2 did neither:

- **Sessions present but none valid for the auth request** (e.g. the user signed out at ZITADEL, leaving stale entries in the multi-session cookie): the handler returned a raw `NextResponse.json({ error: "No active session found" }, { status: 400 })`. Because `prompt=none` is typically a top-level navigation, the browser renders that body directly — an unstyled page with no way back to the relying party.
- **No sessions at all**: the request fell through the `if (authRequest && sessions.length)` guard to the bottom branch and redirected to `/loginname`, showing the interactive login UI that `prompt=none` forbids.

# How the Problems Are Solved

- Adds a `loginRequiredResponse()` helper that calls `createCallback` with the `error` callback kind and `ErrorReason.LOGIN_REQUIRED`, validates the returned URL with `isSafeRedirectUri`, and redirects the user agent to it. This uses the backend path that already exists for exactly this case (`CreateCallbackRequest.callback_kind` → `failAuthRequest` → `oidc.CreateErrorCallbackURL`); no API change is needed.
- The two `noSessionResponse` early returns in the existing `Prompt.NONE` branch now return that helper instead of the JSON 400.
- The no-session fall-through returns the helper when the auth request carries `prompt=none`, instead of redirecting to `/loginname`.
- The JSON 400 remains only as a fallback for when the error callback itself cannot be created — at that point there is no callback URL to send the client to.
- Adds unit tests in `flow-initiation.test.ts` covering the three `prompt=none` scenarios (no sessions in cookie; sessions present but no valid session; valid session but no matching cookie), a regression test for the valid-session path, and the fallback.

The `Prompt.NONE` branch keeps its position in the existing `else if` chain, so behaviour for every other prompt value — including `prompt=none` combined with another prompt value — is unchanged.

# Additional Changes

- Moves the `getSecuritySettings()` call in the `Prompt.NONE` branch to after the session/cookie checks. Its result is only used to set CSP headers on the session-callback response, so fetching it up front meant an extra API call on every request that ends in the error callback.

# Additional Context

- Closes #12165
- OpenID Connect Core 1.0 §3.1.2.6 — Authentication Error Response: https://openid.net/specs/openid-connect-core-1_0.html#AuthError
- Discussion #10469 — silent login in a second app via `prompt=none`
- Discussion #3959 — iframe-based silent check is intentionally unsupported; redirect/popup `prompt=none` is the supported path
- Reporter's analysis and proposed patch: https://gist.github.com/rud/263c30d8e056fc87d6e0b33e144e75ab
- Deliberately out of scope, to keep this change reviewable — each is a separate `prompt=none` gap that would change behaviour for a different flow, and I'd rather not change those without discussion. I'm happy to file follow-up issues if you'd like:
  - `prompt=none` combined with an `urn:zitadel:iam:org:idp:id:` scope still redirects to the external IdP (or `/ldap`), because the IdP-scope branch returns before any prompt handling.
  - `prompt=none` with a valid session still surfaces a JSON error if `createCallback` rejects (e.g. the user has no authorization for the requesting project), since that call is not wrapped like its counterpart in the branch below.
  - `prompt=none` combined with `prompt=create` still redirects to `/register`.

