### PR TITLE
fix(login): carry sessionId from loginname to password and passkey

### DIFF
--- a/apps/login/src/app/(login)/password/change/page.tsx
+++ b/apps/login/src/app/(login)/password/change/page.tsx
@@ -4,7 +4,7 @@ import { DynamicTheme } from "@/components/dynamic-theme";
 import { Translated } from "@/components/translated";
 import { UserAvatar } from "@/components/user-avatar";
 import { getServiceConfig } from "@/lib/service-url";
-import { loadMostRecentSession } from "@/lib/session";
+import { loadMostRecentSession, loadSessionById } from "@/lib/session";
 import { getBrandingSettings, getPasswordComplexitySettings } from "@/lib/zitadel";
 import { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
@@ -21,16 +21,21 @@ export default async function Page(props: { searchParams: Promise<Record<string 
 
   const searchParams = await props.searchParams;
 
-  const { loginName, organization, requestId } = searchParams;
+  const { loginName, organization, requestId, sessionId } = searchParams;
 
-  // also allow no session to be found (ignoreUnkownUsername)
-  const sessionFactors = await loadMostRecentSession({
-    serviceConfig,
-    sessionParams: {
-      loginName,
-      organization,
-    },
-  });
+  // Prefer the session from the password-change redirect. Fall back to
+  // loginName+org cookie lookup when sessionId is missing (direct visit).
+  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId, organization }) : undefined;
+
+  if (!sessionFactors) {
+    sessionFactors = await loadMostRecentSession({
+      serviceConfig,
+      sessionParams: {
+        loginName,
+        organization,
+      },
+    });
+  }
 
   const branding = await getBrandingSettings({ serviceConfig, organization });
 

--- a/apps/login/src/app/(login)/password/change/page.tsx
+++ b/apps/login/src/app/(login)/password/change/page.tsx
@@ -25,7 +25,7 @@ export default async function Page(props: { searchParams: Promise<Record<string 
 
   // Prefer the session from the password-change redirect. Fall back to
   // loginName+org cookie lookup when sessionId is missing (direct visit).
-  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId, organization }) : undefined;
+  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId }) : undefined;
 
   if (!sessionFactors) {
     sessionFactors = await loadMostRecentSession({
@@ -37,7 +37,10 @@ export default async function Page(props: { searchParams: Promise<Record<string 
     });
   }
 
-  const branding = await getBrandingSettings({ serviceConfig, organization });
+  const branding = await getBrandingSettings({
+    serviceConfig,
+    organization: sessionFactors?.factors?.user?.organizationId ?? organization,
+  });
 
   const passwordComplexity = await getPasswordComplexitySettings({
     serviceConfig,

--- a/apps/login/src/app/(login)/password/page.tsx
+++ b/apps/login/src/app/(login)/password/page.tsx
@@ -35,7 +35,7 @@ export default async function Page(props: { searchParams: Promise<Record<string 
   // Prefer the session created at loginname (explicit id). Fall back to
   // loginName+org cookie lookup for direct /password visits and enumeration
   // protection, where no session exists by design.
-  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId, organization }) : undefined;
+  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId }) : undefined;
 
   if (!sessionFactors) {
     sessionFactors = await loadMostRecentSession({
@@ -47,13 +47,15 @@ export default async function Page(props: { searchParams: Promise<Record<string 
     });
   }
 
+  const resolvedOrganization = sessionFactors?.factors?.user?.organizationId ?? organization ?? defaultOrganization;
+
   const branding = await getBrandingSettings({
     serviceConfig,
-    organization: organization ?? sessionFactors?.factors?.user?.organizationId ?? defaultOrganization,
+    organization: resolvedOrganization,
   });
   const loginSettings = await getLoginSettings({
     serviceConfig,
-    organization: organization ?? sessionFactors?.factors?.user?.organizationId ?? defaultOrganization,
+    organization: resolvedOrganization,
   });
 
   return (

--- a/apps/login/src/app/(login)/password/page.tsx
+++ b/apps/login/src/app/(login)/password/page.tsx
@@ -4,7 +4,7 @@ import { PasswordForm } from "@/components/password-form";
 import { Translated } from "@/components/translated";
 import { UserAvatar } from "@/components/user-avatar";
 import { getServiceConfig } from "@/lib/service-url";
-import { loadMostRecentSession } from "@/lib/session";
+import { loadMostRecentSession, loadSessionById } from "@/lib/session";
 import { getBrandingSettings, getDefaultOrg, getLoginSettings } from "@/lib/zitadel";
 import { Organization } from "@zitadel/proto/zitadel/org/v2/org_pb";
 import { Metadata } from "next";
@@ -18,7 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page(props: { searchParams: Promise<Record<string | number | symbol, string | undefined>> }) {
   const searchParams = await props.searchParams;
-  let { loginName, organization, requestId } = searchParams;
+  let { loginName, organization, requestId, sessionId } = searchParams;
 
   const _headers = await headers();
   const { serviceConfig } = getServiceConfig(_headers);
@@ -32,14 +32,20 @@ export default async function Page(props: { searchParams: Promise<Record<string 
     }
   }
 
-  // also allow no session to be found (ignoreUnkownUsername)
-  const sessionFactors = await loadMostRecentSession({
-    serviceConfig,
-    sessionParams: {
-      loginName,
-      organization,
-    },
-  });
+  // Prefer the session created at loginname (explicit id). Fall back to
+  // loginName+org cookie lookup for direct /password visits and enumeration
+  // protection, where no session exists by design.
+  let sessionFactors = sessionId ? await loadSessionById({ serviceConfig, sessionId, organization }) : undefined;
+
+  if (!sessionFactors) {
+    sessionFactors = await loadMostRecentSession({
+      serviceConfig,
+      sessionParams: {
+        loginName,
+        organization,
+      },
+    });
+  }
 
   const branding = await getBrandingSettings({
     serviceConfig,
@@ -88,6 +94,7 @@ export default async function Page(props: { searchParams: Promise<Record<string 
         {loginName && (
           <PasswordForm
             loginName={loginName}
+            sessionId={sessionId}
             requestId={requestId}
             organization={organization} // stick to "organization" as we still want to do user discovery based on the searchParams not the default organization, later the organization is determined by the found user
             defaultOrganization={defaultOrganization}

--- a/apps/login/src/components/change-password-form.tsx
+++ b/apps/login/src/components/change-password-form.tsx
@@ -82,6 +82,7 @@ export function ChangePasswordForm({ passwordComplexitySettings, sessionId, logi
 
     const passwordResponse = await sendPassword({
       loginName,
+      sessionId,
       organization,
       checks: create(ChecksSchema, {
         password: { password: values.password },

--- a/apps/login/src/components/password-form.tsx
+++ b/apps/login/src/components/password-form.tsx
@@ -27,9 +27,10 @@ type Props = {
   organization?: string;
   defaultOrganization?: string;
   requestId?: string;
+  sessionId?: string;
 };
 
-export function PasswordForm({ loginSettings, loginName, organization, defaultOrganization, requestId }: Props) {
+export function PasswordForm({ loginSettings, loginName, organization, defaultOrganization, requestId, sessionId }: Props) {
   const { register, handleSubmit, formState } = useForm<Inputs>({
     mode: "onChange",
   });
@@ -51,6 +52,7 @@ export function PasswordForm({ loginSettings, loginName, organization, defaultOr
     try {
       const response = await sendPassword({
         loginName,
+        sessionId,
         organization,
         defaultOrganization,
         checks: create(ChecksSchema, {

--- a/apps/login/src/lib/server/loginname.test.ts
+++ b/apps/login/src/lib/server/loginname.test.ts
@@ -188,6 +188,7 @@ describe("sendLoginname", () => {
     };
 
     const mockSession = {
+      id: "session123",
       factors: {
         user: {
           id: "user123",
@@ -256,6 +257,7 @@ describe("sendLoginname", () => {
         expect((result as any).redirect).toMatch(/^\/password\?/);
         expect((result as any).redirect).toContain("loginName=user%40example.com");
         expect((result as any).redirect).toContain("requestId=req123");
+        expect((result as any).redirect).toContain("sessionId=session123");
       });
 
       test("should attempt IDP redirect when password is not allowed but user has IDP links", async () => {
@@ -334,6 +336,7 @@ describe("sendLoginname", () => {
         expect((result as any).redirect).toMatch(/^\/passkey\?/);
         expect((result as any).redirect).toContain("loginName=user%40example.com");
         expect((result as any).redirect).toContain("requestId=req123");
+        expect((result as any).redirect).toContain("sessionId=session123");
       });
 
       test("should return error when passkeys are not allowed", async () => {
@@ -404,6 +407,7 @@ describe("sendLoginname", () => {
         expect(result).toHaveProperty("redirect");
         expect((result as any).redirect).toMatch(/^\/password\?/);
         expect((result as any).redirect).toContain("loginName=user%40example.com");
+        expect((result as any).redirect).not.toContain("sessionId=");
       });
     });
 
@@ -420,6 +424,7 @@ describe("sendLoginname", () => {
         expect(result).toHaveProperty("redirect");
         expect((result as any).redirect).toMatch(/^\/passkey\?/);
         expect((result as any).redirect).toContain("altPassword=true"); // password is allowed
+        expect((result as any).redirect).toContain("sessionId=session123");
       });
 
       test("should return error when allowLocalAuthentication is false (disabling both password and passkey)", async () => {
@@ -464,6 +469,7 @@ describe("sendLoginname", () => {
 
         expect(result).toBeDefined();
         expect(result?.redirect).toMatch(/^\/password\?/);
+        expect(result?.redirect).toContain("sessionId=session123");
       });
 
       test("should return error when password is only method in multi-method scenario but not allowed", async () => {

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -40,6 +40,16 @@ export type SendLoginnameCommand = {
 
 const ORG_SUFFIX_REGEX = /(?<=@)(.+)/;
 
+// Carry sessionId so the next page can load the cookie by id. LoginName+org
+// lookup is fragile (proxy cookie scoping, org mismatch) and is what dropped
+// user context on /password and /passkey (zitadel/zitadel#12112).
+function withSessionId(params: URLSearchParams, sessionId?: string) {
+  if (sessionId) {
+    params.append("sessionId", sessionId);
+  }
+  return params;
+}
+
 export async function sendLoginname(command: SendLoginnameCommand) {
   const _headers = await headers();
   const { serviceConfig } = getServiceConfig(_headers);
@@ -424,7 +434,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
             }
 
             return {
-              redirect: "/password?" + paramsPassword,
+              redirect: "/password?" + withSessionId(paramsPassword, session?.id),
             };
           }
 
@@ -450,7 +460,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
               paramsPasskey.append("organization", organization);
             }
 
-            return { redirect: "/passkey?" + paramsPasskey };
+            return { redirect: "/passkey?" + withSessionId(paramsPasskey, session?.id) };
           }
 
         case AuthenticationMethodType.IDP: {
@@ -483,7 +493,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
           passkeyParams.append("organization", organization);
         }
 
-        return { redirect: "/passkey?" + passkeyParams };
+        return { redirect: "/passkey?" + withSessionId(passkeyParams, session?.id) };
       } else if (methods.authMethodTypes.includes(AuthenticationMethodType.IDP)) {
         return redirectUserToIDP(userId, organization);
       } else if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
@@ -511,7 +521,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         }
 
         return {
-          redirect: "/password?" + paramsPasswordDefault,
+          redirect: "/password?" + withSessionId(paramsPasswordDefault, session?.id),
         };
       }
     }

--- a/apps/login/src/lib/server/loginname.ts
+++ b/apps/login/src/lib/server/loginname.ts
@@ -45,7 +45,9 @@ const ORG_SUFFIX_REGEX = /(?<=@)(.+)/;
 // user context on /password and /passkey (zitadel/zitadel#12112).
 function withSessionId(params: URLSearchParams, sessionId?: string) {
   if (sessionId) {
-    params.append("sessionId", sessionId);
+    // set (not append) so a pre-existing sessionId from retry/back nav stays unique.
+    // Duplicate keys make Next.js searchParams.sessionId an array.
+    params.set("sessionId", sessionId);
   }
   return params;
 }

--- a/apps/login/src/lib/server/password.test.ts
+++ b/apps/login/src/lib/server/password.test.ts
@@ -296,6 +296,7 @@ describe("sendPassword", () => {
   let mockHeaders: any;
   let mockGetServiceConfig: any;
   let mockGetSessionCookieByLoginName: any;
+  let mockGetSessionCookieById: any;
   let mockSearchUsers: any;
   let mockGetLoginSettings: any;
   let mockCreateSessionAndUpdateCookie: any;
@@ -307,13 +308,14 @@ describe("sendPassword", () => {
 
     const { headers } = await import("next/headers");
     const { getServiceConfig } = await import("../service-url");
-    const { getSessionCookieByLoginName } = await import("../cookies");
+    const { getSessionCookieByLoginName, getSessionCookieById } = await import("../cookies");
     const { getLoginSettings, getLockoutSettings, searchUsers } = await import("../zitadel");
     const { createSessionAndUpdateCookie, setSessionAndUpdateCookie } = await import("./cookie");
 
     mockHeaders = vi.mocked(headers);
     mockGetServiceConfig = vi.mocked(getServiceConfig);
     mockGetSessionCookieByLoginName = vi.mocked(getSessionCookieByLoginName);
+    mockGetSessionCookieById = vi.mocked(getSessionCookieById);
     mockSearchUsers = vi.mocked(searchUsers);
     mockGetLoginSettings = vi.mocked(getLoginSettings);
     mockCreateSessionAndUpdateCookie = vi.mocked(createSessionAndUpdateCookie);
@@ -454,6 +456,89 @@ describe("sendPassword", () => {
 
     expect(mockSetSessionAndUpdateCookie).toHaveBeenCalled();
     expect(mockCreateSessionAndUpdateCookie).toHaveBeenCalled();
+  });
+
+  test("should prefer session cookie lookup by sessionId when provided", async () => {
+    mockGetSessionCookieById.mockResolvedValue({
+      id: "session123",
+      token: "token123",
+      organization: "org123",
+    });
+    mockGetLoginSettings.mockResolvedValue({
+      allowLocalAuthentication: true,
+      passwordCheckLifetime: { seconds: BigInt(60 * 60 * 24), nanos: 0 },
+    });
+    mockSetSessionAndUpdateCookie.mockResolvedValue({
+      id: "session123",
+      factors: { user: { id: "user123", loginName: "user@example.com" }, password: { verifiedAt: {} } },
+    });
+
+    const { getUserByID, getPasswordExpirySettings, listAuthenticationMethodTypes } = await import("../zitadel");
+    vi.mocked(getUserByID).mockResolvedValue({
+      user: { userId: "user123", type: { case: "human", value: {} }, state: 1 },
+    } as any);
+    vi.mocked(getPasswordExpirySettings).mockResolvedValue({});
+    vi.mocked(listAuthenticationMethodTypes).mockResolvedValue({
+      authMethodTypes: [AuthenticationMethodType.PASSWORD],
+    } as any);
+
+    await sendPassword({
+      loginName: "user@example.com",
+      sessionId: "session123",
+      checks: { password: { password: "password" } } as any,
+    });
+
+    expect(mockGetSessionCookieById).toHaveBeenCalledWith({ sessionId: "session123" });
+    expect(mockGetSessionCookieByLoginName).not.toHaveBeenCalled();
+    expect(mockSetSessionAndUpdateCookie).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recentCookie: expect.objectContaining({ id: "session123" }),
+      }),
+    );
+  });
+
+  test("should fall back to loginName cookie lookup when sessionId cookie is missing", async () => {
+    mockGetSessionCookieById.mockResolvedValue(undefined);
+    mockGetSessionCookieByLoginName.mockResolvedValue({
+      id: "session-from-name",
+      token: "token123",
+      organization: "org123",
+    });
+    mockGetLoginSettings.mockResolvedValue({
+      allowLocalAuthentication: true,
+      passwordCheckLifetime: { seconds: BigInt(60 * 60 * 24), nanos: 0 },
+    });
+    mockSetSessionAndUpdateCookie.mockResolvedValue({
+      id: "session-from-name",
+      factors: { user: { id: "user123", loginName: "user@example.com" }, password: { verifiedAt: {} } },
+    });
+
+    const { getUserByID, getPasswordExpirySettings, listAuthenticationMethodTypes } = await import("../zitadel");
+    vi.mocked(getUserByID).mockResolvedValue({
+      user: { userId: "user123", type: { case: "human", value: {} }, state: 1 },
+    } as any);
+    vi.mocked(getPasswordExpirySettings).mockResolvedValue({});
+    vi.mocked(listAuthenticationMethodTypes).mockResolvedValue({
+      authMethodTypes: [AuthenticationMethodType.PASSWORD],
+    } as any);
+
+    await sendPassword({
+      loginName: "user@example.com",
+      sessionId: "missing-session",
+      organization: "org123",
+      checks: { password: { password: "password" } } as any,
+    });
+
+    expect(mockGetSessionCookieById).toHaveBeenCalledWith({ sessionId: "missing-session" });
+    expect(mockGetSessionCookieByLoginName).toHaveBeenCalledWith({
+      loginName: "user@example.com",
+      organization: "org123",
+    });
+    expect(mockSetSessionAndUpdateCookie).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recentCookie: expect.objectContaining({ id: "session-from-name" }),
+      }),
+    );
   });
 });
 describe("resetPassword", () => {

--- a/apps/login/src/lib/server/password.ts
+++ b/apps/login/src/lib/server/password.ts
@@ -134,6 +134,7 @@ export type UpdateSessionCommand = {
   defaultOrganization?: string;
   checks: Checks;
   requestId?: string;
+  sessionId?: string;
 };
 
 export async function sendPassword(
@@ -145,10 +146,16 @@ export async function sendPassword(
 
   recordAuthAttempt("password", command.organization);
 
-  let sessionCookie = await getSessionCookieByLoginName({
-    loginName: command.loginName,
-    organization: command.organization,
-  });
+  // Prefer the explicit session from the loginname handoff. Id is unique, so skip
+  // the organization filter that can miss a valid cookie on org mismatch.
+  let sessionCookie = command.sessionId ? await getSessionCookieById({ sessionId: command.sessionId }) : undefined;
+
+  if (!sessionCookie) {
+    sessionCookie = await getSessionCookieByLoginName({
+      loginName: command.loginName,
+      organization: command.organization,
+    });
+  }
 
   let session;
   let user: User | undefined;

--- a/apps/login/src/lib/session.test.ts
+++ b/apps/login/src/lib/session.test.ts
@@ -18,7 +18,7 @@ import { timestampDate } from "@zitadel/client";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as cookiesModule from "./cookies";
-import { isSessionValid, loadMostRecentSession } from "./session";
+import { isSessionValid, loadMostRecentSession, loadSessionById } from "./session";
 import * as verifyHelperModule from "./verify-helper";
 import * as zitadelModule from "./zitadel";
 
@@ -35,6 +35,7 @@ vi.mock("./zitadel", () => ({
 
 vi.mock("./cookies", () => ({
   getMostRecentCookieWithLoginname: vi.fn(),
+  getSessionCookieById: vi.fn(),
 }));
 
 vi.mock("./verify-helper", () => ({
@@ -1678,6 +1679,56 @@ describe("loadMostRecentSession", () => {
 
     await expect(loadMostRecentSession({ serviceConfig, sessionParams })).rejects.toBe(unexpected);
     expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("loadSessionById", () => {
+  const serviceConfig = { baseUrl: "https://zitadel-abc123.zitadel.cloud" };
+  const cookie = { id: "session-id", token: "session-token", loginName: "test@example.com", organization: "test-org-id" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns undefined without calling getSession when no cookie is found", async () => {
+    vi.mocked(cookiesModule.getSessionCookieById).mockResolvedValue(undefined as any);
+
+    const result = await loadSessionById({ serviceConfig, sessionId: "session-id", organization: "test-org-id" });
+
+    expect(result).toBeUndefined();
+    expect(zitadelModule.getSession).not.toHaveBeenCalled();
+  });
+
+  test("returns the session when getSession succeeds", async () => {
+    const session = { id: "session-id", factors: { user: { id: "user-id" } } };
+    vi.mocked(cookiesModule.getSessionCookieById).mockResolvedValue(cookie as any);
+    vi.mocked(zitadelModule.getSession).mockResolvedValue({ session } as any);
+
+    const result = await loadSessionById({ serviceConfig, sessionId: "session-id", organization: "test-org-id" });
+
+    expect(result).toBe(session);
+    expect(cookiesModule.getSessionCookieById).toHaveBeenCalledWith({
+      sessionId: "session-id",
+      organization: "test-org-id",
+    });
+    expect(zitadelModule.getSession).toHaveBeenCalledWith({
+      serviceConfig,
+      sessionId: cookie.id,
+      sessionToken: cookie.token,
+    });
+  });
+
+  test("returns undefined instead of throwing when getSession rejects with NotFound (stale cookie)", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const notFound = new ConnectError("Session does not exist (QUERY-SFeaa)", Code.NotFound);
+    vi.mocked(cookiesModule.getSessionCookieById).mockResolvedValue(cookie as any);
+    vi.mocked(zitadelModule.getSession).mockRejectedValue(notFound);
+
+    const result = await loadSessionById({ serviceConfig, sessionId: "session-id" });
+
+    expect(result).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith("[Session] Could not load most recent session", notFound);
     consoleSpy.mockRestore();
   });
 });

--- a/apps/login/src/lib/session.test.ts
+++ b/apps/login/src/lib/session.test.ts
@@ -1694,7 +1694,7 @@ describe("loadSessionById", () => {
   test("returns undefined without calling getSession when no cookie is found", async () => {
     vi.mocked(cookiesModule.getSessionCookieById).mockResolvedValue(undefined as any);
 
-    const result = await loadSessionById({ serviceConfig, sessionId: "session-id", organization: "test-org-id" });
+    const result = await loadSessionById({ serviceConfig, sessionId: "session-id" });
 
     expect(result).toBeUndefined();
     expect(zitadelModule.getSession).not.toHaveBeenCalled();
@@ -1705,12 +1705,11 @@ describe("loadSessionById", () => {
     vi.mocked(cookiesModule.getSessionCookieById).mockResolvedValue(cookie as any);
     vi.mocked(zitadelModule.getSession).mockResolvedValue({ session } as any);
 
-    const result = await loadSessionById({ serviceConfig, sessionId: "session-id", organization: "test-org-id" });
+    const result = await loadSessionById({ serviceConfig, sessionId: "session-id" });
 
     expect(result).toBe(session);
     expect(cookiesModule.getSessionCookieById).toHaveBeenCalledWith({
       sessionId: "session-id",
-      organization: "test-org-id",
     });
     expect(zitadelModule.getSession).toHaveBeenCalledWith({
       serviceConfig,
@@ -1728,7 +1727,7 @@ describe("loadSessionById", () => {
     const result = await loadSessionById({ serviceConfig, sessionId: "session-id" });
 
     expect(result).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith("[Session] Could not load most recent session", notFound);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.any(String), notFound);
     consoleSpy.mockRestore();
   });
 });

--- a/apps/login/src/lib/session.ts
+++ b/apps/login/src/lib/session.ts
@@ -21,7 +21,6 @@ type LoadMostRecentSessionParams = {
 type LoadSessionByIdParams = {
   serviceConfig: ServiceConfig;
   sessionId: string;
-  organization?: string;
 };
 
 async function sessionFromCookie(
@@ -66,12 +65,10 @@ export async function loadMostRecentSession({
   return sessionFromCookie(serviceConfig, recent);
 }
 
-export async function loadSessionById({
-  serviceConfig,
-  sessionId,
-  organization,
-}: LoadSessionByIdParams): Promise<Session | undefined> {
-  const recent = await getSessionCookieById({ sessionId, organization });
+export async function loadSessionById({ serviceConfig, sessionId }: LoadSessionByIdParams): Promise<Session | undefined> {
+  // Session ids are unique; skip the org filter so a mismatched URL org cannot
+  // hide a valid cookie (the loginname → password/passkey handoff case).
+  const recent = await getSessionCookieById({ sessionId });
   return sessionFromCookie(serviceConfig, recent);
 }
 

--- a/apps/login/src/lib/session.ts
+++ b/apps/login/src/lib/session.ts
@@ -4,9 +4,11 @@ import { SAMLRequest } from "@zitadel/proto/zitadel/saml/v2/authorization_pb";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { GetSessionResponse } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
-import { getMostRecentCookieWithLoginname } from "./cookies";
+import { getMostRecentCookieWithLoginname, getSessionCookieById } from "./cookies";
 import { shouldEnforceMFA } from "./verify-helper";
 import { getLoginSettings, getSession, getUserByID, listAuthenticationMethodTypes, ServiceConfig } from "./zitadel";
+
+type SessionCookieRef = { id: string; token: string };
 
 type LoadMostRecentSessionParams = {
   serviceConfig: ServiceConfig;
@@ -16,15 +18,16 @@ type LoadMostRecentSessionParams = {
   };
 };
 
-export async function loadMostRecentSession({
-  serviceConfig,
-  sessionParams,
-}: LoadMostRecentSessionParams): Promise<Session | undefined> {
-  const recent = await getMostRecentCookieWithLoginname({
-    loginName: sessionParams.loginName,
-    organization: sessionParams.organization,
-  });
+type LoadSessionByIdParams = {
+  serviceConfig: ServiceConfig;
+  sessionId: string;
+  organization?: string;
+};
 
+async function sessionFromCookie(
+  serviceConfig: ServiceConfig,
+  recent: SessionCookieRef | undefined,
+): Promise<Session | undefined> {
   if (!recent) {
     return undefined;
   }
@@ -49,6 +52,27 @@ export async function loadMostRecentSession({
 
       throw error;
     });
+}
+
+export async function loadMostRecentSession({
+  serviceConfig,
+  sessionParams,
+}: LoadMostRecentSessionParams): Promise<Session | undefined> {
+  const recent = await getMostRecentCookieWithLoginname({
+    loginName: sessionParams.loginName,
+    organization: sessionParams.organization,
+  });
+
+  return sessionFromCookie(serviceConfig, recent);
+}
+
+export async function loadSessionById({
+  serviceConfig,
+  sessionId,
+  organization,
+}: LoadSessionByIdParams): Promise<Session | undefined> {
+  const recent = await getSessionCookieById({ sessionId, organization });
+  return sessionFromCookie(serviceConfig, recent);
 }
 
 /**

--- a/apps/login/src/lib/verify-helper.test.ts
+++ b/apps/login/src/lib/verify-helper.test.ts
@@ -396,6 +396,8 @@ describe("checkPasswordChangeRequired", () => {
     expect(result).toEqual({
       redirect: expect.stringContaining("/password/change"),
     });
+    expect(result?.redirect).toContain("sessionId=session-123");
+    expect(result?.redirect).toContain("loginName=user%40example.com");
   });
 
   it("should redirect if password is expired based on maxAgeDays", () => {

--- a/apps/login/src/lib/verify-helper.ts
+++ b/apps/login/src/lib/verify-helper.ts
@@ -36,6 +36,10 @@ export function checkPasswordChangeRequired(
       params.append("requestId", requestId);
     }
 
+    if (session.id) {
+      params.append("sessionId", session.id);
+    }
+
     return { redirect: "/password/change?" + params };
   }
 }


### PR DESCRIPTION
## Summary
- Login V2 created a session at the username step but omitted `sessionId` on the redirect to `/password` and `/passkey`, so the next page had to reconstruct the session via loginName+org cookie lookup.
- That lookup is fragile behind reverse proxies and on org mismatch, which produced `unknownContext` on the password page, a missing form on `/password/change`, and broken passkeys ([#12112](https://github.com/zitadel/zitadel/issues/12112)).
- Carry `sessionId` through those redirects (same pattern MFA already uses), load the session by id first, and prefer id-based cookie lookup in `sendPassword`. Enumeration protection still creates no session and adds no `sessionId`.

Closes #12112

## Test plan
- [x] Unit tests: `loginname`, `session`, `password`, `verify-helper` (178 passed)
- [x] Manual browser: loginname → password (`sessionId` in URL, no unknownContext) → change-password form renders with the same `sessionId`
- [x] API logs: `CreateSession` on Continue, `SetSession` only after password submit
- [ ] Passkey-only user: loginname → `/passkey?...&sessionId=`
- [ ] `ignoreUnknownUsernames`: password redirect has no `sessionId`


Made with [Cursor](https://cursor.com)