### PR TITLE
fix(actions): set instance ID in async execution worker context

### DIFF
--- a/internal/execution/ctx.go
+++ b/internal/execution/ctx.go
@@ -15,5 +15,6 @@ func HandlerContext(parent context.Context, event *eventstore.Aggregate) context
 }
 
 func ContextWithExecuter(ctx context.Context, aggregate *eventstore.Aggregate) context.Context {
+	ctx = authz.WithInstanceID(ctx, aggregate.InstanceID)
 	return authz.SetCtxData(ctx, authz.CtxData{UserID: ExecutionUserID, OrgID: aggregate.ResourceOwner})
 }

--- a/internal/execution/ctx_test.go
+++ b/internal/execution/ctx_test.go
@@ -1,0 +1,23 @@
+package execution_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/zitadel/internal/api/authz"
+	"github.com/zitadel/zitadel/internal/eventstore"
+	"github.com/zitadel/zitadel/internal/execution"
+)
+
+func TestContextWithExecuter(t *testing.T) {
+	ctx := execution.ContextWithExecuter(context.Background(), &eventstore.Aggregate{
+		InstanceID:    instanceID,
+		ResourceOwner: orgID,
+	})
+
+	assert.Equal(t, instanceID, authz.GetInstance(ctx).InstanceID())
+	assert.Equal(t, orgID, authz.GetCtxData(ctx).OrgID)
+	assert.Equal(t, execution.ExecutionUserID, authz.GetCtxData(ctx).UserID)
+}

--- a/internal/execution/worker_test.go
+++ b/internal/execution/worker_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/assert"
@@ -59,10 +61,19 @@ func newExecutionWorker(f fieldsWorker) *execution.Worker {
 			MaxTtl:              5 * time.Minute,
 		},
 		nil,
-		mockGetActiveSigningWebKey,
+		instanceSigningWebKey,
 		f.now,
 		http.DefaultClient,
 	)
+}
+
+// instanceSigningWebKey mimics [query.Queries.GetActiveSigningWebKey], which
+// resolves the key of the instance in the context.
+func instanceSigningWebKey(ctx context.Context) (*jose.JSONWebKey, error) {
+	if id := authz.GetInstance(ctx).InstanceID(); id != instanceID {
+		return nil, fmt.Errorf("no active signing web key for instance %q", id)
+	}
+	return mockGetActiveSigningWebKey(ctx)
 }
 
 const (
@@ -276,8 +287,10 @@ func Test_handleEventExecution(t *testing.T) {
 			require.NoError(t, err)
 			a.job.Args.TargetsData = data
 
+			// river invokes the worker with a plain context, so the instance
+			// has to be taken from the job's aggregate
 			err = newExecutionWorker(f).Work(
-				authz.WithInstanceID(context.Background(), instanceID),
+				context.Background(),
 				a.job,
 			)
 


### PR DESCRIPTION
# Which Problems Are Solved

Actions v2 targets with `PAYLOAD_TYPE_JWT` or `PAYLOAD_TYPE_JWE` never fire when the execution is triggered by an event. The target endpoint receives no request at all, and the only symptom is a repeated server log:

```
level=error msg="error calling target" instanceID= target=<target-id>
  error="ID=QUERY-Opoh7 Message=Errors.WebKey.NoActive Parent=(sql: no rows in result set)"
```

Targets with `PAYLOAD_TYPE_JSON` on the same events work, because that path never signs the payload.

The async River worker builds its context with `ContextWithExecuter`, which sets `authz.CtxData` but not the instance. `payloadJWT` then resolves the signing key through `Queries.GetActiveSigningWebKey`, which looks it up by `authz.GetInstance(ctx).InstanceID()`. That value is empty, so the query runs against `instance_id = ''` and returns no rows, even when the instance has an active web key.

Because the error is returned before the HTTP call and targets commonly run with `interruptOnError` false, it is only logged and the job is still reported as processed, so the failure is silent.

# How the Problems Are Solved

`ContextWithExecuter` now takes the instance ID from the aggregate it already receives, the same way `HandlerContext` does directly above it.

# Additional Changes

- `Test_handleEventExecution` called `Work` with an instance already on the context, which does not match how River invokes the worker. It now passes a plain `context.Background()`.
- The signing key function used by the worker test resolves the key for the instance on the context, mirroring `Queries.GetActiveSigningWebKey`. Together with the change above, the existing JSON/JWT/JWE case now fails without the fix.
- Adds a unit test for `ContextWithExecuter`.

# Additional Context

- Closes #11985
- Reproduced on a self hosted v4.15.3 instance: REST webhook target, `PAYLOAD_TYPE_JWE`, execution bound to the `user` event group. The instance had an active web key (`projections.web_keys1.state = 2`) and the same target delivered normally with `PAYLOAD_TYPE_JSON`.
- Verified locally: `go test ./internal/execution/...` passes with the fix, and `Test_handleEventExecution/multiple` plus `TestContextWithExecuter` fail with it reverted, reproducing `no active signing web key for instance ""`.

