### PR TITLE
fix(api): make the font upload size limit configurable

### DIFF
--- a/cmd/defaults.yaml
+++ b/cmd/defaults.yaml
@@ -498,6 +498,9 @@ Machine:
 # Storage for assets like user avatar, organization logo, icon, font, ...
 AssetStorage:
   Type: db # ZITADEL_ASSET_STORAGE_TYPE
+  # Maximum size of uploaded fonts in bytes. Must be greater than zero.
+  # Defaults to 512 KiB. For larger fonts, set e.g. 33554432 (32 MiB).
+  MaxFontSize: 524288 # ZITADEL_ASSETSTORAGE_MAXFONTSIZE
   # HTTP cache control settings for serving assets in the assets API and login UI
   # the assets will also be served with an etag and last-modified header
   Cache:

--- a/cmd/start/config.go
+++ b/cmd/start/config.go
@@ -142,7 +142,9 @@ func NewConfig(cmd *cobra.Command, v *viper.Viper) (*Config, instrumentation.Shu
 }
 
 func readConfig(v *viper.Viper) (*Config, error) {
-	config := new(Config)
+	config := &Config{
+		AssetStorage: static_config.AssetStorageConfig{MaxFontSize: 1 << 19},
+	}
 
 	err := v.Unmarshal(config,
 		viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
@@ -165,5 +167,11 @@ func readConfig(v *viper.Viper) (*Config, error) {
 			mapstructure.TextUnmarshallerHookFunc(),
 		)),
 	)
-	return config, err
+	if err != nil {
+		return nil, err
+	}
+	if config.AssetStorage.MaxFontSize <= 0 {
+		return nil, errors.New("AssetStorage.MaxFontSize must be greater than zero")
+	}
+	return config, nil
 }

--- a/cmd/start/font_config_test.go
+++ b/cmd/start/font_config_test.go
@@ -1,0 +1,56 @@
+package start
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadConfigMaxFontSize(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		yaml    string
+		env     string
+		want    int64
+		wantErr bool
+	}{
+		{name: "default", want: 524288},
+		{name: "configured", yaml: "AssetStorage:\n  MaxFontSize: 33554432\n", want: 33554432},
+		{name: "environment overrides yaml", yaml: "AssetStorage:\n  MaxFontSize: 1048576\n", env: "33554432", want: 33554432},
+		{name: "zero", yaml: "AssetStorage:\n  MaxFontSize: 0\n", wantErr: true},
+		{name: "negative", yaml: "AssetStorage:\n  MaxFontSize: -1\n", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defaults, err := os.ReadFile("../defaults.yaml")
+			require.NoError(t, err)
+			v := viper.New()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(strings.NewReader(string(defaults))))
+			if tt.yaml != "" {
+				require.NoError(t, v.MergeConfig(strings.NewReader(tt.yaml)))
+			}
+			if tt.env != "" {
+				t.Setenv("ZITADEL_ASSETSTORAGE_MAXFONTSIZE", tt.env)
+				v.SetEnvPrefix("ZITADEL")
+				v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+				v.AutomaticEnv()
+			}
+			config, err := readConfig(v)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "AssetStorage.MaxFontSize")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, config.AssetStorage.MaxFontSize)
+		})
+	}
+}
+
+func TestReadConfigMaxFontSizeOmitted(t *testing.T) {
+	config, err := readConfig(viper.New())
+	require.NoError(t, err)
+	require.Equal(t, int64(524288), config.AssetStorage.MaxFontSize)
+}

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -637,6 +637,7 @@ func startAPIs(
 		assetsCache.Handler,
 		limitingAccessInterceptor.Handle,
 		translator,
+		config.AssetStorage.MaxFontSize,
 	))
 
 	federatedLogoutsCache, err := connector.StartCache[federatedlogout.Index, string, *federatedlogout.FederatedLogout](ctx, []federatedlogout.Index{federatedlogout.IndexRequestID}, cache.PurposeFederatedLogout, cacheConnectors.Config.FederatedLogouts, cacheConnectors)

--- a/internal/api/assets/asset.go
+++ b/internal/api/assets/asset.go
@@ -36,6 +36,7 @@ type Handler struct {
 	authInterceptor *http_mw.AuthInterceptor
 	idGenerator     id.Generator
 	query           *query.Queries
+	maxFontSize     int64
 }
 
 func (h *Handler) AuthInterceptor() *http_mw.AuthInterceptor {
@@ -103,6 +104,7 @@ func NewHandler(
 	queries *query.Queries,
 	callDurationInterceptor, instanceInterceptor, assetCacheInterceptor, accessInterceptor func(handler http.Handler) http.Handler,
 	translator *i18n.Translator,
+	maxFontSize int64,
 ) http.Handler {
 	h := &Handler{
 		commands:        commands,
@@ -111,6 +113,7 @@ func NewHandler(
 		idGenerator:     idGenerator,
 		storage:         storage,
 		query:           queries,
+		maxFontSize:     maxFontSize,
 	}
 
 	verifier.RegisterServer("Assets-API", "assets", AssetsService_AuthMethods)

--- a/internal/api/assets/login_policy.go
+++ b/internal/api/assets/login_policy.go
@@ -276,11 +276,11 @@ func (l *labelPolicyIconDownloader) ResourceOwner(ctx context.Context, _ string)
 }
 
 func (h *Handler) UploadDefaultLabelPolicyFont() Uploader {
-	return &labelPolicyFontUploader{h.idGenerator, true, []string{"font/", "application/octet-stream"}, 1 << 19}
+	return &labelPolicyFontUploader{h.idGenerator, true, []string{"font/", "application/octet-stream"}, h.maxFontSize}
 }
 
 func (h *Handler) UploadOrgLabelPolicyFont() Uploader {
-	return &labelPolicyFontUploader{h.idGenerator, false, []string{"font/", "application/octet-stream"}, 1 << 19}
+	return &labelPolicyFontUploader{h.idGenerator, false, []string{"font/", "application/octet-stream"}, h.maxFontSize}
 }
 
 type labelPolicyFontUploader struct {

--- a/internal/api/assets/login_policy_test.go
+++ b/internal/api/assets/login_policy_test.go
@@ -1,0 +1,97 @@
+package assets
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/command"
+)
+
+func TestFontUploadSizeLimit(t *testing.T) {
+	for _, factory := range []struct {
+		name string
+		new  func(*Handler) Uploader
+	}{
+		{"instance", (*Handler).UploadDefaultLabelPolicyFont},
+		{"organization", (*Handler).UploadOrgLabelPolicyFont},
+	} {
+		for _, tt := range []struct {
+			name   string
+			limit  int64
+			size   int
+			status int
+		}{
+			{"default boundary", 524288, 524288, http.StatusOK},
+			{"default exceeded", 524288, 524289, http.StatusBadRequest},
+			{"increased limit", 3145728, 524289, http.StatusOK},
+			{"increased boundary", 3145728, 3145728, http.StatusOK},
+			{"increased exceeded", 3145728, 3145729, http.StatusBadRequest},
+			{"decreased exceeded", 262144, 262145, http.StatusBadRequest},
+		} {
+			t.Run(factory.name+"/"+tt.name, func(t *testing.T) {
+				t.Parallel()
+				h := &Handler{
+					maxFontSize: tt.limit,
+					errorHandler: func(w http.ResponseWriter, r *http.Request, err error, code int) {
+						http.Error(w, err.Error(), code)
+					},
+				}
+				// Keep the real font type and size validation, replacing only the
+				// persistence operations that would require a database.
+				uploader := &fontUploadRecorder{Uploader: factory.new(h)}
+				font := make([]byte, tt.size)
+				copy(font, "OTTO") // OpenType signature for content-type detection.
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				part, err := writer.CreateFormFile("file", "font.otf")
+				require.NoError(t, err)
+				_, err = part.Write(font)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				req := httptest.NewRequest(http.MethodPost, "/", &body)
+				req.Header.Set("Content-Type", writer.FormDataContentType())
+				t.Cleanup(func() {
+					if req.MultipartForm != nil {
+						require.NoError(t, req.MultipartForm.RemoveAll())
+					}
+				})
+				response := httptest.NewRecorder()
+				UploadHandleFunc(h, uploader)(response, req)
+				require.Equal(t, tt.status, response.Code, response.Body.String())
+				if tt.status == http.StatusOK {
+					require.Equal(t, font, uploader.data)
+				} else {
+					require.Nil(t, uploader.data)
+					require.Contains(t, response.Body.String(), "file too big")
+				}
+			})
+		}
+	}
+}
+
+type fontUploadRecorder struct {
+	Uploader
+	data []byte
+}
+
+func (u *fontUploadRecorder) ResourceOwner(authz.Instance, authz.CtxData) string {
+	return "owner"
+}
+
+func (u *fontUploadRecorder) ObjectName(authz.CtxData) (string, error) {
+	return "font", nil
+}
+
+func (u *fontUploadRecorder) UploadAsset(_ context.Context, _ string, asset *command.AssetUpload, _ *command.Commands) error {
+	var err error
+	u.data, err = io.ReadAll(asset.File)
+	return err
+}

--- a/internal/static/config/config.go
+++ b/internal/static/config/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 type AssetStorageConfig struct {
-	Type   string
-	Cache  middleware.CacheConfig
-	Config map[string]interface{} `mapstructure:",remain"`
+	MaxFontSize int64
+	Type        string
+	Cache       middleware.CacheConfig
+	Config      map[string]interface{} `mapstructure:",remain"`
 }
 
 func (a *AssetStorageConfig) NewStorage(client *sql.DB) (static.Storage, error) {


### PR DESCRIPTION
# Which Problems Are Solved

Font uploads larger than 512 KiB are always rejected, preventing administrators from using larger fonts such as Chinese fonts.

# How the Problems Are Solved

Adds `AssetStorage.MaxFontSize`, configurable in bytes through YAML or `ZITADEL_ASSETSTORAGE_MAXFONTSIZE`, and applies it to instance and organization font uploads. The default remains 524288 bytes (512 KiB). Nonpositive values are rejected during configuration loading.

For example, administrators can allow fonts up to 32 MiB with:

```yaml
AssetStorage:
  MaxFontSize: 33554432
```

# Additional Changes

- Documents the setting in `cmd/defaults.yaml`.
- Adds tests for configuration defaults, YAML and environment overrides, invalid values, and HTTP upload boundaries, including files larger than the multipart memory threshold.

# Additional Context

Closes #7054.

Validation:

- Regression tests reproduced the hardcoded upload limit before the fix.
- `go test ./internal/api/assets ./internal/static/config ./cmd/start -count=1` passed on Windows with Go 1.25.11 (the toolchain in `go.mod`) and Go 1.26.1.
- `golangci-lint run --timeout 15m --config ./.golangci.yaml ./internal/api/assets/... ./internal/static/config/... ./cmd/start/...` passed with 0 issues (golangci-lint 2.11.4).
- Full Linux CI, race detection, and Nx integration checks remain pending; this PR is a draft.

<details>
<summary>Existing Windows failures in the full Go test suite</summary>

`go test ./... -count=1` on Windows with Go 1.26.1 failed in five existing tests:

- `TestCreateInstance` and `TestSetOrganizationMetadata_UpdatedAt`: database timestamps outside the expected time bounds.
- `TestTook`: zero elapsed duration.
- `TestCommands_RevokeAccessToken/not_active_error`: unexpected mock call.
- `TestIsCodeExpired/expired`: expiration check.

All five failures also reproduced with the original files from base commit `13948f2bcd6f257794dbd6d342c2ac30bc88fe54`, using Go's `-overlay` option. Two required repeated runs. The changed packages passed in the full run.

Protobuf generation used local source dependencies because the Buf registry returned HTTP 403. Generated files are excluded from this PR.

</details>
