### PR TITLE
docs: error reference page fails to load, missing basePath in fetch 

### DIFF
--- a/apps/docs/components/ErrorReference/index.tsx
+++ b/apps/docs/components/ErrorReference/index.tsx
@@ -91,7 +91,10 @@ export default function ErrorReference() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/error-reference')
+    // The app is served under basePath '/docs' (next.config.mjs), and a plain
+    // fetch() doesn't get that prefix added automatically the way <Link> and
+    // router.push() do, so this has to spell it out or it 404s.
+    fetch('/docs/api/error-reference')
       .then((res) => {
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
         return res.json();


### PR DESCRIPTION
# Which Problems Are Solved

The API error reference page (`/docs/apis/errors`) shows "Couldn't load the error reference. Try reloading the page." instead of the table. This started after #12502 switched the page from a static import of `data.json` to fetching it from a route handler at runtime.

# How the Problems Are Solved

`apps/docs` is served under `basePath: '/docs'` (`next.config.mjs`). The fetch call in `ErrorReference` used `/api/error-reference`, but a plain `fetch()` does not get the basePath prefix added the way `<Link>` and `router.push()` do, so the request always 404'd. Fetches `/docs/api/error-reference` instead, the actual prefixed route.

# Additional Changes

None.

# Additional Context

- Follow-up for #12502
- Confirmed locally: `curl localhost:3000/api/error-reference` returns 404, `curl localhost:3000/docs/api/error-reference` returns 200 with the full catalog
