### PR TITLE
fix(login): stop the CSP blocking the page's own fonts

### DIFF
--- a/apps/login/src/lib/csp.test.ts
+++ b/apps/login/src/lib/csp.test.ts
@@ -9,7 +9,7 @@ describe("buildCSP", () => {
     expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
     expect(csp).toContain("connect-src 'self'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("font-src 'self'");
+    expect(csp).toContain("font-src 'self' data:");
     expect(csp).toContain("img-src 'self'");
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
@@ -19,7 +19,7 @@ describe("buildCSP", () => {
     const csp = buildCSP({ serviceUrl: "https://my-instance.zitadel.cloud" });
 
     expect(csp).toContain("img-src 'self' https://my-instance.zitadel.cloud");
-    expect(csp).toContain("font-src 'self' https://my-instance.zitadel.cloud");
+    expect(csp).toContain("font-src 'self' data: https://my-instance.zitadel.cloud");
   });
 
   test("keeps frame-ancestors as 'none' when iframeOrigins is empty", () => {
@@ -44,7 +44,7 @@ describe("buildCSP", () => {
     });
 
     expect(csp).toContain("img-src 'self' https://zitadel.mycompany.com");
-    expect(csp).toContain("font-src 'self' https://zitadel.mycompany.com");
+    expect(csp).toContain("font-src 'self' data: https://zitadel.mycompany.com");
     expect(csp).toContain("frame-ancestors https://portal.mycompany.com");
     expect(csp).not.toContain("frame-ancestors 'none'");
   });
@@ -60,5 +60,19 @@ describe("buildCSP", () => {
     expect(csp).toContain("connect-src 'self'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
     expect(csp).toContain("object-src 'none'");
+  });
+
+  test("omits a service URL the browser cannot resolve", () => {
+    const csp = buildCSP({ serviceUrl: "http://zitadel:8080" });
+
+    expect(csp).not.toContain("zitadel:8080");
+    expect(csp).toContain("font-src 'self' data:");
+    expect(csp).toContain("img-src 'self'");
+  });
+
+  test("keeps localhost, which a browser can resolve", () => {
+    const csp = buildCSP({ serviceUrl: "http://localhost:8080" });
+
+    expect(csp).toContain("http://localhost:8080");
   });
 });

--- a/apps/login/src/lib/csp.test.ts
+++ b/apps/login/src/lib/csp.test.ts
@@ -70,9 +70,15 @@ describe("buildCSP", () => {
     expect(csp).toContain("img-src 'self'");
   });
 
-  test("keeps localhost, which a browser can resolve", () => {
-    const csp = buildCSP({ serviceUrl: "http://localhost:8080" });
-
-    expect(csp).toContain("http://localhost:8080");
+  test("keeps hosts a browser can reach", () => {
+    for (const serviceUrl of [
+      "http://localhost:8080",
+      "http://127.0.0.1:8080",
+      "http://[::1]:8080",
+      "http://[2001:db8::1]:8080",
+      "https://zitadel.example.com",
+    ]) {
+      expect(buildCSP({ serviceUrl })).toContain(serviceUrl);
+    }
   });
 });

--- a/apps/login/src/lib/csp.ts
+++ b/apps/login/src/lib/csp.ts
@@ -14,10 +14,27 @@ export interface CSPOptions {
   iframeOrigins?: string[] | null;
 }
 
+/* The API URL is how the server reaches ZITADEL. In a container deployment that
+ * is an internal name such as `http://zitadel:8080`. Putting it in a header the
+ * browser reads grants nothing, because no browser can resolve it, and it
+ * publishes the service's internal hostname to every visitor. */
+function isBrowserReachable(serviceUrl: string): boolean {
+  try {
+    const { hostname } = new URL(serviceUrl);
+    return hostname.includes(".") || hostname === "localhost";
+  } catch {
+    return false;
+  }
+}
+
 export function buildCSP(options: CSPOptions = {}): string {
   const directives: Record<string, string[]> = { ...BASE_DIRECTIVES };
 
-  if (options.serviceUrl) {
+  // next/font inlines the fallback faces it generates as data: URIs, and a
+  // policy without `data:` blocks every font on the page.
+  directives["font-src"] = [...directives["font-src"], "data:"];
+
+  if (options.serviceUrl && isBrowserReachable(options.serviceUrl)) {
     directives["img-src"] = [...directives["img-src"], options.serviceUrl];
     directives["font-src"] = [...directives["font-src"], options.serviceUrl];
   }

--- a/apps/login/src/lib/csp.ts
+++ b/apps/login/src/lib/csp.ts
@@ -14,14 +14,21 @@ export interface CSPOptions {
   iframeOrigins?: string[] | null;
 }
 
-/* The API URL is how the server reaches ZITADEL. In a container deployment that
- * is an internal name such as `http://zitadel:8080`. Putting it in a header the
- * browser reads grants nothing, because no browser can resolve it, and it
- * publishes the service's internal hostname to every visitor. */
+/* The API URL is how the server reaches ZITADEL, which in a container
+ * deployment is an internal name such as `http://zitadel:8080`. Naming it in a
+ * header the browser reads publishes the service's internal hostname to every
+ * visitor, and is of no use to a browser that is not on that network.
+ *
+ * Best effort, on the shape of the hostname alone: a dotted name, an IPv6
+ * literal, or `localhost` can be a real destination for a browser; a bare
+ * single label is a container or service name. It errs towards keeping the
+ * URL, so a reachable host is never dropped by mistake. */
 function isBrowserReachable(serviceUrl: string): boolean {
   try {
     const { hostname } = new URL(serviceUrl);
-    return hostname.includes(".") || hostname === "localhost";
+    // URL keeps the brackets around an IPv6 literal, e.g. "[::1]".
+    const isIpv6Literal = hostname.startsWith("[") && hostname.endsWith("]");
+    return hostname.includes(".") || isIpv6Literal || hostname === "localhost";
   } catch {
     return false;
   }


### PR DESCRIPTION
# Which Problems Are Solved

The Content Security Policy the login app sets on every response has two faults, and the first one breaks the page it protects.

**`font-src` has no `data:`.** `next/font` inlines the fallback faces it generates as `data:` URIs, so every font on the page is refused. The only evidence is a console line, and the page renders in whatever the browser falls back to:

```
Loading the font 'data:font/woff2;base64,...' violates the following
Content Security Policy directive: "font-src 'self' http://zitadel:8080"
```

**The service URL is added unconditionally.** It is how the server reaches the API, not how a browser would, so in a container deployment it is an internal name. The header above went to a public browser advertising `http://zitadel:8080`. That grants nothing, because no browser can resolve it, and it tells every visitor what the service is called inside the network.

# How the Problems Are Solved

- `data:` is added to `font-src`.
- The service URL is added to `font-src` and `img-src` only when a browser could reach it. A hostname with no dot and not `localhost` cannot be a real destination, so it is left out.

# Additional Changes

Two existing assertions in `csp.test.ts` are updated for the new ordering (`font-src 'self' data: <url>`). Two tests are added: one for an internal hostname being omitted, one for `localhost` being kept.

# Additional Context

Found while running the login UI behind a reverse proxy with the API reachable only on the compose network, which is the ordinary shape of a self-hosted deployment: `ZITADEL_API_URL=http://zitadel:8080`.

`vitest --run src/lib/csp.test.ts` passes at 8 tests on this branch.
