### PR TITLE
fix(login): apply secondFactorCheckLifetime to TOTP sessions

### DIFF
--- a/apps/login/src/lib/server/session.test.ts
+++ b/apps/login/src/lib/server/session.test.ts
@@ -1,6 +1,6 @@
 import { Code } from "@connectrpc/connect";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { clearSession } from "./session";
+import { clearSession, updateOrCreateSession } from "./session";
 
 vi.mock("@zitadel/client", async () => {
   const { Code } = await import("@connectrpc/connect");
@@ -126,5 +126,52 @@ describe("clearSession", () => {
 
     expect(res).toBeUndefined();
     expect(deleteSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateOrCreateSession lifetime mapping", () => {
+  let getLoginSettings: any;
+  let getMostRecentSessionCookie: any;
+  let setSessionAndUpdateCookie: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const zitadel = await import("@/lib/zitadel");
+    const cookies = await import("../cookies");
+    const cookieServer = await import("@/lib/server/cookie");
+    getLoginSettings = vi.mocked(zitadel.getLoginSettings);
+    getMostRecentSessionCookie = vi.mocked(cookies.getMostRecentSessionCookie);
+    setSessionAndUpdateCookie = vi.mocked(cookieServer.setSessionAndUpdateCookie);
+
+    getMostRecentSessionCookie.mockResolvedValue(cookie);
+    setSessionAndUpdateCookie.mockResolvedValue({ factors: { user: {} } });
+  });
+
+  test("applies secondFactorCheckLifetime to a TOTP check", async () => {
+    const secondFactorCheckLifetime = { seconds: BigInt(600), nanos: 0 };
+    getLoginSettings.mockResolvedValue({ secondFactorCheckLifetime });
+
+    await updateOrCreateSession({ checks: { totp: {} } as any });
+
+    expect(setSessionAndUpdateCookie).toHaveBeenCalledWith(expect.objectContaining({ lifetime: secondFactorCheckLifetime }));
+  });
+
+  test("applies secondFactorCheckLifetime to an otpEmail/otpSms check the same way", async () => {
+    const secondFactorCheckLifetime = { seconds: BigInt(600), nanos: 0 };
+    getLoginSettings.mockResolvedValue({ secondFactorCheckLifetime });
+
+    await updateOrCreateSession({ checks: { otpEmail: {} } as any });
+
+    expect(setSessionAndUpdateCookie).toHaveBeenCalledWith(expect.objectContaining({ lifetime: secondFactorCheckLifetime }));
+  });
+
+  test("falls back to the 24h default when no lifetime policy is configured for a TOTP check", async () => {
+    getLoginSettings.mockResolvedValue({});
+
+    await updateOrCreateSession({ checks: { totp: {} } as any });
+
+    expect(setSessionAndUpdateCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ lifetime: { seconds: BigInt(60 * 60 * 24), nanos: 0 } }),
+    );
   });
 });

--- a/apps/login/src/lib/server/session.ts
+++ b/apps/login/src/lib/server/session.ts
@@ -206,7 +206,7 @@ export async function updateOrCreateSession(options: UpdateSessionCommand) {
   if (!lifetime) {
     lifetime = checks?.webAuthN
       ? loginSettings?.multiFactorCheckLifetime // TODO different lifetime for webauthn u2f/passkey
-      : checks?.otpEmail || checks?.otpSms
+      : checks?.otpEmail || checks?.otpSms || checks?.totp
         ? loginSettings?.secondFactorCheckLifetime
         : undefined;
   }


### PR DESCRIPTION
# Which Problems Are Solved

- The session lifetime mapping in `updateOrCreateSession` (`apps/login/src/lib/server/session.ts`) only special-cased `webAuthN`, `otpEmail` and `otpSms` checks. A `totp` check (authenticator app / TOTP) fell through the mapping entirely, so it never picked up the instance's `secondFactorCheckLifetime` policy and defaulted to the 24h fallback instead.

# How the Problems Are Solved

- Added `checks?.totp` to the condition that selects `secondFactorCheckLifetime`, so TOTP-based sessions are treated the same as `otpEmail`/`otpSms` and correctly honor the configured second-factor session lifetime.

# Additional Changes

None.

# Additional Context

Found while validating that a login policy with `secondFactorCheckLifetime` set to several days actually applied to users authenticating with an authenticator app; TOTP sessions were unexpectedly expiring after 24h instead.