### PR TITLE
Correct email verification text in nl.yaml

### DIFF
--- a/internal/api/ui/login/static/i18n/nl.yaml
+++ b/internal/api/ui/login/static/i18n/nl.yaml
@@ -73,7 +73,7 @@ InitPasswordDone:
 
 InitUser:
   Title: Activeer Gebruiker
-  Description: Verifieer uw e-mail met de onderstaande code en stel uw wachtwoord in.
+  Description: Verifieer uw e-mailadres hieronder met de code die u per e-mail heeft ontvangen.
   CodeLabel: Code
   NewPasswordLabel: Nieuw Wachtwoord
   NewPasswordConfirm: Bevestig Wachtwoord


### PR DESCRIPTION
This was a confusing error due to mistranslation. 

Original 'Code below' was translated as though the code could be found below ('onderstaande code'), instead of *should be inserted below* (and can be found in an email sent to the user previously).

# Which Problems Are Solved

The Dutch translation of `InitUser.Description` reads as if the verification
code is printed on the page itself: "Verifieer uw e-mail met de onderstaande
code" translates back as "verify your e-mail with the code shown below".
Users look for a code on the screen, do not find one, and get stuck on the
activation form. The code is of course the one from the initialization e-mail.

# How the Problems Are Solved

Rephrases the sentence so "hieronder" refers to the input field and the origin
of the code is explicit: "Verifieer uw e-mailadres hieronder met de code die u
per e-mail heeft ontvangen en stel uw wachtwoord in."

# Additional Changes

None.

# Additional Context

The new Login UI already phrases this correctly in
`apps/login/locales/nl.json` ("Voer de code in uit de verificatie-e-mail"),
so this only affects the legacy login UI. Observed with a real user on a
self-hosted v4 instance.