### PR TITLE
fix(login): handle stale sessions in loadMostRecentSession

### DIFF
--- a/apps/login/src/lib/session.test.ts
+++ b/apps/login/src/lib/session.test.ts
@@ -35,7 +35,6 @@ vi.mock("./zitadel", () => ({
 
 vi.mock("./cookies", () => ({
   getMostRecentCookieWithLoginname: vi.fn(),
-  removeSessionFromCookie: vi.fn(),
 }));
 
 vi.mock("./verify-helper", () => ({
@@ -1642,29 +1641,19 @@ describe("loadMostRecentSession", () => {
     });
   });
 
-  test("removes the stale cookie and returns undefined when getSession rejects with NotFound", async () => {
+  test("returns undefined instead of throwing when getSession rejects with NotFound (stale cookie)", async () => {
+    // The `sessions` cookie can outlive the server-side session, so getSession may reject with
+    // a NotFound ConnectError. loadMostRecentSession must treat that the same as no session.
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = new ConnectError("session is gone", Code.NotFound);
+    const notFound = new ConnectError("Session does not exist (QUERY-SFeaa)", Code.NotFound);
     vi.mocked(cookiesModule.getMostRecentCookieWithLoginname).mockResolvedValue(cookie as any);
-    vi.mocked(zitadelModule.getSession).mockRejectedValue(error);
+    vi.mocked(zitadelModule.getSession).mockRejectedValue(notFound);
 
     const result = await loadMostRecentSession({ serviceConfig, sessionParams });
 
     expect(result).toBeUndefined();
-    expect(cookiesModule.removeSessionFromCookie).toHaveBeenCalledWith({ session: cookie });
-    expect(consoleSpy).toHaveBeenCalledWith("[Session] Removing stale session from cookie", error);
+    expect(consoleSpy).toHaveBeenCalledWith("[Session] Could not load most recent session", notFound);
     consoleSpy.mockRestore();
-  });
-
-  test("returns undefined when cookie mutation is unavailable during render", async () => {
-    const notFound = new ConnectError("session is gone", Code.NotFound);
-    vi.mocked(cookiesModule.getMostRecentCookieWithLoginname).mockResolvedValue(cookie as any);
-    vi.mocked(zitadelModule.getSession).mockRejectedValue(notFound);
-    vi.mocked(cookiesModule.removeSessionFromCookie).mockRejectedValue(
-      new Error("Cookies can only be modified in a Server Action or Route Handler"),
-    );
-
-    await expect(loadMostRecentSession({ serviceConfig, sessionParams })).resolves.toBeUndefined();
   });
 
   test("re-throws non-NotFound ConnectErrors (real failures must propagate)", async () => {

--- a/apps/login/src/lib/session.test.ts
+++ b/apps/login/src/lib/session.test.ts
@@ -35,6 +35,7 @@ vi.mock("./zitadel", () => ({
 
 vi.mock("./cookies", () => ({
   getMostRecentCookieWithLoginname: vi.fn(),
+  removeSessionFromCookie: vi.fn(),
 }));
 
 vi.mock("./verify-helper", () => ({
@@ -1641,19 +1642,29 @@ describe("loadMostRecentSession", () => {
     });
   });
 
-  test("returns undefined instead of throwing when getSession rejects with NotFound (stale cookie)", async () => {
-    // The `sessions` cookie can outlive the server-side session, so getSession may reject with
-    // a NotFound ConnectError. loadMostRecentSession must treat that the same as no session.
+  test("removes the stale cookie and returns undefined when getSession rejects with NotFound", async () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const notFound = new ConnectError("Session does not exist (QUERY-SFeaa)", Code.NotFound);
+    const error = new ConnectError("session is gone", Code.NotFound);
     vi.mocked(cookiesModule.getMostRecentCookieWithLoginname).mockResolvedValue(cookie as any);
-    vi.mocked(zitadelModule.getSession).mockRejectedValue(notFound);
+    vi.mocked(zitadelModule.getSession).mockRejectedValue(error);
 
     const result = await loadMostRecentSession({ serviceConfig, sessionParams });
 
     expect(result).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith("[Session] Could not load most recent session", notFound);
+    expect(cookiesModule.removeSessionFromCookie).toHaveBeenCalledWith({ session: cookie });
+    expect(consoleSpy).toHaveBeenCalledWith("[Session] Removing stale session from cookie", error);
     consoleSpy.mockRestore();
+  });
+
+  test("returns undefined when cookie mutation is unavailable during render", async () => {
+    const notFound = new ConnectError("session is gone", Code.NotFound);
+    vi.mocked(cookiesModule.getMostRecentCookieWithLoginname).mockResolvedValue(cookie as any);
+    vi.mocked(zitadelModule.getSession).mockRejectedValue(notFound);
+    vi.mocked(cookiesModule.removeSessionFromCookie).mockRejectedValue(
+      new Error("Cookies can only be modified in a Server Action or Route Handler"),
+    );
+
+    await expect(loadMostRecentSession({ serviceConfig, sessionParams })).resolves.toBeUndefined();
   });
 
   test("re-throws non-NotFound ConnectErrors (real failures must propagate)", async () => {

--- a/apps/login/src/lib/session.ts
+++ b/apps/login/src/lib/session.ts
@@ -5,7 +5,7 @@ import { SAMLRequest } from "@zitadel/proto/zitadel/saml/v2/authorization_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { GetSessionResponse } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
-import { getMostRecentCookieWithLoginname, removeSessionFromCookie } from "./cookies";
+import { getMostRecentCookieWithLoginname } from "./cookies";
 import { shouldEnforceMFA } from "./verify-helper";
 import { getLoginSettings, getSession, getUserByID, listAuthenticationMethodTypes, ServiceConfig } from "./zitadel";
 
@@ -38,24 +38,18 @@ export async function loadMostRecentSession({
     });
     return response.session;
   } catch (error) {
-    const isStaleCookieSession = error instanceof ConnectError && error.code === Code.NotFound;
-
-    if (!isStaleCookieSession) {
-      throw error;
+    // The `sessions` cookie has no maxAge, so it can outlive the server-side session
+    // (logout, admin/API termination, removed user/org/instance) and getSession throws
+    // `not_found`. Treat it like the no-cookie case above. The stale entry is not pruned
+    // here: nearly every caller is a server-component render, where Next.js forbids
+    // cookie writes. Pruning lives in the server actions that already rewrite the
+    // cookie with the instance's iframe setting (see clearSession in server/session.ts).
+    if (error instanceof ConnectError && error.code === Code.NotFound) {
+      console.warn("[Session] Could not load most recent session", error);
+      return undefined;
     }
 
-    // A server-side logout or termination can remove a session while the browser
-    // still holds its entry. The most recent-session callers already handle this
-    // as no session; remove the stale entry when the current context permits it.
-    console.warn("[Session] Removing stale session from cookie", error);
-    try {
-      await removeSessionFromCookie({ session: recent });
-    } catch (cookieError) {
-      if (!(cookieError instanceof Error) || !cookieError.message.includes("Cookies can only be modified")) {
-        throw cookieError;
-      }
-    }
-    return undefined;
+    throw error;
   }
 }
 

--- a/apps/login/src/lib/session.ts
+++ b/apps/login/src/lib/session.ts
@@ -1,10 +1,11 @@
+import { Code, ConnectError } from "@connectrpc/connect";
 import { Timestamp, timestampDate } from "@zitadel/client";
 import { AuthRequest } from "@zitadel/proto/zitadel/oidc/v2/authorization_pb";
 import { SAMLRequest } from "@zitadel/proto/zitadel/saml/v2/authorization_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { GetSessionResponse } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
-import { getMostRecentCookieWithLoginname } from "./cookies";
+import { getMostRecentCookieWithLoginname, removeSessionFromCookie } from "./cookies";
 import { shouldEnforceMFA } from "./verify-helper";
 import { getLoginSettings, getSession, getUserByID, listAuthenticationMethodTypes, ServiceConfig } from "./zitadel";
 
@@ -29,26 +30,33 @@ export async function loadMostRecentSession({
     return undefined;
   }
 
-  return getSession({ serviceConfig, sessionId: recent.id, sessionToken: recent.token })
-    .then((resp: GetSessionResponse) => resp.session)
-    .catch(async (error) => {
-      const { Code, ConnectError } = await import("@connectrpc/connect");
-      const isNotFound = error instanceof ConnectError && error.code === Code.NotFound;
-
-      // The `sessions` cookie has no maxAge, so it can outlive the server-side session
-      // and reference one the session projection no longer holds — e.g. the user logged out, an
-      // admin/API terminated the session, or the user/org/instance was removed. In that
-      // case getSession throws `not_found`. Treat it like the no-cookie case above and
-      // return undefined instead of letting the error crash the caller's render. Every
-      // call site already handles an undefined session — either with a graceful fallback
-      // or by throwing its own explicit "no session" error.
-      if (isNotFound) {
-        console.warn("[Session] Could not load most recent session", error);
-        return undefined;
-      }
-
-      throw error;
+  try {
+    const response: GetSessionResponse = await getSession({
+      serviceConfig,
+      sessionId: recent.id,
+      sessionToken: recent.token,
     });
+    return response.session;
+  } catch (error) {
+    const isStaleCookieSession = error instanceof ConnectError && error.code === Code.NotFound;
+
+    if (!isStaleCookieSession) {
+      throw error;
+    }
+
+    // A server-side logout or termination can remove a session while the browser
+    // still holds its entry. The most recent-session callers already handle this
+    // as no session; remove the stale entry when the current context permits it.
+    console.warn("[Session] Removing stale session from cookie", error);
+    try {
+      await removeSessionFromCookie({ session: recent });
+    } catch (cookieError) {
+      if (!(cookieError instanceof Error) || !cookieError.message.includes("Cookies can only be modified")) {
+        throw cookieError;
+      }
+    }
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Please inform yourself about the contribution guidelines on submitting a PR here: https://github.com/zitadel/zitadel/blob/main/CONTRIBUTING.md#submit-a-pull-request-pr. Take note of how PR/commit titles should be written and replace the template texts in the sections below. Don't remove any of the sections. It is important that the commit history clearly shows what is changed and why.
Important: By submitting a contribution you agree to the terms from our Licensing Policy as described here: https://github.com/zitadel/zitadel/blob/main/LICENSING.md#community-contributions.
-->

<img width="320" height="180" alt="image" src="https://github.com/user-attachments/assets/4391866f-3f9f-498e-8121-213c4b805cf7" />
**... but... why?**


A Login V2 browser can retain a sessions cookie entry after its backing
server-side session has been terminated, for example after RP-initiated logout,
an administrative termination, or user/org/instance removal.

A later Login UI flow can then call getSession with that stale cookie entry.
The session service responds with not_found, which must be handled as there
being no resumable session rather than crashing the render. Same issue documented here: 
#12209

**The Fix**
loadMostRecentSession treats a ConnectError with Code.NotFound as no
session and returns undefined. Its callers already have no-session fallback
behaviour.

The helper remains read-only. Most of its callers are Server Component renders,
where Next.js does not allow mutation of the response cookie. Cookie removal
continues to happen through the existing server actions that own cookie writes.
Additional Changes

- Replaces the dynamic ConnectRPC import with static imports.
- Uses try/catch for clearer typed error handling.
- Does not change RP-initiated logout redirects or add an additional logout redirect hop.

**Additional Context**

- Fixes #12209
- The stale-cookie path is covered by the existing
  loadMostRecentSession unit tests.