### PR TITLE
docs: add instance administrator hardening guide

### DIFF
--- a/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
+++ b/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
@@ -30,7 +30,7 @@ Unlike users, service accounts don't rely on traditional login methods (e.g., us
 ### Segregated authorization
 
 Manage authorization for service accounts separately from human users, providing an extra layer of control.
-For service accounts with instance-level permissions (login client, break-glass owner), use a [dedicated platform organization](/guides/manage/console/administrator-hardening). Organization permissions and login policies for application tenants must not overlap with platform operators.
+For service accounts with instance-level permissions (login client, break-glass owner), use a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening). Organization permissions and login settings for application organizations must not overlap with instance administrators.
 
 ### API and backend access
 

--- a/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
+++ b/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
@@ -30,7 +30,7 @@ Unlike users, service accounts don't rely on traditional login methods (e.g., us
 ### Segregated authorization
 
 Manage authorization for service accounts separately from human users, providing an extra layer of control.
-For instance-level service accounts (login client, break-glass owner), use a [dedicated platform organization](/guides/manage/console/administrator-hardening) so org roles and login policies for application tenants do not overlap with platform operators.
+For service accounts with instance-level permissions (login client, break-glass owner), use a [dedicated platform organization](/guides/manage/console/administrator-hardening). Organization permissions and login policies for application tenants must not overlap with platform operators.
 
 ### API and backend access
 

--- a/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
+++ b/apps/docs/content/guides/integrate/service-accounts/authenticate-service-accounts.mdx
@@ -30,6 +30,7 @@ Unlike users, service accounts don't rely on traditional login methods (e.g., us
 ### Segregated authorization
 
 Manage authorization for service accounts separately from human users, providing an extra layer of control.
+For instance-level service accounts (login client, break-glass owner), use a [dedicated platform organization](/guides/manage/console/administrator-hardening) so org roles and login policies for application tenants do not overlap with platform operators.
 
 ### API and backend access
 

--- a/apps/docs/content/guides/manage/console/administrator-hardening.mdx
+++ b/apps/docs/content/guides/manage/console/administrator-hardening.mdx
@@ -6,28 +6,28 @@ sidebar_label: Administrator hardening
 
 Instance administrators (`IAM_*` roles) can manage resources across every organization on an instance.
 Organization administrators (`ORG_*` roles) manage users, projects, and policies within a single organization.
-When both kinds of principals share the same organization, their authorization scope and login experience overlap in ways that are easy to underestimate.
+When both kinds of principals share the same organization, their authorization scope and login experience overlap in ways that can potentially lead to unexpected account takeover.
 
 This guide describes a practical layout that keeps platform operations separate from customer or application organizations, and how to harden the login client and break-glass access.
 
 ## Why use a dedicated platform organization
 
-Create a **platform organization** that is reserved for instance-level operators and automation—not for end users or application teams.
+Create a **platform organization** that is reserved for instance-level operators and automation - not for end users or application teams.
 
-| Concern | When operators share an application org | With a dedicated platform org |
+| Concern | When operators share an application organization | With a dedicated platform organization |
 | --- | --- | --- |
-| **Authorization scope** | Org roles such as `ORG_USER_MANAGER` apply within the same organization where instance admins may also exist. | Instance roles remain on the instance; org roles in application orgs cannot reach platform accounts. |
-| **Login policy** | [Login behavior and security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Org admins may change MFA, passkeys, external IdPs, or self-registration for the org where platform accounts live. | You define a strict login policy only for operators—without coupling it to product org settings. |
-| **Password and lockout policy** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the org context of the user. | Operator accounts inherit policies you chose for the platform org, independent of customer orgs. |
+| **Authorization scope** | Organization roles such as `ORG_USER_MANAGER` apply within the same organization where instance administrators may also exist. | Instance roles remain on the instance; organization roles in application organizations cannot reach platform accounts. |
+| **Login policy** | [Login behavior and security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Organization administrators may change MFA, passkeys, external IdPs, or self-registration for the organization where platform accounts live. | You define a strict login policy only for operators—without coupling it to product organization settings. |
+| **Password and lockout policy** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the organization context of the user. | Operator accounts inherit policies you chose for the platform organization, independent of customer organizations. |
 | **Operational clarity** | Auditing “who is an admin” mixes customers and operators in one user list. | Instance members and platform service accounts are easy to inventory. |
 
 Instance [default settings](/guides/manage/console/default-settings) act as fallbacks for organizations.
-Org-level overrides still apply to users in that org.
-Placing human instance owners or shared break-glass accounts in a customer org means that org’s administrators can shape how those users authenticate and how local policies behave.
+Organization-level permissions override still apply to users in that organization.
+Placing human instance owners or shared break-glass accounts in a customer organization means that organization's administrators can shape how those users authenticate and how local policies behave.
 
 <Callout type="info">
 The default organization created at setup is often used for the ZITADEL Console and internal projects.
-Treat it as a platform org **only** if it does not host customer users and no org-level administrators manage it on behalf of tenants.
+Treat it as a platform organization **only** if it does not host customer users and no organization-level administrators manage it on behalf of tenants.
 Otherwise, create a separate organization for platform operations.
 </Callout>
 
@@ -35,41 +35,39 @@ Otherwise, create a separate organization for platform operations.
 
 ```text
 Instance
-├── Platform org (operators only)
+├── Platform organization (operators only)
 │   ├── Break-glass IAM_OWNER service account (PAT, offline storage)
 │   ├── Login client service account (IAM_LOGIN_CLIENT only)
 │   └── Optional: other instance automation service accounts
-├── Customer / application org A
+├── Customer / application organization A
 │   └── End users, app admins (ORG_* only)
-└── Customer / application org B
+└── Customer / application organization B
     └── End users, app admins (ORG_* only)
 ```
 
 **Guidelines:**
 
-- Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar org roles to humans in the platform org unless they truly manage that org only.
-- Do not add customer end users to the platform org.
-- Assign instance roles (`IAM_OWNER`, `IAM_LOGIN_CLIENT`, …) only on the **instance** administrator list, not as a substitute for org roles on application resources.
-
-See [ZITADEL Administrators](/guides/manage/console/administrators) for the full role list and permission matrix.
+- Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar organization roles to operators or service accounts in the platform organization unless they truly manage that organization only.
+- Do not add customer end users to the platform organization: tenant users inherit that organization's login and lockout policies, and tenant organization administrators can grant organization roles that blur operator and customer boundaries.
+- Grant instance roles only on the **instance** administrator list, not as a substitute for organization roles on application resources. For instance service accounts (login client, break-glass), follow [Login client (`IAM_LOGIN_CLIENT`)](#login-client-iam_login_client) and review critical permissions in the [administrator permission matrix](/guides/manage/console/administrators#administrator-permission-matrix)—for example `iam.member.write`, `org.member.write`, `user.write`, `user.credential.write`, and `user.passkey.write`. Session permissions (`session.write`, `session.link`) are also granted by default and are required for the login UI—do not remove them without testing the full authentication flow. In self-hosted deployments, defaults can be customized via [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/administrators#configure-roles).
 
 ## Login policy for the platform organization
 
-Configure login behavior for the platform org explicitly—do not rely on whatever policy happens to apply to a busy application org.
+Configure login behavior for the platform organization explicitly—do not rely on whatever policy happens to apply to a busy application organization.
 
 1. Open the platform organization in the management console.
 2. Review **Login behavior and security** (or set instance defaults first, then override only where needed).
 3. For operator accounts, consider:
    - **Enforcing MFA** for local authentication.
    - **Restricting external IdPs** if operators should only use credentials you control.
-   - **Disabling self-registration** if the org is not meant for public signup.
+   - **Disabling self-registration** if the organization is not meant for public signup.
    - **Tight lockout** and **password complexity** aligned with your operator baseline.
    - A **default redirect URI** that does not send operators to the customer console by mistake.
 
 Instance-level and organization-level [identity providers](/guides/manage/console/default-settings#identity-providers) are separate from the login policy that controls whether external login is allowed and which providers are linked for a given organization.
-An instance IdP can be used by users in an organization only when the **effective login policy** for that org allows external IdPs (`External IDP allowed`) and the provider is **linked** to that policy—or when the org inherits instance default settings, which includes the default IdP links.
-Organizations with a **custom login policy** must enable external IdPs themselves and explicitly add instance or org IdPs to their provider list; see [Let users login with preferred identity provider](/guides/integrate/identity-providers/introduction).
-Document which IdPs platform operators may use in the platform org.
+An instance IdP can be used by users in an organization only when the **effective login policy** for that organization allows external IdPs (`External IDP allowed`) and the provider is **linked** to that policy—or when the organization inherits instance default settings, which includes the default IdP links.
+Organizations with a **custom login policy** must enable external IdPs themselves and explicitly add instance or organization IdPs to their provider list; see [Let users login with preferred identity provider](/guides/integrate/identity-providers/introduction).
+Document which IdPs platform operators may use in the platform organization.
 
 More context on policy inheritance: [Settings and policies](/concepts/structure/policies).
 
@@ -79,7 +77,7 @@ The self-hosted [Login UI](/guides/integrate/login-ui/fork-and-deploy-login-app)
 
 **Hardening steps:**
 
-- Create the login client user in the **platform org**, not in a tenant org.
+- Create the login client user in the **platform organization**, not in a tenant organization.
 - Use a **dedicated machine user** per login deployment; do not reuse admin or application service account PATs.
 - Grant **only** `IAM_LOGIN_CLIENT` on the instance unless you have a documented exception.
 - Store the PAT in a **secrets manager**; rotate when the login stack is redeployed or team access changes.
@@ -95,7 +93,7 @@ Review the [administrator permission matrix](/guides/manage/console/administrato
 Before changing login routes, features, or instance settings, keep a recovery path that does not depend on the interactive login UI.
 
 <Callout type="warn" title="Avoid lockout">
-Create a service account in the platform org with the **Instance Owner** role (`IAM_OWNER`) and a PAT.
+Create a service account in the platform organization with the **Instance Owner** role (`IAM_OWNER`) and a PAT.
 Store the PAT offline according to your incident-access policy.
 If the login UI or console becomes unreachable, you can still call the [Admin API](/reference/api/admin) to revert settings.
 </Callout>
@@ -114,7 +112,7 @@ If you override [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/
 
 ## Periodic review
 
-Review instance membership on a schedule and after major org or login changes.
+Review instance membership on a schedule and after major organization or login changes.
 
 **List instance administrators** ([Internal Permission Service v2](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators)):
 
@@ -132,7 +130,7 @@ curl -sS -X POST \
   }'
 ```
 
-The response includes each user's `organizationId` and granted `roles`, which helps verify platform-org placement.
+The response includes each user's `organizationId` and granted `roles`, which helps verify platform-organization placement.
 
 <Callout type="info">
 The Admin API `POST /admin/v1/members/_search` endpoint is deprecated; prefer `ListAdministrators` above.
@@ -140,9 +138,9 @@ The Admin API `POST /admin/v1/members/_search` endpoint is deprecated; prefer `L
 
 **Questions to answer:**
 
-- Does every `IAM_*` holder belong to the platform org (or a documented exception)?
+- Does every `IAM_*` holder belong to the platform organization (or a documented exception)?
 - Does the login client service account hold **only** `IAM_LOGIN_CLIENT`?
-- Are there human `IAM_OWNER` accounts in application orgs?
+- Are there human `IAM_OWNER` accounts in application organizations?
 - Did any instance member change since the last review? Use the [Event API](/guides/integrate/zitadel-apis/event-api) or [stream audit logs to external systems](/guides/integrate/external-audit-log) for change history.
 
 ## Detect grants with Actions v2
@@ -224,7 +222,7 @@ Example decoded `event_payload` for a grant:
 
 Combine real-time events with the [periodic `ListAdministrators` review](#periodic-review) above:
 
-- Any `IAM_OWNER` or `IAM_USER_MANAGER` grant outside your platform org (compare `userId` to your allow-list or resolve org via API).
+- Any `IAM_OWNER` or `IAM_USER_MANAGER` grant outside your platform organization (compare `userId` to your allow-list or resolve organization via API).
 - Login client service account holding roles other than `IAM_LOGIN_CLIENT`.
 - `instance.member.changed` where `roles` includes high-privilege `IAM_*` roles you did not expect.
 - Grants performed by users or service accounts that are not on your approved administrator list (`userID` in the outer payload).
@@ -235,9 +233,9 @@ See also: [Actions v2 examples](https://github.com/zitadel/actions/tree/main/act
 
 ## Monitor platform organization administrators
 
-Instance `IAM_*` roles are not the only risk in a mixed layout: **organization roles inside the platform org** (`ORG_USER_MANAGER`, `ORG_OWNER`, …) apply to users in that same org, including break-glass accounts and service users.
+Instance `IAM_*` roles are not the only risk in a mixed layout: **organization roles inside the platform organization** (`ORG_USER_MANAGER`, `ORG_OWNER`, …) apply to users in that same organization, including break-glass accounts and service users.
 
-Monitor organization administrators for the platform org alongside instance membership.
+Monitor organization administrators for the platform organization alongside instance membership.
 
 ### Periodic review (API)
 
@@ -259,11 +257,11 @@ curl -sS -X POST \
 
 **Questions to answer:**
 
-- Are there `ORG_USER_MANAGER` or `ORG_OWNER` grants on the platform org you did not expect?
-- Do any humans hold org admin roles in the platform org without an operational reason?
-- Are customer or tenant admins accidentally granted roles in the platform org?
+- Are there `ORG_USER_MANAGER` or `ORG_OWNER` grants on the platform organization you did not expect?
+- Do any operators or service accounts hold organization administrator roles in the platform organization without an operational reason?
+- Are customer or tenant administrators accidentally granted roles in the platform organization?
 
-In the management console, open the platform organization and review **ADMINISTRATORS** in the org details panel (same UI pattern as [ZITADEL Administrators](/guides/manage/console/administrators)).
+In the management console, open the platform organization and review **ADMINISTRATORS** in the organization details panel (same UI pattern as [ZITADEL Administrators](/guides/manage/console/administrators)).
 
 ### Organization member events (Actions v2)
 
@@ -294,7 +292,7 @@ Repeat for `org.member.changed` and `org.member.removed` as needed.
 
 The webhook payload uses the same [event structure](/guides/integrate/actions/usage#sent-information-event). For `org.member.*` events, `aggregateType` is `org` and `aggregateID` is the organization ID. Filter in your handler so you only alert when `aggregateID` equals your `${PLATFORM_ORG_ID}`. The `event_payload` contains `userId` and `roles` (for example `ORG_USER_MANAGER`, `ORG_OWNER`).
 
-Flag grants such as unexpected `ORG_USER_MANAGER` on the platform org, or any org admin role on users that should be machine-only service accounts.
+Flag grants such as unexpected `ORG_USER_MANAGER` on the platform organization, or any organization administrator role on users that should be machine-only service accounts.
 
 ## Review changes with the Event API
 
@@ -354,12 +352,12 @@ Parse each event payload for `userId` and `roles`, then apply the same allow-lis
 
 ## Checklist
 
-- [ ] Platform org exists; customer users are not members.
-- [ ] Login policy for the platform org enforces your operator authentication baseline (MFA, IdPs, lockout).
-- [ ] Login client service account lives in the platform org with a dedicated PAT.
+- [ ] Platform organization exists; customer users are not members.
+- [ ] Login policy for the platform organization enforces your operator authentication baseline (MFA, IdPs, lockout).
+- [ ] Login client service account lives in the platform organization with a dedicated PAT.
 - [ ] Break-glass `IAM_OWNER` PAT is stored offline and tested periodically.
 - [ ] Custom `RolePermissionMappings` (if any) are reviewed against least privilege.
-- [ ] Platform org **organization** administrators (`ORG_*`) are reviewed and monitored (`org.member.*` events or Event API).
+- [ ] Platform organization administrators (`ORG_*`) are reviewed and monitored (`org.member.*` events or Event API).
 - [ ] Instance membership is reviewed regularly and **Actions v2** monitors `instance.member.*` events (or changes are pulled via the **Event API** / SIEM).
 
 ## Related guides

--- a/apps/docs/content/guides/manage/console/administrator-hardening.mdx
+++ b/apps/docs/content/guides/manage/console/administrator-hardening.mdx
@@ -1,0 +1,373 @@
+---
+title: Hardening instance administrators
+description: "Separate platform operators from application organizations, align login policies, and apply least privilege for instance roles and the login client."
+sidebar_label: Administrator hardening
+---
+
+Instance administrators (`IAM_*` roles) can manage resources across every organization on an instance.
+Organization administrators (`ORG_*` roles) manage users, projects, and policies within a single organization.
+When both kinds of principals share the same organization, their authorization scope and login experience overlap in ways that are easy to underestimate.
+
+This guide describes a practical layout that keeps platform operations separate from customer or application organizations, and how to harden the login client and break-glass access.
+
+## Why use a dedicated platform organization
+
+Create a **platform organization** that is reserved for instance-level operators and automation—not for end users or application teams.
+
+| Concern | When operators share an application org | With a dedicated platform org |
+| --- | --- | --- |
+| **Authorization scope** | Org roles such as `ORG_USER_MANAGER` apply within the same organization where instance admins may also exist. | Instance roles remain on the instance; org roles in application orgs cannot reach platform accounts. |
+| **Login policy** | [Login behavior and security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Org admins may change MFA, passkeys, external IdPs, or self-registration for the org where platform accounts live. | You define a strict login policy only for operators—without coupling it to product org settings. |
+| **Password and lockout policy** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the org context of the user. | Operator accounts inherit policies you chose for the platform org, independent of customer orgs. |
+| **Operational clarity** | Auditing “who is an admin” mixes customers and operators in one user list. | Instance members and platform service accounts are easy to inventory. |
+
+Instance [default settings](/guides/manage/console/default-settings) act as fallbacks for organizations.
+Org-level overrides still apply to users in that org.
+Placing human instance owners or shared break-glass accounts in a customer org means that org’s administrators can shape how those users authenticate and how local policies behave.
+
+<Callout type="info">
+The default organization created at setup is often used for the ZITADEL Console and internal projects.
+Treat it as a platform org **only** if it does not host customer users and no org-level administrators manage it on behalf of tenants.
+Otherwise, create a separate organization for platform operations.
+</Callout>
+
+## Recommended layout
+
+```text
+Instance
+├── Platform org (operators only)
+│   ├── Break-glass IAM_OWNER service account (PAT, offline storage)
+│   ├── Login client service account (IAM_LOGIN_CLIENT only)
+│   └── Optional: other instance automation service accounts
+├── Customer / application org A
+│   └── End users, app admins (ORG_* only)
+└── Customer / application org B
+    └── End users, app admins (ORG_* only)
+```
+
+**Guidelines:**
+
+- Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar org roles to humans in the platform org unless they truly manage that org only.
+- Do not add customer end users to the platform org.
+- Assign instance roles (`IAM_OWNER`, `IAM_LOGIN_CLIENT`, …) only on the **instance** administrator list, not as a substitute for org roles on application resources.
+
+See [ZITADEL Administrators](/guides/manage/console/administrators) for the full role list and permission matrix.
+
+## Login policy for the platform organization
+
+Configure login behavior for the platform org explicitly—do not rely on whatever policy happens to apply to a busy application org.
+
+1. Open the platform organization in the management console.
+2. Review **Login behavior and security** (or set instance defaults first, then override only where needed).
+3. For operator accounts, consider:
+   - **Enforcing MFA** for local authentication.
+   - **Restricting external IdPs** if operators should only use credentials you control.
+   - **Disabling self-registration** if the org is not meant for public signup.
+   - **Tight lockout** and **password complexity** aligned with your operator baseline.
+   - A **default redirect URI** that does not send operators to the customer console by mistake.
+
+Instance-level and organization-level [identity providers](/guides/manage/console/default-settings#identity-providers) are separate from the login policy that controls whether external login is allowed and which providers are linked for a given organization.
+An instance IdP can be used by users in an organization only when the **effective login policy** for that org allows external IdPs (`External IDP allowed`) and the provider is **linked** to that policy—or when the org inherits instance default settings, which includes the default IdP links.
+Organizations with a **custom login policy** must enable external IdPs themselves and explicitly add instance or org IdPs to their provider list; see [Let users login with preferred identity provider](/guides/integrate/identity-providers/introduction).
+Document which IdPs platform operators may use in the platform org.
+
+More context on policy inheritance: [Settings and policies](/concepts/structure/policies).
+
+## Login client (`IAM_LOGIN_CLIENT`)
+
+The self-hosted [Login UI](/guides/integrate/login-ui/fork-and-deploy-login-app) authenticates to ZITADEL with a service account that holds the **Instance Login Client** role (`IAM_LOGIN_CLIENT`).
+
+**Hardening steps:**
+
+- Create the login client user in the **platform org**, not in a tenant org.
+- Use a **dedicated machine user** per login deployment; do not reuse admin or application service account PATs.
+- Grant **only** `IAM_LOGIN_CLIENT` on the instance unless you have a documented exception.
+- Store the PAT in a **secrets manager**; rotate when the login stack is redeployed or team access changes.
+- Do not use the login client PAT for management automation, CI, or customer integrations.
+
+Setup reference: [Create a Login Client](/self-hosting/manage/login-client) and [Adopt Login V2](/self-hosting/manage/adopt-login-v2).
+
+The default `IAM_LOGIN_CLIENT` permission set is broad because the login UI finalizes auth requests, manages users during registration, and may synchronize instance roles when a ZITADEL identity provider grants instance roles from token claims.
+Review the [administrator permission matrix](/guides/manage/console/administrators#administrator-permission-matrix) before customizing roles in self-hosted deployments.
+
+## Break-glass instance owner access
+
+Before changing login routes, features, or instance settings, keep a recovery path that does not depend on the interactive login UI.
+
+<Callout type="warn" title="Avoid lockout">
+Create a service account in the platform org with the **Instance Owner** role (`IAM_OWNER`) and a PAT.
+Store the PAT offline according to your incident-access policy.
+If the login UI or console becomes unreachable, you can still call the [Admin API](/reference/api/admin) to revert settings.
+</Callout>
+
+- Prefer a **machine user** for break-glass access; limit human `IAM_OWNER` accounts.
+- Enroll **multiple MFA methods** for any human instance owners.
+- Invite a **second trusted administrator** on the instance so access is not tied to a single person.
+
+## Self-hosted custom role mappings
+
+If you override [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/administrators#configure-roles) in runtime configuration:
+
+- Diff your mappings against the shipped defaults in `cmd/defaults.yaml`.
+- Remove permissions that your automation does not need.
+- If you use ZITADEL-as-IdP **instance role sync**, the login client still needs permission to manage instance administrators for users logging in through that IdP; do not remove those capabilities without testing the support or federation flow you rely on.
+
+## Periodic review
+
+Review instance membership on a schedule and after major org or login changes.
+
+**List instance administrators** ([Internal Permission Service v2](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators)):
+
+```shell
+curl -sS -X POST \
+  "https://${CUSTOM_DOMAIN}/zitadel.internal_permission.v2.InternalPermissionService/ListAdministrators" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  -d '{
+    "pagination": { "offset": 0, "limit": 100, "asc": true },
+    "filters": [
+      { "resource": { "instance": true } }
+    ]
+  }'
+```
+
+The response includes each user's `organizationId` and granted `roles`, which helps verify platform-org placement.
+
+<Callout type="info">
+The Admin API `POST /admin/v1/members/_search` endpoint is deprecated; prefer `ListAdministrators` above.
+</Callout>
+
+**Questions to answer:**
+
+- Does every `IAM_*` holder belong to the platform org (or a documented exception)?
+- Does the login client service account hold **only** `IAM_LOGIN_CLIENT`?
+- Are there human `IAM_OWNER` accounts in application orgs?
+- Did any instance member change since the last review? Use the [Event API](/guides/integrate/zitadel-apis/event-api) or [stream audit logs to external systems](/guides/integrate/external-audit-log) for change history.
+
+## Detect grants with Actions v2
+
+Use [Actions v2](/concepts/features/actions_v2) to get notified when instance administrator memberships change, instead of relying only on scheduled API reviews.
+Each webhook receives the stored event, including the affected user and role list.
+
+**Prerequisites**
+
+- An access token for a user with `IAM_OWNER` (or another role that can manage Actions targets and executions).
+- A reachable HTTPS endpoint (or [Webhook.site](/guides/integrate/actions/webhook-site-setup) for testing).
+- Familiarity with the [Actions event guide](/guides/integrate/actions/testing-event) and [payload format](/guides/integrate/actions/usage#sent-information-event).
+
+### 1. Create a webhook target
+
+```shell
+curl -sS -X POST "https://${CUSTOM_DOMAIN}/v2/actions/targets" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "name": "instance-administrator-monitor",
+    "restWebhook": { "interruptOnError": false },
+    "endpoint": "https://your-ops-endpoint.example/webhook/zitadel-instance-members",
+    "timeout": "10s"
+  }'
+```
+
+Save the returned target ID. Verify inbound requests with the target [signing key](/guides/integrate/actions/testing-request-signature) in production.
+
+### 2. Register executions for instance member events
+
+Create one execution per event type you want to monitor:
+
+| Event | When it fires |
+| --- | --- |
+| `instance.member.added` | A user is granted instance administrator roles for the first time |
+| `instance.member.changed` | Instance administrator roles for a user are updated |
+| `instance.member.removed` | Instance administrator membership is removed |
+
+Example for new grants:
+
+```shell
+curl -sS -X PUT "https://${CUSTOM_DOMAIN}/v2/actions/executions" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "condition": {
+      "event": {
+        "event": "instance.member.added"
+      }
+    },
+    "targets": ["<TARGET_ID>"]
+  }'
+```
+
+Repeat for `instance.member.changed` and `instance.member.removed` if you want alerts on updates and removals as well.
+
+### 3. Interpret the webhook payload
+
+The webhook body follows the [Actions event payload](/guides/integrate/actions/usage#sent-information-event). For instance member events, relevant fields include:
+
+- `event_type` — e.g. `instance.member.added`
+- `aggregateType` — `instance`
+- `userID` — actor who performed the change (when available)
+- `event_payload` — JSON with at least `userId` (member) and `roles` (granted instance roles)
+
+Example decoded `event_payload` for a grant:
+
+```json
+{
+  "userId": "382586560962387915",
+  "roles": ["IAM_LOGIN_CLIENT", "IAM_OWNER"]
+}
+```
+
+### 4. What to flag in your handler
+
+Combine real-time events with the [periodic `ListAdministrators` review](#periodic-review) above:
+
+- Any `IAM_OWNER` or `IAM_USER_MANAGER` grant outside your platform org (compare `userId` to your allow-list or resolve org via API).
+- Login client service account holding roles other than `IAM_LOGIN_CLIENT`.
+- `instance.member.changed` where `roles` includes high-privilege `IAM_*` roles you did not expect.
+- Grants performed by users or service accounts that are not on your approved administrator list (`userID` in the outer payload).
+
+Post alerts to your operations channel, SIEM, or ticket system. On [ZITADEL Cloud](/guides/manage/cloud/overview), Actions v2 webhooks are supported; self-hosted installations can use the same API.
+
+See also: [Actions v2 examples](https://github.com/zitadel/actions/tree/main/actions-v2-cloudflare-workers) and [streaming audit logs](/guides/integrate/external-audit-log).
+
+## Monitor platform organization administrators
+
+Instance `IAM_*` roles are not the only risk in a mixed layout: **organization roles inside the platform org** (`ORG_USER_MANAGER`, `ORG_OWNER`, …) apply to users in that same org, including break-glass accounts and service users.
+
+Monitor organization administrators for the platform org alongside instance membership.
+
+### Periodic review (API)
+
+List organization administrators with [ListAdministrators](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators), filtered to your platform organization:
+
+```shell
+curl -sS -X POST \
+  "https://${CUSTOM_DOMAIN}/zitadel.internal_permission.v2.InternalPermissionService/ListAdministrators" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -H "Connect-Protocol-Version: 1" \
+  -d '{
+    "pagination": { "offset": 0, "limit": 100, "asc": true },
+    "filters": [
+      { "resource": { "organizationId": "${PLATFORM_ORG_ID}" } }
+    ]
+  }'
+```
+
+**Questions to answer:**
+
+- Are there `ORG_USER_MANAGER` or `ORG_OWNER` grants on the platform org you did not expect?
+- Do any humans hold org admin roles in the platform org without an operational reason?
+- Are customer or tenant admins accidentally granted roles in the platform org?
+
+In the management console, open the platform organization and review **ADMINISTRATORS** in the org details panel (same UI pattern as [ZITADEL Administrators](/guides/manage/console/administrators)).
+
+### Organization member events (Actions v2)
+
+| Event | When it fires |
+| --- | --- |
+| `org.member.added` | A user is granted organization administrator roles |
+| `org.member.changed` | Organization administrator roles are updated |
+| `org.member.removed` | Organization administrator membership is removed |
+
+Use the same [target setup](#1-create-a-webhook-target) as for instance members, then add executions:
+
+```shell
+curl -sS -X PUT "https://${CUSTOM_DOMAIN}/v2/actions/executions" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "condition": {
+      "event": {
+        "event": "org.member.added"
+      }
+    },
+    "targets": ["<TARGET_ID>"]
+  }'
+```
+
+Repeat for `org.member.changed` and `org.member.removed` as needed.
+
+The webhook payload uses the same [event structure](/guides/integrate/actions/usage#sent-information-event). For `org.member.*` events, `aggregateType` is `org` and `aggregateID` is the organization ID. Filter in your handler so you only alert when `aggregateID` equals your `${PLATFORM_ORG_ID}`. The `event_payload` contains `userId` and `roles` (for example `ORG_USER_MANAGER`, `ORG_OWNER`).
+
+Flag grants such as unexpected `ORG_USER_MANAGER` on the platform org, or any org admin role on users that should be machine-only service accounts.
+
+## Review changes with the Event API
+
+If you already pull audit data into a SIEM or batch job, the [Event API](/guides/integrate/zitadel-apis/event-api) is an alternative to [Actions v2 webhooks](#detect-grants-with-actions-v2).
+Poll on a schedule (for example every few minutes) and process new rows since the last `sequence`.
+
+Requires `IAM_OWNER` or `IAM_OWNER_VIEWER`.
+
+### Instance administrator events
+
+```shell
+curl -sS -X POST "https://${CUSTOM_DOMAIN}/admin/v1/events/_search" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "asc": true,
+    "limit": 1000,
+    "sequence": 0,
+    "aggregate_types": ["instance"],
+    "event_types": [
+      "instance.member.added",
+      "instance.member.changed",
+      "instance.member.removed"
+    ]
+  }'
+```
+
+Increase `sequence` on subsequent runs to the highest sequence returned previously so you only fetch new events.
+
+### Platform organization administrator events
+
+Filter by your platform organization ID as `resource_owner` and restrict to organization member events:
+
+```shell
+curl -sS -X POST "https://${CUSTOM_DOMAIN}/admin/v1/events/_search" \
+  -H "Authorization: Bearer ${IAM_OWNER_PAT}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "asc": true,
+    "limit": 1000,
+    "sequence": 0,
+    "resource_owner": "${PLATFORM_ORG_ID}",
+    "aggregate_types": ["org"],
+    "event_types": [
+      "org.member.added",
+      "org.member.changed",
+      "org.member.removed"
+    ]
+  }'
+```
+
+Parse each event payload for `userId` and `roles`, then apply the same allow-list checks as in the Actions handlers above.
+
+<Callout type="info">
+**Actions v2 vs Event API:** Actions push events to your endpoint in near real time with minimal setup. The Event API fits centralized log pipelines, replay, and environments where outbound webhooks are undesirable. You can use both.
+</Callout>
+
+## Checklist
+
+- [ ] Platform org exists; customer users are not members.
+- [ ] Login policy for the platform org enforces your operator authentication baseline (MFA, IdPs, lockout).
+- [ ] Login client service account lives in the platform org with a dedicated PAT.
+- [ ] Break-glass `IAM_OWNER` PAT is stored offline and tested periodically.
+- [ ] Custom `RolePermissionMappings` (if any) are reviewed against least privilege.
+- [ ] Platform org **organization** administrators (`ORG_*`) are reviewed and monitored (`org.member.*` events or Event API).
+- [ ] Instance membership is reviewed regularly and **Actions v2** monitors `instance.member.*` events (or changes are pulled via the **Event API** / SIEM).
+
+## Related guides
+
+- [ZITADEL Administrators](/guides/manage/console/administrators)
+- [Authenticate service accounts](/guides/integrate/service-accounts/authenticate-service-accounts)
+- [Production checklist (Cloud)](/guides/manage/production-checklist)
+- [Production checklist (self-hosting)](/self-hosting/manage/productionchecklist)
+- [Test Actions on events](/guides/integrate/actions/testing-event)
+- [Actions v2 usage and payloads](/guides/integrate/actions/usage)
+- [Get events from ZITADEL](/guides/integrate/zitadel-apis/event-api)

--- a/apps/docs/content/guides/manage/console/administrator-hardening.mdx
+++ b/apps/docs/content/guides/manage/console/administrator-hardening.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hardening instance administrators
-description: "Separate platform operators from application organizations, align login policies, and apply least privilege for instance roles and the login client."
+description: "Separate instance administrators from application organizations, align login settings, and apply least privilege for instance roles and the login client."
 sidebar_label: Administrator hardening
 ---
 
@@ -8,68 +8,68 @@ Instance administrators (`IAM_*` roles) can manage resources across every organi
 Organization administrators (`ORG_*` roles) manage users, projects, and policies within a single organization.
 When both kinds of principals share the same organization, their authorization scope and login experience overlap in ways that can potentially lead to unexpected account takeover.
 
-This guide describes a practical layout that keeps platform operations separate from customer or application organizations, and how to harden the login client and break-glass access.
+This guide describes a practical layout that keeps instance administration separate from customer or application organizations, and how to harden the login client and break-glass access.
 
-## Why use a dedicated platform organization
+## Why use a dedicated organization for instance administrators
 
-Create a **platform organization** that is reserved for instance-level operators and automation - not for end users or application teams.
+Create a **dedicated organization** reserved for instance administrators and automation—not for end users or application teams.
 
-| Concern | When operators share an application organization | With a dedicated platform organization |
+| Concern | When instance administrators share an application organization | With a dedicated organization for instance administrators |
 | --- | --- | --- |
-| **Authorization scope** | Organization roles such as `ORG_USER_MANAGER` apply within the same organization where instance administrators may also exist. | Instance roles remain on the instance; organization roles in application organizations cannot reach platform accounts. |
-| **Login policy** | [Login behavior and security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Organization administrators may change MFA, passkeys, external IdPs, or self-registration for the organization where platform accounts live. | You define a strict login policy only for operators—without coupling it to product organization settings. |
-| **Password and lockout policy** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the organization context of the user. | Operator accounts inherit policies you chose for the platform organization, independent of customer organizations. |
-| **Operational clarity** | Auditing “who is an admin” mixes customers and operators in one user list. | Instance members and platform service accounts are easy to inventory. |
+| **Authorization scope** | Organization roles such as `ORG_USER_MANAGER` apply within the same organization where instance administrators may also exist. | Instance roles remain on the instance; organization roles in application organizations cannot reach instance-administrator accounts. |
+| **Login Behavior and Security** | [Login Behavior and Security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Organization Administrators may change MFA, passkeys, external IdPs, or self-registration for the organization where instance-administrator accounts live. | You define strict Organization Login Settings only for instance administrators—without coupling them to product organization settings. |
+| **Password and lockout settings** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the organization context of the user. | Instance-administrator accounts inherit the Organization Settings you chose for that dedicated organization, independent of customer organizations. |
+| **Operational clarity** | Auditing who is an Administrator mixes customers and operators in one user list. | Instance administrators and service accounts are easy to inventory. |
 
 Instance [default settings](/guides/manage/console/default-settings) act as fallbacks for organizations.
-Organization-level permissions override still apply to users in that organization.
-Placing human instance owners or shared break-glass accounts in a customer organization means that organization's administrators can shape how those users authenticate and how local policies behave.
+Organization-level settings and policies still override instance defaults for users in that organization.
+Placing human instance owners or shared break-glass accounts in a customer organization means that organization's administrators can shape how those users authenticate and how local settings behave.
 
 <Callout type="info">
-The default organization created at setup is often used for the ZITADEL Console and internal projects.
-Treat it as a platform organization **only** if it does not host customer users and no organization-level administrators manage it on behalf of tenants.
-Otherwise, create a separate organization for platform operations.
+The default organization created at setup is often used for the Management Console and internal projects.
+Treat it as the dedicated organization for instance administrators **only** if it does not host customer users and no Organization Administrators manage it on behalf of customer organizations.
+Otherwise, create a separate organization for instance administration.
 </Callout>
 
 ## Recommended layout
 
 ```text
 Instance
-├── Platform organization (operators only)
+├── Dedicated organization (instance administrators only)
 │   ├── Break-glass IAM_OWNER service account (PAT, offline storage)
 │   ├── Login client service account (IAM_LOGIN_CLIENT only)
 │   └── Optional: other instance automation service accounts
 ├── Customer / application organization A
-│   └── End users, app admins (ORG_* only)
+│   └── End users, Organization Administrators (ORG_* only)
 └── Customer / application organization B
-    └── End users, app admins (ORG_* only)
+    └── End users, Organization Administrators (ORG_* only)
 ```
 
 **Guidelines:**
 
-- Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar organization roles to operators or service accounts in the platform organization unless they truly manage that organization only.
-- Do not add customer end users to the platform organization: tenant users inherit that organization's login and lockout policies, and tenant organization administrators can grant organization roles that blur operator and customer boundaries.
+- Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar organization roles to instance administrators or service accounts in the dedicated organization unless they truly manage that organization only.
+- Do not add customer end users to the dedicated organization: users in customer organizations inherit that organization's login and lockout settings, and Organization Administrators can grant organization roles that blur operator and customer boundaries.
 - Grant instance roles only on the **instance** administrator list, not as a substitute for organization roles on application resources. For instance service accounts (login client, break-glass), follow [Login client (`IAM_LOGIN_CLIENT`)](#login-client-iam_login_client) and review critical permissions in the [administrator permission matrix](/guides/manage/console/administrators#administrator-permission-matrix)—for example `iam.member.write`, `org.member.write`, `user.write`, `user.credential.write`, and `user.passkey.write`. Session permissions (`session.write`, `session.link`) are also granted by default and are required for the login UI—do not remove them without testing the full authentication flow. In self-hosted deployments, defaults can be customized via [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/administrators#configure-roles).
 
-## Login policy for the platform organization
+## Login settings for the dedicated organization
 
-Configure login behavior for the platform organization explicitly—do not rely on whatever policy happens to apply to a busy application organization.
+Configure Login Behavior and Security for the dedicated organization explicitly—do not rely on whatever Organization Login Settings happen to apply to a busy application organization.
 
-1. Open the platform organization in the management console.
-2. Review **Login behavior and security** (or set instance defaults first, then override only where needed).
-3. For operator accounts, consider:
+1. Open the dedicated organization in the Management Console.
+2. Review **Login Behavior and Security** (or set Instance Settings first, then override only where needed).
+3. For instance-administrator accounts, consider:
    - **Enforcing MFA** for local authentication.
-   - **Restricting external IdPs** if operators should only use credentials you control.
+   - **Restricting external IdPs** if instance administrators should only use credentials you control.
    - **Disabling self-registration** if the organization is not meant for public signup.
    - **Tight lockout** and **password complexity** aligned with your operator baseline.
-   - A **default redirect URI** that does not send operators to the customer console by mistake.
+   - A **default redirect URI** that does not send instance administrators to a customer application by mistake.
 
-Instance-level and organization-level [identity providers](/guides/manage/console/default-settings#identity-providers) are separate from the login policy that controls whether external login is allowed and which providers are linked for a given organization.
-An instance IdP can be used by users in an organization only when the **effective login policy** for that organization allows external IdPs (`External IDP allowed`) and the provider is **linked** to that policy—or when the organization inherits instance default settings, which includes the default IdP links.
-Organizations with a **custom login policy** must enable external IdPs themselves and explicitly add instance or organization IdPs to their provider list; see [Let users login with preferred identity provider](/guides/integrate/identity-providers/introduction).
-Document which IdPs platform operators may use in the platform organization.
+Instance-level and organization-level [identity providers](/guides/manage/console/default-settings#identity-providers) are separate from the Organization Login Settings that control whether external login is allowed and which providers are linked for a given organization.
+An instance IdP can be used by users in an organization only when the **effective Organization Login Settings** for that organization allow external IdPs (`External IDP allowed`) and the provider is **linked** to those settings—or when the organization inherits Instance Settings, which includes the default IdP links.
+Organizations with **custom Organization Login Settings** must enable external IdPs themselves and explicitly add instance or organization IdPs to their provider list; see [Let users login with preferred identity provider](/guides/integrate/identity-providers/introduction).
+Document which IdPs instance administrators may use in the dedicated organization.
 
-More context on policy inheritance: [Settings and policies](/concepts/structure/policies).
+More context on settings and policy inheritance: [Settings and policies](/concepts/structure/policies).
 
 ## Login client (`IAM_LOGIN_CLIENT`)
 
@@ -77,8 +77,8 @@ The self-hosted [Login UI](/guides/integrate/login-ui/fork-and-deploy-login-app)
 
 **Hardening steps:**
 
-- Create the login client user in the **platform organization**, not in a tenant organization.
-- Use a **dedicated machine user** per login deployment; do not reuse admin or application service account PATs.
+- Create the login client user in the **dedicated organization for instance administrators**, not in a customer or application organization.
+- Use a **dedicated service account** per login deployment; do not reuse administrator or application service account PATs.
 - Grant **only** `IAM_LOGIN_CLIENT` on the instance unless you have a documented exception.
 - Store the PAT in a **secrets manager**; rotate when the login stack is redeployed or team access changes.
 - Do not use the login client PAT for management automation, CI, or customer integrations.
@@ -90,15 +90,15 @@ Review the [administrator permission matrix](/guides/manage/console/administrato
 
 ## Break-glass instance owner access
 
-Before changing login routes, features, or instance settings, keep a recovery path that does not depend on the interactive login UI.
+Before changing login routes, features, or Instance Settings, keep a recovery path that does not depend on the interactive login UI.
 
 <Callout type="warn" title="Avoid lockout">
-Create a service account in the platform organization with the **Instance Owner** role (`IAM_OWNER`) and a PAT.
-Store the PAT offline according to your incident-access policy.
-If the login UI or console becomes unreachable, you can still call the [Admin API](/reference/api/admin) to revert settings.
+Create a service account in the dedicated organization with the **Instance Owner** role (`IAM_OWNER`) and a PAT.
+Store the PAT offline according to your incident-access procedures.
+If the login UI or Management Console becomes unreachable, you can still call the [Admin API](/reference/api/admin) to revert settings.
 </Callout>
 
-- Prefer a **machine user** for break-glass access; limit human `IAM_OWNER` accounts.
+- Prefer a **service account** for break-glass access; limit human `IAM_OWNER` accounts.
 - Enroll **multiple MFA methods** for any human instance owners.
 - Invite a **second trusted administrator** on the instance so access is not tied to a single person.
 
@@ -112,7 +112,7 @@ If you override [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/
 
 ## Periodic review
 
-Review instance membership on a schedule and after major organization or login changes.
+Review instance administrators on a schedule and after major organization or login changes.
 
 **List instance administrators** ([Internal Permission Service v2](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators)):
 
@@ -130,7 +130,7 @@ curl -sS -X POST \
   }'
 ```
 
-The response includes each user's `organizationId` and granted `roles`, which helps verify platform-organization placement.
+The response includes each user's `organizationId` and granted `roles`, which helps verify placement in the dedicated organization.
 
 <Callout type="info">
 The Admin API `POST /admin/v1/members/_search` endpoint is deprecated; prefer `ListAdministrators` above.
@@ -138,14 +138,14 @@ The Admin API `POST /admin/v1/members/_search` endpoint is deprecated; prefer `L
 
 **Questions to answer:**
 
-- Does every `IAM_*` holder belong to the platform organization (or a documented exception)?
+- Does every `IAM_*` holder belong to the dedicated organization for instance administrators (or a documented exception)?
 - Does the login client service account hold **only** `IAM_LOGIN_CLIENT`?
 - Are there human `IAM_OWNER` accounts in application organizations?
-- Did any instance member change since the last review? Use the [Event API](/guides/integrate/zitadel-apis/event-api) or [stream audit logs to external systems](/guides/integrate/external-audit-log) for change history.
+- Did any instance administrator change since the last review? Use the [Event API](/guides/integrate/zitadel-apis/event-api) or [stream audit logs to external systems](/guides/integrate/external-audit-log) for change history.
 
 ## Detect grants with Actions v2
 
-Use [Actions v2](/concepts/features/actions_v2) to get notified when instance administrator memberships change, instead of relying only on scheduled API reviews.
+Use [Actions v2](/concepts/features/actions_v2) to get notified when instance administrators change, instead of relying only on scheduled API reviews.
 Each webhook receives the stored event, including the affected user and role list.
 
 **Prerequisites**
@@ -179,7 +179,7 @@ Create one execution per event type you want to monitor:
 | --- | --- |
 | `instance.member.added` | A user is granted instance administrator roles for the first time |
 | `instance.member.changed` | Instance administrator roles for a user are updated |
-| `instance.member.removed` | Instance administrator membership is removed |
+| `instance.member.removed` | Instance administrator roles are removed |
 
 Example for new grants:
 
@@ -207,7 +207,7 @@ The webhook body follows the [Actions event payload](/guides/integrate/actions/u
 - `event_type` — e.g. `instance.member.added`
 - `aggregateType` — `instance`
 - `userID` — actor who performed the change (when available)
-- `event_payload` — JSON with at least `userId` (member) and `roles` (granted instance roles)
+- `event_payload` — JSON with at least `userId` (administrator) and `roles` (granted instance roles)
 
 Example decoded `event_payload` for a grant:
 
@@ -222,7 +222,7 @@ Example decoded `event_payload` for a grant:
 
 Combine real-time events with the [periodic `ListAdministrators` review](#periodic-review) above:
 
-- Any `IAM_OWNER` or `IAM_USER_MANAGER` grant outside your platform organization (compare `userId` to your allow-list or resolve organization via API).
+- Any `IAM_OWNER` or `IAM_USER_MANAGER` grant outside your dedicated organization for instance administrators (compare `userId` to your allow-list or resolve organization via API).
 - Login client service account holding roles other than `IAM_LOGIN_CLIENT`.
 - `instance.member.changed` where `roles` includes high-privilege `IAM_*` roles you did not expect.
 - Grants performed by users or service accounts that are not on your approved administrator list (`userID` in the outer payload).
@@ -231,15 +231,15 @@ Post alerts to your operations channel, SIEM, or ticket system. On [ZITADEL Clou
 
 See also: [Actions v2 examples](https://github.com/zitadel/actions/tree/main/actions-v2-cloudflare-workers) and [streaming audit logs](/guides/integrate/external-audit-log).
 
-## Monitor platform organization administrators
+## Monitor organization administrators in the dedicated organization
 
-Instance `IAM_*` roles are not the only risk in a mixed layout: **organization roles inside the platform organization** (`ORG_USER_MANAGER`, `ORG_OWNER`, …) apply to users in that same organization, including break-glass accounts and service users.
+Instance `IAM_*` roles are not the only risk in a mixed layout: **organization roles inside the dedicated organization** (`ORG_USER_MANAGER`, `ORG_OWNER`, …) apply to users in that same organization, including break-glass accounts and service accounts.
 
-Monitor organization administrators for the platform organization alongside instance membership.
+Monitor Organization Administrators for the dedicated organization alongside instance administrators.
 
 ### Periodic review (API)
 
-List organization administrators with [ListAdministrators](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators), filtered to your platform organization:
+List Organization Administrators with [ListAdministrators](/reference/api/internal_permission/zitadel.internal_permission.v2.InternalPermissionService.ListAdministrators), filtered to your dedicated organization:
 
 ```shell
 curl -sS -X POST \
@@ -250,18 +250,18 @@ curl -sS -X POST \
   -d '{
     "pagination": { "offset": 0, "limit": 100, "asc": true },
     "filters": [
-      { "resource": { "organizationId": "${PLATFORM_ORG_ID}" } }
+      { "resource": { "organizationId": "${PLATFORM_ORGANIZATION_ID}" } }
     ]
   }'
 ```
 
 **Questions to answer:**
 
-- Are there `ORG_USER_MANAGER` or `ORG_OWNER` grants on the platform organization you did not expect?
-- Do any operators or service accounts hold organization administrator roles in the platform organization without an operational reason?
-- Are customer or tenant administrators accidentally granted roles in the platform organization?
+- Are there `ORG_USER_MANAGER` or `ORG_OWNER` grants on the dedicated organization you did not expect?
+- Do any instance administrators or service accounts hold Organization Administrator roles in the dedicated organization without an operational reason?
+- Are customer Organization Administrators accidentally granted roles in the dedicated organization?
 
-In the management console, open the platform organization and review **ADMINISTRATORS** in the organization details panel (same UI pattern as [ZITADEL Administrators](/guides/manage/console/administrators)).
+In the Management Console, open the dedicated organization and review **ADMINISTRATORS** in the organization details panel (same UI pattern as [ZITADEL Administrators](/guides/manage/console/administrators)).
 
 ### Organization member events (Actions v2)
 
@@ -269,9 +269,9 @@ In the management console, open the platform organization and review **ADMINISTR
 | --- | --- |
 | `org.member.added` | A user is granted organization administrator roles |
 | `org.member.changed` | Organization administrator roles are updated |
-| `org.member.removed` | Organization administrator membership is removed |
+| `org.member.removed` | Organization administrator roles are removed |
 
-Use the same [target setup](#1-create-a-webhook-target) as for instance members, then add executions:
+Use the same [target setup](#1-create-a-webhook-target) as for instance member events, then add executions:
 
 ```shell
 curl -sS -X PUT "https://${CUSTOM_DOMAIN}/v2/actions/executions" \
@@ -290,9 +290,9 @@ curl -sS -X PUT "https://${CUSTOM_DOMAIN}/v2/actions/executions" \
 
 Repeat for `org.member.changed` and `org.member.removed` as needed.
 
-The webhook payload uses the same [event structure](/guides/integrate/actions/usage#sent-information-event). For `org.member.*` events, `aggregateType` is `org` and `aggregateID` is the organization ID. Filter in your handler so you only alert when `aggregateID` equals your `${PLATFORM_ORG_ID}`. The `event_payload` contains `userId` and `roles` (for example `ORG_USER_MANAGER`, `ORG_OWNER`).
+The webhook payload uses the same [event structure](/guides/integrate/actions/usage#sent-information-event). For `org.member.*` events, `aggregateType` is `org` and `aggregateID` is the organization ID. Filter in your handler so you only alert when `aggregateID` equals your `${PLATFORM_ORGANIZATION_ID}`. The `event_payload` contains `userId` and `roles` (for example `ORG_USER_MANAGER`, `ORG_OWNER`).
 
-Flag grants such as unexpected `ORG_USER_MANAGER` on the platform organization, or any organization administrator role on users that should be machine-only service accounts.
+Flag grants such as unexpected `ORG_USER_MANAGER` on the dedicated organization, or any Organization Administrator role on users that should be service accounts only.
 
 ## Review changes with the Event API
 
@@ -322,9 +322,9 @@ curl -sS -X POST "https://${CUSTOM_DOMAIN}/admin/v1/events/_search" \
 
 Increase `sequence` on subsequent runs to the highest sequence returned previously so you only fetch new events.
 
-### Platform organization administrator events
+### Dedicated organization administrator events
 
-Filter by your platform organization ID as `resource_owner` and restrict to organization member events:
+Filter by your dedicated organization ID as `resource_owner` and restrict to organization member events:
 
 ```shell
 curl -sS -X POST "https://${CUSTOM_DOMAIN}/admin/v1/events/_search" \
@@ -334,7 +334,7 @@ curl -sS -X POST "https://${CUSTOM_DOMAIN}/admin/v1/events/_search" \
     "asc": true,
     "limit": 1000,
     "sequence": 0,
-    "resource_owner": "${PLATFORM_ORG_ID}",
+    "resource_owner": "${PLATFORM_ORGANIZATION_ID}",
     "aggregate_types": ["org"],
     "event_types": [
       "org.member.added",
@@ -352,13 +352,13 @@ Parse each event payload for `userId` and `roles`, then apply the same allow-lis
 
 ## Checklist
 
-- [ ] Platform organization exists; customer users are not members.
-- [ ] Login policy for the platform organization enforces your operator authentication baseline (MFA, IdPs, lockout).
-- [ ] Login client service account lives in the platform organization with a dedicated PAT.
+- [ ] Dedicated organization for instance administrators exists; customer users are not members.
+- [ ] Login Behavior and Security for the dedicated organization enforces your operator authentication baseline (MFA, IdPs, lockout).
+- [ ] Login client service account lives in the dedicated organization with a dedicated PAT.
 - [ ] Break-glass `IAM_OWNER` PAT is stored offline and tested periodically.
 - [ ] Custom `RolePermissionMappings` (if any) are reviewed against least privilege.
-- [ ] Platform organization administrators (`ORG_*`) are reviewed and monitored (`org.member.*` events or Event API).
-- [ ] Instance membership is reviewed regularly and **Actions v2** monitors `instance.member.*` events (or changes are pulled via the **Event API** / SIEM).
+- [ ] Organization Administrators (`ORG_*`) on the dedicated organization are reviewed and monitored (`org.member.*` events or Event API).
+- [ ] Instance administrators are reviewed regularly and **Actions v2** monitors `instance.member.*` events (or changes are pulled via the **Event API** / SIEM).
 
 ## Related guides
 

--- a/apps/docs/content/guides/manage/console/administrator-hardening.mdx
+++ b/apps/docs/content/guides/manage/console/administrator-hardening.mdx
@@ -4,6 +4,11 @@ description: "Separate instance administrators from application organizations, a
 sidebar_label: Administrator hardening
 ---
 
+<TerminologyUpdate
+    newTerm="Administrators"
+    oldTerms={["Members", "Memberships", "Managers"]}
+/>
+
 Instance administrators (`IAM_*` roles) can manage resources across every organization on an instance.
 Organization administrators (`ORG_*` roles) manage users, projects, and policies within a single organization.
 When both kinds of principals share the same organization, their authorization scope and login experience overlap in ways that can potentially lead to unexpected account takeover.
@@ -19,7 +24,7 @@ Create a **dedicated organization** reserved for instance administrators and aut
 | **Authorization scope** | Organization roles such as `ORG_USER_MANAGER` apply within the same organization where instance administrators may also exist. | Instance roles remain on the instance; organization roles in application organizations cannot reach instance-administrator accounts. |
 | **Login Behavior and Security** | [Login Behavior and Security](/guides/manage/console/default-settings#login-behavior-and-security) can be overridden per organization. Organization Administrators may change MFA, passkeys, external IdPs, or self-registration for the organization where instance-administrator accounts live. | You define strict Organization Login Settings only for instance administrators—without coupling them to product organization settings. |
 | **Password and lockout settings** | [Password complexity](/guides/manage/console/default-settings#password-complexity), [password expiry](/guides/manage/console/default-settings#password-expiry), and [lockout](/guides/manage/console/default-settings#lockout) follow the organization context of the user. | Instance-administrator accounts inherit the Organization Settings you chose for that dedicated organization, independent of customer organizations. |
-| **Operational clarity** | Auditing who is an Administrator mixes customers and operators in one user list. | Instance administrators and service accounts are easy to inventory. |
+| **Operational clarity** | Auditing who is an Administrator mixes customers and instance administrators in one user list. | Instance administrators and service accounts are easy to inventory. |
 
 Instance [default settings](/guides/manage/console/default-settings) act as fallbacks for organizations.
 Organization-level settings and policies still override instance defaults for users in that organization.
@@ -48,7 +53,7 @@ Instance
 **Guidelines:**
 
 - Do not assign `ORG_USER_MANAGER`, `ORG_OWNER`, or similar organization roles to instance administrators or service accounts in the dedicated organization unless they truly manage that organization only.
-- Do not add customer end users to the dedicated organization: users in customer organizations inherit that organization's login and lockout settings, and Organization Administrators can grant organization roles that blur operator and customer boundaries.
+- Do not add customer end users to the dedicated organization: users in customer organizations inherit that organization's login and lockout settings, and Organization Administrators can grant organization roles that blur instance-administrator and customer boundaries.
 - Grant instance roles only on the **instance** administrator list, not as a substitute for organization roles on application resources. For instance service accounts (login client, break-glass), follow [Login client (`IAM_LOGIN_CLIENT`)](#login-client-iam_login_client) and review critical permissions in the [administrator permission matrix](/guides/manage/console/administrators#administrator-permission-matrix)—for example `iam.member.write`, `org.member.write`, `user.write`, `user.credential.write`, and `user.passkey.write`. Session permissions (`session.write`, `session.link`) are also granted by default and are required for the login UI—do not remove them without testing the full authentication flow. In self-hosted deployments, defaults can be customized via [`InternalAuthZ.RolePermissionMappings`](/guides/manage/console/administrators#configure-roles).
 
 ## Login settings for the dedicated organization
@@ -61,7 +66,7 @@ Configure Login Behavior and Security for the dedicated organization explicitly�
    - **Enforcing MFA** for local authentication.
    - **Restricting external IdPs** if instance administrators should only use credentials you control.
    - **Disabling self-registration** if the organization is not meant for public signup.
-   - **Tight lockout** and **password complexity** aligned with your operator baseline.
+   - **Tight lockout** and **password complexity** aligned with your instance-administrator baseline.
    - A **default redirect URI** that does not send instance administrators to a customer application by mistake.
 
 Instance-level and organization-level [identity providers](/guides/manage/console/default-settings#identity-providers) are separate from the Organization Login Settings that control whether external login is allowed and which providers are linked for a given organization.
@@ -353,7 +358,7 @@ Parse each event payload for `userId` and `roles`, then apply the same allow-lis
 ## Checklist
 
 - [ ] Dedicated organization for instance administrators exists; customer users are not members.
-- [ ] Login Behavior and Security for the dedicated organization enforces your operator authentication baseline (MFA, IdPs, lockout).
+- [ ] Login Behavior and Security for the dedicated organization enforces your instance-administrator authentication baseline (MFA, IdPs, lockout).
 - [ ] Login client service account lives in the dedicated organization with a dedicated PAT.
 - [ ] Break-glass `IAM_OWNER` PAT is stored offline and tested periodically.
 - [ ] Custom `RolePermissionMappings` (if any) are reviewed against least privilege.

--- a/apps/docs/content/guides/manage/console/administrators.mdx
+++ b/apps/docs/content/guides/manage/console/administrators.mdx
@@ -24,7 +24,7 @@ In the right part of the management console you can find **ADMINISTRATORS** in t
 <AddAdministrator components={props.components}  name="AddAdministrator" />
 
 <Callout type="info">
-For separation of platform operators from application organizations, login policy alignment, and login client hygiene, see [Hardening instance administrators](/guides/manage/console/administrator-hardening).
+For separation of instance administrators from application organizations, login settings alignment, and login client hygiene, see [Hardening instance administrators](/guides/manage/console/administrator-hardening).
 </Callout>
 
 ## Roles

--- a/apps/docs/content/guides/manage/console/administrators.mdx
+++ b/apps/docs/content/guides/manage/console/administrators.mdx
@@ -23,6 +23,10 @@ In the right part of the management console you can find **ADMINISTRATORS** in t
 
 <AddAdministrator components={props.components}  name="AddAdministrator" />
 
+<Callout type="info">
+For separation of platform operators from application organizations, login policy alignment, and login client hygiene, see [Hardening instance administrators](/guides/manage/console/administrator-hardening).
+</Callout>
+
 ## Roles
 
 | Name                          | Role                          | Description                                                                                                  |

--- a/apps/docs/content/guides/manage/production-checklist.mdx
+++ b/apps/docs/content/guides/manage/production-checklist.mdx
@@ -32,7 +32,7 @@ Eliminate Single Points of Failure (SPOF) for administrative access.
 - [ ] **Diverse MFA Methods**: Ensure your administrators enroll multiple MFA methods (e.g., one on a YubiKey, one on an Authenticator app) to maximize recovery options.
 - [ ] **Backup Service Account**: Create a dedicated Service Account with a PAT and with administrative roles (IAM_OWNER).
   - **Why**: If a misconfigured "Action" or a CSS error breaks the Management Console UI, you can still revert changes or manage the instance directly via the ZITADEL Management API using this PAT.
-
+- [ ] **Platform organization**: Keep instance administrators and the login client service account in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with a login policy suited for operators—not mixed with customer users or org admins.
 
 ### ZITADEL Setup and Configuration
 

--- a/apps/docs/content/guides/manage/production-checklist.mdx
+++ b/apps/docs/content/guides/manage/production-checklist.mdx
@@ -32,7 +32,7 @@ Eliminate Single Points of Failure (SPOF) for administrative access.
 - [ ] **Diverse MFA Methods**: Ensure your administrators enroll multiple MFA methods (e.g., one on a YubiKey, one on an Authenticator app) to maximize recovery options.
 - [ ] **Backup Service Account**: Create a dedicated Service Account with a PAT and with administrative roles (IAM_OWNER).
   - **Why**: If a misconfigured "Action" or a CSS error breaks the Management Console UI, you can still revert changes or manage the instance directly via the ZITADEL Management API using this PAT.
-- [ ] **Dedicated organization for instance administrators**: Keep instance administrators and the login client service account in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with Login Behavior and Security suited for operators—not mixed with customer users or Organization Administrators.
+- [ ] **Dedicated administrator organization**: Keep instance administrators and the login client service account in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with Login Behavior and Security suited for instance administrators—not mixed with customer users or Organization Administrators.
 
 ### ZITADEL Setup and Configuration
 

--- a/apps/docs/content/guides/manage/production-checklist.mdx
+++ b/apps/docs/content/guides/manage/production-checklist.mdx
@@ -32,7 +32,7 @@ Eliminate Single Points of Failure (SPOF) for administrative access.
 - [ ] **Diverse MFA Methods**: Ensure your administrators enroll multiple MFA methods (e.g., one on a YubiKey, one on an Authenticator app) to maximize recovery options.
 - [ ] **Backup Service Account**: Create a dedicated Service Account with a PAT and with administrative roles (IAM_OWNER).
   - **Why**: If a misconfigured "Action" or a CSS error breaks the Management Console UI, you can still revert changes or manage the instance directly via the ZITADEL Management API using this PAT.
-- [ ] **Platform organization**: Keep instance administrators and the login client service account in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with a login policy suited for operators—not mixed with customer users or organization administrators.
+- [ ] **Dedicated organization for instance administrators**: Keep instance administrators and the login client service account in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with Login Behavior and Security suited for operators—not mixed with customer users or Organization Administrators.
 
 ### ZITADEL Setup and Configuration
 

--- a/apps/docs/content/guides/manage/production-checklist.mdx
+++ b/apps/docs/content/guides/manage/production-checklist.mdx
@@ -32,7 +32,7 @@ Eliminate Single Points of Failure (SPOF) for administrative access.
 - [ ] **Diverse MFA Methods**: Ensure your administrators enroll multiple MFA methods (e.g., one on a YubiKey, one on an Authenticator app) to maximize recovery options.
 - [ ] **Backup Service Account**: Create a dedicated Service Account with a PAT and with administrative roles (IAM_OWNER).
   - **Why**: If a misconfigured "Action" or a CSS error breaks the Management Console UI, you can still revert changes or manage the instance directly via the ZITADEL Management API using this PAT.
-- [ ] **Platform organization**: Keep instance administrators and the login client service account in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with a login policy suited for operators—not mixed with customer users or org admins.
+- [ ] **Platform organization**: Keep instance administrators and the login client service account in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with a login policy suited for operators—not mixed with customer users or organization administrators.
 
 ### ZITADEL Setup and Configuration
 

--- a/apps/docs/content/self-hosting/manage/login-client.mdx
+++ b/apps/docs/content/self-hosting/manage/login-client.mdx
@@ -5,7 +5,7 @@ sidebar_label: Create a Login Client
 ---
 
 To enable your self-hosted Login UI to connect to the Zitadel API, it needs a token for a user with the IAM_LOGIN_CLIENT role.
-Place that service account in a dedicated platform organization and follow [Hardening instance administrators](/guides/manage/console/administrator-hardening) for least-privilege and login policy alignment.
+Place that service account in a dedicated organization for instance administrators and follow [Hardening instance administrators](/guides/manage/console/administrator-hardening) for least-privilege and login settings alignment.
 
 On new installations, the Zitadel setup job can be configured to automatically write a Personal Access Token (PAT) for the login client.
 Check out [one of the deployment examples](https://zitadel.com/docs/self-hosting/deploy/overview) to learn how to do this.

--- a/apps/docs/content/self-hosting/manage/login-client.mdx
+++ b/apps/docs/content/self-hosting/manage/login-client.mdx
@@ -5,6 +5,8 @@ sidebar_label: Create a Login Client
 ---
 
 To enable your self-hosted Login UI to connect to the Zitadel API, it needs a token for a user with the IAM_LOGIN_CLIENT role.
+Place that service account in a dedicated platform organization and follow [Hardening instance administrators](/guides/manage/console/administrator-hardening) for least-privilege and login policy alignment.
+
 On new installations, the Zitadel setup job can be configured to automatically write a Personal Access Token (PAT) for the login client.
 Check out [one of the deployment examples](https://zitadel.com/docs/self-hosting/deploy/overview) to learn how to do this.
 

--- a/apps/docs/content/self-hosting/manage/productionchecklist.mdx
+++ b/apps/docs/content/self-hosting/manage/productionchecklist.mdx
@@ -52,6 +52,7 @@ To apply best practices to your production setup we created a step by step check
 - [ ] Ensure that your ZITADEL does not use [the default, example or _easy-to-guess_ credentials](/self-hosting/manage/database#zitadel-credentials)
 - [ ] Use a FQDN and a trusted valid certificate for external [TLS](/self-hosting/manage/tls_modes) connections
 - [ ] Create service accounts for applications that interact with ZITADEL's APIs
+- [ ] Isolate instance administrators and the login client in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with operator-appropriate login and lockout policies
 - [ ] Make use of a CDN service to decrease the load for static assets served by ZITADEL
 - [ ] Make use of a [security scanner](https://owasp.org/www-community/Vulnerability_Scanning_Tools) to test your application and deployment environment
 

--- a/apps/docs/content/self-hosting/manage/productionchecklist.mdx
+++ b/apps/docs/content/self-hosting/manage/productionchecklist.mdx
@@ -52,7 +52,7 @@ To apply best practices to your production setup we created a step by step check
 - [ ] Ensure that your ZITADEL does not use [the default, example or _easy-to-guess_ credentials](/self-hosting/manage/database#zitadel-credentials)
 - [ ] Use a FQDN and a trusted valid certificate for external [TLS](/self-hosting/manage/tls_modes) connections
 - [ ] Create service accounts for applications that interact with ZITADEL's APIs
-- [ ] Isolate instance administrators and the login client in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with operator-appropriate login and lockout settings
+- [ ] Isolate instance administrators and the login client in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with login and lockout settings suited for instance administrators
 - [ ] Make use of a CDN service to decrease the load for static assets served by ZITADEL
 - [ ] Make use of a [security scanner](https://owasp.org/www-community/Vulnerability_Scanning_Tools) to test your application and deployment environment
 

--- a/apps/docs/content/self-hosting/manage/productionchecklist.mdx
+++ b/apps/docs/content/self-hosting/manage/productionchecklist.mdx
@@ -52,7 +52,7 @@ To apply best practices to your production setup we created a step by step check
 - [ ] Ensure that your ZITADEL does not use [the default, example or _easy-to-guess_ credentials](/self-hosting/manage/database#zitadel-credentials)
 - [ ] Use a FQDN and a trusted valid certificate for external [TLS](/self-hosting/manage/tls_modes) connections
 - [ ] Create service accounts for applications that interact with ZITADEL's APIs
-- [ ] Isolate instance administrators and the login client in a [dedicated platform organization](/guides/manage/console/administrator-hardening) with operator-appropriate login and lockout policies
+- [ ] Isolate instance administrators and the login client in a [dedicated organization for instance administrators](/guides/manage/console/administrator-hardening) with operator-appropriate login and lockout settings
 - [ ] Make use of a CDN service to decrease the load for static assets served by ZITADEL
 - [ ] Make use of a [security scanner](https://owasp.org/www-community/Vulnerability_Scanning_Tools) to test your application and deployment environment
 

--- a/apps/docs/lib/sidebar-data.ts
+++ b/apps/docs/lib/sidebar-data.ts
@@ -663,6 +663,7 @@ export const guidesSidebar: readonly SidebarItem[] = [
           "guides/integrate/retrieve-user-roles",
           "concepts/structure/granted_projects",
           "guides/manage/console/administrators",
+          "guides/manage/console/administrator-hardening",
         ],
       },
       {


### PR DESCRIPTION
# Which Problems Are Solved

- Operators lack a single guide for separating instance-level principals (break-glass, login client) from tenant organizations.
- Login policy and IdP behavior for platform accounts is easy to conflate with customer org settings when admins share one organization.
- There is no documented procedure to inventory instance administrators or detect unexpected grants over time.

# How the Problems Are Solved

- Add Hardening instance administrators covering:
  - Dedicated platform organization layout and why login, password, and lockout policies matter for operator accounts.
  - Login client (`IAM_LOGIN_CLIENT`) and break-glass (`IAM_OWNER`) hygiene.
  - Periodic review with Internal Permission Service v2 `ListAdministrators` (instance and platform org filters).
  - Actions v2 webhooks for `instance.member.*` and `org.member.*` events (with payload interpretation and alert hints).
  - Event API polling alternative for SIEM/batch pipelines (`instance.member.*` and platform-org `org.member.*`).
- Register the page in the docs sidebar under Roles & Permissions.
- Cross-link from administrators, production checklists, login-client setup, and service account authentication guides.

# Additional Changes

- Clarify instance vs org IdP availability depends on effective login policy and linked providers (not automatic for all orgs).
- Note deprecated Admin API `POST /admin/v1/members/_search` vs v2 `ListAdministrators`.

# Additional Context

- Operational hardening guide only (no product authz changes).
