### PR TITLE
fix(login): look users up ignoring case and surrounding whitespace

### DIFF
--- a/apps/login/src/lib/login-name.test.ts
+++ b/apps/login/src/lib/login-name.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { loginNameEquals, normalizeLoginName } from "./login-name";
+
+describe("normalizeLoginName", () => {
+  it.each([
+    ["user@example.com  ", "user@example.com"],
+    ["  user@example.com", "user@example.com"],
+    ["\tuser@example.com\n", "user@example.com"],
+    ["user@example.com", "user@example.com"],
+  ])("should strip surrounding whitespace from %j", (input, expected) => {
+    expect(normalizeLoginName(input)).toBe(expected);
+  });
+
+  it("should keep the casing so it can be echoed back to the user", () => {
+    expect(normalizeLoginName("  User@Example.com ")).toBe("User@Example.com");
+  });
+
+  it("should not touch inner characters, a username is not necessarily an email", () => {
+    expect(normalizeLoginName(" my user ")).toBe("my user");
+  });
+});
+
+describe("loginNameEquals", () => {
+  it.each([
+    ["user@example.com", "USER@EXAMPLE.COM"],
+    ["User@Example.com", "user@example.com"],
+    ["BREcloud@example.com", "brecloud@example.com"],
+    ["user@example.com", "user@example.com  "],
+    ["  user@example.com", "USER@example.com"],
+  ])("should treat %j and %j as the same login name", (a, b) => {
+    expect(loginNameEquals(a, b)).toBe(true);
+  });
+
+  it.each([
+    ["user@example.com", "other@example.com"],
+    ["user@example.com", "user@example.org"],
+    ["user@example.com", "us er@example.com"],
+  ])("should not match %j with %j", (a, b) => {
+    expect(loginNameEquals(a, b)).toBe(false);
+  });
+
+  // The callers use this to check whether the input identified the user by email or
+  // phone. An unset value must never count as a match, otherwise the enumeration
+  // guards would accept a user the input did not actually name.
+  it.each([
+    [undefined, "user@example.com"],
+    ["user@example.com", undefined],
+    [undefined, undefined],
+    ["", ""],
+    ["", "user@example.com"],
+  ])("should not match when a value is missing (%j, %j)", (a, b) => {
+    expect(loginNameEquals(a, b)).toBe(false);
+  });
+});

--- a/apps/login/src/lib/login-name.ts
+++ b/apps/login/src/lib/login-name.ts
@@ -1,0 +1,37 @@
+/**
+ * Helpers for comparing user supplied login names with stored values.
+ *
+ * ZITADEL treats usernames as case insensitive when it writes them: the
+ * eventstore lowercases the username unique constraint, so a single
+ * organization can never hold both "user@example.com" and "User@example.com".
+ * Lookups therefore have to be case insensitive too, otherwise an account that
+ * demonstrably exists is reported as not found — for example when an upstream
+ * IdP returns a different casing than what was stored, or when a mobile
+ * keyboard capitalizes the first letter of the address.
+ */
+
+/**
+ * Normalizes raw login name input.
+ *
+ * Only surrounding whitespace is removed: the casing is kept so it can still be
+ * echoed back to the user, and inner characters are left untouched because a
+ * username is not required to be an email address.
+ */
+export function normalizeLoginName(loginName: string): string {
+  return loginName.trim();
+}
+
+/**
+ * Compares a user supplied login name with a stored one, ignoring case and
+ * surrounding whitespace.
+ *
+ * An absent or empty value never matches. The callers use this to check whether
+ * the input identified the user by their login name, email or phone, and an
+ * unset email must not be treated as a match for an empty input.
+ */
+export function loginNameEquals(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}

--- a/apps/login/src/lib/server/idp-intent.test.ts
+++ b/apps/login/src/lib/server/idp-intent.test.ts
@@ -681,6 +681,117 @@ describe("processIDPCallback", () => {
 
       expect(result.redirect).toContain("/idp/google/linking-failed");
     });
+
+    // Email addresses are not unique in ZITADEL, so the lookup can match several
+    // users. Linking to an arbitrary one of them would attach the external identity
+    // to the wrong account.
+    test("should not link when more than one user matches", async () => {
+      mockListUsers.mockResolvedValue({
+        result: [
+          { userId: "found123", details: { resourceOwner: "org123" } },
+          { userId: "found456", details: { resourceOwner: "org123" } },
+        ],
+      });
+
+      const result = await processIDPCallback(defaultParams);
+
+      expect(mockAddIDPLink).not.toHaveBeenCalled();
+      expect(mockCreateNewSessionFromIdpIntent).not.toHaveBeenCalled();
+      expect(result.redirect).toContain("/idp/google/linking-failed");
+      expect(result.redirect).toContain("error=ambiguous_match");
+    });
+
+    // With several case-insensitive matches, the candidate whose casing matches what
+    // the provider sent is the strongest signal available, so prefer it rather than
+    // failing closed. This keeps instances working that still hold usernames differing
+    // only by case.
+    test("should link the exact case match when several users match", async () => {
+      mockListUsers.mockResolvedValue({
+        result: [
+          {
+            userId: "other456",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "TEST@example.com" } } },
+          },
+          {
+            userId: "exact123",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "test@example.com" } } },
+          },
+        ],
+      });
+
+      const result = await processIDPCallback(defaultParams);
+
+      expect(mockAddIDPLink).toHaveBeenCalledWith(expect.objectContaining({ userId: "exact123" }));
+      expect(result.redirect).toBe("https://app.example.com/success");
+    });
+
+    test("should refuse when several users match and none matches the casing exactly", async () => {
+      mockListUsers.mockResolvedValue({
+        result: [
+          {
+            userId: "a",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "TEST@example.com" } } },
+          },
+          {
+            userId: "b",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "Test@Example.com" } } },
+          },
+        ],
+      });
+
+      const result = await processIDPCallback(defaultParams);
+
+      expect(mockAddIDPLink).not.toHaveBeenCalled();
+      expect(result.redirect).toContain("error=ambiguous_match");
+    });
+
+    test("should refuse when several users match the casing exactly", async () => {
+      mockListUsers.mockResolvedValue({
+        result: [
+          {
+            userId: "a",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "test@example.com" } } },
+          },
+          {
+            userId: "b",
+            details: { resourceOwner: "org123" },
+            type: { case: "human", value: { email: { email: "test@example.com" } } },
+          },
+        ],
+      });
+
+      const result = await processIDPCallback(defaultParams);
+
+      expect(mockAddIDPLink).not.toHaveBeenCalled();
+      expect(result.redirect).toContain("error=ambiguous_match");
+    });
+
+    // An ambiguous match must not silently fall through to creating yet another user.
+    test("should not create a user when more than one user matches", async () => {
+      mockGetIDPByID.mockResolvedValue({
+        ...defaultIdp,
+        config: {
+          options: {
+            ...defaultIdp.config.options,
+            autoLinking: AutoLinkingOption.EMAIL,
+            isLinkingAllowed: true,
+            isAutoCreation: true,
+          },
+        },
+      });
+      mockListUsers.mockResolvedValue({
+        result: [{ userId: "found123" }, { userId: "found456" }],
+      });
+
+      const result = await processIDPCallback(defaultParams);
+
+      expect(result.redirect).toContain("error=ambiguous_match");
+    });
   });
 
   describe("CASE 3: Auto-linking by username", () => {

--- a/apps/login/src/lib/server/idp-intent.ts
+++ b/apps/login/src/lib/server/idp-intent.ts
@@ -496,6 +496,26 @@ async function handleUserExists(ctx: IDPHandlerContext): Promise<IDPHandlerResul
 }
 
 /**
+ * Reads the identifier that an auto-linking lookup matched on, so candidates can be
+ * compared against the value the provider sent with their original casing.
+ *
+ * Returns undefined when the user does not carry that identifier, which never equals
+ * the searched value and therefore never counts as an exact match.
+ */
+function identifierOf(
+  user: NonNullable<Awaited<ReturnType<typeof listUsers>>["result"]>[number],
+  matchedBy: "email" | "username" | undefined,
+): string | undefined {
+  if (matchedBy === "username") {
+    return user.username;
+  }
+  if (matchedBy === "email") {
+    return user.type?.case === "human" ? user.type.value.email?.email : undefined;
+  }
+  return undefined;
+}
+
+/**
  * CASE 3: Auto-linking (search for user and link)
  */
 async function handleAutoLinking(ctx: IDPHandlerContext): Promise<IDPHandlerResult> {
@@ -505,24 +525,58 @@ async function handleAutoLinking(ctx: IDPHandlerContext): Promise<IDPHandlerResu
   const { organization, provider } = ctx.params;
 
   if (options?.autoLinking) {
-    let foundUser;
+    let foundUsers: Awaited<ReturnType<typeof listUsers>>["result"] = [];
+    let matchedBy: "email" | "username" | undefined;
+    let searchedValue: string | undefined;
     const email = createUserData?.email?.email;
     const emailVerified =
       createUserData?.email?.verification?.case === "isVerified" && createUserData?.email?.verification?.value;
 
     if (options.autoLinking === AutoLinkingOption.EMAIL && email && emailVerified) {
-      foundUser = await listUsers({ serviceConfig, email, organizationId: organization }).then((response) => {
-        return response.result ? response.result[0] : null;
+      matchedBy = "email";
+      searchedValue = email;
+      foundUsers = await listUsers({ serviceConfig, email, organizationId: organization }).then((response) => {
+        return response.result ?? [];
       });
     } else if (options.autoLinking === AutoLinkingOption.USERNAME) {
-      foundUser = await listUsers({
+      matchedBy = "username";
+      searchedValue = idpInformation!.userName;
+      foundUsers = await listUsers({
         serviceConfig,
         userName: idpInformation!.userName,
         organizationId: organization,
       }).then((response) => {
-        return response.result ? response.result[0] : null;
+        return response.result ?? [];
       });
     }
+
+    // Only an unambiguous match may be linked. The lookup ignores case, and ZITADEL
+    // does not enforce email uniqueness, so it can legitimately return several users;
+    // instances upgraded from before the unique constraints were lowercased can also
+    // still hold usernames that differ only by case.
+    //
+    // Prefer the candidate that matches what the provider sent exactly: it is the
+    // strongest signal available, and it keeps such instances working instead of
+    // failing them closed. Only when that does not single one out is the result truly
+    // ambiguous, and then the identity must neither be linked to an arbitrary account
+    // nor fall through to user creation.
+    if (foundUsers.length > 1) {
+      const exactMatches = foundUsers.filter((user) => identifierOf(user, matchedBy) === searchedValue);
+
+      if (exactMatches.length === 1) {
+        logger.info("Auto-linking resolved several matches by exact casing", { count: foundUsers.length });
+        foundUsers = exactMatches;
+      } else {
+        logger.error("Auto-linking matched more than one user", {
+          count: foundUsers.length,
+          exactMatches: exactMatches.length,
+        });
+        const params = buildRedirectParams();
+        return { redirect: `/idp/${provider}/linking-failed?${params}&error=ambiguous_match` };
+      }
+    }
+
+    const foundUser = foundUsers[0];
 
     if (foundUser) {
       try {

--- a/apps/login/src/lib/server/loginname.test.ts
+++ b/apps/login/src/lib/server/loginname.test.ts
@@ -1048,6 +1048,88 @@ describe("sendLoginname", () => {
       expect(mockCreateSessionAndUpdateCookie).not.toHaveBeenCalled();
     });
 
+    // Regression tests for: https://github.com/zitadel/zitadel/issues/12572
+    // A username cannot exist twice with different casing, so a casing difference must
+    // never make the user unfindable.
+    test("should allow login when the login name casing differs from the stored one", async () => {
+      const mockUser = {
+        userId: "user123",
+        preferredLoginName: "BREcloud@foodman.no",
+        details: { resourceOwner: "org123" },
+        type: {
+          case: "human",
+          value: { email: { email: "BREcloud@foodman.no" } },
+        },
+        state: UserState.ACTIVE,
+      };
+
+      mockSearchUsers.mockResolvedValue({ result: [mockUser] });
+      mockGetLoginSettings.mockResolvedValue({
+        disableLoginWithPhone: true,
+        allowLocalAuthentication: true,
+      });
+      mockCreateSessionAndUpdateCookie.mockResolvedValue({
+        session: { factors: { user: { id: "user123", loginName: "BREcloud@foodman.no", organizationId: "org123" } } },
+        sessionCookie: {},
+      });
+      mockListAuthenticationMethodTypes.mockResolvedValue({
+        authMethodTypes: [AuthenticationMethodType.PASSWORD],
+      });
+
+      const result = await sendLoginname({
+        loginName: "brecloud@foodman.no", // same user, typed in lower case
+      });
+
+      expect(result).not.toEqual({ error: "errors.userNotFound" });
+      expect(mockCreateSessionAndUpdateCookie).toHaveBeenCalled();
+    });
+
+    test("should allow login when the email casing differs from the stored one", async () => {
+      const mockUser = {
+        userId: "user123",
+        preferredLoginName: "user@orgdomain.com",
+        details: { resourceOwner: "org123" },
+        type: {
+          case: "human",
+          value: { email: { email: "User@Test.com" } },
+        },
+        state: UserState.ACTIVE,
+      };
+
+      mockSearchUsers.mockResolvedValue({ result: [mockUser] });
+      mockGetLoginSettings.mockResolvedValue({
+        disableLoginWithPhone: true,
+        allowLocalAuthentication: true,
+      });
+      mockCreateSessionAndUpdateCookie.mockResolvedValue({
+        session: { factors: { user: { id: "user123", loginName: "user@orgdomain.com", organizationId: "org123" } } },
+        sessionCookie: {},
+      });
+      mockListAuthenticationMethodTypes.mockResolvedValue({
+        authMethodTypes: [AuthenticationMethodType.PASSWORD],
+      });
+
+      const result = await sendLoginname({ loginName: "user@test.com" });
+
+      expect(result).not.toEqual({ error: "errors.userNotFound" });
+      expect(mockCreateSessionAndUpdateCookie).toHaveBeenCalled();
+    });
+
+    test("should trim the login name before searching and echoing it back", async () => {
+      mockGetLoginSettings.mockResolvedValue({
+        ignoreUnknownUsernames: true,
+        allowLocalAuthentication: true,
+      });
+      mockSearchUsers.mockResolvedValue({ result: [] });
+
+      const result = await sendLoginname({ loginName: "  user@example.com  " });
+
+      expect(mockSearchUsers).toHaveBeenCalledWith(expect.objectContaining({ searchValue: "user@example.com" }));
+      // the raw input is echoed into the redirect while enumeration protection applies,
+      // so it has to be normalized there too
+      expect((result as any).redirect).toContain("loginName=user%40example.com");
+    });
+
     test("should redirect to password when ignoreUnknownUsernames is true and more than one user found", async () => {
       mockGetLoginSettings.mockResolvedValue({
         ignoreUnknownUsernames: true,

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -12,6 +12,7 @@ import { idpTypeToIdentityProviderType, idpTypeToSlug } from "../idp";
 import { PasskeysType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 import { IDPLink } from "@zitadel/proto/zitadel/user/v2/idp_pb";
 import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
+import { loginNameEquals, normalizeLoginName } from "../login-name";
 import { getServiceConfig } from "../service-url";
 import {
   getActiveIdentityProviders,
@@ -45,6 +46,12 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   const { serviceConfig } = getServiceConfig(_headers);
 
   const t = await getTranslations("loginname");
+
+  // Normalize once, so the lookup, the comparisons below and the login name echoed
+  // into redirect URLs all operate on the same value. Browsers and mobile keyboards
+  // readily submit a trailing space, which would otherwise make an existing user
+  // unfindable.
+  command = { ...command, loginName: normalizeLoginName(command.loginName) };
 
   const loginSettingsByContext = await getLoginSettings({ serviceConfig, organization: command.organization });
 
@@ -258,15 +265,18 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
     // recheck login settings after user discovery, as the search might have been done without org scope
     if (userLoginSettings?.disableLoginWithEmail && userLoginSettings?.disableLoginWithPhone) {
-      if (user.preferredLoginName !== concatLoginname) {
+      if (!loginNameEquals(user.preferredLoginName, concatLoginname)) {
         return preventUserEnumeration(command.organization);
       }
     } else if (userLoginSettings?.disableLoginWithEmail) {
-      if (user.preferredLoginName !== concatLoginname && humanUser?.phone?.phone !== command.loginName) {
+      if (!loginNameEquals(user.preferredLoginName, concatLoginname) && humanUser?.phone?.phone !== command.loginName) {
         return preventUserEnumeration(command.organization);
       }
     } else if (userLoginSettings?.disableLoginWithPhone) {
-      if (user.preferredLoginName !== concatLoginname && humanUser?.email?.email !== command.loginName) {
+      if (
+        !loginNameEquals(user.preferredLoginName, concatLoginname) &&
+        !loginNameEquals(humanUser?.email?.email, command.loginName)
+      ) {
         return preventUserEnumeration(command.organization);
       }
     }

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -25,6 +25,7 @@ import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 import { completeFlowOrGetUrl } from "../client";
 import { getSessionCookieById, getSessionCookieByLoginName } from "../cookies";
+import { loginNameEquals } from "../login-name";
 import { getServiceConfig } from "../service-url";
 import {
   checkEmailVerification,
@@ -91,7 +92,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
   const userLoginSettings = await getLoginSettings({ serviceConfig, organization: user.details?.resourceOwner });
 
   if (userLoginSettings?.disableLoginWithEmail && userLoginSettings?.disableLoginWithPhone) {
-    if (user.preferredLoginName !== command.loginName) {
+    if (!loginNameEquals(user.preferredLoginName, command.loginName)) {
       if (userLoginSettings?.ignoreUnknownUsernames) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return {};
@@ -99,7 +100,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
       return { error: t("errors.couldNotSendResetLink") };
     }
   } else if (userLoginSettings?.disableLoginWithEmail) {
-    if (user.preferredLoginName !== command.loginName && humanUser?.phone?.phone !== command.loginName) {
+    if (!loginNameEquals(user.preferredLoginName, command.loginName) && humanUser?.phone?.phone !== command.loginName) {
       if (userLoginSettings?.ignoreUnknownUsernames) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return {};
@@ -107,7 +108,10 @@ export async function resetPassword(command: ResetPasswordCommand) {
       return { error: t("errors.couldNotSendResetLink") };
     }
   } else if (userLoginSettings?.disableLoginWithPhone) {
-    if (user.preferredLoginName !== command.loginName && humanUser?.email?.email !== command.loginName) {
+    if (
+      !loginNameEquals(user.preferredLoginName, command.loginName) &&
+      !loginNameEquals(humanUser?.email?.email, command.loginName)
+    ) {
       if (userLoginSettings?.ignoreUnknownUsernames) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return {};
@@ -239,7 +243,7 @@ export async function sendPassword(
 
       // recheck login settings after user discovery, as the search might have been done without org scope
       if (userLoginSettings?.disableLoginWithEmail && userLoginSettings?.disableLoginWithPhone) {
-        if (user.preferredLoginName !== command.loginName) {
+        if (!loginNameEquals(user.preferredLoginName, command.loginName)) {
           // emulate user not found to prevent enumeration (use context settings not user settings)
           recordAuthFailure("password", "login_name_mismatch", command.organization);
           if (loginSettingsByContext?.ignoreUnknownUsernames) {
@@ -248,7 +252,7 @@ export async function sendPassword(
           return { error: t("errors.couldNotVerifyPassword") };
         }
       } else if (userLoginSettings?.disableLoginWithEmail) {
-        if (user.preferredLoginName !== command.loginName && humanUser?.phone?.phone !== command.loginName) {
+        if (!loginNameEquals(user.preferredLoginName, command.loginName) && humanUser?.phone?.phone !== command.loginName) {
           recordAuthFailure("password", "login_name_mismatch", command.organization);
           if (loginSettingsByContext?.ignoreUnknownUsernames) {
             return { error: t("errors.failedToAuthenticateNoLimit") };
@@ -256,7 +260,10 @@ export async function sendPassword(
           return { error: t("errors.couldNotVerifyPassword") };
         }
       } else if (userLoginSettings?.disableLoginWithPhone) {
-        if (user.preferredLoginName !== command.loginName && humanUser?.email?.email !== command.loginName) {
+        if (
+          !loginNameEquals(user.preferredLoginName, command.loginName) &&
+          !loginNameEquals(humanUser?.email?.email, command.loginName)
+        ) {
           recordAuthFailure("password", "login_name_mismatch", command.organization);
           if (loginSettingsByContext?.ignoreUnknownUsernames) {
             return { error: t("errors.failedToAuthenticateNoLimit") };

--- a/apps/login/src/lib/zitadel.test.ts
+++ b/apps/login/src/lib/zitadel.test.ts
@@ -1,0 +1,142 @@
+import { TextQueryMethod } from "@zitadel/proto/zitadel/object/v2/object_pb";
+import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createServiceForHost } from "./service";
+import { getOrgsByDomain, listUsers, searchUsers } from "./zitadel";
+
+vi.mock("./service", () => ({
+  createServiceForHost: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(() => (key: string) => key),
+}));
+
+const serviceConfig = {} as never;
+const emptyResponse = { details: { totalResult: BigInt(0) }, result: [] };
+
+type Request = { queries: any[] };
+
+/** Captures the requests that the login app sends to the API. */
+function mockService() {
+  const listUsersMock = vi.fn(async (_request: Request) => emptyResponse);
+  const listOrganizationsMock = vi.fn(async (_request: Request) => emptyResponse);
+  vi.mocked(createServiceForHost).mockResolvedValue({
+    listUsers: listUsersMock,
+    listOrganizations: listOrganizationsMock,
+  } as never);
+  return { listUsersMock, listOrganizationsMock };
+}
+
+/** Finds a query by its oneof case in a (possibly nested) query list. */
+function findQuery(queries: any[], queryCase: string): any {
+  for (const entry of queries) {
+    if (entry.query?.case === queryCase) {
+      return entry.query.value;
+    }
+    if (entry.query?.case === "orQuery" || entry.query?.case === "andQuery") {
+      const nested = findQuery(entry.query.value.queries, queryCase);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// A user cannot be stored twice with different casing: the username unique
+// constraint is lowercased when it is written. Looking users up case sensitively
+// therefore reports accounts as missing that provably exist — which is what breaks
+// IdP auto-linking when the provider returns a different casing than was stored.
+describe("listUsers", () => {
+  it("should look up a login name ignoring case", async () => {
+    const { listUsersMock } = mockService();
+
+    await listUsers({ serviceConfig, loginName: "user@example.com" });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "loginNameQuery");
+    expect(query.loginName).toBe("user@example.com");
+    expect(query.method).toBe(TextQueryMethod.EQUALS_IGNORE_CASE);
+  });
+
+  it("should look up an email ignoring case", async () => {
+    const { listUsersMock } = mockService();
+
+    await listUsers({ serviceConfig, email: "BREcloud@example.com" });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "emailQuery");
+    expect(query.emailAddress).toBe("BREcloud@example.com");
+    expect(query.method).toBe(TextQueryMethod.EQUALS_IGNORE_CASE);
+  });
+
+  it("should look up a username ignoring case", async () => {
+    const { listUsersMock } = mockService();
+
+    await listUsers({ serviceConfig, userName: "BREcloud" });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "userNameQuery");
+    expect(query.method).toBe(TextQueryMethod.EQUALS_IGNORE_CASE);
+  });
+
+  // Phone numbers have no casing, so there is nothing to fold.
+  it("should match a phone number exactly", async () => {
+    const { listUsersMock } = mockService();
+
+    await listUsers({ serviceConfig, phone: "+41791234567" });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "phoneQuery");
+    expect(query.method).toBe(TextQueryMethod.EQUALS);
+  });
+});
+
+describe("searchUsers", () => {
+  const loginSettings = {} as LoginSettings;
+
+  it("should trim the search value before looking the user up", async () => {
+    const { listUsersMock } = mockService();
+
+    await searchUsers({ serviceConfig, searchValue: "  user@example.com \n", loginSettings });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "loginNameQuery");
+    expect(query.loginName).toBe("user@example.com");
+  });
+
+  it("should trim before concatenating the organization suffix", async () => {
+    const { listUsersMock } = mockService();
+
+    await searchUsers({ serviceConfig, searchValue: " user ", loginSettings, suffix: "example.com" });
+
+    const query = findQuery(listUsersMock.mock.calls[0][0].queries, "loginNameQuery");
+    expect(query.loginName).toBe("user@example.com");
+  });
+
+  it("should keep looking up login name and email ignoring case", async () => {
+    const { listUsersMock } = mockService();
+
+    await searchUsers({ serviceConfig, searchValue: "User@Example.com", loginSettings });
+
+    expect(findQuery(listUsersMock.mock.calls[0][0].queries, "loginNameQuery").method).toBe(
+      TextQueryMethod.EQUALS_IGNORE_CASE,
+    );
+    // no user was found by login name, so the email/phone fallback ran
+    expect(findQuery(listUsersMock.mock.calls[1][0].queries, "emailQuery").method).toBe(TextQueryMethod.EQUALS_IGNORE_CASE);
+  });
+});
+
+// Domains are case insensitive, and this one is the suffix of a user supplied login
+// name, so it arrives in whatever casing was typed.
+describe("getOrgsByDomain", () => {
+  it("should look the domain up ignoring case", async () => {
+    const { listOrganizationsMock } = mockService();
+
+    await getOrgsByDomain({ serviceConfig, domain: "Example.com" });
+
+    const query = findQuery(listOrganizationsMock.mock.calls[0][0].queries, "domainQuery");
+    expect(query.domain).toBe("Example.com");
+    expect(query.method).toBe(TextQueryMethod.EQUALS_IGNORE_CASE);
+  });
+});

--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -40,6 +40,7 @@ import { errorClassificationInterceptor, isClassifiedError } from "@/lib/grpc/in
 import { otelGrpcInterceptor } from "@/lib/grpc/interceptors/otel";
 import { Code, Interceptor } from "@connectrpc/connect";
 import { PromiseCache } from "./cache";
+import { normalizeLoginName } from "./login-name";
 import { createServiceForHost } from "./service";
 
 const useCache = process.env.API_CACHE_ENABLED !== "false";
@@ -630,7 +631,12 @@ const userLookupQuery = { limit: 2 };
 export async function listUsers({ serviceConfig, loginName, userName, phone, email, organizationId }: ListUsersCommand) {
   const queries: SearchQuery[] = [];
 
-  // either use loginName or userName, email, phone
+  // Either use loginName or userName, email, phone.
+  //
+  // Login names, usernames and email addresses are matched ignoring case: they are
+  // written case insensitively (the username unique constraint is lowercased), so a
+  // case sensitive lookup would miss users that do exist. Phone numbers have no
+  // casing to fold.
   if (loginName) {
     queries.push(
       create(SearchQuerySchema, {
@@ -638,7 +644,7 @@ export async function listUsers({ serviceConfig, loginName, userName, phone, ema
           case: "loginNameQuery",
           value: {
             loginName,
-            method: TextQueryMethod.EQUALS,
+            method: TextQueryMethod.EQUALS_IGNORE_CASE,
           },
         },
       }),
@@ -652,7 +658,7 @@ export async function listUsers({ serviceConfig, loginName, userName, phone, ema
           case: "userNameQuery",
           value: {
             userName,
-            method: TextQueryMethod.EQUALS,
+            method: TextQueryMethod.EQUALS_IGNORE_CASE,
           },
         },
       });
@@ -665,7 +671,7 @@ export async function listUsers({ serviceConfig, loginName, userName, phone, ema
           case: "emailQuery",
           value: {
             emailAddress: email,
-            method: TextQueryMethod.EQUALS,
+            method: TextQueryMethod.EQUALS_IGNORE_CASE,
           },
         },
       });
@@ -769,6 +775,10 @@ export async function searchUsers({
   const queries: SearchQuery[] = [];
 
   const t = await getTranslations("zitadel");
+
+  // Surrounding whitespace is never part of a login name, an email address or a
+  // phone number, but it is easily submitted by a browser or a mobile keyboard.
+  searchValue = normalizeLoginName(searchValue);
 
   // if a suffix is provided, we search for the userName concatenated with the suffix
   if (suffix) {
@@ -916,7 +926,9 @@ export async function getOrgsByDomain({ serviceConfig, domain }: WithServiceConf
         {
           query: {
             case: "domainQuery",
-            value: { domain, method: TextQueryMethod.EQUALS },
+            // Domains are case insensitive, and this one is taken from the suffix of a
+            // user supplied login name, so it may arrive in any casing.
+            value: { domain, method: TextQueryMethod.EQUALS_IGNORE_CASE },
           },
         },
       ],


### PR DESCRIPTION
# Which Problems Are Solved

ZITADEL writes usernames **case insensitively**: `internal/eventstore/v3/unique_constraints.go` lowercases the unique field before storing it, so one organization can never hold both `user@example.com` and `User@example.com`. Several lookups in the login app compared **case sensitively**, so accounts that provably exist were reported as missing.

Measured against a running instance — user created as `BREcloud@casetest.local`, looked up with the lower case spelling:

| Query | `EQUALS` | `EQUALS_IGNORE_CASE` |
| --- | --- | --- |
| `loginNameQuery` | 0 hits | 1 hit |
| `emailQuery` | 0 hits | 1 hit |
| `userNameQuery` | 0 hits | 1 hit |

Creating the lower case twin in the same organization is rejected with `User already exists (V3-DKcYh)`, confirming the two spellings are one user as far as writes are concerned.

**IdP account matching.** `listUsers()` in `apps/login/src/lib/zitadel.ts` requested `TEXT_QUERY_METHOD_EQUALS`. `handleAutoLinking` uses it to find the account to link the external identity to, so when the provider returns a different casing the existing user is never found and the flow falls through to auto-creation — refused by the unique constraint with `Errors.User.AlreadyExists` — or to `account-not-found`. Entra ID does this readily, and its `email`, `preferred_username` and `upn` claims do not agree with each other.

**A found user could still be rejected as unknown.** The guards that re-check the discovered user against the raw input compared with `!==`, so when `disableLoginWithEmail` or `disableLoginWithPhone` is set, a user the search had just found was turned into `userNotFound` / `couldNotVerifyPassword` purely because of casing. On the password-reset path this is silent: the flow sleeps and returns success while no code is sent.

**Organization domain discovery.** `getOrgsByDomain()` matched with `EQUALS`, but the domain is the suffix of a user supplied login name and arrives in whatever casing was typed. Verified: `ZITADEL.LOCALHOST` returns 0 organizations with `EQUALS` and 1 with `EQUALS_IGNORE_CASE`, so discovery silently does not happen and an IdP-only organization never redirects.

**Input is not trimmed**, so a trailing space from autofill or a mobile keyboard makes an existing user unfindable. The API already trims usernames on write, so the lookup was inconsistent with storage.

# How the Problems Are Solved

- `listUsers()` matches login name, username and email with `EQUALS_IGNORE_CASE`. `searchUsers()`, used by the login name page, already did this since #10475. Phone numbers keep `EQUALS`.
- `getOrgsByDomain()` matches the domain ignoring case.
- The post-search guards in `loginname.ts` and `password.ts` go through a new `loginNameEquals()` helper that ignores case and surrounding whitespace. Phone comparisons stay exact.
- `sendLoginname()` normalizes the raw input once, so the lookup, the comparisons and the login name echoed into redirect URLs agree. `searchUsers()` normalizes too, covering a login name that arrives directly through a URL.
- Both helpers live in `src/lib/login-name.ts` and document why the folding must stay.

**Auto-linking no longer trusts `result[0]`.** Email addresses have no unique constraint, and instances upgraded from before the constraints were lowercased can still hold usernames differing only by case (`cmd/setup/16.sql` skips collisions by design), so the now case insensitive lookup can return several users. The candidate whose identifier matches what the provider sent byte for byte is preferred; only when that does not single one out is the result ambiguous, and then the identity is neither linked to an arbitrary account nor passed on to user creation — it redirects to `linking-failed?error=ambiguous_match`.

# Additional Changes

- `src/lib/login-name.test.ts` — helper semantics, including that an absent value never matches.
- `src/lib/zitadel.test.ts` — asserts the query method each lookup actually sends, plus trimming.
- `src/lib/server/loginname.test.ts` — three regression tests: differing login name casing, differing email casing, and trimming.
- `src/lib/server/idp-intent.test.ts` — links the exact case match among several candidates, refuses when none matches the casing, refuses when two match identically, and does not fall through to creation when ambiguous.

# Additional Context

- Closes #11124
- Also fixes the whitespace and case sensitivity items of #12572. The email format validation and duplicate-email timing items there are registration flow rather than lookup and are not addressed here.
- The guard analysis in #11124 (the `!==` comparisons behind the disable flags) is what this implements for those two files; the `getOrgsByDomain`, `listUsers` and trimming parts were not previously reported.
- Refusing ambiguous matches outright was the alternative considered. Preferring the exact casing was chosen because it keeps upgraded instances holding legacy duplicates working instead of failing them closed, and it still refuses rather than guessing when the casing does not resolve to one candidate. Happy to switch to the stricter behaviour if preferred.
- One limitation worth flagging: `listUsers` uses `limit: 2`, so with three or more matching users the exact-casing check only sees two of them and could treat a match as unique while another exact match exists unseen. Reaching it needs duplicate emails and three or more collisions inside one organization. I left the shared limit alone rather than change behaviour for every other caller; happy to raise it for this lookup if you would rather close that gap.
- This has been running in our own deployment since the case sensitivity broke Entra logins for us.
