### PR TITLE
fix(login): correct typo in RegisterUserAndLinkToIDPCommand type

### DIFF
--- a/apps/login/src/lib/server/register.ts
+++ b/apps/login/src/lib/server/register.ts
@@ -189,7 +189,7 @@ export async function registerUser(
   }
 }
 
-type RegisterUserAndLinkToIDPommand = {
+type RegisterUserAndLinkToIDPCommand = {
   email: string;
   firstName: string;
   lastName: string;
@@ -210,7 +210,7 @@ export type registerUserAndLinkToIDPResponse = {
   factors: Factors | undefined;
 };
 export async function registerUserAndLinkToIDP(
-  command: RegisterUserAndLinkToIDPommand,
+  command: RegisterUserAndLinkToIDPCommand,
 ): Promise<{ error: string } | { redirect: string } | { samlData: { url: string; fields: Record<string, string> } }> {
   const t = await getTranslations("register");
 


### PR DESCRIPTION
Closes #12605

`RegisterUserAndLinkToIDPommand` in `apps/login/src/lib/server/register.ts:192,213`
is a typo for `RegisterUserAndLinkToIDPCommand` (missing `C` in `Command`).

This PR renames the type at its definition and its single usage.
`gh search code "Pommand" --repo zitadel/zitadel` shows no other
occurrences, so the change is complete.

No behavior change, type name only.