### PR TITLE
feat(query): add state filter to ListProjects

### DIFF
--- a/internal/api/grpc/project/v2/integration_test/query_test.go
+++ b/internal/api/grpc/project/v2/integration_test/query_test.go
@@ -311,6 +311,70 @@ func TestServer_ListProjects(t *testing.T) {
 			},
 		},
 		{
+			name: "list by state active",
+			args: args{
+				ctx: iamOwnerCtx,
+				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
+					orgID := instance.DefaultOrg.GetId()
+					response.Projects[0] = createProject(iamOwnerCtx, instance, t, orgID, false, false)
+					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
+						InProjectIdsFilter: &filter.InIDsFilter{
+							Ids: []string{response.Projects[0].GetProjectId()},
+						},
+					}
+					request.Filters[1].Filter = &project.ProjectSearchFilter_StateFilter{
+						StateFilter: project.ProjectState_PROJECT_STATE_ACTIVE,
+					}
+				},
+				req: &project.ListProjectsRequest{
+					Filters: []*project.ProjectSearchFilter{{}, {}},
+				},
+			},
+			want: &project.ListProjectsResponse{
+				Pagination: &filter.PaginationResponse{
+					TotalResult:  1,
+					AppliedLimit: 100,
+				},
+				Projects: []*project.Project{
+					{},
+				},
+			},
+		},
+		{
+			name: "list by state inactive",
+			args: args{
+				ctx: iamOwnerCtx,
+				dep: func(request *project.ListProjectsRequest, response *project.ListProjectsResponse) {
+					orgID := instance.DefaultOrg.GetId()
+					created := createProject(iamOwnerCtx, instance, t, orgID, false, false)
+					deactivateResp := instance.DeactivateProject(iamOwnerCtx, t, created.GetProjectId())
+					created.State = project.ProjectState_PROJECT_STATE_INACTIVE
+					created.ChangeDate = deactivateResp.GetChangeDate()
+					response.Projects[0] = created
+					request.Filters[0].Filter = &project.ProjectSearchFilter_InProjectIdsFilter{
+						InProjectIdsFilter: &filter.InIDsFilter{
+							Ids: []string{created.GetProjectId()},
+						},
+					}
+					request.Filters[1].Filter = &project.ProjectSearchFilter_StateFilter{
+						StateFilter: project.ProjectState_PROJECT_STATE_INACTIVE,
+					}
+				},
+				req: &project.ListProjectsRequest{
+					Filters: []*project.ProjectSearchFilter{{}, {}},
+				},
+			},
+			want: &project.ListProjectsResponse{
+				Pagination: &filter.PaginationResponse{
+					TotalResult:  1,
+					AppliedLimit: 100,
+				},
+				Projects: []*project.Project{
+					{},
+				},
+			},
+		},
+		{
 			name: "list multiple id",
 			args: args{
 				ctx: iamOwnerCtx,

--- a/internal/api/grpc/project/v2/query.go
+++ b/internal/api/grpc/project/v2/query.go
@@ -98,6 +98,8 @@ func projectFilterToModel(filter *project_pb.ProjectSearchFilter) (query.SearchQ
 		return projectInIDsFilterToQuery(q.InProjectIdsFilter)
 	case *project_pb.ProjectSearchFilter_OrganizationIdFilter:
 		return projectOrganizationIDFilterToQuery(q.OrganizationIdFilter)
+	case *project_pb.ProjectSearchFilter_StateFilter:
+		return projectStateFilterToQuery(q.StateFilter)
 	default:
 		return nil, zerrors.ThrowInvalidArgument(nil, "ORG-vR9nC", "List.Query.Invalid")
 	}
@@ -109,6 +111,10 @@ func projectNameFilterToQuery(q *project_pb.ProjectNameFilter) (query.SearchQuer
 
 func projectInIDsFilterToQuery(q *filter_pb.InIDsFilter) (query.SearchQuery, error) {
 	return query.NewGrantedProjectIDSearchQuery(q.Ids)
+}
+
+func projectStateFilterToQuery(state project_pb.ProjectState) (query.SearchQuery, error) {
+	return query.NewGrantedProjectStateSearchQuery(projectStateToDomain(state))
 }
 
 func projectOrganizationIDFilterToQuery(q *project_pb.ProjectOrganizationIDFilter) (query.SearchQuery, error) {
@@ -187,6 +193,20 @@ func projectStateToPb(state domain.ProjectState) project_pb.ProjectState {
 		return project_pb.ProjectState_PROJECT_STATE_UNSPECIFIED
 	}
 }
+
+func projectStateToDomain(state project_pb.ProjectState) domain.ProjectState {
+	switch state {
+	case project_pb.ProjectState_PROJECT_STATE_ACTIVE:
+		return domain.ProjectStateActive
+	case project_pb.ProjectState_PROJECT_STATE_INACTIVE:
+		return domain.ProjectStateInactive
+	case project_pb.ProjectState_PROJECT_STATE_UNSPECIFIED:
+		fallthrough
+	default:
+		return domain.ProjectStateUnspecified
+	}
+}
+
 func grantedProjectStateToPb(state domain.ProjectGrantState) project_pb.GrantedProjectState {
 	switch state {
 	case domain.ProjectGrantStateActive:

--- a/internal/query/project.go
+++ b/internal/query/project.go
@@ -352,6 +352,10 @@ func NewGrantedProjectGrantedOrganizationIDSearchQuery(value string) (SearchQuer
 	return NewTextQuery(grantedProjectColumnGrantedOrganization, value, TextEquals)
 }
 
+func NewGrantedProjectStateSearchQuery(value domain.ProjectState) (SearchQuery, error) {
+	return NewNumberQuery(grantedProjectColumnState, value, NumberEquals)
+}
+
 func NewProjectNameSearchQuery(method TextComparison, value string) (SearchQuery, error) {
 	return NewTextQuery(ProjectColumnName, value, method)
 }

--- a/proto/zitadel/project/v2/query.proto
+++ b/proto/zitadel/project/v2/query.proto
@@ -144,6 +144,9 @@ message ProjectSearchFilter {
     // Filter for projects that are owned by or granted to a specific organization.
     // You can specify whether to search for owned, granted or both types of projects.
     ProjectOrganizationIDFilter organization_id_filter = 3;
+
+    // Filter the projects by their state.
+    ProjectState state_filter = 4;
   }
 }
 

--- a/proto/zitadel/project/v2/query.proto
+++ b/proto/zitadel/project/v2/query.proto
@@ -146,7 +146,7 @@ message ProjectSearchFilter {
     ProjectOrganizationIDFilter organization_id_filter = 3;
 
     // Filter the projects by their state.
-    ProjectState state_filter = 4;
+    ProjectState state_filter = 4 [(validate.rules).enum = {defined_only: true, not_in: [0]}];
   }
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

- `ListProjects` (v2, GA) has no way to filter results by project state (`Active`/`Inactive`), unlike sibling resources `ListOrganizations` (`OrganizationStateQuery`) and `ListApplications` (`state_filter`), which both already support this.

# How the Problems Are Solved

- Adds a `state_filter` case to `ProjectSearchFilter` in `proto/zitadel/project/v2/query.proto`, reusing the existing `ProjectState` enum.
- Adds `NewGrantedProjectStateSearchQuery` in `internal/query/project.go`, filtering on the existing (already selected, already indexed) `project_state` column used by `SearchGrantedProjects` — no new column or migration needed.
- Wires the new filter case through `projectStateFilterToQuery`/`projectStateToDomain` in `internal/api/grpc/project/v2/query.go`, following the exact pattern already used by `orgStateToDomain` in the org v2 API.

# Additional Changes

None.

# Additional Context

- No existing issue/PR found covering this gap during a full-text search of issues and merged PRs.
- Closes #12714 