### PR TITLE
fix: match ZitadelError against wrapped targets in errors.Is

### DIFF
--- a/internal/zerrors/zerror.go
+++ b/internal/zerrors/zerror.go
@@ -206,7 +206,8 @@ func (err *ZitadelError) WithDetails(details ErrorDetails) *ZitadelError {
 }
 
 func (err *ZitadelError) Is(target error) bool {
-	t, ok := target.(*ZitadelError)
+	var t *ZitadelError
+	ok := errors.As(target, &t)
 	if !ok {
 		return false
 	}

--- a/internal/zerrors/zerror_test.go
+++ b/internal/zerrors/zerror_test.go
@@ -2,6 +2,7 @@ package zerrors
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,43 @@ func TestZitadelError_Is(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := errors.Is(tt.err, target)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestZitadelError_Is_WrappedTarget(t *testing.T) {
+	parent := errors.New("parent error")
+	err := CreateZitadelError(KindAborted, parent, "id", "message", 0)
+	tests := []struct {
+		name   string // description of this test case
+		target error
+		want   bool
+	}{
+		{
+			name:   "unwrapped target",
+			target: CreateZitadelError(KindAborted, parent, "id", "message", 0),
+			want:   true,
+		},
+		{
+			name:   "wrapped target",
+			target: fmt.Errorf("wrapped: %w", CreateZitadelError(KindAborted, parent, "id", "message", 0)),
+			want:   true,
+		},
+		{
+			name:   "wrapped target of different kind",
+			target: fmt.Errorf("wrapped: %w", CreateZitadelError(KindNotFound, parent, "id", "message", 0)),
+			want:   false,
+		},
+		{
+			name:   "wrapped target without zitadel error",
+			target: fmt.Errorf("wrapped: %w", errors.New("some other error")),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := errors.Is(err, tt.target)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
# Which Problems Are Solved

- `ZitadelError.Is` type-asserted the target to `*ZitadelError`. When the target was wrapped — for example with `fmt.Errorf("...: %w", zerrors.ThrowNotFound(...))` — the assertion failed and `errors.Is` reported no match, even though the wrapped target was a `*ZitadelError` with an identical kind, ID, message, parent and details.

# How the Problems Are Solved

- Replaces the type assertion with `errors.As`, so the target's error chain is unwrapped before the comparison. Every other matching rule is left untouched, and the behaviour only widens: any comparison that matched before still matches, since `errors.As` also succeeds on a direct type match.

# Additional Changes

- Adds `TestZitadelError_Is_WrappedTarget`, covering an unwrapped target, a wrapped target, a wrapped target of a different kind, and a wrapped error that contains no `*ZitadelError`. The "wrapped target" case fails without the change in `zerror.go`.

# Additional Context

- None
