### PR TITLE
fix(authz): log expected token verifier fall-through at debug level

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -120,8 +120,9 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		sysMemberships, userID, sysTokenErr = t.VerifySystemToken(ctx, tokenWOBearer, orgID)
 		if sysTokenErr != nil || sysMemberships == nil {
 			// Both verifications failed, so the token really is invalid.
-			logging.WithFields("org_id", orgID, "org_domain", orgDomain).WithError(errors.Join(err, sysTokenErr)).Warn("authz: token is neither a valid access token nor a valid system token")
-			return CtxData{}, zerrors.ThrowUnauthenticated(errors.Join(err, sysTokenErr), "AUTH-7fs1e", "Errors.Token.Invalid")
+			tokenErr := errors.Join(err, sysTokenErr)
+			logging.WithFields("org_id", orgID, "org_domain", orgDomain).WithError(tokenErr).Warn("authz: token is neither a valid access token nor a valid system token")
+			return CtxData{}, zerrors.ThrowUnauthenticated(tokenErr, "AUTH-7fs1e", "Errors.Token.Invalid")
 		}
 	}
 	projectID, err := projectIDAndCheckOriginForClientID(ctx, clientID, t)

--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -112,10 +112,15 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID, orgDomain st
 		return CtxData{}, err
 	}
 	if err != nil {
-		logging.WithFields("org_id", orgID, "org_domain", orgDomain).WithError(err).Warn("authz: verify access token")
+		// Not a regular access token. It may still be a system token, so this is an
+		// expected fall-through rather than a failure: warning here would emit a log
+		// line on every successful system API call.
+		logging.WithFields("org_id", orgID, "org_domain", orgDomain).WithError(err).Debug("authz: verify access token")
 		var sysTokenErr error
 		sysMemberships, userID, sysTokenErr = t.VerifySystemToken(ctx, tokenWOBearer, orgID)
 		if sysTokenErr != nil || sysMemberships == nil {
+			// Both verifications failed, so the token really is invalid.
+			logging.WithFields("org_id", orgID, "org_domain", orgDomain).WithError(errors.Join(err, sysTokenErr)).Warn("authz: token is neither a valid access token nor a valid system token")
 			return CtxData{}, zerrors.ThrowUnauthenticated(errors.Join(err, sysTokenErr), "AUTH-7fs1e", "Errors.Token.Invalid")
 		}
 	}

--- a/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
+++ b/internal/authz/repository/eventsourcing/eventstore/token_verifier.go
@@ -307,11 +307,16 @@ func (repo *TokenVerifierRepo) getTokenIDAndSubject(ctx context.Context, accessT
 	// let's try opaque first:
 	tokenIDSubject, err := repo.AuthAlgorithm.DecryptToken(accessToken)
 	if err != nil {
-		logging.WithError(err).Warn("token verifier repo: decrypt access token")
+		// Failing to decrypt only rules out the opaque format, it does not mean the
+		// token is invalid, so this is logged at debug level: every JWT access token
+		// takes this path and would otherwise produce a warning on success.
+		logging.WithError(err).Debug("token verifier repo: decrypt access token")
 		// if decryption did not work, it might be a JWT
 		accessTokenClaims, err := op.VerifyAccessToken[*oidc.AccessTokenClaims](ctx, accessToken, repo.jwtTokenVerifier(ctx))
 		if err != nil {
-			logging.WithError(err).Warn("token verifier repo: verify JWT access token")
+			// The caller falls back to system token verification, so this is not yet
+			// a terminal failure either. The final verdict is logged by the caller.
+			logging.WithError(err).Debug("token verifier repo: verify JWT access token")
 			return "", "", false
 		}
 		return accessTokenClaims.JWTID, accessTokenClaims.Subject, true


### PR DESCRIPTION
## Which problems does this PR solve?

Closes #12186.

`VerifyTokenAndCreateCtxData` walks two independent verifiers: the regular access
token path first and, only when that fails, the system token path. Every step of the
first path logged at `warn`, so a **successful** system token authentication emitted
two or three warnings:

```
level=warning msg="token verifier repo: decrypt access token" error="ID=CRYPT-ha6Oh Message=malformed encrypted value Parent=(go-jose/go-jose: compact JWE format must have five parts)"
level=warning msg="token verifier repo: verify JWT access token" error="issuer does not match: Expected: https://<domain>, got: login-client"
level=warning msg="authz: verify access token" error="ID=APP-Reb32 Message=invalid token"
```

The login v2 client authenticates this way on every call, so a healthy instance
produces a continuous stream of warnings. Measured on one production instance
(v4.15.3, 3 API replicas, 2 login replicas): ~46k occurrences per day, ~138k log
lines, every one of them on a request that succeeded.

A second trigger is reported on the issue: any machine user with
`accessTokenType = JWT` emits the first line on every successful call, because
`DecryptToken` only rules out the opaque format.

## How do we solve it?

- `getTokenIDAndSubject`: both log calls become `debug`. Failing to decrypt only rules
  out the opaque format, and failing JWT verification is not terminal either, because
  the caller still tries the system token verifier.
- `VerifyTokenAndCreateCtxData`: the pre-fallback log becomes `debug`, and a single
  `warn` is emitted in the branch where both verifiers have rejected the token,
  carrying the joined error.

Net effect: nothing is logged on the success path, and a genuinely invalid token still
produces exactly one warning — with more information than before, since both errors
now appear in one line instead of being split across the two paths.

## Additional Context

- Behaviour is unchanged; only log severity and placement move.
- No new tests: the change carries no branching logic of its own, and the surrounding
  behaviour is already covered.
