### PR TITLE
fix(login): let the user pick when more than one identity provider applies

### DIFF
--- a/apps/login/src/lib/server/loginname.test.ts
+++ b/apps/login/src/lib/server/loginname.test.ts
@@ -385,6 +385,36 @@ describe("sendLoginname", () => {
         expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
       });
 
+      test("should redirect to the IDP selection when user has only IDP method and multiple IDP links", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.IDP],
+        });
+        mockListIDPLinks.mockResolvedValue({
+          result: [{ idpId: "idp123" }, { idpId: "idp456" }],
+        });
+
+        const result = await sendLoginname({
+          loginName: "user@example.com",
+        });
+
+        expect(result).toEqual({ redirect: "/idp?organization=org123" });
+        expect(mockStartIdentityProviderFlow).not.toHaveBeenCalled();
+      });
+
+      test("should return error when user has only IDP method and no identity provider is available", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.IDP],
+        });
+        mockListIDPLinks.mockResolvedValue({ result: [] });
+        mockGetActiveIdentityProviders.mockResolvedValue({ identityProviders: [] });
+
+        const result = await sendLoginname({
+          loginName: "user@example.com",
+        });
+
+        expect(result).toEqual({ error: "errors.couldNotFindIdentityProvider" });
+      });
+
       test("should NOT create session when ignoreUnknownUsernames is true", async () => {
         mockGetLoginSettings.mockResolvedValue({
           allowLocalAuthentication: true,
@@ -453,6 +483,37 @@ describe("sendLoginname", () => {
         expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
       });
 
+      test("should redirect to the IDP selection when user has multiple IDP links next to a password", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.PASSWORD, AuthenticationMethodType.IDP],
+        });
+        mockListIDPLinks.mockResolvedValue({
+          result: [{ idpId: "idp123" }, { idpId: "idp456" }],
+        });
+
+        const result = await sendLoginname({
+          loginName: "user@example.com",
+          requestId: "request123",
+        });
+
+        expect(result).toEqual({ redirect: "/idp?requestId=request123&organization=org123" });
+        expect(mockStartIdentityProviderFlow).not.toHaveBeenCalled();
+      });
+
+      test("should redirect to password when the IDP method has no identity provider available", async () => {
+        mockListAuthenticationMethodTypes.mockResolvedValue({
+          authMethodTypes: [AuthenticationMethodType.PASSWORD, AuthenticationMethodType.IDP],
+        });
+        mockListIDPLinks.mockResolvedValue({ result: [] });
+        mockGetActiveIdentityProviders.mockResolvedValue({ identityProviders: [] });
+
+        const result = await sendLoginname({
+          loginName: "user@example.com",
+        });
+
+        expect(result?.redirect).toMatch(/^\/password\?/);
+      });
+
       test("should redirect to password when no passkey or IDP, only password available and allowed", async () => {
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
@@ -505,6 +566,26 @@ describe("sendLoginname", () => {
       });
 
       expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
+    });
+
+    test("should redirect to the IDP selection when register allowed, password not allowed and several IDPs are active", async () => {
+      mockGetLoginSettings.mockResolvedValue({
+        allowRegister: true,
+        allowLocalAuthentication: false,
+      });
+      mockGetActiveIdentityProviders.mockResolvedValue({
+        identityProviders: [
+          { id: "idp123", type: "OIDC", options: { isAutoCreation: true } },
+          { id: "idp456", type: "OIDC", options: { isAutoCreation: true } },
+        ],
+      });
+
+      const result = await sendLoginname({
+        loginName: "user@example.com",
+      });
+
+      expect(result).toEqual({ redirect: "/idp" });
+      expect(mockStartIdentityProviderFlow).not.toHaveBeenCalled();
     });
 
     test("should redirect to register when both register and password allowed", async () => {

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -38,6 +38,14 @@ export type SendLoginnameCommand = {
   suffix?: string;
 };
 
+// What sending a user to an identity provider can result in. Spelled out because `undefined` is a
+// real outcome here (there may be no provider to send them to), and callers have to handle it
+// instead of passing it on to the form, which then has nothing to act on.
+type IdentityProviderRedirect =
+  | { redirect: string; error?: undefined; samlData?: undefined }
+  | { error: string; redirect?: undefined; samlData?: undefined }
+  | { samlData: { url: string; fields: Record<string, string> }; redirect?: undefined; error?: undefined };
+
 const ORG_SUFFIX_REGEX = /(?<=@)(.+)/;
 
 export async function sendLoginname(command: SendLoginnameCommand) {
@@ -115,7 +123,28 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     return { error: t("errors.userNotFound") };
   };
 
-  const redirectUserToIDP = async (userId?: string, organization?: string) => {
+  // No single identity provider can be chosen for the user, so let them pick one on the IDP
+  // selection page instead of returning nothing at all.
+  const redirectUserToIDPSelection = (organization?: string): IdentityProviderRedirect => {
+    const params = new URLSearchParams();
+
+    if (command.requestId) {
+      params.set("requestId", command.requestId);
+    }
+
+    if (organization) {
+      params.set("organization", organization);
+    }
+
+    const query = params.toString();
+
+    return { redirect: query ? "/idp?" + query : "/idp" };
+  };
+
+  const redirectUserToIDP = async (
+    userId?: string,
+    organization?: string,
+  ): Promise<IdentityProviderRedirect | undefined> => {
     // If userId is provided, check for user-specific IDP links first
     let identityProviders: IDPLink[] = [];
     if (userId) {
@@ -129,6 +158,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       const activeIdps = await getActiveIdentityProviders({ serviceConfig, orgId: organization }).then((resp) => {
         return resp.identityProviders.filter((idp) => idp.options?.isAutoCreation || idp.options?.isCreationAllowed);
       });
+
+      // Several providers are available and none of them is the obvious one, so the user chooses.
+      if (activeIdps.length > 1) {
+        return redirectUserToIDPSelection(organization);
+      }
 
       // If exactly one active IDP exists in the organization, redirect to it
       if (activeIdps.length === 1) {
@@ -236,6 +270,11 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       }
 
       return { redirect: response.url };
+    }
+
+    // The user has linked more than one identity provider, so there is no single destination.
+    if (identityProviders.length > 1) {
+      return redirectUserToIDPSelection(organization);
     }
   };
 
@@ -460,6 +499,12 @@ export async function sendLoginname(command: SendLoginnameCommand) {
             return { error: resp.error };
           }
 
+          // The user authenticates through an identity provider, but none is available to send
+          // them to. Say so, because an empty response leaves the form with nothing to act on.
+          if (!resp) {
+            return { error: t("errors.couldNotFindIdentityProvider") };
+          }
+
           return resp;
         }
       }
@@ -485,8 +530,17 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
         return { redirect: "/passkey?" + passkeyParams };
       } else if (methods.authMethodTypes.includes(AuthenticationMethodType.IDP)) {
-        return redirectUserToIDP(userId, organization);
-      } else if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
+        const idpResponse = await redirectUserToIDP(userId, organization);
+
+        if (idpResponse) {
+          return idpResponse;
+        }
+
+        // No identity provider to send the user to, so fall through to the other methods below
+        // rather than answering with nothing.
+      }
+
+      if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
         // Check if password authentication is allowed
         if (!userLoginSettings?.allowLocalAuthentication) {
           if (ignoreUnknownUsernames) {


### PR DESCRIPTION
# Which Problems Are Solved

`sendLoginname` resolves a single destination for the user or nothing at all, so a user for whom more than one identity provider applies gets a dead **Continue** button on the login-name screen: the request returns HTTP 200, every gRPC call succeeds, a session is created, and the browser does not navigate. There is no error text either, so there is nothing on screen to explain it.

`redirectUserToIDP` handles exactly two cases: one IDP link on the user, or no links plus exactly one active organization IDP. It falls through both `if`s and returns `undefined` when

- the user has **two or more IDP links** (e.g. Google and Microsoft), or
- the user has no links and the organization has **two or more active IDPs** while local authentication is not allowed.

Two callers hand that `undefined` straight to the client, and `handleServerActionResponse` returns `false` on a falsy response, which is why nothing at all happens:

- `case AuthenticationMethodType.IDP` returns `resp` after only checking `resp?.error`;
- the multi-method branch `return redirectUserToIDP(userId, organization)`, so a user who has a password *and* two IDP links cannot use their password either, because `IDP` is checked before `PASSWORD`.

Reported in #11412 for re-authentication from the accounts page; it is the same code path on a plain first login, and it locks the affected user out of the login-name route entirely. Clicking a provider button on the same screen still works, which is what makes it look like a UI bug rather than a block.

# How the Problems Are Solved

- `redirectUserToIDP` sends the user to the existing `/idp` selection page whenever more than one provider applies: more than one IDP link, or more than one active organization IDP. That page already lists the providers as buttons, so "there is no single destination" becomes "pick one" instead of a silent `undefined`.
- `case AuthenticationMethodType.IDP` returns `errors.couldNotFindIdentityProvider` (an existing key) when there is genuinely no provider to send the user to, rather than returning nothing.
- The multi-method branch falls through to the remaining methods when the IDP attempt yields nothing, so a user who also has a password still reaches `/password`.
- `redirectUserToIDP` gets an explicit return type. `undefined` is a real outcome of that function, and leaving it implicit is what let both call sites pass it on unnoticed.

# Additional Changes

- Five unit tests in `loginname.test.ts`: multiple IDP links with `IDP` as the only method, multiple IDP links alongside a password, an unknown user with several active organization IDPs, and the two "no provider available" fallbacks (error, and fall-through to password).

# Additional Context

- Closes #11412
- Reproduced on v4.16.0 and unchanged on `main`; #11412 reports it from v4.9.2 onwards.
