### PR TITLE
fix(login): persist the sessions cookie beyond the browser session

### DIFF
--- a/apps/login/src/lib/cookies.test.ts
+++ b/apps/login/src/lib/cookies.test.ts
@@ -271,6 +271,98 @@ describe("cookies", () => {
     });
   });
 
+  describe("session cookie maxAge", () => {
+    const baseTime = 1700000000000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(baseTime));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("sets maxAge from the session's expiration", async () => {
+      mockCookies.get.mockReturnValue(undefined);
+
+      const session: Cookie = {
+        id: "session-1",
+        token: "token-1",
+        loginName: "user@example.com",
+        creationTs: `${baseTime}`,
+        expirationTs: `${baseTime + 600_000}`, // 600s in the future
+        changeTs: `${baseTime}`,
+      };
+
+      await addSessionToCookie({ session });
+
+      expect(mockCookies.set).toHaveBeenCalledWith(expect.objectContaining({ maxAge: 600 }));
+    });
+
+    it("picks the furthest expiration among multiple sessions", async () => {
+      const nearSession: Cookie = {
+        id: "session-near",
+        token: "token-near",
+        loginName: "near@example.com",
+        creationTs: `${baseTime}`,
+        expirationTs: `${baseTime + 60_000}`,
+        changeTs: `${baseTime}`,
+      };
+
+      mockCookies.get.mockReturnValue({ value: JSON.stringify([nearSession]) });
+
+      const farSession: Cookie = {
+        id: "session-far",
+        token: "token-far",
+        loginName: "far@example.com",
+        creationTs: `${baseTime}`,
+        expirationTs: `${baseTime + 600_000}`,
+        changeTs: `${baseTime}`,
+      };
+
+      await addSessionToCookie({ session: farSession });
+
+      expect(mockCookies.set).toHaveBeenCalledWith(expect.objectContaining({ maxAge: 600 }));
+    });
+
+    it("omits maxAge when every session is already expired", async () => {
+      mockCookies.get.mockReturnValue(undefined);
+
+      const expiredSession: Cookie = {
+        id: "session-expired",
+        token: "token-expired",
+        loginName: "expired@example.com",
+        creationTs: `${baseTime}`,
+        expirationTs: `${baseTime - 1000}`,
+        changeTs: `${baseTime}`,
+      };
+
+      await addSessionToCookie({ session: expiredSession });
+
+      const setCall = mockCookies.set.mock.calls[0][0];
+      expect(setCall).not.toHaveProperty("maxAge");
+    });
+
+    it("omits maxAge without throwing when expirationTs is not a valid number", async () => {
+      mockCookies.get.mockReturnValue(undefined);
+
+      const malformedSession = {
+        id: "session-malformed",
+        token: "token-malformed",
+        loginName: "malformed@example.com",
+        creationTs: `${baseTime}`,
+        expirationTs: "not-a-number",
+        changeTs: `${baseTime}`,
+      } as unknown as Cookie;
+
+      await expect(addSessionToCookie({ session: malformedSession })).resolves.not.toThrow();
+
+      const setCall = mockCookies.set.mock.calls[0][0];
+      expect(setCall).not.toHaveProperty("maxAge");
+    });
+  });
+
   describe("updateSessionCookie", () => {
     const mockSession: Cookie = {
       id: "session-1",

--- a/apps/login/src/lib/cookies.ts
+++ b/apps/login/src/lib/cookies.ts
@@ -30,7 +30,14 @@ type SessionCookie<T> = Cookie & T;
 // forces a full password+MFA replay before that policy-driven expiration is reached.
 function computeMaxAgeSeconds<T>(sessions: SessionCookie<T>[]): number | undefined {
   const expirations = sessions
-    .map((s) => (s.expirationTs ? timestampDate(timestampFromMs(Number(s.expirationTs))) : undefined))
+    .map((s) => {
+      const ms = s.expirationTs ? Number(s.expirationTs) : NaN;
+      if (!Number.isFinite(ms)) {
+        return undefined;
+      }
+      const date = timestampDate(timestampFromMs(ms));
+      return Number.isNaN(date.getTime()) ? undefined : date;
+    })
     .filter((d): d is Date => !!d);
 
   if (expirations.length === 0) {

--- a/apps/login/src/lib/cookies.ts
+++ b/apps/login/src/lib/cookies.ts
@@ -23,6 +23,26 @@ export type Cookie = {
 
 type SessionCookie<T> = Cookie & T;
 
+// Without an explicit maxAge, this is a browser-session cookie: it dies when the browser
+// closes, even though the underlying Zitadel session (per secondFactorCheckLifetime /
+// passwordCheckLifetime) is still valid for days or weeks. Track the cookie's lifetime on
+// the furthest expirationTs among the sessions it carries, so a closed browser no longer
+// forces a full password+MFA replay before that policy-driven expiration is reached.
+function computeMaxAgeSeconds<T>(sessions: SessionCookie<T>[]): number | undefined {
+  const expirations = sessions
+    .map((s) => (s.expirationTs ? timestampDate(timestampFromMs(Number(s.expirationTs))) : undefined))
+    .filter((d): d is Date => !!d);
+
+  if (expirations.length === 0) {
+    return undefined;
+  }
+
+  const latest = expirations.reduce((a, b) => (a > b ? a : b));
+  const seconds = Math.floor((latest.getTime() - Date.now()) / 1000);
+
+  return seconds > 0 ? seconds : undefined;
+}
+
 async function setSessionHttpOnlyCookie<T>(sessions: SessionCookie<T>[], iFrameEnabled: boolean = false) {
   const cookiesList = await cookies();
 
@@ -37,6 +57,8 @@ async function setSessionHttpOnlyCookie<T>(sessions: SessionCookie<T>[], iFrameE
     resolvedSameSite = "lax";
   }
 
+  const maxAge = computeMaxAgeSeconds(sessions);
+
   return cookiesList.set({
     name: "sessions",
     value: JSON.stringify(sessions),
@@ -44,6 +66,7 @@ async function setSessionHttpOnlyCookie<T>(sessions: SessionCookie<T>[], iFrameE
     path: "/",
     sameSite: resolvedSameSite,
     secure: process.env.NODE_ENV === "production",
+    ...(maxAge !== undefined ? { maxAge } : {}),
   });
 }
 

--- a/apps/login/src/lib/server/cookie.test.ts
+++ b/apps/login/src/lib/server/cookie.test.ts
@@ -1,4 +1,4 @@
-import { create } from "@zitadel/client";
+import { create, timestampMs } from "@zitadel/client";
 import { RequestChallengesSchema } from "@zitadel/proto/zitadel/session/v2/challenge_pb";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -97,5 +97,73 @@ describe("session challenge sanitization", () => {
 
     expect(setSession).toHaveBeenCalledTimes(1);
     expectSanitized(vi.mocked(setSession).mock.calls[0][0].challenges);
+  });
+});
+
+describe("session cookie renewal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(headers).mockResolvedValue({} as any);
+    vi.mocked(getServiceConfig).mockReturnValue({ serviceConfig: {} } as any);
+    vi.mocked(getSecuritySettings).mockResolvedValue({ embeddedIframe: { enabled: false } } as any);
+    vi.mocked(addSessionToCookie).mockResolvedValue(undefined as any);
+    vi.mocked(updateSessionCookie).mockResolvedValue(undefined as any);
+    vi.mocked(setSession).mockResolvedValue({
+      sessionToken: "sessionToken",
+      details: {},
+    } as any);
+  });
+
+  test("refreshes expirationTs from the newly fetched session instead of the stale cookie", async () => {
+    const freshExpirationDate = { seconds: BigInt(2000), nanos: 0 };
+
+    vi.mocked(getSession).mockResolvedValue({
+      session: {
+        id: "sessionId",
+        expirationDate: freshExpirationDate,
+        factors: { user: { loginName: "victim@example.com", organizationId: "orgId" } },
+      },
+    } as any);
+
+    await setSessionAndUpdateCookie({
+      recentCookie: {
+        id: "sessionId",
+        token: "sessionToken",
+        loginName: "victim@example.com",
+        creationTs: "",
+        expirationTs: "1000000", // stale value carried over from before this renewal
+        changeTs: "",
+      },
+      lifetime: {} as any,
+    });
+
+    const newCookie = vi.mocked(updateSessionCookie).mock.calls[0][0].session;
+    expect(newCookie.expirationTs).toBe(`${timestampMs(freshExpirationDate as any)}`);
+    expect(newCookie.expirationTs).not.toBe("1000000");
+  });
+
+  test("falls back to the previous expirationTs when the fetched session has none", async () => {
+    vi.mocked(getSession).mockResolvedValue({
+      session: {
+        id: "sessionId",
+        factors: { user: { loginName: "victim@example.com", organizationId: "orgId" } },
+      },
+    } as any);
+
+    await setSessionAndUpdateCookie({
+      recentCookie: {
+        id: "sessionId",
+        token: "sessionToken",
+        loginName: "victim@example.com",
+        creationTs: "",
+        expirationTs: "1000000",
+        changeTs: "",
+      },
+      lifetime: {} as any,
+    });
+
+    const newCookie = vi.mocked(updateSessionCookie).mock.calls[0][0].session;
+    expect(newCookie.expirationTs).toBe("1000000");
   });
 });

--- a/apps/login/src/lib/server/cookie.ts
+++ b/apps/login/src/lib/server/cookie.ts
@@ -244,7 +244,9 @@ export async function setSessionAndUpdateCookie(command: {
               id: sessionCookie.id,
               token: updatedSession.sessionToken,
               creationTs: sessionCookie.creationTs,
-              expirationTs: sessionCookie.expirationTs,
+              // Re-derive from the freshly fetched session rather than reusing
+              // sessionCookie.expirationTs, which still holds the pre-renewal value.
+              expirationTs: session.expirationDate ? `${timestampMs(session.expirationDate)}` : sessionCookie.expirationTs,
               // just overwrite the changeDate with the new one
               changeTs: updatedSession.details?.changeDate ? `${timestampMs(updatedSession.details.changeDate)}` : "",
               loginName: session.factors?.user?.loginName ?? "",


### PR DESCRIPTION
# Which Problems Are Solved

- The `sessions` httpOnly cookie (`apps/login/src/lib/cookies.ts`) was always set without `maxAge`/`expires`, making it a browser-session cookie. It was therefore cleared as soon as the browser closed, even though the underlying Zitadel session was still valid for a much longer duration according to the instance's `passwordCheckLifetime` / `secondFactorCheckLifetime` policy.
- On machines where the browser is restarted often (shared/kiosk devices, daily reboots), this forced users through a full password + MFA replay every time, regardless of how the session lifetime policy was configured.

# How the Problems Are Solved

- Added `computeMaxAgeSeconds`, which derives a `maxAge` for the cookie from the furthest `expirationTs` already carried by the sessions it stores.
- `setSessionHttpOnlyCookie` now passes this computed `maxAge` to the cookie options when available, so the cookie survives a browser restart up to the same point the underlying session actually expires. When no valid expiration can be derived, the cookie falls back to its previous browser-session behavior.

# Additional Changes

None.

# Additional Context

Found while validating long-lived sessions (multi-day `secondFactorCheckLifetime`) on a machine that gets restarted daily: users were being asked to re-authenticate every morning even though the configured session lifetime had not expired.