### PR TITLE
perf(query): use UNION of index seeks for ListUsers login equality

### DIFF
--- a/apps/login/src/lib/zitadel.ts
+++ b/apps/login/src/lib/zitadel.ts
@@ -485,6 +485,8 @@ export type ListUsersCommand = WithServiceConfig<{
   organizationId?: string;
 }>;
 
+const userLookupQuery = { limit: 2 };
+
 export async function listUsers({ serviceConfig, loginName, userName, phone, email, organizationId }: ListUsersCommand) {
   const queries: SearchQuery[] = [];
 
@@ -570,7 +572,7 @@ export async function listUsers({ serviceConfig, loginName, userName, phone, ema
 
   const userService: Client<typeof UserService> = await createServiceForHost(UserService, serviceConfig);
 
-  return userService.listUsers({ queries });
+  return userService.listUsers({ query: userLookupQuery, queries });
 }
 
 export type SearchUsersCommand = WithServiceConfig<{
@@ -653,7 +655,7 @@ export async function searchUsers({
 
   const userService: Client<typeof UserService> = await createServiceForHost(UserService, serviceConfig);
 
-  const loginNameResult = await userService.listUsers({ queries });
+  const loginNameResult = await userService.listUsers({ query: userLookupQuery, queries });
 
   if (!loginNameResult || !loginNameResult.details) {
     return { error: t("errors.errorOccured") };
@@ -715,6 +717,7 @@ export async function searchUsers({
   }
 
   const emailOrPhoneResult = await userService.listUsers({
+    query: userLookupQuery,
     queries: emailAndPhoneQueries,
   });
 

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -74,6 +74,10 @@ users_by_metadata_key: ensure_modules bundle
 users_by_metadata_value: ensure_modules bundle
 	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/users_by_metadata_value.js --vus ${VUS} --duration ${DURATION} --out csv=output/users_by_metadata_${DATE}.csv
 
+.PHONY: users_by_login_name
+users_by_login_name: ensure_modules bundle
+	${K6} run --summary-trend-stats "min,avg,max,p(50),p(95),p(99)" dist/users_by_login_name.js --vus ${VUS} --duration ${DURATION} --out csv=output/users_by_login_name_${DATE}.csv
+
 .PHONY: lint
 lint:
 	npm i

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,10 +4,11 @@ This package contains code for benchmarking specific endpoints of the API using 
 
 ## Prerequisite
 
-* [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-* [k6](https://k6.io/docs/get-started/installation/)
-* [go](https://go.dev/doc/install)
-* running the API
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [k6](https://k6.io/docs/get-started/installation/)
+- [go](https://go.dev/doc/install)
+- [xk6](https://github.com/grafana/xk6#local-installation) (make sure `~/go/bin` is in your `${PATH}`)
+- running the API
 
 ## Structure
 
@@ -17,63 +18,69 @@ The use cases under tests are defined in `src/use_cases`. The implementation of 
 
 ### Env vars
 
-* `VUS`: Amount of parallel processes execute the test (default is 20)
-* `DURATION`: Defines how long the tests are executed (default is `200s`)
-* `ZITADEL_HOST`: URL of ZITADEL (default is `http://localhost:8080`)
-* `ADMIN_LOGIN_NAME`: Loginanme of a human user with `IAM_OWNER`-role
-* `ADMIN_PASSWORD`: password of the human user
+- `VUS`: Amount of parallel processes execute the test (default is 20)
+- `DURATION`: Defines how long the tests are executed (default is `200s`)
+- `ZITADEL_HOST`: URL of ZITADEL (default is `http://localhost:8080`)
+- `ADMIN_LOGIN_NAME`: Loginanme of a human user with `IAM_OWNER`-role
+- `ADMIN_PASSWORD`: password of the human user
+- `USER_AMOUNT`: Number of users created during setup for list-users benchmarks (default is `2500`)
+- `SETUP_CONCURRENCY`: Max in-flight user-create requests during list-users setup (default is `50`). Large `USER_AMOUNT` with unbounded parallelism can exhaust ephemeral ports (`can't assign requested address`).
 
 To setup the tests we use the credentials of management console and log in using an admin. The user must be able to create organizations and all resources inside organizations.
 
-* `ADMIN_LOGIN_NAME`: `zitadel-admin@zitadel.localhost`
-* `ADMIN_PASSWORD`: `Password1!`
+- `ADMIN_LOGIN_NAME`: `zitadel-admin@zitadel.localhost`
+- `ADMIN_PASSWORD`: `Password1!`
 
 ### Test
 
 Before you run the tests you need an initialized user. The tests don't implement the change password screen during login.
 
-* `make human_password_login`  
+- `make human_password_login`  
   setup: creates human users  
   test: uses the previously created humans to sign in using the login ui
-* `make machine_pat_login`  
+- `make machine_pat_login`  
   setup: creates machines and a pat for each machine  
   test: calls user info endpoint with the given pats
-* `make machine_client_credentials_login`  
+- `make machine_client_credentials_login`  
   setup: creates machines and a client credential secret for each machine  
   test: calls token endpoint with the `client_credentials` grant type.
-* `make user_info`  
+- `make user_info`  
   setup: creates human users and signs them in  
   test: calls user info endpoint using the given humans
-* `make manipulate_user`  
-  test: creates a human, updates its profile, locks the user and then deletes it 
-* `make introspect`  
+- `make manipulate_user`  
+  test: creates a human, updates its profile, locks the user and then deletes it
+- `make introspect`  
   setup: creates projects, one api per project, one key per api and generates the jwt from the given keys  
   test: calls introspection endpoint using the given JWTs
-* `make add_session`  
+- `make add_session`  
   setup: creates human users  
   test: creates new sessions with user id check
-* `make oidc_session`  
+- `make oidc_session`  
   setup: creates a service account to create the auth request and session.  
   test: creates an auth request, a session and links the session to the auth request. Implementation of [this flow](https://zitadel.com/docs/guides/integrate/login-ui/oidc-standard).
-* `make otp_session`  
+- `make otp_session`  
   setup: creates 1 human user for each VU and adds OTP Email to it  
   test: creates a session based on the login name of the user, sets the OTP Email challenge to the session and afterwards checks the OTP code
-* `make password_session`  
+- `make password_session`  
   setup: creates 1 human user for each VU and adds OTP Email to it  
   test: creates a session based on the login name of the user and checks for the password on a second step
-* `make machine_jwt_profile_grant`  
+- `make machine_jwt_profile_grant`  
   setup: generates private/public key, creates service accounts, adds a key  
-  test: creates a token and calls user info 
-* `make machine_jwt_profile_grant_single_user`  
+  test: creates a token and calls user info
+- `make machine_jwt_profile_grant_single_user`  
   setup: generates private/public key, creates service account, adds a key  
   test: creates a token and calls user info in parallel for the same user
-* `make users_by_metadata_key`  
+- `make users_by_metadata_key`  
   setup: creates for half of the VUS a human user and a machine for the other half, adds 3 metadata to each user
   test: calls the list users endpoint and filters by a metadata key
-* `make users_by_metadata_value`  
+- `make users_by_metadata_value`  
   setup: creates for half of the VUS a human user and a machine for the other half, adds 3 metadata to each user
   test: calls the list users endpoint and filters by a metadata value
-* `make verify_all_user_grants_exists`  
+- `make users_by_login_name`  
+  setup: creates `USER_AMOUNT` human users (default `2500`) in a new org, with `SETUP_CONCURRENCY` parallel creates (default `50`)  
+  test: calls ListUsers the same way as login v2 (`loginNameQuery` with `EQUALS_IGNORE_CASE`, `organizationIdQuery`, `limit: 2`)  
+  note: to reproduce multi-second latency on the old query plan, use a large dataset, e.g. `USER_AMOUNT=100000 VUS=10 DURATION=60s`
+- `make verify_all_user_grants_exists`  
   setup: creates 50 projects, 1 machine per VU
   test: creates a machine and grants all projects to the machine
   teardown: the organization is not removed to verify the data of the projections are correct. You can find additional information [at the bottom of this file](./src/use_cases/verify_all_user_grants_exist.ts)

--- a/benchmark/src/pool.ts
+++ b/benchmark/src/pool.ts
@@ -1,0 +1,32 @@
+/**
+ * Run async work over items with a fixed number of in-flight tasks.
+ * Avoids unbounded Promise.all which can exhaust ephemeral ports
+ * when seeding large USER_AMOUNT datasets.
+ */
+export async function mapPool<T, R>(
+  items: T[],
+  concurrency: number, 
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}

--- a/benchmark/src/url.ts
+++ b/benchmark/src/url.ts
@@ -1,4 +1,6 @@
-import { options } from 'k6/http';
+// @ts-ignore Import module
+import { URL } from 'https://jslib.k6.io/url/1.0.0/index.js';
+
 import { Config } from './config';
 
 export type options = {

--- a/benchmark/src/use_cases/users_by_login_name.ts
+++ b/benchmark/src/use_cases/users_by_login_name.ts
@@ -1,0 +1,79 @@
+import { check } from 'k6';
+
+import { Config } from '../config';
+import { loginByUsernamePassword } from '../login_ui';
+import { createOrg, Org, removeOrg } from '../org';
+import { mapPool } from '../pool';
+import { createHuman, listUsers, User } from '../user';
+
+const userAmount = parseInt(__ENV.USER_AMOUNT) || 2500;
+// Unbounded Promise.all over large USER_AMOUNT exhausts ephemeral ports
+// (dial tcp ... can't assign requested address). Keep a modest in-flight cap.
+const setupConcurrency = parseInt(__ENV.SETUP_CONCURRENCY) || 50;
+
+type SetupData = {
+  tokens: { accessToken?: string };
+  org: Org;
+  targetLoginName: string;
+};
+
+export async function setup(): Promise<SetupData> {
+  const tokens = loginByUsernamePassword(Config.admin as User);
+  console.info('setup: admin signed in');
+
+  const org = await createOrg(tokens.accessToken!);
+  console.info(`setup: org (${org.organizationId}) created`);
+
+  const progressEvery = Math.max(1, Math.floor(userAmount / 100));
+  const users = await mapPool(
+    Array.from({ length: userAmount }, (_, i) => i),
+    setupConcurrency,
+    async (i) => {
+      const user = await createHuman(`zitizen-${i}`, org, tokens.accessToken!);
+      if (i % progressEvery === 0 || i === userAmount - 1) {
+        console.log(`setup: ${i + 1} of ${userAmount} users setup`);
+      }
+      return user;
+    },
+  );
+  console.info(`setup: ${users.length} users created (concurrency=${setupConcurrency})`);
+
+  const targetLoginName = users[0].loginNames[0];
+  console.info(`setup: target login name ${targetLoginName}`);
+
+  return { tokens, org, targetLoginName };
+}
+
+export default async function (data: SetupData) {
+  const result = await listUsers(
+    {
+      query: { limit: 2 },
+      queries: [
+        {
+          loginNameQuery: {
+            loginName: data.targetLoginName,
+            method: 'TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE',
+          },
+        },
+        {
+          organizationIdQuery: {
+            organizationId: data.org.organizationId,
+          },
+        },
+      ],
+    },
+    data.tokens.accessToken!,
+  );
+
+  check(result, {
+    'exact one user found': (res) => (res.result?.length ?? 0) === 1 || res.details.totalResult == 1,
+  }) ||
+    console.log(
+      `unexpected list users result. expected 1 user but got result=${result.result?.length} totalResult=${result.details.totalResult}`,
+    );
+}
+
+export function teardown(data: SetupData) {
+  removeOrg(data.org, data.tokens.accessToken!);
+  console.info('teardown: org removed');
+}

--- a/benchmark/src/use_cases/users_by_metadata_key.ts
+++ b/benchmark/src/use_cases/users_by_metadata_key.ts
@@ -1,11 +1,13 @@
 import { loginByUsernamePassword } from '../login_ui';
 import { createOrg, removeOrg } from '../org';
+import { mapPool } from '../pool';
 import { createHuman, User, createMachine, setUserMetadata, listUsers } from '../user';
 import { Config } from '../config';
 import { check } from 'k6';
 import encoding from 'k6/encoding';
 
 const userAmount = parseInt(__ENV.USER_AMOUNT) || 2500;
+const setupConcurrency = parseInt(__ENV.SETUP_CONCURRENCY) || 50;
 
 export async function setup() {
   const tokens = loginByUsernamePassword(Config.admin as User);
@@ -14,10 +16,11 @@ export async function setup() {
   const org = await createOrg(tokens.accessToken!);
   console.info(`setup: org (${org.organizationId}) created`);
 
-  const users: User[] = [];
-
-  await Promise.all(
-    Array.from({ length: userAmount }, async (_, i) => {
+  const progressEvery = Math.max(1, Math.floor(userAmount / 100));
+  const users = await mapPool(
+    Array.from({ length: userAmount }, (_, i) => i),
+    setupConcurrency,
+    async (i) => {
       let user: User;
       let type: 'human' | 'machine';
       if (i % 2 === 0) {
@@ -27,7 +30,6 @@ export async function setup() {
         user = await createMachine(`zitachine-${i}`, org, tokens.accessToken!);
         type = 'machine';
       }
-      users.push(user);
       await setUserMetadata(
         [
           { key: 'type', value: encoding.b64encode(type, 'rawurl') },
@@ -37,12 +39,13 @@ export async function setup() {
         user.userId,
         tokens.accessToken!,
       );
-      if (i % 10 === 0) {
-        console.log(`setup: ${i} of ${userAmount} users setup`);
+      if (i % progressEvery === 0 || i === userAmount - 1) {
+        console.log(`setup: ${i + 1} of ${userAmount} users setup`);
       }
-    }),
+      return user;
+    },
   );
-  console.info(`setup: ${users.length} users created`);
+  console.info(`setup: ${users.length} users created (concurrency=${setupConcurrency})`);
 
   return { tokens, org, users };
 }

--- a/benchmark/src/use_cases/users_by_metadata_value.ts
+++ b/benchmark/src/use_cases/users_by_metadata_value.ts
@@ -1,11 +1,13 @@
 import { loginByUsernamePassword } from '../login_ui';
 import { createOrg, removeOrg } from '../org';
+import { mapPool } from '../pool';
 import { createHuman, User, createMachine, setUserMetadata, listUsers } from '../user';
 import { Config } from '../config';
 import { check } from 'k6';
 import encoding from 'k6/encoding';
 
 const userAmount = parseInt(__ENV.USER_AMOUNT) || 2500;
+const setupConcurrency = parseInt(__ENV.SETUP_CONCURRENCY) || 50;
 
 export async function setup() {
   const tokens = loginByUsernamePassword(Config.admin as User);
@@ -14,10 +16,11 @@ export async function setup() {
   const org = await createOrg(tokens.accessToken!);
   console.info(`setup: org (${org.organizationId}) created`);
 
-  const users: User[] = [];
-
-  await Promise.all(
-    Array.from({ length: userAmount }, async (_, i) => {
+  const progressEvery = Math.max(1, Math.floor(userAmount / 100));
+  const users = await mapPool(
+    Array.from({ length: userAmount }, (_, i) => i),
+    setupConcurrency,
+    async (i) => {
       let user: User;
       let type: 'human' | 'machine';
       if (i % 2 === 0) {
@@ -27,7 +30,6 @@ export async function setup() {
         user = await createMachine(`zitachine-${i}`, org, tokens.accessToken!);
         type = 'machine';
       }
-      users.push(user);
       await setUserMetadata(
         [
           { key: 'type', value: encoding.b64encode(type, 'rawurl') },
@@ -37,12 +39,13 @@ export async function setup() {
         user.userId,
         tokens.accessToken!,
       );
-      if (i % 10 === 0) {
-        console.log(`setup: ${i} of ${userAmount} users setup`);
+      if (i % progressEvery === 0 || i === userAmount - 1) {
+        console.log(`setup: ${i + 1} of ${userAmount} users setup`);
       }
-    }),
+      return user;
+    },
   );
-  console.info(`setup: ${users.length} users created`);
+  console.info(`setup: ${users.length} users created (concurrency=${setupConcurrency})`);
 
   return { tokens, org, users };
 }

--- a/benchmark/src/user.ts
+++ b/benchmark/src/user.ts
@@ -325,7 +325,26 @@ export function setUserMetadata(metadata: Metadata[], userId: string, accessToke
 }
 
 export type ListUsersRequest = {
+  query?: {
+    limit?: number;
+    offset?: number;
+  };
   queries: {
+    loginNameQuery?: {
+      loginName: string;
+      method:
+        | 'TEXT_QUERY_METHOD_EQUALS'
+        | 'TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE'
+        | 'TEXT_QUERY_METHOD_STARTS_WITH'
+        | 'TEXT_QUERY_METHOD_STARTS_WITH_IGNORE_CASE'
+        | 'TEXT_QUERY_METHOD_CONTAINS'
+        | 'TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE'
+        | 'TEXT_QUERY_METHOD_ENDS_WITH'
+        | 'TEXT_QUERY_METHOD_ENDS_WITH_IGNORE_CASE';
+    };
+    organizationIdQuery?: {
+      organizationId: string;
+    };
     metadataKeyFilter?: {
       key: string;
       method: 'TEXT_FILTER_METHOD_EQUALS' | 'TEXT_FILTER_METHOD_CONTAINS' | 'TEXT_FILTER_METHOD_CONTAINS_IGNORE_CASE';
@@ -341,6 +360,7 @@ export type ListUsersResult = {
   details: {
     totalResult: number;
   };
+  result?: unknown[];
 };
 
 const listUsersTrend = new Trend('list_users_duration', true);

--- a/cmd/setup/72.go
+++ b/cmd/setup/72.go
@@ -1,0 +1,27 @@
+package setup
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 72.sql
+	addColumnsToLoginNamesView string
+)
+
+type AddColumnsToLoginNamesView struct {
+	dbClient *database.DB
+}
+
+func (mig *AddColumnsToLoginNamesView) Execute(ctx context.Context, _ eventstore.Event) error {
+	_, err := mig.dbClient.ExecContext(ctx, addColumnsToLoginNamesView)
+	return err
+}
+
+func (mig *AddColumnsToLoginNamesView) String() string {
+	return "72_add_columns_to_login_names_view"
+}

--- a/cmd/setup/72.sql
+++ b/cmd/setup/72.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE VIEW projections.login_names3 AS (
+    SELECT
+        u.id AS user_id
+        , CASE
+            WHEN p.must_be_domain THEN CONCAT(u.user_name, '@', d.name)
+            ELSE u.user_name
+        END AS login_name
+        , COALESCE(d.is_primary, TRUE) AS is_primary
+        , u.instance_id
+        , u.resource_owner
+        , CASE
+                WHEN p.must_be_domain THEN CONCAT(u.user_name_lower, '@', d.name_lower)
+                ELSE u.user_name_lower
+        END AS login_name_lower
+    FROM
+        projections.login_names3_users AS u
+    LEFT JOIN LATERAL (
+        SELECT
+            must_be_domain
+            , is_default
+        FROM
+            projections.login_names3_policies AS p
+        WHERE
+            (
+                p.instance_id = u.instance_id
+                AND NOT p.is_default
+                AND p.resource_owner = u.resource_owner
+            ) OR (
+                p.instance_id = u.instance_id
+                AND p.is_default
+            )
+        ORDER BY
+            p.is_default -- custom first
+        LIMIT 1
+    ) AS p ON TRUE
+    LEFT JOIN 
+        projections.login_names3_domains d
+        ON 
+            p.must_be_domain 
+            AND u.resource_owner = d.resource_owner 
+            AND u.instance_id = d.instance_id
+);

--- a/cmd/setup/76.go
+++ b/cmd/setup/76.go
@@ -1,0 +1,93 @@
+package setup
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"fmt"
+
+	"github.com/zitadel/zitadel/backend/v3/instrumentation/logging"
+	"github.com/zitadel/zitadel/internal/database"
+	"github.com/zitadel/zitadel/internal/eventstore"
+)
+
+var (
+	//go:embed 76/*.sql
+	users14LoginEqualityIndexes embed.FS
+)
+
+const (
+	users14TableExistsQuery  = "SELECT exists(SELECT 1 FROM information_schema.tables WHERE table_schema = 'projections' AND table_name = 'users14')"
+	users14InvalidIndexQuery = `SELECT EXISTS (
+	SELECT 1
+	FROM pg_index i
+	JOIN pg_class c ON c.oid = i.indexrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE n.nspname = 'projections'
+		AND c.relname = $1
+		AND NOT i.indisvalid
+)`
+	users14UsernameLowerIdx      = "users14_username_lower_idx"
+	users14HumansPhoneLowerIdx   = "users14_humans_phone_lower_idx"
+	dropInvalidIndexConcurrently = "DROP INDEX CONCURRENTLY IF EXISTS projections."
+)
+
+var users14LoginEqualityIndexNames = []string{
+	users14UsernameLowerIdx,
+	users14HumansPhoneLowerIdx,
+}
+
+type Users14LoginEqualityIndexes struct {
+	dbClient *database.DB
+}
+
+func (mig *Users14LoginEqualityIndexes) Execute(ctx context.Context, _ eventstore.Event) error {
+	var exists bool
+	err := mig.dbClient.QueryRowContext(ctx, func(r *sql.Row) error {
+		return r.Scan(&exists)
+	}, users14TableExistsQuery)
+	if err != nil || !exists {
+		return err
+	}
+
+	if err := mig.dropInvalidIndexes(ctx); err != nil {
+		return err
+	}
+
+	statements, err := readStatements(users14LoginEqualityIndexes, "76")
+	if err != nil {
+		return err
+	}
+	for _, stmt := range statements {
+		logging.Info(ctx, "execute statement", "file", stmt.file, "migration", mig.String())
+		if _, err := mig.dbClient.ExecContext(ctx, stmt.query); err != nil {
+			return fmt.Errorf("%s %s: %w", mig.String(), stmt.file, err)
+		}
+	}
+	return nil
+}
+
+func (mig *Users14LoginEqualityIndexes) dropInvalidIndexes(ctx context.Context) error {
+	for _, name := range users14LoginEqualityIndexNames {
+		var invalid bool
+		err := mig.dbClient.QueryRowContext(ctx, func(r *sql.Row) error {
+			return r.Scan(&invalid)
+		}, users14InvalidIndexQuery, name)
+		if err != nil {
+			return fmt.Errorf("%s check invalid index %s: %w", mig.String(), name, err)
+		}
+		if !invalid {
+			continue
+		}
+		drop := dropInvalidIndexConcurrently + name
+		logging.Info(ctx, "drop invalid leftover index", "index", name, "migration", mig.String())
+		if _, err := mig.dbClient.ExecContext(ctx, drop); err != nil {
+			return fmt.Errorf("%s drop invalid index %s: %w", mig.String(), name, err)
+		}
+	}
+	return nil
+}
+
+func (mig *Users14LoginEqualityIndexes) String() string {
+	return "76_users14_login_equality_indexes"
+}

--- a/cmd/setup/76/01_users14_username_lower_idx.sql
+++ b/cmd/setup/76/01_users14_username_lower_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users14_username_lower_idx ON projections.users14 (instance_id, LOWER(username));

--- a/cmd/setup/76/02_users14_humans_phone_lower_idx.sql
+++ b/cmd/setup/76/02_users14_humans_phone_lower_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS users14_humans_phone_lower_idx ON projections.users14_humans (instance_id, LOWER(phone));

--- a/cmd/setup/76_test.go
+++ b/cmd/setup/76_test.go
@@ -1,0 +1,92 @@
+package setup
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/database"
+)
+
+const (
+	users14UsernameLowerCreate = "CREATE INDEX CONCURRENTLY IF NOT EXISTS users14_username_lower_idx ON projections.users14 (instance_id, LOWER(username));\n"
+	users14PhoneLowerCreate    = "CREATE INDEX CONCURRENTLY IF NOT EXISTS users14_humans_phone_lower_idx ON projections.users14_humans (instance_id, LOWER(phone));\n"
+)
+
+func TestUsers14LoginEqualityIndexes_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		expects func(sqlmock.Sqlmock)
+		wantErr bool
+	}{
+		{
+			name: "table missing, no drop or create",
+			expects: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta(users14TableExistsQuery)).
+					WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+			},
+		},
+		{
+			name: "table exists, indexes valid, creates both concurrently",
+			expects: func(mock sqlmock.Sqlmock) {
+				expectUsers14TableExists(mock, true)
+				expectInvalidIndex(mock, users14UsernameLowerIdx, false)
+				expectInvalidIndex(mock, users14HumansPhoneLowerIdx, false)
+				mock.ExpectExec(regexp.QuoteMeta(users14UsernameLowerCreate)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta(users14PhoneLowerCreate)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			},
+		},
+		{
+			name: "username index invalid, drop then create both",
+			expects: func(mock sqlmock.Sqlmock) {
+				expectUsers14TableExists(mock, true)
+				expectInvalidIndex(mock, users14UsernameLowerIdx, true)
+				mock.ExpectExec(regexp.QuoteMeta(dropInvalidIndexConcurrently + users14UsernameLowerIdx)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				expectInvalidIndex(mock, users14HumansPhoneLowerIdx, false)
+				mock.ExpectExec(regexp.QuoteMeta(users14UsernameLowerCreate)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta(users14PhoneLowerCreate)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, mock.ExpectationsWereMet())
+			}()
+			defer db.Close()
+			tt.expects(mock)
+
+			mig := &Users14LoginEqualityIndexes{
+				dbClient: &database.DB{DB: db},
+			}
+			err = mig.Execute(context.Background(), nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func expectUsers14TableExists(mock sqlmock.Sqlmock, exists bool) {
+	mock.ExpectQuery(regexp.QuoteMeta(users14TableExistsQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(exists))
+}
+
+func expectInvalidIndex(mock sqlmock.Sqlmock, name string, invalid bool) {
+	mock.ExpectQuery(regexp.QuoteMeta(users14InvalidIndexQuery)).
+		WithArgs(name).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(invalid))
+}

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -186,6 +186,7 @@ type Steps struct {
 	s68TargetAddPayloadTypeColumn           *TargetAddPayloadTypeColumn
 	s69CacheTablesLogged                    *CacheTablesLogged
 	s72AddColumnsToLoginNamesView           *AddColumnsToLoginNamesView
+	s76Users14LoginEqualityIndexes          *Users14LoginEqualityIndexes
 }
 
 func NewSteps(ctx context.Context, v *viper.Viper) (*Steps, error) {

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -185,6 +185,7 @@ type Steps struct {
 	s67SyncMemberRoleFields                 *SyncMemberRoleFields
 	s68TargetAddPayloadTypeColumn           *TargetAddPayloadTypeColumn
 	s69CacheTablesLogged                    *CacheTablesLogged
+	s72AddColumnsToLoginNamesView           *AddColumnsToLoginNamesView
 }
 
 func NewSteps(ctx context.Context, v *viper.Viper) (*Steps, error) {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -248,6 +248,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s67SyncMemberRoleFields = &SyncMemberRoleFields{dbClient: dbClient}
 	steps.s68TargetAddPayloadTypeColumn = &TargetAddPayloadTypeColumn{dbClient: dbClient}
 	steps.s69CacheTablesLogged = &CacheTablesLogged{dbClient: dbClient}
+	steps.s72AddColumnsToLoginNamesView = &AddColumnsToLoginNamesView{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -366,6 +367,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s59SetupWebkeys, // this step needs commands.
 		steps.s66SessionRecoveryCodeCheckedAt,
 		steps.s68TargetAddPayloadTypeColumn,
+		steps.s72AddColumnsToLoginNamesView,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -249,6 +249,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 	steps.s68TargetAddPayloadTypeColumn = &TargetAddPayloadTypeColumn{dbClient: dbClient}
 	steps.s69CacheTablesLogged = &CacheTablesLogged{dbClient: dbClient}
 	steps.s72AddColumnsToLoginNamesView = &AddColumnsToLoginNamesView{dbClient: dbClient}
+	steps.s76Users14LoginEqualityIndexes = &Users14LoginEqualityIndexes{dbClient: dbClient}
 
 	err = projection.Create(ctx, dbClient, eventstoreClient, config.Projections, nil, nil, nil)
 	if err != nil {
@@ -306,6 +307,7 @@ func Setup(ctx context.Context, config *Config, steps *Steps, masterKey string) 
 		steps.s65FixUserMetadata5Index,
 		steps.s67SyncMemberRoleFields,
 		steps.s69CacheTablesLogged,
+		steps.s76Users14LoginEqualityIndexes,
 	} {
 		setupErr = executeMigration(ctx, eventstoreClient, step, "migration failed")
 		if setupErr != nil {

--- a/internal/api/grpc/user/v2/integration_test/query_test.go
+++ b/internal/api/grpc/user/v2/integration_test/query_test.go
@@ -1252,6 +1252,64 @@ func TestServer_SystemUsers_ListUsers(t *testing.T) {
 	}
 }
 
+func TestServer_ListUsers_UsernameAndOr(t *testing.T) {
+	iamOwnerCtx := InstancePermissionV2.WithAuthorizationToken(OrgCTX, integration.UserTypeIAMOwner)
+	orgResp := InstancePermissionV2.CreateOrganization(iamOwnerCtx, integration.OrganizationName(), integration.Email())
+	alice := createUser(iamOwnerCtx, InstancePermissionV2, orgResp.OrganizationId, false)
+	bob := createUser(iamOwnerCtx, InstancePermissionV2, orgResp.OrganizationId, false)
+	orgQuery := OrganizationIdQuery(orgResp.OrganizationId)
+
+	tests := []struct {
+		name          string
+		queries       []*user.SearchQuery
+		wantUsernames []string
+	}{
+		{
+			name: "org and username or username",
+			queries: []*user.SearchQuery{
+				orgQuery,
+				OrQuery([]*user.SearchQuery{UsernameQuery(alice.Username), UsernameQuery(bob.Username)}),
+			},
+			wantUsernames: []string{alice.Username, bob.Username},
+		},
+		{
+			name: "org and sibling usernames",
+			queries: []*user.SearchQuery{
+				orgQuery,
+				UsernameQuery(alice.Username),
+				UsernameQuery(bob.Username),
+			},
+		},
+		{
+			name: "nested and of or and org",
+			queries: []*user.SearchQuery{
+				AndQuery([]*user.SearchQuery{
+					OrQuery([]*user.SearchQuery{UsernameQuery(alice.Username), UsernameQuery(bob.Username)}),
+					orgQuery,
+				}),
+			},
+			wantUsernames: []string{alice.Username, bob.Username},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &user.ListUsersRequest{Queries: tt.queries}
+			retryDuration, tick := integration.WaitForAndTickWithMaxDuration(iamOwnerCtx, 20*time.Second)
+			require.EventuallyWithT(t, func(ttt *assert.CollectT) {
+				got, err := InstancePermissionV2.Client.UserV2.ListUsers(iamOwnerCtx, req)
+				require.NoError(ttt, err)
+
+				gotUsernames := make([]string, 0, len(got.GetResult()))
+				for _, u := range got.GetResult() {
+					gotUsernames = append(gotUsernames, u.GetUsername())
+				}
+				assert.ElementsMatch(ttt, tt.wantUsernames, gotUsernames)
+			}, retryDuration, tick, "timeout waiting for expected user result")
+		})
+	}
+}
+
 func InUserIDsQuery(ids []string) *user.SearchQuery {
 	return &user.SearchQuery{
 		Query: &user.SearchQuery_InUserIdsQuery{
@@ -1306,6 +1364,16 @@ func OrQuery(queries []*user.SearchQuery) *user.SearchQuery {
 	return &user.SearchQuery{
 		Query: &user.SearchQuery_OrQuery{
 			OrQuery: &user.OrQuery{
+				Queries: queries,
+			},
+		},
+	}
+}
+
+func AndQuery(queries []*user.SearchQuery) *user.SearchQuery {
+	return &user.SearchQuery{
+		Query: &user.SearchQuery_AndQuery{
+			AndQuery: &user.AndQuery{
 				Queries: queries,
 			},
 		},

--- a/internal/eventstore/handler/v2/init.go
+++ b/internal/eventstore/handler/v2/init.go
@@ -70,6 +70,8 @@ type InitColumn struct {
 	nullable      bool
 	defaultValue  interface{}
 	deleteCascade string
+	generated     string
+	isStored      bool
 }
 
 type ColumnOption func(*InitColumn)
@@ -102,6 +104,13 @@ func Default(value interface{}) ColumnOption {
 func DeleteCascade(column string) ColumnOption {
 	return func(c *InitColumn) {
 		c.deleteCascade = column
+	}
+}
+
+func Generated(stmt string, isStored bool) ColumnOption {
+	return func(c *InitColumn) {
+		c.generated = stmt
+		c.isStored = isStored
 	}
 }
 
@@ -380,6 +389,12 @@ func createColumnsStatement(cols []*InitColumn, tableName string) string {
 		}
 		if col.defaultValue != nil {
 			column += " DEFAULT " + defaultValue(col.defaultValue)
+		}
+		if col.generated != "" {
+			column += " GENERATED ALWAYS AS (" + col.generated + ")"
+			if col.isStored {
+				column += " STORED"
+			}
 		}
 		if len(col.deleteCascade) != 0 {
 			column += fmt.Sprintf(" REFERENCES %s (%s) ON DELETE CASCADE", tableName, col.deleteCascade)

--- a/internal/query/login_name.go
+++ b/internal/query/login_name.go
@@ -15,12 +15,20 @@ var (
 		name:  projection.LoginNameCol,
 		table: loginNameTable,
 	}
+	LoginNameNameLowerCol = Column{
+		name:  projection.LoginNameLowerCol,
+		table: loginNameTable,
+	}
 	LoginNameIsPrimaryCol = Column{
 		name:  projection.LoginNameIsPrimaryCol,
 		table: loginNameTable,
 	}
 	LoginNameInstanceIDCol = Column{
 		name:  projection.LoginNameInstanceIDCol,
+		table: loginNameTable,
+	}
+	LoginNameResourceOwnerCol = Column{
+		name:  projection.LoginNameResourceOwnerCol,
 		table: loginNameTable,
 	}
 )

--- a/internal/query/projection/login_name.go
+++ b/internal/query/projection/login_name.go
@@ -22,10 +22,12 @@ const (
 	LoginNamePolicyProjectionTable = LoginNameProjectionTable + "_" + loginNamePolicySuffix
 	LoginNameDomainProjectionTable = LoginNameProjectionTable + "_" + loginNameDomainSuffix
 
-	LoginNameCol           = "login_name"
-	LoginNameUserCol       = "user_id"
-	LoginNameIsPrimaryCol  = "is_primary"
-	LoginNameInstanceIDCol = "instance_id"
+	LoginNameCol              = "login_name"
+	LoginNameUserCol          = "user_id"
+	LoginNameIsPrimaryCol     = "is_primary"
+	LoginNameInstanceIDCol    = "instance_id"
+	LoginNameLowerCol         = "login_name_lower"
+	LoginNameResourceOwnerCol = "resource_owner"
 
 	usersAlias         = "users"
 	policyCustomAlias  = "policy_custom"
@@ -76,8 +78,7 @@ func (*loginNameProjection) Init() *old_handler.Check {
 			[]*handler.InitColumn{
 				handler.NewColumn(LoginNameUserIDCol, handler.ColumnTypeText),
 				handler.NewColumn(LoginNameUserUserNameCol, handler.ColumnTypeText),
-				// TODO: implement computed columns
-				// handler.NewComputedColumn(loginNameUserUserNameLowerCol, handler.ColumnTypeText),
+				handler.NewColumn(loginNameUserUserNameLowerCol, handler.ColumnTypeText, handler.Generated("lower("+LoginNameUserUserNameCol+")", true)),
 				handler.NewColumn(LoginNameUserResourceOwnerCol, handler.ColumnTypeText),
 				handler.NewColumn(LoginNameUserInstanceIDCol, handler.ColumnTypeText),
 			},
@@ -93,33 +94,30 @@ func (*loginNameProjection) Init() *old_handler.Check {
 					),
 				),
 			),
-			// TODO: uncomment the following line when login_names4 will be created
-			// handler.WithIndex(
-			// 	handler.NewIndex("search", []string{LoginNameUserInstanceIDCol, loginNameUserUserNameLowerCol},
-			// 		handler.WithInclude(LoginNameUserResourceOwnerCol),
-			// 	),
-			// ),
+			handler.WithIndex(
+				handler.NewIndex("search", []string{LoginNameUserInstanceIDCol, loginNameUserUserNameLowerCol},
+					handler.WithInclude(LoginNameUserResourceOwnerCol),
+				),
+			),
 		),
 		handler.NewSuffixedTable(
 			[]*handler.InitColumn{
 				handler.NewColumn(LoginNameDomainNameCol, handler.ColumnTypeText),
-				// TODO: implement computed columns
-				// handler.NewComputedColumn(loginNameDomainNameLowerCol, handler.ColumnTypeText),
+				handler.NewColumn(loginNameDomainNameLowerCol, handler.ColumnTypeText, handler.Generated("lower("+LoginNameDomainNameCol+")", true)),
 				handler.NewColumn(LoginNameDomainIsPrimaryCol, handler.ColumnTypeBool, handler.Default(false)),
 				handler.NewColumn(LoginNameDomainResourceOwnerCol, handler.ColumnTypeText),
 				handler.NewColumn(LoginNameDomainInstanceIDCol, handler.ColumnTypeText),
 			},
 			handler.NewPrimaryKey(LoginNameDomainInstanceIDCol, LoginNameDomainResourceOwnerCol, LoginNameDomainNameCol),
 			loginNameDomainSuffix,
-			// TODO: uncomment the following line when login_names4 will be created
-			// handler.WithIndex(
-			// 	handler.NewIndex("search", []string{LoginNameDomainInstanceIDCol, LoginNameDomainResourceOwnerCol, loginNameDomainNameLowerCol}),
-			// ),
-			// handler.WithIndex(
-			// 	handler.NewIndex("search_result", []string{LoginNameDomainInstanceIDCol, LoginNameDomainResourceOwnerCol},
-			// 		handler.WithInclude(LoginNameDomainIsPrimaryCol),
-			// 	),
-			// ),
+			handler.WithIndex(
+				handler.NewIndex("search", []string{LoginNameDomainInstanceIDCol, LoginNameDomainResourceOwnerCol, loginNameDomainNameLowerCol}),
+			),
+			handler.WithIndex(
+				handler.NewIndex("search_result", []string{LoginNameDomainInstanceIDCol, LoginNameDomainResourceOwnerCol},
+					handler.WithInclude(LoginNameDomainIsPrimaryCol),
+				),
+			),
 		),
 		handler.NewSuffixedTable(
 			[]*handler.InitColumn{

--- a/internal/query/projection/login_name_query.sql
+++ b/internal/query/projection/login_name_query.sql
@@ -6,6 +6,11 @@ SELECT
     END AS login_name
     , COALESCE(d.is_primary, TRUE) AS is_primary
     , u.instance_id
+    , u.resource_owner
+    , CASE
+            WHEN p.must_be_domain THEN CONCAT(u.user_name_lower, '@', d.name_lower)
+            ELSE u.user_name_lower
+    END AS login_name_lower
 FROM
     projections.login_names3_users AS u
 LEFT JOIN LATERAL (

--- a/internal/query/projection/projection.go
+++ b/internal/query/projection/projection.go
@@ -209,6 +209,7 @@ func Projections() []projection {
 func Init(ctx context.Context) error {
 	for _, p := range projections {
 		if err := p.Init(ctx); err != nil {
+			logging.WithError(err).WithField("projection", p.ProjectionName()).Error("failed to initialize projection")
 			return err
 		}
 	}

--- a/internal/query/projection/user.go
+++ b/internal/query/projection/user.go
@@ -101,6 +101,7 @@ func (*userProjection) Init() *old_handler.Check {
 		},
 			handler.NewPrimaryKey(UserInstanceIDCol, UserIDCol),
 			handler.WithIndex(handler.NewIndex("username", []string{UserUsernameCol})),
+			handler.WithIndex(handler.NewIndex("username_lower", []string{UserInstanceIDCol, "LOWER(" + UserUsernameCol + ")"})),
 			handler.WithIndex(handler.NewIndex("resource_owner", []string{UserResourceOwnerCol})),
 		),
 		handler.NewSuffixedTable([]*handler.InitColumn{
@@ -125,6 +126,7 @@ func (*userProjection) Init() *old_handler.Check {
 			UserHumanSuffix,
 			handler.WithForeignKey(handler.NewForeignKeyOfPublicKeys()),
 			handler.WithIndex(handler.NewIndex("email", []string{HumanUserInstanceIDCol, "LOWER(" + HumanEmailCol + ")"})),
+			handler.WithIndex(handler.NewIndex("phone_lower", []string{HumanUserInstanceIDCol, "LOWER(" + HumanPhoneCol + ")"})),
 		),
 		handler.NewSuffixedTable([]*handler.InitColumn{
 			handler.NewColumn(MachineUserIDCol, handler.ColumnTypeText),

--- a/internal/query/user.go
+++ b/internal/query/user.go
@@ -803,13 +803,21 @@ func NewUserLoginNameExistsQuery(value string, comparison TextComparison) (Searc
 	if err != nil {
 		return nil, err
 	}
+	resourceOwnerQuery, err := NewColumnComparisonQuery(LoginNameResourceOwnerCol, UserResourceOwnerCol, ColumnEquals)
+	if err != nil {
+		return nil, err
+	}
 	// text query to select data from the linked sub select
-	loginNameQuery, err := NewTextQuery(LoginNameNameCol, value, comparison)
+	var loginNameQuery SearchQuery
+	loginNameQuery, err = NewTextQuery(LoginNameNameCol, value, comparison)
+	if comparison == TextEqualsIgnoreCase {
+		loginNameQuery, err = NewTextQuery(LoginNameNameLowerCol, strings.ToLower(value), TextEquals)
+	}
 	if err != nil {
 		return nil, err
 	}
 	// full definition of the sub select
-	subSelect, err := NewSubSelect(LoginNameUserIDCol, []SearchQuery{instanceQuery, userIDQuery, loginNameQuery})
+	subSelect, err := NewSubSelect(LoginNameUserIDCol, []SearchQuery{instanceQuery, userIDQuery, resourceOwnerQuery, loginNameQuery})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/user.go
+++ b/internal/query/user.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"errors"
+	"slices"
 	"strings"
 	"time"
 
@@ -793,8 +794,23 @@ func NewUserPreferredLoginNameSearchQuery(value string, comparison TextCompariso
 	return NewTextQuery(userPreferredLoginNameCol, value, comparison)
 }
 
+//go:embed user_login_name_matches.sql
+var userLoginNameMatchesQuery string
+
+//go:embed user_login_name_matches_case_sensitive.sql
+var userLoginNameMatchesCaseSensitiveQuery string
+
+// NewUserLoginNameExistsQuery filters users by login name.
+// Equals / EqualsIgnoreCase use a planner marker rewritten in prepareUsersQuery
+// into an indexed join on login_names3_users. Other comparisons use the view.
 func NewUserLoginNameExistsQuery(value string, comparison TextComparison) (SearchQuery, error) {
-	// linking queries for the sub select
+	if comparison == TextEquals || comparison == TextEqualsIgnoreCase {
+		return newLoginNameEqualsFilter(value, comparison == TextEqualsIgnoreCase)
+	}
+	return newLoginNameExistsViewQuery(value, comparison)
+}
+
+func newLoginNameExistsViewQuery(value string, comparison TextComparison) (SearchQuery, error) {
 	instanceQuery, err := NewColumnComparisonQuery(LoginNameInstanceIDCol, UserInstanceIDCol, ColumnEquals)
 	if err != nil {
 		return nil, err
@@ -807,7 +823,6 @@ func NewUserLoginNameExistsQuery(value string, comparison TextComparison) (Searc
 	if err != nil {
 		return nil, err
 	}
-	// text query to select data from the linked sub select
 	var loginNameQuery SearchQuery
 	loginNameQuery, err = NewTextQuery(LoginNameNameCol, value, comparison)
 	if comparison == TextEqualsIgnoreCase {
@@ -816,17 +831,156 @@ func NewUserLoginNameExistsQuery(value string, comparison TextComparison) (Searc
 	if err != nil {
 		return nil, err
 	}
-	// full definition of the sub select
 	subSelect, err := NewSubSelect(LoginNameUserIDCol, []SearchQuery{instanceQuery, userIDQuery, resourceOwnerQuery, loginNameQuery})
 	if err != nil {
 		return nil, err
 	}
-	// "WHERE * IN (*)" query with subquery as list-data provider
 	return NewListQuery(
 		UserIDCol,
 		subSelect,
 		ListIn,
 	)
+}
+
+// loginNameEqualsFilter marks a login-name equality filter for prepareUsersQuery
+// to rewrite as an indexed join. Unextracted markers (e.g. inside OrQuery) fall
+// back to the view-based exists query.
+type loginNameEqualsFilter struct {
+	username   string
+	domain     string
+	loginName  string
+	ignoreCase bool
+}
+
+func newLoginNameEqualsFilter(value string, ignoreCase bool) (*loginNameEqualsFilter, error) {
+	if ignoreCase {
+		value = strings.ToLower(value)
+	}
+	username := value
+	domainIndex := strings.LastIndex(value, "@")
+	var domainSuffix string
+	// split between the last @ (so ignore it if the login name ends with it)
+	if domainIndex > 0 && domainIndex != len(value)-1 {
+		domainSuffix = value[domainIndex+1:]
+		username = value[:domainIndex]
+	}
+	return &loginNameEqualsFilter{
+		username:   username,
+		domain:     domainSuffix,
+		loginName:  value,
+		ignoreCase: ignoreCase,
+	}, nil
+}
+
+func (q *loginNameEqualsFilter) comparison() TextComparison {
+	if q.ignoreCase {
+		return TextEqualsIgnoreCase
+	}
+	return TextEquals
+}
+
+func (q *loginNameEqualsFilter) fallback() SearchQuery {
+	// Equals / EqualsIgnoreCase construction cannot fail for valid columns.
+	fallback, _ := newLoginNameExistsViewQuery(q.loginName, q.comparison())
+	return fallback
+}
+
+func (q *loginNameEqualsFilter) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
+	return q.fallback().toQuery(query)
+}
+
+func (q *loginNameEqualsFilter) Col() Column {
+	return UserIDCol
+}
+
+func (q *loginNameEqualsFilter) comp() sq.Sqlizer {
+	return q.fallback().comp()
+}
+
+func (q *loginNameEqualsFilter) matchesArgs(instanceID string) []interface{} {
+	return []interface{}{
+		instanceID,
+		instanceID,
+		q.domain,
+		instanceID,
+		q.username,
+		q.loginName,
+		q.username,
+		q.domain,
+		q.loginName,
+	}
+}
+
+func (q *loginNameEqualsFilter) joinMatches(instanceID string) sq.Sqlizer {
+	subQuery := userLoginNameMatchesQuery
+	if !q.ignoreCase {
+		subQuery = userLoginNameMatchesCaseSensitiveQuery
+	}
+	return sq.Expr(
+		"INNER JOIN ("+subQuery+") AS login_name_matches ON "+UserIDCol.identifier()+" = login_name_matches.user_id",
+		q.matchesArgs(instanceID)...,
+	)
+}
+
+// extractLoginNameEqualsFilter extracts one login-name equals marker from
+// top-level or AndQuery filters. Markers inside OrQuery / NotQuery are kept.
+func extractLoginNameEqualsFilter(queries []SearchQuery) (filter *loginNameEqualsFilter, remaining []SearchQuery, ok bool) {
+	remaining = make([]SearchQuery, 0, len(queries))
+	var found *loginNameEqualsFilter
+
+	for _, qry := range queries {
+		switch v := qry.(type) {
+		case *loginNameEqualsFilter:
+			if found != nil {
+				return nil, queries, false
+			}
+			found = v
+		case *AndQuery:
+			inner, rest, extracted := extractLoginNameEqualsFilter(v.queries)
+			if !extracted {
+				remaining = append(remaining, qry)
+				continue
+			}
+			if found != nil {
+				return nil, queries, false
+			}
+			found = inner
+			if len(rest) == 1 {
+				remaining = append(remaining, rest[0])
+			} else if len(rest) > 1 {
+				andQuery, _ := NewAndQuery(rest...)
+				remaining = append(remaining, andQuery)
+			}
+		default:
+			remaining = append(remaining, qry)
+		}
+	}
+
+	if found == nil {
+		return nil, queries, false
+	}
+	return found, remaining, true
+}
+
+func (q *UserSearchQueries) hasMetadataFilter() bool {
+	return searchQueriesHaveMetadataFilter(q.Queries)
+}
+
+func searchQueriesHaveMetadataFilter(queries []SearchQuery) bool {
+	return slices.ContainsFunc(queries, searchQueryHasMetadataFilter)
+}
+
+func searchQueryHasMetadataFilter(qry SearchQuery) bool {
+	switch v := qry.(type) {
+	case *OrQuery:
+		return searchQueriesHaveMetadataFilter(v.queries)
+	case *AndQuery:
+		return searchQueriesHaveMetadataFilter(v.queries)
+	case *NotQuery:
+		return searchQueryHasMetadataFilter(v.query)
+	default:
+		return qry.Col().table.name == userMetadataTable.name
+	}
 }
 
 func triggerUserProjections(ctx context.Context) {
@@ -1257,13 +1411,24 @@ func prepareUserUniqueQuery() (sq.SelectBuilder, func(*sql.Row) (bool, error)) {
 }
 
 // prepareUsersQuery creates the select query for searching users and returns a matching scan function.
-// Permissions, filters and sorting are applied in a `SELECT FROM` distinct sub-select.
+// Permissions, filters and sorting are applied in a `SELECT FROM` sub-select.
 // The count over window function and limit are applied in the outer query.
 // It is not possible to pass more filters to the returned query, as they need to be applied in the sub-select.
+//
+// Metadata JOIN and DISTINCT are only applied when a metadata filter is present.
+// Login-name equals markers are rewritten into an indexed join when extractable.
 func (q *UserSearchQueries) prepareUsersQuery(ctx context.Context, permissionCheckV2 bool) (sq.SelectBuilder, func(*sql.Rows) (*Users, error)) {
 	if q.SortingColumn.isZero() {
 		q.SortingColumn = UserIDCol
 	}
+
+	instanceID := authz.GetInstance(ctx).InstanceID()
+	loginNameFilter, remainingFilters, loginNameExtracted := extractLoginNameEqualsFilter(q.Queries)
+	filters := q.Queries
+	if loginNameExtracted {
+		filters = remainingFilters
+	}
+	needsMetadataJoin := q.hasMetadataFilter()
 
 	// start building the sub-select
 	query := sq.Select(
@@ -1298,18 +1463,24 @@ func (q *UserSearchQueries) prepareUsersQuery(ctx context.Context, permissionChe
 		MachineSecretCol.identifier(),
 		MachineAccessTokenTypeCol.identifier(),
 		q.SortingColumn.orderBy()).
-		Distinct().
 		From(userTable.identifier()).
 		LeftJoin(join(HumanUserIDCol, UserIDCol)).
 		LeftJoin(join(MachineUserIDCol, UserIDCol)).
-		LeftJoin(join(UserMetadataUserIDCol, UserIDCol)).
 		JoinClause(joinLoginNames).
-		Where(sq.Eq{UserInstanceIDCol.identifier(): authz.GetInstance(ctx).InstanceID()})
+		Where(sq.Eq{UserInstanceIDCol.identifier(): instanceID})
 
-	query = userPermissionCheckV2(ctx, query, permissionCheckV2, q.Queries)
-	// apply requested filters
-	for _, q := range q.Queries {
-		query = q.toQuery(query)
+	if loginNameExtracted {
+		query = query.JoinClause(loginNameFilter.joinMatches(instanceID))
+	}
+
+	if needsMetadataJoin {
+		query = query.Distinct().
+			LeftJoin(join(UserMetadataUserIDCol, UserIDCol))
+	}
+
+	query = userPermissionCheckV2(ctx, query, permissionCheckV2, filters)
+	for _, filter := range filters {
+		query = filter.toQuery(query)
 	}
 	// apply sorting in the sub-select,because the identifier is fully qualified.
 	query = q.consumeSorting(query)

--- a/internal/query/user.go
+++ b/internal/query/user.go
@@ -747,7 +747,7 @@ func NewUserResourceOwnerSearchQuery(value string, comparison TextComparison) (S
 }
 
 func NewUserUsernameSearchQuery(value string, comparison TextComparison) (SearchQuery, error) {
-	return NewTextQuery(UserUsernameCol, value, comparison)
+	return newLowerEqualsSearchQuery(UserUsernameCol, userTable, UserIDCol, value, comparison)
 }
 
 func NewUserFirstNameSearchQuery(value string, comparison TextComparison) (SearchQuery, error) {
@@ -767,11 +767,11 @@ func NewUserDisplayNameSearchQuery(value string, comparison TextComparison) (Sea
 }
 
 func NewUserEmailSearchQuery(value string, comparison TextComparison) (SearchQuery, error) {
-	return NewTextQuery(HumanEmailCol, value, comparison)
+	return newLowerEqualsSearchQuery(HumanEmailCol, humanTable, HumanUserIDCol, value, comparison)
 }
 
 func NewUserPhoneSearchQuery(value string, comparison TextComparison) (SearchQuery, error) {
-	return NewTextQuery(HumanPhoneCol, value, comparison)
+	return newLowerEqualsSearchQuery(HumanPhoneCol, humanTable, HumanUserIDCol, value, comparison)
 }
 
 func NewUserVerifiedEmailSearchQuery(value string) (SearchQuery, error) {
@@ -801,8 +801,8 @@ var userLoginNameMatchesQuery string
 var userLoginNameMatchesCaseSensitiveQuery string
 
 // NewUserLoginNameExistsQuery filters users by login name.
-// Equals / EqualsIgnoreCase use a planner marker rewritten in prepareUsersQuery
-// into an indexed join on login_names3_users. Other comparisons use the view.
+// Equals / EqualsIgnoreCase are rewritten in prepareUsersQuery into an indexed
+// ID-seek. Other comparisons use the login_names3 view.
 func NewUserLoginNameExistsQuery(value string, comparison TextComparison) (SearchQuery, error) {
 	if comparison == TextEquals || comparison == TextEqualsIgnoreCase {
 		return newLoginNameEqualsFilter(value, comparison == TextEqualsIgnoreCase)
@@ -840,126 +840,6 @@ func newLoginNameExistsViewQuery(value string, comparison TextComparison) (Searc
 		subSelect,
 		ListIn,
 	)
-}
-
-// loginNameEqualsFilter marks a login-name equality filter for prepareUsersQuery
-// to rewrite as an indexed join. Unextracted markers (e.g. inside OrQuery) fall
-// back to the view-based exists query.
-type loginNameEqualsFilter struct {
-	username   string
-	domain     string
-	loginName  string
-	ignoreCase bool
-}
-
-func newLoginNameEqualsFilter(value string, ignoreCase bool) (*loginNameEqualsFilter, error) {
-	if ignoreCase {
-		value = strings.ToLower(value)
-	}
-	username := value
-	domainIndex := strings.LastIndex(value, "@")
-	var domainSuffix string
-	// split between the last @ (so ignore it if the login name ends with it)
-	if domainIndex > 0 && domainIndex != len(value)-1 {
-		domainSuffix = value[domainIndex+1:]
-		username = value[:domainIndex]
-	}
-	return &loginNameEqualsFilter{
-		username:   username,
-		domain:     domainSuffix,
-		loginName:  value,
-		ignoreCase: ignoreCase,
-	}, nil
-}
-
-func (q *loginNameEqualsFilter) comparison() TextComparison {
-	if q.ignoreCase {
-		return TextEqualsIgnoreCase
-	}
-	return TextEquals
-}
-
-func (q *loginNameEqualsFilter) fallback() SearchQuery {
-	// Equals / EqualsIgnoreCase construction cannot fail for valid columns.
-	fallback, _ := newLoginNameExistsViewQuery(q.loginName, q.comparison())
-	return fallback
-}
-
-func (q *loginNameEqualsFilter) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
-	return q.fallback().toQuery(query)
-}
-
-func (q *loginNameEqualsFilter) Col() Column {
-	return UserIDCol
-}
-
-func (q *loginNameEqualsFilter) comp() sq.Sqlizer {
-	return q.fallback().comp()
-}
-
-func (q *loginNameEqualsFilter) matchesArgs(instanceID string) []interface{} {
-	return []interface{}{
-		instanceID,
-		instanceID,
-		q.domain,
-		instanceID,
-		q.username,
-		q.loginName,
-		q.username,
-		q.domain,
-		q.loginName,
-	}
-}
-
-func (q *loginNameEqualsFilter) joinMatches(instanceID string) sq.Sqlizer {
-	subQuery := userLoginNameMatchesQuery
-	if !q.ignoreCase {
-		subQuery = userLoginNameMatchesCaseSensitiveQuery
-	}
-	return sq.Expr(
-		"INNER JOIN ("+subQuery+") AS login_name_matches ON "+UserIDCol.identifier()+" = login_name_matches.user_id",
-		q.matchesArgs(instanceID)...,
-	)
-}
-
-// extractLoginNameEqualsFilter extracts one login-name equals marker from
-// top-level or AndQuery filters. Markers inside OrQuery / NotQuery are kept.
-func extractLoginNameEqualsFilter(queries []SearchQuery) (filter *loginNameEqualsFilter, remaining []SearchQuery, ok bool) {
-	remaining = make([]SearchQuery, 0, len(queries))
-	var found *loginNameEqualsFilter
-
-	for _, qry := range queries {
-		switch v := qry.(type) {
-		case *loginNameEqualsFilter:
-			if found != nil {
-				return nil, queries, false
-			}
-			found = v
-		case *AndQuery:
-			inner, rest, extracted := extractLoginNameEqualsFilter(v.queries)
-			if !extracted {
-				remaining = append(remaining, qry)
-				continue
-			}
-			if found != nil {
-				return nil, queries, false
-			}
-			found = inner
-			if len(rest) == 1 {
-				remaining = append(remaining, rest[0])
-			} else if len(rest) > 1 {
-				andQuery, _ := NewAndQuery(rest...)
-				remaining = append(remaining, andQuery)
-			}
-		default:
-			remaining = append(remaining, qry)
-		}
-	}
-
-	if found == nil {
-		return nil, queries, false
-	}
-	return found, remaining, true
 }
 
 func (q *UserSearchQueries) hasMetadataFilter() bool {
@@ -1416,18 +1296,15 @@ func prepareUserUniqueQuery() (sq.SelectBuilder, func(*sql.Row) (bool, error)) {
 // It is not possible to pass more filters to the returned query, as they need to be applied in the sub-select.
 //
 // Metadata JOIN and DISTINCT are only applied when a metadata filter is present.
-// Login-name equals markers are rewritten into an indexed join when extractable.
+// Login-equality filters (username, email, phone, login name EQUALS /
+// EQUALS_IGNORE_CASE) become an indexed UNION of ID seeks.
 func (q *UserSearchQueries) prepareUsersQuery(ctx context.Context, permissionCheckV2 bool) (sq.SelectBuilder, func(*sql.Rows) (*Users, error)) {
 	if q.SortingColumn.isZero() {
 		q.SortingColumn = UserIDCol
 	}
 
 	instanceID := authz.GetInstance(ctx).InstanceID()
-	loginNameFilter, remainingFilters, loginNameExtracted := extractLoginNameEqualsFilter(q.Queries)
-	filters := q.Queries
-	if loginNameExtracted {
-		filters = remainingFilters
-	}
+	loginEqualitySeeks, filters, loginEqualityExtracted := extractLoginEqualitySeeks(instanceID, q.Queries)
 	needsMetadataJoin := q.hasMetadataFilter()
 
 	// start building the sub-select
@@ -1469,8 +1346,8 @@ func (q *UserSearchQueries) prepareUsersQuery(ctx context.Context, permissionChe
 		JoinClause(joinLoginNames).
 		Where(sq.Eq{UserInstanceIDCol.identifier(): instanceID})
 
-	if loginNameExtracted {
-		query = query.JoinClause(loginNameFilter.joinMatches(instanceID))
+	if loginEqualityExtracted {
+		query = query.JoinClause(joinLoginEqualitySeeks(loginEqualitySeeks))
 	}
 
 	if needsMetadataJoin {

--- a/internal/query/user_login_equality.go
+++ b/internal/query/user_login_equality.go
@@ -1,0 +1,227 @@
+package query
+
+import (
+	"strings"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+type loginEqualitySeek struct {
+	sql  string
+	args []interface{}
+}
+
+// loginNameEqualsFilter marks login-name equality for an indexed ID-seek in
+// prepareUsersQuery. Unextracted markers fall back to the view-based exists query.
+type loginNameEqualsFilter struct {
+	username   string
+	domain     string
+	loginName  string
+	ignoreCase bool
+}
+
+func newLoginNameEqualsFilter(value string, ignoreCase bool) (*loginNameEqualsFilter, error) {
+	if ignoreCase {
+		value = strings.ToLower(value)
+	}
+	username := value
+	domainIndex := strings.LastIndex(value, "@")
+	var domainSuffix string
+	// split between the last @ (so ignore it if the login name ends with it)
+	if domainIndex > 0 && domainIndex != len(value)-1 {
+		domainSuffix = value[domainIndex+1:]
+		username = value[:domainIndex]
+	}
+	return &loginNameEqualsFilter{
+		username:   username,
+		domain:     domainSuffix,
+		loginName:  value,
+		ignoreCase: ignoreCase,
+	}, nil
+}
+
+func (q *loginNameEqualsFilter) comparison() TextComparison {
+	if q.ignoreCase {
+		return TextEqualsIgnoreCase
+	}
+	return TextEquals
+}
+
+func (q *loginNameEqualsFilter) fallback() SearchQuery {
+	fallback, _ := newLoginNameExistsViewQuery(q.loginName, q.comparison())
+	return fallback
+}
+
+func (q *loginNameEqualsFilter) toQuery(query sq.SelectBuilder) sq.SelectBuilder {
+	return q.fallback().toQuery(query)
+}
+
+func (q *loginNameEqualsFilter) Col() Column {
+	return UserIDCol
+}
+
+func (q *loginNameEqualsFilter) comp() sq.Sqlizer {
+	return q.fallback().comp()
+}
+
+func (q *loginNameEqualsFilter) matchesArgs(instanceID string) []interface{} {
+	return []interface{}{
+		instanceID,
+		instanceID,
+		q.domain,
+		instanceID,
+		q.username,
+		q.loginName,
+		q.username,
+		q.domain,
+		q.loginName,
+	}
+}
+
+func (q *loginNameEqualsFilter) idSeek(instanceID string) loginEqualitySeek {
+	// userLoginNameMatchesQuery uses *_lower columns; the _case_sensitive embed uses raw columns.
+	subQuery := userLoginNameMatchesQuery
+	if !q.ignoreCase {
+		subQuery = userLoginNameMatchesCaseSensitiveQuery
+	}
+	return loginEqualitySeek{
+		sql:  "SELECT user_id AS id FROM (" + subQuery + ") AS login_name_matches",
+		args: q.matchesArgs(instanceID),
+	}
+}
+
+// lowerEqualsFilter is username, email, or phone EQUALS / EQUALS_IGNORE_CASE.
+// Unextracted filters compile to the same WHERE clause as textQuery.
+type lowerEqualsFilter struct {
+	textQuery
+	tbl   table
+	idCol Column
+}
+
+func newLowerEqualsSearchQuery(valueCol Column, tbl table, idCol Column, value string, comparison TextComparison) (SearchQuery, error) {
+	if comparison != TextEquals && comparison != TextEqualsIgnoreCase {
+		return NewTextQuery(valueCol, value, comparison)
+	}
+	tq, err := NewTextQuery(valueCol, value, comparison)
+	if err != nil {
+		return nil, err
+	}
+	return &lowerEqualsFilter{textQuery: *tq, tbl: tbl, idCol: idCol}, nil
+}
+
+func (q *lowerEqualsFilter) idSeek(instanceID string) loginEqualitySeek {
+	sql := "SELECT " + q.idCol.identifier() + " AS id FROM " + q.tbl.identifier() +
+		" WHERE " + q.tbl.InstanceIDIdentifier() + " = ? AND LOWER(" + q.Column.identifier() + ") = "
+	args := []interface{}{instanceID}
+	if q.Compare == TextEquals {
+		sql += "LOWER(?) AND " + q.Column.identifier() + " = ?"
+		args = append(args, q.Text, q.Text)
+	} else {
+		sql += "?"
+		args = append(args, strings.ToLower(q.Text))
+	}
+	return loginEqualitySeek{sql: sql, args: args}
+}
+
+func loginEqualitySeekFromLeaf(instanceID string, qry SearchQuery) (loginEqualitySeek, bool) {
+	switch v := qry.(type) {
+	case *loginNameEqualsFilter:
+		if v.loginName == "" {
+			return loginEqualitySeek{}, false
+		}
+		return v.idSeek(instanceID), true
+	case *lowerEqualsFilter:
+		if v.Text == "" {
+			return loginEqualitySeek{}, false
+		}
+		return v.idSeek(instanceID), true
+	default:
+		return loginEqualitySeek{}, false
+	}
+}
+
+func loginEqualitySeeksFromQuery(instanceID string, qry SearchQuery) ([]loginEqualitySeek, bool) {
+	if seek, ok := loginEqualitySeekFromLeaf(instanceID, qry); ok {
+		return []loginEqualitySeek{seek}, true
+	}
+	or, ok := qry.(*OrQuery)
+	if !ok {
+		return nil, false
+	}
+	seeks := make([]loginEqualitySeek, 0, len(or.queries))
+	for _, inner := range or.queries {
+		seek, ok := loginEqualitySeekFromLeaf(instanceID, inner)
+		if !ok {
+			return nil, false
+		}
+		seeks = append(seeks, seek)
+	}
+	if len(seeks) == 0 {
+		return nil, false
+	}
+	return seeks, true
+}
+
+// extractLoginEqualitySeeks pulls one login-equality filter from queries.
+// A match may be a top-level equals leaf, a flat OrQuery of those leaves, or
+// the same nested under AndQuery. Remaining AND conjuncts stay as WHERE.
+// Equality nested under OrQuery or NotQuery is not extracted.
+func extractLoginEqualitySeeks(instanceID string, queries []SearchQuery) ([]loginEqualitySeek, []SearchQuery, bool) {
+	for i, qry := range queries {
+		if and, ok := qry.(*AndQuery); ok {
+			seeks, andRest, ok := extractLoginEqualitySeeks(instanceID, and.queries)
+			if !ok {
+				continue
+			}
+			return seeks, spliceRemainingQuery(queries, i, remainingAndQuery(andRest)), true
+		}
+		seeks, ok := loginEqualitySeeksFromQuery(instanceID, qry)
+		if !ok {
+			continue
+		}
+		return seeks, spliceRemainingQuery(queries, i, nil), true
+	}
+	return nil, queries, false
+}
+
+func remainingAndQuery(rest []SearchQuery) SearchQuery {
+	switch len(rest) {
+	case 0:
+		return nil
+	case 1:
+		return rest[0]
+	default:
+		and, err := NewAndQuery(rest...)
+		if err != nil {
+			return nil
+		}
+		return and
+	}
+}
+
+func spliceRemainingQuery(queries []SearchQuery, i int, replacement SearchQuery) []SearchQuery {
+	n := len(queries) - 1
+	if replacement != nil {
+		n++
+	}
+	remaining := make([]SearchQuery, 0, n)
+	remaining = append(remaining, queries[:i]...)
+	if replacement != nil {
+		remaining = append(remaining, replacement)
+	}
+	remaining = append(remaining, queries[i+1:]...)
+	return remaining
+}
+
+func joinLoginEqualitySeeks(seeks []loginEqualitySeek) sq.Sqlizer {
+	parts := make([]string, len(seeks))
+	args := make([]interface{}, 0, len(seeks)*2)
+	for i, seek := range seeks {
+		parts[i] = seek.sql
+		args = append(args, seek.args...)
+	}
+	return sq.Expr(
+		"INNER JOIN ("+strings.Join(parts, " UNION ")+") AS matches ON "+UserIDCol.identifier()+" = matches.id",
+		args...,
+	)
+}

--- a/internal/query/user_login_name_exists_test.go
+++ b/internal/query/user_login_name_exists_test.go
@@ -1,0 +1,175 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+)
+
+func TestNewUserLoginNameExistsQuery_EqualsIgnoreCaseIsMarker(t *testing.T) {
+	qry, err := NewUserLoginNameExistsQuery("User.Name@Org.Localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	ln, ok := qry.(*loginNameEqualsFilter)
+	require.True(t, ok)
+	assert.Equal(t, "user.name", ln.username)
+	assert.Equal(t, "org.localhost", ln.domain)
+	assert.Equal(t, "user.name@org.localhost", ln.loginName)
+	assert.True(t, ln.ignoreCase)
+}
+
+func TestNewUserLoginNameExistsQuery_EqualsIsMarker(t *testing.T) {
+	qry, err := NewUserLoginNameExistsQuery("User.Name@Org.Localhost", TextEquals)
+	require.NoError(t, err)
+
+	ln, ok := qry.(*loginNameEqualsFilter)
+	require.True(t, ok)
+	assert.Equal(t, "User.Name", ln.username)
+	assert.Equal(t, "Org.Localhost", ln.domain)
+	assert.Equal(t, "User.Name@Org.Localhost", ln.loginName)
+	assert.False(t, ln.ignoreCase)
+}
+
+func TestNewUserLoginNameExistsQuery_ContainsFallsBackToView(t *testing.T) {
+	qry, err := NewUserLoginNameExistsQuery("user", TextContains)
+	require.NoError(t, err)
+
+	_, ok := qry.(*loginNameEqualsFilter)
+	assert.False(t, ok)
+
+	sql, _, err := qry.comp().ToSql()
+	require.NoError(t, err)
+	assert.Contains(t, sql, "projections.login_names3")
+	assert.Contains(t, strings.ToLower(sql), "login_name")
+}
+
+func TestExtractLoginNameEqualsFilter_TopLevel(t *testing.T) {
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
+	require.NoError(t, err)
+
+	filter, remaining, ok := extractLoginNameEqualsFilter([]SearchQuery{loginNameQuery, orgQuery})
+	require.True(t, ok)
+	require.NotNil(t, filter)
+	assert.Equal(t, "user", filter.username)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, orgQuery, remaining[0])
+}
+
+func TestExtractLoginNameEqualsFilter_SkipsOrQuery(t *testing.T) {
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	emailQuery, err := NewUserEmailSearchQuery("user@example.com", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(loginNameQuery, emailQuery)
+	require.NoError(t, err)
+
+	_, remaining, ok := extractLoginNameEqualsFilter([]SearchQuery{orQuery})
+	assert.False(t, ok)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, orQuery, remaining[0])
+}
+
+func TestPrepareUsersQuery_LoginNameEqualsUsesIndexedJoin(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user165000@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{loginNameQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "INNER JOIN")
+	assert.Contains(t, sql, "login_name_matches")
+	assert.Contains(t, sql, "login_names3_users")
+	assert.Contains(t, sql, "user_name_lower")
+	assert.NotContains(t, sql, "login_name_lower")
+	assert.NotContains(t, sql, "user_metadata5")
+	assert.NotContains(t, sql, "SELECT DISTINCT")
+	assert.Contains(t, args, "inst-1")
+	assert.Contains(t, args, "user165000")
+	assert.Contains(t, args, "org.localhost")
+}
+
+func TestPrepareUsersQuery_LoginNameEqualsCaseSensitive(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	loginNameQuery, err := NewUserLoginNameExistsQuery("User165000@Org.Localhost", TextEquals)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{loginNameQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "login_name_matches")
+	assert.Contains(t, sql, "u.user_name IN")
+	assert.NotContains(t, sql, "user_name_lower")
+	assert.Contains(t, args, "User165000")
+	assert.Contains(t, args, "Org.Localhost")
+}
+
+func TestPrepareUsersQuery_LoginNameEqualsWithOrgFilter(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{loginNameQuery, orgQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "login_name_matches")
+	assert.Contains(t, sql, "resource_owner")
+	assert.Contains(t, args, "org1")
+	assert.Contains(t, args, "user")
+}
+
+func TestPrepareUsersQuery_LoginNameOrEmailDoesNotRewrite(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	emailQuery, err := NewUserEmailSearchQuery("user@example.com", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(loginNameQuery, emailQuery)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, _, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.NotContains(t, sql, "login_name_matches")
+	assert.Contains(t, sql, "projections.login_names3")
+}
+
+func TestPrepareUsersQuery_MetadataFilterKeepsDistinctJoin(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	metadataQuery, err := NewUserMetadataKeySearchQuery("key", TextContains)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{metadataQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, _, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "SELECT DISTINCT")
+	assert.Contains(t, sql, "user_metadata5")
+}

--- a/internal/query/user_login_name_exists_test.go
+++ b/internal/query/user_login_name_exists_test.go
@@ -47,21 +47,33 @@ func TestNewUserLoginNameExistsQuery_ContainsFallsBackToView(t *testing.T) {
 	assert.Contains(t, strings.ToLower(sql), "login_name")
 }
 
-func TestExtractLoginNameEqualsFilter_TopLevel(t *testing.T) {
+func TestExtractLoginEqualitySeeks_LoginNameAndOrg(t *testing.T) {
 	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
 	require.NoError(t, err)
 	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
 	require.NoError(t, err)
 
-	filter, remaining, ok := extractLoginNameEqualsFilter([]SearchQuery{loginNameQuery, orgQuery})
+	seeks, remaining, ok := extractLoginEqualitySeeks("inst-1", []SearchQuery{loginNameQuery, orgQuery})
 	require.True(t, ok)
-	require.NotNil(t, filter)
-	assert.Equal(t, "user", filter.username)
+	require.Len(t, seeks, 1)
+	assert.Contains(t, seeks[0].sql, "login_name_matches")
 	require.Len(t, remaining, 1)
 	assert.Equal(t, orgQuery, remaining[0])
 }
 
-func TestExtractLoginNameEqualsFilter_SkipsOrQuery(t *testing.T) {
+func TestNewUserEmailSearchQuery_EqualsIsLowerEqualsFilter(t *testing.T) {
+	qry, err := NewUserEmailSearchQuery("Ada@Example.com", TextEquals)
+	require.NoError(t, err)
+	_, ok := qry.(*lowerEqualsFilter)
+	require.True(t, ok)
+
+	contains, err := NewUserEmailSearchQuery("Ada", TextContains)
+	require.NoError(t, err)
+	_, ok = contains.(*lowerEqualsFilter)
+	assert.False(t, ok)
+}
+
+func TestExtractLoginEqualitySeeks_OrLoginNameAndEmail(t *testing.T) {
 	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
 	require.NoError(t, err)
 	emailQuery, err := NewUserEmailSearchQuery("user@example.com", TextEqualsIgnoreCase)
@@ -69,10 +81,43 @@ func TestExtractLoginNameEqualsFilter_SkipsOrQuery(t *testing.T) {
 	orQuery, err := NewOrQuery(loginNameQuery, emailQuery)
 	require.NoError(t, err)
 
-	_, remaining, ok := extractLoginNameEqualsFilter([]SearchQuery{orQuery})
+	seeks, remaining, ok := extractLoginEqualitySeeks("inst-1", []SearchQuery{orQuery})
+	require.True(t, ok)
+	require.Len(t, seeks, 2)
+	assert.Contains(t, seeks[0].sql, "login_name_matches")
+	assert.Contains(t, seeks[1].sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.Empty(t, remaining)
+}
+
+func TestExtractLoginEqualitySeeks_EmptyOrArmDoesNotExtract(t *testing.T) {
+	emailQuery, err := NewUserEmailSearchQuery("", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	phoneQuery, err := NewUserPhoneSearchQuery("+41000000000", TextEquals)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(emailQuery, phoneQuery)
+	require.NoError(t, err)
+
+	seeks, remaining, ok := extractLoginEqualitySeeks("inst-1", []SearchQuery{orQuery})
 	assert.False(t, ok)
+	assert.Nil(t, seeks)
 	require.Len(t, remaining, 1)
 	assert.Equal(t, orQuery, remaining[0])
+}
+
+func TestExtractLoginEqualitySeeks_NestedAndExtractsLoginName(t *testing.T) {
+	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
+	require.NoError(t, err)
+	andQuery, err := NewAndQuery(loginNameQuery, orgQuery)
+	require.NoError(t, err)
+
+	seeks, remaining, ok := extractLoginEqualitySeeks("inst-1", []SearchQuery{andQuery})
+	require.True(t, ok)
+	require.Len(t, seeks, 1)
+	assert.Contains(t, seeks[0].sql, "login_name_matches")
+	require.Len(t, remaining, 1)
+	assert.Equal(t, orgQuery, remaining[0])
 }
 
 func TestPrepareUsersQuery_LoginNameEqualsUsesIndexedJoin(t *testing.T) {
@@ -138,7 +183,7 @@ func TestPrepareUsersQuery_LoginNameEqualsWithOrgFilter(t *testing.T) {
 	assert.Contains(t, args, "user")
 }
 
-func TestPrepareUsersQuery_LoginNameOrEmailDoesNotRewrite(t *testing.T) {
+func TestPrepareUsersQuery_LoginNameOrEmailUsesUnion(t *testing.T) {
 	ctx := authz.WithInstanceID(t.Context(), "inst-1")
 	loginNameQuery, err := NewUserLoginNameExistsQuery("user@org.localhost", TextEqualsIgnoreCase)
 	require.NoError(t, err)
@@ -151,11 +196,268 @@ func TestPrepareUsersQuery_LoginNameOrEmailDoesNotRewrite(t *testing.T) {
 		Queries: []SearchQuery{orQuery},
 	}
 	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "UNION")
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, "login_name_matches")
+	assert.Contains(t, sql, "login_names3_users")
+	assert.Contains(t, sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.NotContains(t, sql, "login_name_lower")
+	assert.Contains(t, args, "user@example.com")
+}
+
+func TestPrepareUsersQuery_UsernameOrEmailUsesUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	usernameQuery, err := NewUserUsernameSearchQuery("user165000", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	emailQuery, err := NewUserEmailSearchQuery("user@example.com", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(usernameQuery, emailQuery)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "UNION")
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, "LOWER("+UserUsernameCol.identifier()+")")
+	assert.Contains(t, sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.NotContains(t, sql, "login_name_matches")
+	assert.Contains(t, args, "user165000")
+	assert.Contains(t, args, "user@example.com")
+}
+
+func TestPrepareUsersQuery_EmailOrPhoneUsesUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	emailQuery, err := NewUserEmailSearchQuery("user@example.com", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	phoneQuery, err := NewUserPhoneSearchQuery("+41000000000", TextEquals)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(emailQuery, phoneQuery)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "UNION")
+	assert.Contains(t, sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.Contains(t, sql, "LOWER("+HumanPhoneCol.identifier()+")")
+	assert.Contains(t, args, "user@example.com")
+	assert.Contains(t, args, "+41000000000")
+}
+
+func TestPrepareUsersQuery_EmailEqualsRechecksExactColumn(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	emailQuery, err := NewUserEmailSearchQuery("Ada@Example.com", TextEquals)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{emailQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.Contains(t, sql, "LOWER($")
+	assert.Contains(t, sql, HumanEmailCol.identifier()+" =")
+	assert.Contains(t, args, "Ada@Example.com")
+	assert.NotContains(t, args, "ada@example.com")
+}
+
+func TestPrepareUsersQuery_EmailIgnoreCaseDoesNotRecheckExactColumn(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	emailQuery, err := NewUserEmailSearchQuery("Ada@Example.com", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{emailQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, "LOWER("+HumanEmailCol.identifier()+")")
+	assert.NotContains(t, sql, "LOWER($")
+	assert.NotContains(t, sql, HumanEmailCol.identifier()+" =")
+	assert.Contains(t, args, "ada@example.com")
+	assert.NotContains(t, args, "Ada@Example.com")
+}
+
+func TestPrepareUsersQuery_PhoneIgnoreCaseUsesUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	phoneQuery, err := NewUserPhoneSearchQuery("+41000000000", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{phoneQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, "LOWER("+HumanPhoneCol.identifier()+")")
+	assert.Contains(t, args, "+41000000000")
+}
+
+func TestPrepareUsersQuery_ContainsDoesNotUseUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	usernameQuery, err := NewUserUsernameSearchQuery("user", TextContainsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{usernameQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
 	sql, _, err := builder.ToSql()
 	require.NoError(t, err)
 
-	assert.NotContains(t, sql, "login_name_matches")
-	assert.Contains(t, sql, "projections.login_names3")
+	assert.NotContains(t, sql, "AS matches")
+	assert.NotContains(t, sql, " UNION ")
+}
+
+func TestPrepareUsersQuery_DisplayNameDoesNotUseUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	displayNameQuery, err := NewUserDisplayNameSearchQuery("Ada Lovelace", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{displayNameQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, _, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.NotContains(t, sql, "AS matches")
+	assert.NotContains(t, sql, " UNION ")
+}
+
+func TestPrepareUsersQuery_UsernameOrContainsDoesNotUseUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	usernameQuery, err := NewUserUsernameSearchQuery("user165000", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	displayNameQuery, err := NewUserDisplayNameSearchQuery("user", TextContainsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(usernameQuery, displayNameQuery)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, _, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.NotContains(t, sql, "AS matches")
+	assert.NotContains(t, sql, " UNION ")
+}
+
+func TestPrepareUsersQuery_UsernameOrUsernameUsesUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	alice, err := NewUserUsernameSearchQuery("alice", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	bob, err := NewUserUsernameSearchQuery("bob", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(alice, bob)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "UNION")
+	assert.Contains(t, sql, "AS matches")
+	assert.Equal(t, 2, strings.Count(sql, "LOWER("+UserUsernameCol.identifier()+")"))
+	assert.Contains(t, args, "alice")
+	assert.Contains(t, args, "bob")
+}
+
+func TestPrepareUsersQuery_SiblingUsernameAndKeepsRemainingWhere(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	alice, err := NewUserUsernameSearchQuery("alice", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	bob, err := NewUserUsernameSearchQuery("bob", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{alice, bob},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "AS matches")
+	assert.NotContains(t, sql, " UNION ")
+	assert.Contains(t, args, "alice")
+	assert.Contains(t, args, "bob")
+}
+
+func TestPrepareUsersQuery_NestedAndOfOrUsesUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	alice, err := NewUserUsernameSearchQuery("alice", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	bob, err := NewUserUsernameSearchQuery("bob", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(alice, bob)
+	require.NoError(t, err)
+	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
+	require.NoError(t, err)
+	andQuery, err := NewAndQuery(orQuery, orgQuery)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{andQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, args, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "AS matches")
+	assert.Contains(t, sql, " UNION ")
+	assert.Contains(t, sql, "resource_owner")
+	assert.Contains(t, args, "org1")
+	assert.Contains(t, args, "alice")
+	assert.Contains(t, args, "bob")
+}
+
+func TestPrepareUsersQuery_NestedOrOfAndDoesNotUseUnion(t *testing.T) {
+	ctx := authz.WithInstanceID(t.Context(), "inst-1")
+	alice, err := NewUserUsernameSearchQuery("alice", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orgQuery, err := NewUserResourceOwnerSearchQuery("org1", TextEquals)
+	require.NoError(t, err)
+	andQuery, err := NewAndQuery(alice, orgQuery)
+	require.NoError(t, err)
+	bob, err := NewUserUsernameSearchQuery("bob", TextEqualsIgnoreCase)
+	require.NoError(t, err)
+	orQuery, err := NewOrQuery(andQuery, bob)
+	require.NoError(t, err)
+
+	q := &UserSearchQueries{
+		Queries: []SearchQuery{orQuery},
+	}
+	builder, _ := q.prepareUsersQuery(ctx, false)
+	sql, _, err := builder.ToSql()
+	require.NoError(t, err)
+
+	assert.NotContains(t, sql, "AS matches")
+	assert.NotContains(t, sql, " UNION ")
 }
 
 func TestPrepareUsersQuery_MetadataFilterKeepsDistinctJoin(t *testing.T) {

--- a/internal/query/user_login_name_matches.sql
+++ b/internal/query/user_login_name_matches.sql
@@ -1,0 +1,29 @@
+SELECT u.id AS user_id
+FROM projections.login_names3_users u
+LEFT JOIN LATERAL (
+    SELECT p.must_be_domain
+    FROM projections.login_names3_policies AS p
+    WHERE
+        (
+            p.instance_id = ?
+            AND NOT p.is_default
+            AND p.resource_owner = u.resource_owner
+        ) OR (
+            p.instance_id = ?
+            AND p.is_default
+        )
+    ORDER BY p.is_default
+    LIMIT 1
+) AS p ON TRUE
+LEFT JOIN projections.login_names3_domains d
+    ON p.must_be_domain
+    AND u.resource_owner = d.resource_owner
+    AND u.instance_id = d.instance_id
+    AND d.name_lower = ?
+WHERE
+    u.instance_id = ?
+    AND u.user_name_lower IN (?, ?)
+    AND (
+        (p.must_be_domain AND u.user_name_lower = ? AND d.name_lower = ?)
+        OR (NOT COALESCE(p.must_be_domain, FALSE) AND u.user_name_lower = ?)
+    )

--- a/internal/query/user_login_name_matches_case_sensitive.sql
+++ b/internal/query/user_login_name_matches_case_sensitive.sql
@@ -1,0 +1,29 @@
+SELECT u.id AS user_id
+FROM projections.login_names3_users u
+LEFT JOIN LATERAL (
+    SELECT p.must_be_domain
+    FROM projections.login_names3_policies AS p
+    WHERE
+        (
+            p.instance_id = ?
+            AND NOT p.is_default
+            AND p.resource_owner = u.resource_owner
+        ) OR (
+            p.instance_id = ?
+            AND p.is_default
+        )
+    ORDER BY p.is_default
+    LIMIT 1
+) AS p ON TRUE
+LEFT JOIN projections.login_names3_domains d
+    ON p.must_be_domain
+    AND u.resource_owner = d.resource_owner
+    AND u.instance_id = d.instance_id
+    AND d.name = ?
+WHERE
+    u.instance_id = ?
+    AND u.user_name IN (?, ?)
+    AND (
+        (p.must_be_domain AND u.user_name = ? AND d.name = ?)
+        OR (NOT COALESCE(p.must_be_domain, FALSE) AND u.user_name = ?)
+    )

--- a/internal/query/user_test.go
+++ b/internal/query/user_test.go
@@ -244,7 +244,7 @@ var (
 		"count",
 	}
 	usersQuery = `SELECT *, COUNT(*) OVER () FROM (` +
-		`SELECT DISTINCT projections.users14.id,` +
+		`SELECT projections.users14.id,` +
 		` projections.users14.creation_date,` +
 		` projections.users14.change_date,` +
 		` projections.users14.resource_owner,` +
@@ -278,7 +278,6 @@ var (
 		` FROM projections.users14` +
 		` LEFT JOIN projections.users14_humans ON projections.users14.id = projections.users14_humans.user_id AND projections.users14.instance_id = projections.users14_humans.instance_id` +
 		` LEFT JOIN projections.users14_machines ON projections.users14.id = projections.users14_machines.user_id AND projections.users14.instance_id = projections.users14_machines.instance_id` +
-		` LEFT JOIN projections.user_metadata5 ON projections.users14.id = projections.user_metadata5.user_id AND projections.users14.instance_id = projections.user_metadata5.instance_id` +
 		` LEFT JOIN LATERAL (SELECT ARRAY_AGG(ln.login_name ORDER BY ln.login_name) AS login_names, MAX(CASE WHEN ln.is_primary THEN ln.login_name ELSE NULL END) AS preferred_login_name FROM projections.login_names3 AS ln WHERE ln.user_id = projections.users14.id AND ln.instance_id = projections.users14.instance_id) AS login_names ON TRUE` +
 		` WHERE projections.users14.instance_id = $1 ORDER BY projections.users14.id DESC` +
 		`) AS results`


### PR DESCRIPTION
Backport of #12701 to `next`.

**This PR carries three upstream commits, not one.** `next` predates the login-name equality work that #12701 builds on, so the cherry-pick does not stand alone here:

| Commit | Upstream PR | Why it is needed |
| --- | --- | --- |
| `f9995ee39c` | #12350 | Adds `login_names3.name_lower` / `resource_owner` (setup step 72) and the projection changes. Without it `NewUserLoginNameExistsQuery` has no lower-case column to seek on. |
| `318acd4bc3` | #12460 | The login-name equals rewrite (`user_login_name_matches*.sql`, `hasMetadataFilter`) that #12701 extends to username/email/phone OR trees. |
| `684de2e691` | #12701 | This PR. |

If `next` should not take #12350 and #12460, then #12701 cannot be backported as such: it would have to be re-implemented against the older query builder.

Adaptations, all in `cmd/setup`: steps 70, 71 and 73-75 and `RelationalTables` do not exist on this branch, so only steps 72 and 76 are taken. The upstream step numbers are kept so the migration names match `main` and `v4.x-wo-te`; 70-75 stay unused on `next`.

`go test ./internal/query/ ./internal/query/projection/ ./cmd/setup/ ./internal/eventstore/handler/v2/` passes, and the integration test compiles under the `integration` tag.

---

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Which Problems Are Solved

Login V2 `ListUsers` lookups of the form username OR email (and email OR phone) hash-join the full `users14` / `users14_humans` tables, then filter. That cost grows with instance size (~40ms at 10k users, ~650ms at 200k).

Top-level login-name equals already used an indexed join, but the same login-name filter inside an `OrQuery` fell back to the slow view-based exists query.

# How the Problems Are Solved

**TL;DR:** equality lookups on username, email, phone, or login name become `INNER JOIN (UNION of indexed ID seeks) AS matches`. Mixed / contains / name searches keep the old WHERE shape.

### Reviewer map

| Read first | Why |
| --- | --- |
| `internal/query/user_login_equality.go` | Typed filters + extractor + UNION join |
| `internal/query/user.go` (`prepareUsersQuery`, constructors) | Wiring; username/email/phone equals return `lowerEqualsFilter` |
| `cmd/setup/76.go` + `cmd/setup/76/*.sql` | Concurrent indexes for existing deployments; drop invalid leftovers |
| `internal/query/projection/user.go` | Same indexes in `Init()` for new databases |
| `internal/query/user_login_name_exists_test.go` | SQL-shape coverage |
| `internal/api/grpc/user/v2/integration_test/query_test.go` | Nested username AND/OR user results |

### Query rewrite

- Extract one equals leaf, a flat `OrQuery` of those leaves, or the same nested under `AndQuery`. Remaining AND conjuncts stay as WHERE. Equality nested under `OrQuery` / `NotQuery` is left as WHERE.
- Login-name equals is a UNION arm that reuses `login_names3_users` SQL, so it works inside OR as well as at the top level.
- EQUALS seeks use `LOWER(col)` for the index, then recheck `col = value` so case-sensitive searches do not match extra rows. EQUALS_IGNORE_CASE is unchanged.
- Empty OR arms are not skipped (that would change OR meaning); mixed empty-OR falls back to WHERE. Login UI already omits empty arms.

### Indexes

- Setup 76: `CREATE INDEX CONCURRENTLY IF NOT EXISTS` on `users14_username_lower_idx` `(instance_id, LOWER(username))` and `users14_humans_phone_lower_idx` `(instance_id, LOWER(phone))`. Not wrapped in a transaction.
- Before create, drop any leftover `pg_index.indisvalid = false` indexes of those names (failed/cancelled `CREATE INDEX CONCURRENTLY`). `IF NOT EXISTS` would otherwise skip rebuild.
- `Init()` creates the same indexes without `CONCURRENTLY` (empty tables). Existing `users14_username` and email lower indexes are unchanged.

# Additional Changes

- Unit tests assert UNION SQL for username OR email, email OR phone, login name OR email, username OR username, nested `AndQuery(loginName, org)`, and nested `AndQuery(Or(...), org)`; that contains / display-name / mixed OR / nested `OrQuery(AndQuery(...), ...)` do not UNION; that email EQUALS rechecks the raw column; and that empty-OR is not extracted.
- Setup 76 sqlmock coverage: missing `users14` skips work; valid/absent indexes only create; invalid leftover username index is dropped then both creates run.
- `TestServer_ListUsers_UsernameAndOr` checks live results: org AND (alice OR bob) returns both users, sibling username AND is empty, nested `AndQuery(Or(...), org)` returns both.

# Additional Context

- Base branch: `main`
- Extends the login-name equals rewrite from #12460 to username/email/phone OR trees used by Login V2 search.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f043b1c-6168-45ca-9e9e-c18451994207?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f043b1c-6168-45ca-9e9e-c18451994207&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




🤖 Generated with [Claude Code](https://claude.com/claude-code)
