### PR TITLE
fix(login): render right-to-left locales right-to-left

### DIFF
--- a/apps/login/src/app/(login)/layout.tsx
+++ b/apps/login/src/app/(login)/layout.tsx
@@ -11,8 +11,8 @@ import { getServiceConfig } from "@/lib/service-url";
 import { getAllowedLanguages } from "@/lib/zitadel";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import { Lato } from "next/font/google";
+import { getLocale, getTranslations } from "next-intl/server";
+import { Lato, Noto_Kufi_Arabic } from "next/font/google";
 import { headers } from "next/headers";
 import React, { Suspense } from "react";
 
@@ -20,6 +20,17 @@ const lato = Lato({
   weight: ["400", "700", "900"],
   subsets: ["latin"],
 });
+
+// Lato ships no Arabic glyphs, so an Arabic page falls back to whatever face
+// the operating system happens to substitute.
+const arabic = Noto_Kufi_Arabic({
+  weight: ["400", "700"],
+  subsets: ["arabic"],
+});
+
+// Locales in LANGS that are written right to left. Currently only Arabic, but
+// the set keeps the check in one place if Hebrew, Persian or Urdu are added.
+const RTL_LOCALES = new Set(["ar", "he", "fa", "ur"]);
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("common");
@@ -29,6 +40,8 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const _headers = await headers();
   const { serviceConfig } = getServiceConfig(_headers);
+  const locale = await getLocale();
+  const isRtl = RTL_LOCALES.has(locale);
 
   let languages = LANGS;
   try {
@@ -43,7 +56,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <html className={`${lato.className}`} suppressHydrationWarning>
+    <html
+      lang={locale}
+      dir={isRtl ? "rtl" : "ltr"}
+      className={isRtl ? arabic.className : lato.className}
+      suppressHydrationWarning
+    >
       <head />
       <body>
         <ThemeProvider>


### PR DESCRIPTION
# Which Problems Are Solved

Arabic is shipped by the login app and cannot be used.

- `apps/login/locales/ar.json` is complete and `ar` is registered in `LANGS` with its native name, so the language switcher offers it and every string is translated. But `<html>` carries no `dir`, so the page stays laid out left-to-right. Labels, arrows and the whole form read backwards.
- `Lato` is loaded with `subsets: ["latin"]` and has no Arabic glyphs. The browser silently substitutes whatever face the operating system happens to have, so the same sign-in screen renders in a different typeface on every machine, none of them chosen.

The two together mean the shipped Arabic translation reaches the user mis-set and mis-laid-out. The same applies to any right-to-left locale added later.

# How the Problems Are Solved

- `<html>` now carries `lang` and `dir`, both derived from the active locale via `getLocale()`.
- An Arabic face (`Noto_Kufi_Arabic`, `subsets: ["arabic"]`) is loaded and used for right-to-left locales; `Lato` continues to serve every other locale.
- `RTL_LOCALES` holds the set of right-to-left codes, so adding Hebrew, Persian or Urdu to `LANGS` needs one edit in one place rather than a second condition somewhere else.

One file, twenty-one lines. `dir` is chosen per locale rather than set globally, so left-to-right locales are untouched.

# Additional Changes

None.

# Additional Context

Verified against `v4.17.1`, built with `nx run @zitadel/login:pack` and served behind a reverse proxy on the instance origin:

| `Accept-Language` | rendered `<html>` |
|---|---|
| `ar` | `lang="ar" dir="rtl" class="noto_kufi_arabic_…"` |
| `en` | `lang="en" dir="ltr" class="lato_…"` |
| `de` | `lang="de" dir="ltr" class="lato_…"` |

The page renders right-to-left in the browser, with the language switcher reading العربية.

`tsc --noEmit` reports no error in the changed file. It reports 64 pre-existing errors elsewhere in `apps/login`, all in test files and all present unchanged on `v4.17.1` before this commit.

Related: #6067 (Arabic localization and RTL layout).

One note for review: the font is the only judgement call here. Noto Kufi Arabic is a reasonable default with wide coverage, but if you would rather use a different face, or a stack instead of a Google font, the layout change stands on its own and the font can be swapped without touching it.
