### PR TITLE
fix(i18n): log only argument keys on missing translation

### DIFF
--- a/internal/i18n/translator.go
+++ b/internal/i18n/translator.go
@@ -2,7 +2,9 @@ package i18n
 
 import (
 	"context"
+	"maps"
 	"net/http"
+	"slices"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -166,7 +168,9 @@ func localize(localizer *i18n.Localizer, id string, args map[string]interface{})
 		TemplateData: args,
 	})
 	if err != nil {
-		logging.WithFields("id", id, "args", args).WithError(err).Warnf("missing translation")
+		// Only the argument keys are logged: the values regularly contain PII
+		// such as e-mail addresses (https://github.com/zitadel/zitadel/issues/9385).
+		logging.WithFields("id", id, "argKeys", slices.Sorted(maps.Keys(args))).WithError(err).Warnf("missing translation")
 		return id
 	}
 	return s

--- a/internal/i18n/translator.go
+++ b/internal/i18n/translator.go
@@ -170,7 +170,7 @@ func localize(localizer *i18n.Localizer, id string, args map[string]interface{})
 	if err != nil {
 		// Only the argument keys are logged: the values regularly contain PII
 		// such as e-mail addresses (https://github.com/zitadel/zitadel/issues/9385).
-		logging.WithFields("id", id, "argKeys", slices.Sorted(maps.Keys(args))).WithError(err).Warnf("missing translation")
+		logging.WithFields("id", id, "argKeys", slices.Sorted(maps.Keys(args))).WithError(err).Warn("missing translation")
 		return id
 	}
 	return s


### PR DESCRIPTION
# Which Problems Are Solved

- Missing-translation warnings log the full localization arguments (`args`). These regularly carry PII — e.g. `LastEmail` / `VerifiedEmail` with the user's e-mail address — into the logs, which often flow into sinks not authorized to process PII (#9385).

# How the Problems Are Solved

- The warning in `internal/i18n/translator.go` now logs only the **sorted argument keys** (`argKeys`) instead of the full map. This keeps the debugging value — you still see which placeholders the failing message used — without exposing the values where the PII lives. The message `id` and the error are logged unchanged.

# Additional Changes

- None. A repo-wide search shows this was the only place logging the localization `args`.

# Additional Context

- Closes #9385