### PR TITLE
chore(ci): let nx stop continuous run-db tasks instead of compose down from within the test targets

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -240,8 +240,7 @@
                 "commands": [
                     "wait-on --verbose --interval 2000 --simultaneous 1 --timeout 30m \"${ZITADEL_API_URL}/debug/ready\"",
                     "bash -c 'go test -race -count 1 -tags integration -timeout 60m -parallel 1 $(go list -tags integration ./... | grep -e \"integration_test\")'",
-                    "go tool covdata textfmt -i=$GOCOVERDIR -pkg=github.com/zitadel/zitadel/internal/...,github.com/zitadel/zitadel/cmd/... -o profile.api.test-integration.cov",
-                    "nx run @zitadel/api:test-integration-stop"
+                    "go tool covdata textfmt -i=$GOCOVERDIR -pkg=github.com/zitadel/zitadel/internal/...,github.com/zitadel/zitadel/cmd/... -o profile.api.test-integration.cov"
                 ]
             },
             "inputs": [

--- a/tests/functional-ui/project.json
+++ b/tests/functional-ui/project.json
@@ -31,8 +31,7 @@
         "commands": [
           "cypress install",
           "wait-on --verbose --interval 2000 --simultaneous 1 --timeout 30m \"${CYPRESS_BACKEND_URL}/debug/ready\"",
-          "DISPLAY='' cypress run",
-          "nx run @zitadel/functional-ui:stop"
+          "DISPLAY='' cypress run"
         ]
       },
       "cache": true,


### PR DESCRIPTION
# Which Problems Are Solved

CI runs have been flaky since ~Aug 27 with the nx step failing on

```
Task "@zitadel/api:test-integration-run-db" is continuous but exited with code 0
Task "@zitadel/functional-ui:run-db" is continuous but exited with code 0
```

even when every test passed, and with the sibling test suite killed mid-run (`Process completed with exit code 130`).

Root cause: the test targets shoot their own database. `@zitadel/api:test-integration` and `@zitadel/functional-ui:test` end their command list with an explicit `nx run ...:stop` (`compose down`) of the very service their **continuous** `run-db` dependency (`compose up`) is supervising. The `run-db` task then exits on its own, which nx (22.x) counts as a **failed task**:

1. the nx run is marked failed even with all tests green, and
2. with `--nxBail`, the other suite that is still running is aborted mid-flight.

Whichever suite finishes first triggers it, so the failure is timing-dependent and flaky. Recent examples: [attempt 1 of this run](https://github.com/zitadel/zitadel/actions/runs/33161619698/attempts/1) (all 42 integration packages + all Cypress specs green, job still failed) and [this run](https://github.com/zitadel/zitadel/actions/runs/33166856821) (Cypress finished first, integration tests killed at 4m13s).

# How the Problems Are Solved

Drop the trailing `nx run ...:stop` commands from the two test targets. nx stops continuous dependencies itself once all their dependents finish, so the self-inflicted exit never happens. The `stop` targets remain unchanged for manual use as documented in CONTRIBUTING.md.

Since this PR touches both projects' configuration, both test suites run on this PR — a green pipeline here exercises exactly the raced path.

# Additional Context

- The race existed since the nx 22 upgrade (#12592) but only started losing consistently around Aug 27, presumably due to changed teardown timing on the updated Depot runner images (same window as the `*.integration.localhost` DNS breakage worked around in #12621).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
