### PR TITLE
docs: remove outdated Actions v2 feature flag references

### DIFF
--- a/apps/docs/content/concepts/features/actions_v2.mdx
+++ b/apps/docs/content/concepts/features/actions_v2.mdx
@@ -6,16 +6,6 @@ sidebar_label: Actions v2
 
 By using ZITADEL Actions v2, you can modify ZITADEL's behavior on specific API calls, events, or functions. This is useful when you have special business requirements that ZITADEL does not support out-of-the-box.
 
-<Callout>
-We're working on Actions continuously. In the [roadmap](https://zitadel.com/roadmap), you can see how we plan to expand and improve this feature. Please tell us about your needs to help us prioritize further improvements and features.
-</Callout>
-
-<Callout>
-To use Actions v2, activate the "Actions" [feature flag](/reference/api/feature/zitadel.feature.v2.FeatureService.SetInstanceFeatures) in order to manage the related resources.
-
-Actions v2 will always be executed if available, even if the feature flag is switched off. To remove any Actions v2, the related Execution must be removed.
-</Callout>
-
 ## Why Actions?
 ZITADEL can't anticipate or solve every possible business rule and integration requirement for all users. Here are some examples:
 - A business requires domain-specific data validation before a user can be created or authenticated.

--- a/apps/docs/content/guides/integrate/actions/testing-event.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-event.mdx
@@ -12,7 +12,6 @@ This is useful for integrating with other systems or for triggering workflows ba
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-function-manipulation.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-function-manipulation.mdx
@@ -12,7 +12,6 @@ This is useful for integrating with other systems which need specific claims in 
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-function.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-function.mdx
@@ -12,7 +12,6 @@ This is useful for integrating with other systems which need specific claims in 
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-request-manipulation.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-request-manipulation.mdx
@@ -12,7 +12,6 @@ This is useful for adding information to managed resources in ZITADEL.
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-request.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-request.mdx
@@ -12,7 +12,6 @@ This is useful for information provisioning in between systems or for triggering
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-response-manipulation.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-response-manipulation.mdx
@@ -12,7 +12,6 @@ This is useful for triggering workflows based on API responses in ZITADEL. You c
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.

--- a/apps/docs/content/guides/integrate/actions/testing-response.mdx
+++ b/apps/docs/content/guides/integrate/actions/testing-response.mdx
@@ -12,7 +12,6 @@ This is useful for information provisioning in between systems or for triggering
 Before you start, make sure you have everything set up correctly.
 
 - You need to be at least a ZITADEL [_IAM_OWNER_](/guides/manage/console/administrators)
-- Your ZITADEL instance needs to have the actions feature enabled.
 
 <Callout>
 Note that this guide assumes that ZITADEL is running on the same machine as the target and can be reached via `localhost`.


### PR DESCRIPTION
# Which Problems Are Solved

The docs ([Actions v2 concepts page](https://zitadel.com/docs/concepts/features/actions_v2) and the Actions testing guides) state that Actions v2 must be enabled via the "Actions" feature flag. That flag no longer exists — it is `reserved` in `proto/zitadel/feature/v2/instance.proto` and `system.proto` — and Actions v2 is available by default. The callout even linked to a non-existent API field.

# How the Problems Are Solved

- Removed the stale feature-flag callout (and the roadmap teaser callout) from `concepts/features/actions_v2.mdx`.
- Removed the "Your ZITADEL instance needs to have the actions feature enabled." prerequisite bullet from the seven `guides/integrate/actions/testing-*.mdx` guides.

Pure deletions, 17 lines across 8 files.

# Additional Context

The `SetInstanceFeatures` mentions in `hosted-login.mdx` and `webkeys.mdx` refer to flags that still exist and are untouched.